### PR TITLE
Update projects to beta

### DIFF
--- a/src/Google.Bigquery.V2/project.json
+++ b/src/Google.Bigquery.V2/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0-*",
+  "version": "1.0.0-*",
   "summary": "Wrapper library for Google.Apis.Bigquery.v2",
   "description": "Wrapper library for Google.Apis.Bigquery.v2, making common operations simpler in client code.",
   "authors": [ "Google Inc." ],
@@ -15,11 +15,11 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Rest": "0.1.0-CI00057",
-    "Google.Apis": "1.13.0",
-    "Google.Apis.Auth": "1.13.0",
-    "Google.Apis.Bigquery.v2": "1.13.0.487",
-    "Google.Apis.Core": "1.13.0"
+    "Google.Api.Gax.Rest": "1.0.0-beta01",
+    "Google.Apis": "1.14.0",
+    "Google.Apis.Auth": "1.14.0",
+    "Google.Apis.Bigquery.v2": "1.14.0.545",
+    "Google.Apis.Core": "1.14.0"
   },
   "frameworks": {
     "net45": {

--- a/src/Google.Datastore.V1Beta3/project.json
+++ b/src/Google.Datastore.V1Beta3/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.1.0-*",
+  "version": "1.0.0-*",
   "summary": "Google Cloud Datastore v1beta3 client library",
   "description": "Google Cloud Datastore v1beta3 client library",
   "authors": [ "Google Inc." ],
@@ -14,9 +14,9 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "0.1.0-CI00061",
-    "Google.Api.Gax": "0.1.0-CI00061",
-    "Google.Apis.Auth": "1.13.0",
+    "Google.Api.CommonProtos": "1.0.0-beta01",
+    "Google.Api.Gax": "1.0.0-beta01",
+    "Google.Apis.Auth": "1.14.0",
     "Google.Protobuf": "3.0.0-beta3",
     "Grpc.Auth": "0.15.0",
     "Grpc.Core": "0.15.0",

--- a/src/Google.Logging.Log4Net/project.json
+++ b/src/Google.Logging.Log4Net/project.json
@@ -14,8 +14,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "0.1.0-CI00061",
-    "Google.Api.Gax": "0.1.0-CI00061",
+    "Google.Api.CommonProtos": "1.0.0-beta01",
+    "Google.Api.Gax": "1.0.0-beta01",
     "Google.Logging.V2": "",
     "log4net": "2.0.5"
   },

--- a/src/Google.Logging.Type/project.json
+++ b/src/Google.Logging.Type/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0-*",
+  "version": "1.0.0-*",
   "summary": "Google Logging version-agnostic types",
   "description": "Google Logging version-agnostic types",
   "authors": [ "Google Inc." ],
@@ -14,7 +14,7 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "0.1.0-CI00061",
+    "Google.Api.CommonProtos": "1.0.0-beta01",
     "Google.Protobuf": "3.0.0-beta3"
   },
 

--- a/src/Google.Logging.V2/project.json
+++ b/src/Google.Logging.V2/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0-*",
+  "version": "1.0.0-*",
   "summary": "Google Logging v2 client library",
   "description": "Google Logging v2 client library",
   "authors": [ "Google Inc." ],
@@ -14,9 +14,9 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "0.1.0-CI00061",
-    "Google.Api.Gax": "0.1.0-CI00061",
-    "Google.Apis.Auth": "1.13.0",
+    "Google.Api.CommonProtos": "1.0.0-beta01",
+    "Google.Api.Gax": "1.0.0-beta01",
+    "Google.Apis.Auth": "1.14.0",
     "Google.Logging.Type": "",
     "Google.Protobuf": "3.0.0-beta3",
     "Grpc.Auth": "0.15.0",

--- a/src/Google.Pubsub.V1/project.json
+++ b/src/Google.Pubsub.V1/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.1.0-*",
+  "version": "1.0.0-*",
   "summary": "Google Pubsub v1 client library",
   "description": "Google Pubsub v1 client library",
   "authors": [ "Google Inc." ],
@@ -14,9 +14,9 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "0.1.0-CI00061",
-    "Google.Api.Gax": "0.1.0-CI00061",
-    "Google.Apis.Auth": "1.13.0",
+    "Google.Api.CommonProtos": "1.0.0-beta01",
+    "Google.Api.Gax": "1.0.0-beta01",
+    "Google.Apis.Auth": "1.14.0",
     "Google.Protobuf": "3.0.0-beta3",
     "Grpc.Auth": "0.15.0",
     "Grpc.Core": "0.15.0",

--- a/src/Google.Storage.V1/project.json
+++ b/src/Google.Storage.V1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0-*",
+  "version": "1.0.0-*",
   "summary": "Wrapper library for Google.Apis.Storage.v1",
   "description": "Wrapper library for Google.Apis.Storage.v1, making common operations simpler in client code.",
   "authors": [ "Google Inc." ],
@@ -15,11 +15,11 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Rest": "0.1.0-CI00057",
-    "Google.Apis": "1.13.0",
-    "Google.Apis.Auth": "1.13.0",
-    "Google.Apis.Core": "1.13.0",
-    "Google.Apis.Storage.v1": "1.13.0.482"
+    "Google.Api.Gax.Rest": "1.0.0-beta01",
+    "Google.Apis": "1.14.0",
+    "Google.Apis.Auth": "1.14.0",
+    "Google.Apis.Core": "1.14.0",
+    "Google.Apis.Storage.v1": "1.14.0.538"
   },
   "frameworks": {
     "net45": {

--- a/test/Google.Logging.Log4Net.Tests/project.json
+++ b/test/Google.Logging.Log4Net.Tests/project.json
@@ -7,7 +7,7 @@
 
   "dependencies": {
     "Google.Logging.Log4Net": "",
-    "Google.Api.Gax.Testing": "0.1.0-CI00061",
+    "Google.Api.Gax.Testing": "1.0.0-beta01",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204",
     "Moq": "4.5.10"


### PR DESCRIPTION
This change:

- Starts consuming beta01 of GAX
- Updates Google.Apis.* to 1.14
- Updates *our* version number to 1.0.0, so we can build 1.0.0-beta01.