### PR TITLE
Manually-written change to use channel pool scoping.

### DIFF
--- a/src/Google.Bigquery.V2/project.json
+++ b/src/Google.Bigquery.V2/project.json
@@ -16,7 +16,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Rest": "1.0.0-CI00072",
+    "Google.Api.Gax.Rest": "1.0.0-CI00074",
     "Google.Apis": "1.14.0",
     "Google.Apis.Auth": "1.14.0",
     "Google.Apis.Bigquery.v2": "1.14.0.545",

--- a/src/Google.Cloud.Language.V1Beta1/LanguageServiceClient.cs
+++ b/src/Google.Cloud.Language.V1Beta1/LanguageServiceClient.cs
@@ -243,8 +243,6 @@ namespace Google.Cloud.Language.V1Beta1
     /// </summary>
     public abstract partial class LanguageServiceClient
     {
-        private static readonly ChannelPool s_channelPool = new ChannelPool();
-
         /// <summary>
         /// The default endpoint for the LanguageService service, which is a host of "language.googleapis.com" and a port of 443.
         /// </summary>
@@ -262,6 +260,8 @@ namespace Google.Cloud.Language.V1Beta1
         public static IReadOnlyList<string> DefaultScopes { get; } = new ReadOnlyCollection<string>(new[] {
             "https://www.googleapis.com/auth/cloud-platform",
         });
+
+        private static readonly ChannelPool s_channelPool = new ChannelPool(DefaultScopes);
 
         // Note: we could have parameterless overloads of Create and CreateAsync,
         // documented to just use the default endpoint, settings and credentials.

--- a/src/Google.Cloud.Language.V1Beta1/project.json
+++ b/src/Google.Cloud.Language.V1Beta1/project.json
@@ -15,8 +15,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00072",
-    "Google.Api.Gax": "1.0.0-CI00072",
+    "Google.Api.CommonProtos": "1.0.0-CI00074",
+    "Google.Api.Gax": "1.0.0-CI00074",
     "Google.Apis.Auth": "1.14.0",
     "Google.Protobuf": "3.0.0-beta3",
     "Grpc.Auth": "0.15.0",

--- a/src/Google.Datastore.V1Beta3/DatastoreClient.cs
+++ b/src/Google.Datastore.V1Beta3/DatastoreClient.cs
@@ -326,8 +326,6 @@ namespace Google.Datastore.V1Beta3
     /// </summary>
     public abstract partial class DatastoreClient
     {
-        private static readonly ChannelPool s_channelPool = new ChannelPool();
-
         /// <summary>
         /// The default endpoint for the Datastore service, which is a host of "datastore.googleapis.com" and a port of 443.
         /// </summary>
@@ -348,6 +346,8 @@ namespace Google.Datastore.V1Beta3
             "https://www.googleapis.com/auth/datastore",
         });
 
+        private static readonly ChannelPool s_channelPool = new ChannelPool(DefaultScopes);
+        
         // Note: we could have parameterless overloads of Create and CreateAsync,
         // documented to just use the default endpoint, settings and credentials.
         // Pros:

--- a/src/Google.Datastore.V1Beta3/project.json
+++ b/src/Google.Datastore.V1Beta3/project.json
@@ -15,8 +15,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00072",
-    "Google.Api.Gax": "1.0.0-CI00072",
+    "Google.Api.CommonProtos": "1.0.0-CI00074",
+    "Google.Api.Gax": "1.0.0-CI00074",
     "Google.Apis.Auth": "1.14.0",
     "Google.Protobuf": "3.0.0-beta3",
     "Grpc.Auth": "0.15.0",

--- a/src/Google.Logging.Log4Net/project.json
+++ b/src/Google.Logging.Log4Net/project.json
@@ -15,8 +15,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00072",
-    "Google.Api.Gax": "1.0.0-CI00072",
+    "Google.Api.CommonProtos": "1.0.0-CI00074",
+    "Google.Api.Gax": "1.0.0-CI00074",
     "Google.Logging.V2": "",
     "log4net": "2.0.5"
   },

--- a/src/Google.Logging.Type/project.json
+++ b/src/Google.Logging.Type/project.json
@@ -15,7 +15,7 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00072",
+    "Google.Api.CommonProtos": "1.0.0-CI00074",
     "Google.Protobuf": "3.0.0-beta3"
   },
 

--- a/src/Google.Logging.V2/ConfigServiceV2Client.cs
+++ b/src/Google.Logging.V2/ConfigServiceV2Client.cs
@@ -311,8 +311,6 @@ namespace Google.Logging.V2
     /// </summary>
     public abstract partial class ConfigServiceV2Client
     {
-        private static readonly ChannelPool s_channelPool = new ChannelPool();
-
         /// <summary>
         /// The default endpoint for the ConfigServiceV2 service, which is a host of "logging.googleapis.com" and a port of 443.
         /// </summary>
@@ -338,6 +336,8 @@ namespace Google.Logging.V2
             "https://www.googleapis.com/auth/cloud-platform.read-only",
             "https://www.googleapis.com/auth/cloud-platform",
         });
+
+        private static readonly ChannelPool s_channelPool = new ChannelPool(DefaultScopes);
 
         /// <summary>
         /// Path template for a project resource. Parameters:

--- a/src/Google.Logging.V2/LoggingServiceV2Client.cs
+++ b/src/Google.Logging.V2/LoggingServiceV2Client.cs
@@ -283,8 +283,6 @@ namespace Google.Logging.V2
     /// </summary>
     public abstract partial class LoggingServiceV2Client
     {
-        private static readonly ChannelPool s_channelPool = new ChannelPool();
-
         /// <summary>
         /// The default endpoint for the LoggingServiceV2 service, which is a host of "logging.googleapis.com" and a port of 443.
         /// </summary>
@@ -310,6 +308,8 @@ namespace Google.Logging.V2
             "https://www.googleapis.com/auth/cloud-platform.read-only",
             "https://www.googleapis.com/auth/cloud-platform",
         });
+
+        private static readonly ChannelPool s_channelPool = new ChannelPool(DefaultScopes);
 
         /// <summary>
         /// Path template for a project resource. Parameters:

--- a/src/Google.Logging.V2/MetricsServiceV2Client.cs
+++ b/src/Google.Logging.V2/MetricsServiceV2Client.cs
@@ -311,8 +311,6 @@ namespace Google.Logging.V2
     /// </summary>
     public abstract partial class MetricsServiceV2Client
     {
-        private static readonly ChannelPool s_channelPool = new ChannelPool();
-
         /// <summary>
         /// The default endpoint for the MetricsServiceV2 service, which is a host of "logging.googleapis.com" and a port of 443.
         /// </summary>
@@ -338,6 +336,8 @@ namespace Google.Logging.V2
             "https://www.googleapis.com/auth/cloud-platform.read-only",
             "https://www.googleapis.com/auth/cloud-platform",
         });
+
+        private static readonly ChannelPool s_channelPool = new ChannelPool(DefaultScopes);
 
         /// <summary>
         /// Path template for a project resource. Parameters:

--- a/src/Google.Logging.V2/project.json
+++ b/src/Google.Logging.V2/project.json
@@ -15,8 +15,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00072",
-    "Google.Api.Gax": "1.0.0-CI00072",
+    "Google.Api.CommonProtos": "1.0.0-CI00074",
+    "Google.Api.Gax": "1.0.0-CI00074",
     "Google.Apis.Auth": "1.14.0",
     "Google.Logging.Type": "",
     "Google.Protobuf": "3.0.0-beta3",

--- a/src/Google.Pubsub.V1/PublisherClient.cs
+++ b/src/Google.Pubsub.V1/PublisherClient.cs
@@ -399,8 +399,6 @@ namespace Google.Pubsub.V1
     /// </summary>
     public abstract partial class PublisherClient
     {
-        private static readonly ChannelPool s_channelPool = new ChannelPool();
-
         /// <summary>
         /// The default endpoint for the Publisher service, which is a host of "pubsub.googleapis.com" and a port of 443.
         /// </summary>
@@ -420,6 +418,8 @@ namespace Google.Pubsub.V1
             "https://www.googleapis.com/auth/pubsub",
             "https://www.googleapis.com/auth/cloud-platform",
         });
+
+        private static readonly ChannelPool s_channelPool = new ChannelPool(DefaultScopes);
 
         /// <summary>
         /// Path template for a project resource. Parameters:

--- a/src/Google.Pubsub.V1/SubscriberClient.cs
+++ b/src/Google.Pubsub.V1/SubscriberClient.cs
@@ -449,8 +449,6 @@ namespace Google.Pubsub.V1
     /// </summary>
     public abstract partial class SubscriberClient
     {
-        private static readonly ChannelPool s_channelPool = new ChannelPool();
-
         /// <summary>
         /// The default endpoint for the Subscriber service, which is a host of "pubsub.googleapis.com" and a port of 443.
         /// </summary>
@@ -470,6 +468,8 @@ namespace Google.Pubsub.V1
             "https://www.googleapis.com/auth/pubsub",
             "https://www.googleapis.com/auth/cloud-platform",
         });
+
+        private static readonly ChannelPool s_channelPool = new ChannelPool(DefaultScopes);
 
         /// <summary>
         /// Path template for a project resource. Parameters:

--- a/src/Google.Pubsub.V1/project.json
+++ b/src/Google.Pubsub.V1/project.json
@@ -15,8 +15,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00072",
-    "Google.Api.Gax": "1.0.0-CI00072",
+    "Google.Api.CommonProtos": "1.0.0-CI00074",
+    "Google.Api.Gax": "1.0.0-CI00074",
     "Google.Apis.Auth": "1.14.0",
     "Google.Protobuf": "3.0.0-beta3",
     "Grpc.Auth": "0.15.0",

--- a/src/Google.Storage.V1/project.json
+++ b/src/Google.Storage.V1/project.json
@@ -16,7 +16,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Rest": "1.0.0-CI00072",
+    "Google.Api.Gax.Rest": "1.0.0-CI00074",
     "Google.Apis": "1.14.0",
     "Google.Apis.Auth": "1.14.0",
     "Google.Apis.Core": "1.14.0",

--- a/test/Google.Logging.Log4Net.Tests/project.json
+++ b/test/Google.Logging.Log4Net.Tests/project.json
@@ -7,7 +7,7 @@
 
   "dependencies": {
     "Google.Logging.Log4Net": "",
-    "Google.Api.Gax.Testing": "1.0.0-CI00072",
+    "Google.Api.Gax.Testing": "1.0.0-CI00074",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204",
     "Moq": "4.5.10"


### PR DESCRIPTION
Note that the declaration of s_channelPool must be moved to after
the declaration of DefaultScopes as otherwise DefaultScopes would be
null at the point of pool creation.

This change should end up in the code generator, but for now this
simple change will unblock us.

All versions of packages from gax-dotnet upgraded to CI00074 for
simplicity.