### PR TITLE
Improves documentation and behaviour for KeyFactory and Key

### DIFF
--- a/src/Google.Datastore.V1Beta3/KeyFactory.cs
+++ b/src/Google.Datastore.V1Beta3/KeyFactory.cs
@@ -21,6 +21,12 @@ namespace Google.Datastore.V1Beta3
     /// Provides a convenient way of producing keys of a specific kind, from a specified parent entity or key,
     /// or for root entities based on a partition ID.
     /// </summary>
+    /// <remarks>
+    /// If the key factory is constructed with just a partition ID and kind, then the parent key has an empty
+    /// path, and all keys created by the factory will be root keys. Otherwise, all keys created by the factory will
+    /// be direct children of the parent key, so both the parent key itself and any ancestors of that key will be
+    /// ancestors of the child key. Ancestors can be determined in queries using <see cref="Filter.HasAncestor(Key)"/>.
+    /// </remarks>
     public sealed class KeyFactory
     {
         private readonly Key _parent;

--- a/src/Google.Datastore.V1Beta3/KeyPartial.cs
+++ b/src/Google.Datastore.V1Beta3/KeyPartial.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using System;
 using static Google.Datastore.V1Beta3.Key.Types;
 
 namespace Google.Datastore.V1Beta3
@@ -62,9 +63,19 @@ namespace Google.Datastore.V1Beta3
         public Key GetParent()
         {
             var clone = Clone();
+            if (clone.IsRoot)
+            {
+                throw new InvalidOperationException("A root key has no parent");
+            }
             clone.Path.RemoveAt(clone.Path.Count - 1);
             return clone;
         }
+
+        /// <summary>
+        /// Convenience property to determine whether this key is a root or not. A root key is one
+        /// whose <see cref="Path"/> is empty.
+        /// </summary>
+        public bool IsRoot => Path.Count == 0;
 
         public static partial class Types
         {

--- a/test/Google.Datastore.V1Beta3.Tests/KeyTest.cs
+++ b/test/Google.Datastore.V1Beta3.Tests/KeyTest.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Xunit;
 using static Google.Datastore.V1Beta3.Key.Types;
 
@@ -49,6 +50,31 @@ namespace Google.Datastore.V1Beta3.Tests
                 }
             };
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetParent_Valid()
+        {
+            var partitionId = new PartitionId("project", "ns");
+            var parent = new Key { PartitionId = partitionId }.WithElement("foo", 0);
+            var child = parent.WithElement("bar", 1);
+            Assert.Equal(parent, child.GetParent());
+        }
+
+        [Fact]
+        public void GetParent_Invalid()
+        {
+            var key = new Key { PartitionId = new PartitionId("project", "ns") };
+            Assert.Throws<InvalidOperationException>(() => key.GetParent());
+        }
+
+        [Fact]
+        public void IsRoot()
+        {
+            var root = new Key { PartitionId = new PartitionId("project", "ns") };
+            var notRoot = root.WithElement("foo", 0);
+            Assert.True(root.IsRoot);
+            Assert.False(notRoot.IsRoot);
         }
     }
 }


### PR DESCRIPTION
This is related to the uses of the terms "root", "child", "parent"
and "ancestor".

Potential extra methods on Key:

- `HasAncestor(Key)` (the in-process equivalent of an ancestor filter)
- `GetAncestors()` (an iterator using `GetParent()` until it reaches a
  root)

Part of fixing #301.

Jeff - is this additional ancestor-related documentation at the top of `KeyFactory` enough? It would be enough for you to hit it when searching for it in the API docs, but I don't know whether it would have given you enough information for what you were trying to do. Happy to add more - let me know where.