### PR TITLE
Changes property name

### DIFF
--- a/snippets/Google.Datastore.V1Beta3.Snippets/DatastoreClientSnippets.cs
+++ b/snippets/Google.Datastore.V1Beta3.Snippets/DatastoreClientSnippets.cs
@@ -271,7 +271,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             Entity entity = new Entity
             {
                 Key = keyFactory.CreateIncompleteKey(),
-                ["type"] = "Personal",
+                ["category"] = "Personal",
                 ["done"] = false,
                 ["priority"] = 4,
                 ["description"] = "Learn Cloud Datastore",
@@ -291,7 +291,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             Entity entity = new Entity
             {
                 Key = keyFactory.CreateIncompleteKey(),
-                ["type"] = "Personal",
+                ["category"] = "Personal",
                 ["done"] = false,
                 ["priority"] = 4,
                 ["description"] = "Learn Cloud Datastore",
@@ -351,7 +351,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             Entity entity = new Entity
             {
                 Key = keyFactory.CreateIncompleteKey(),
-                ["type"] = "Personal",
+                ["category"] = "Personal",
                 ["done"] = false,
                 ["priority"] = 4,
                 ["description"] = "Learn Cloud Datastore",
@@ -513,11 +513,11 @@ namespace Google.Datastore.V1Beta3.Snippets
             // Sample: GroupingQuery
             Query query = new Query("Task")
             {
-                Projection = { "type", "priority" },
-                DistinctOn = { "type" },
+                Projection = { "category", "priority" },
+                DistinctOn = { "category" },
                 Order =
                 {
-                    { "type", Direction.Ascending },
+                    { "category", Direction.Ascending },
                     { "priority", Direction.Ascending }
                 }
             };

--- a/snippets/Google.Datastore.V1Beta3.Snippets/DatastoreDbSnippets.cs
+++ b/snippets/Google.Datastore.V1Beta3.Snippets/DatastoreDbSnippets.cs
@@ -458,7 +458,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             Entity entity = new Entity
             {
                 Key = keyFactory.CreateIncompleteKey(),
-                ["type"] = "Personal",
+                ["category"] = "Personal",
                 ["done"] = false,
                 ["priority"] = 4,
                 ["description"] = "Learn Cloud Datastore",
@@ -479,7 +479,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             Entity entity = new Entity
             {
                 Key = keyFactory.CreateIncompleteKey(),
-                ["type"] = "Personal",
+                ["category"] = "Personal",
                 ["done"] = false,
                 ["priority"] = 4,
                 ["description"] = "Learn Cloud Datastore",
@@ -533,7 +533,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             Entity entity = new Entity
             {
                 Key = keyFactory.CreateIncompleteKey(),
-                ["type"] = "Personal",
+                ["category"] = "Personal",
                 ["done"] = false,
                 ["priority"] = 4,
                 ["description"] = "Learn Cloud Datastore",
@@ -693,11 +693,11 @@ namespace Google.Datastore.V1Beta3.Snippets
             // Sample: GroupingQuery
             Query query = new Query("Task")
             {
-                Projection = { "type", "priority" },
-                DistinctOn = { "type" },
+                Projection = { "category", "priority" },
+                DistinctOn = { "category" },
                 Order =
                 {
-                    "type", // If only the name is specified, it's implicitly ascending
+                    "category", // If only the name is specified, it's implicitly ascending
                     { "priority", Direction.Ascending } // Either direction can be specified explicitly
                 }
             };

--- a/snippets/Google.Datastore.V1Beta3.Snippets/DatastoreSnippetFixture.cs
+++ b/snippets/Google.Datastore.V1Beta3.Snippets/DatastoreSnippetFixture.cs
@@ -71,7 +71,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             var entity = new Entity
             {
                 Key = keyFactory.CreateIncompleteKey(),
-                ["type"] = "Personal",
+                ["category"] = "Personal",
                 ["done"] = false,
                 ["priority"] = 4,
                 ["description"] = "Learn Cloud Datastore",


### PR DESCRIPTION
Uses 'category' instead of 'type' as a property name.

'type' could cause confusion with data types.