### PR TITLE
Modify project.json to include beta01 for beta APIs

### DIFF
--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/project.json
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "1.0.0-beta01-*",
   "description": "Wrapper library for Google.Apis.Bigquery.v2, making common operations simpler in client code.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/project.json
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0-*",
+  "version": "1.0.0-beta01-*",
   "description": "Google Cloud Datastore v1beta3 client library",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Logging.V2/Google.Logging.Log4Net/project.json
+++ b/apis/Google.Logging.V2/Google.Logging.Log4Net/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0-*",
+  "version": "1.0.0-beta01-*",
   "description": "Google StackdriverLogging Log4Net client Library",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Logging.V2/Google.Logging.Type/project.json
+++ b/apis/Google.Logging.V2/Google.Logging.Type/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "1.0.0-beta01-*",
   "description": "Google Logging version-agnostic types",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Logging.V2/Google.Logging.V2/project.json
+++ b/apis/Google.Logging.V2/Google.Logging.V2/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "1.0.0-beta01-*",
   "description": "Google Logging v2 client library",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1/project.json
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0-*",
+  "version": "1.0.0-beta01-*",
   "description": "Google Pubsub v1 client library",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Storage.V1/Google.Storage.V1/project.json
+++ b/apis/Google.Storage.V1/Google.Storage.V1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "1.0.0-beta01-*",
   "description": "Wrapper library for Google.Apis.Storage.v1, making common operations simpler in client code.",
   "authors": [ "Google Inc." ],
 

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ then
   DOTNET_BUILD_ARGS="$DOTNET_BUILD_ARGS --version-suffix $PRERELEASETAG"
 elif [ -z "$NOVERSIONSUFFIX" ]
 then
-  DOTNET_BUILD_ARGS="$DOTNET_BUILD_ARGS --version-suffix not-for-release"  
+  DOTNET_BUILD_ARGS="$DOTNET_BUILD_ARGS --version-suffix dont-release"
 fi
 
 echo CLI args: $DOTNET_BUILD_ARGS


### PR DESCRIPTION
This means that our CI builds will become 1.0.0-beta01-CI00100 etc, which means
beta02 is later than any of those, etc - which is what we want.

Note that the version in project.json should refer to the "most recently released" version;
we can't accidentally push that a second time (as nuget will stop us from doing so) and it
means that CI build subscribers will see "the right thing". There should be a change to
update to the next version (e.g. beta02) at the same time as that version is released.