### PR TITLE
Handle repeated fields and records in ListRows

### DIFF
--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.IntegrationTests/BigqueryFixture.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.IntegrationTests/BigqueryFixture.cs
@@ -137,6 +137,13 @@ namespace Google.Bigquery.V2.IntegrationTests
                         { "x", BigqueryDbType.Integer },
                         { "y", BigqueryDbType.Integer }
                     }
+                },
+                { "names", new TableSchemaBuilder
+                    {
+                        { "first", BigqueryDbType.String },
+                        { "last", BigqueryDbType.String }
+                    },
+                    FieldMode.Repeated
                 }
             }.Build());
         }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.sln
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.sln
@@ -13,6 +13,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Bigquery.V2.Snippets
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Bigquery.V2.Tests", "Google.Bigquery.V2.Tests\Google.Bigquery.V2.Tests.xproj", "{96BDCC84-EF76-4B35-A390-D2F6D7B8F55B}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Storage.V1", "..\Google.Storage.V1\Google.Storage.V1\Google.Storage.V1.xproj", "{E8814844-5FA9-4F2B-AEAD-E7CE427DE48A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{96BDCC84-EF76-4B35-A390-D2F6D7B8F55B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{96BDCC84-EF76-4B35-A390-D2F6D7B8F55B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{96BDCC84-EF76-4B35-A390-D2F6D7B8F55B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8814844-5FA9-4F2B-AEAD-E7CE427DE48A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8814844-5FA9-4F2B-AEAD-E7CE427DE48A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8814844-5FA9-4F2B-AEAD-E7CE427DE48A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8814844-5FA9-4F2B-AEAD-E7CE427DE48A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Although repeated fields and records aren't exposed in queries, you
can access them via listing the rows in a table, and we weren't
handling them properly.

We now expose them as arrays (for repeated fields) and dictionaries
of type Dictionary<string, object> (for records). It's potentially
not quite ideal, but it's pretty reasonable for a relatively rare use
case. Feedback would be useful from actual usage. (It's likely I'll
need this when making performance data available in Noda Time, so
hopefully I'll discover the usability then.)

Fixes #324 and #325.