### PR TITLE
Revise query handling for Datastore (again)

### DIFF
--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3.IntegrationTests/DatastoreDbTest.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3.IntegrationTests/DatastoreDbTest.cs
@@ -92,7 +92,7 @@ namespace Google.Datastore.V1Beta3.IntegrationTests
         public void RunQuery_NoResults()
         {
             var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
-            var query = db.RunQuery(new Query("absent"));
+            var query = db.RunQueryLazily(new Query("absent"));
             // Each of the checks below will run the query again, as the query is only lazily
             // evaluated.
             Assert.Equal(0, query.Count());

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3.IntegrationTests/DatastoreDbTest.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3.IntegrationTests/DatastoreDbTest.cs
@@ -96,9 +96,6 @@ namespace Google.Datastore.V1Beta3.IntegrationTests
             // Each of the checks below will run the query again, as the query is only lazily
             // evaluated.
             Assert.Equal(0, query.Count());
-            Assert.Equal(0, query.AsEntityResults().Count());
-            var singleBatch = query.AsBatches().Single();
-            Assert.Equal(MoreResultsType.NoMoreResults, singleBatch.MoreResults);
             var singleResponse = query.AsResponses().Single();
             Assert.Equal(MoreResultsType.NoMoreResults, singleResponse.Batch.MoreResults);
         }

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3.IntegrationTests/DatastoreTransactionTest.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3.IntegrationTests/DatastoreTransactionTest.cs
@@ -48,7 +48,7 @@ namespace Google.Datastore.V1Beta3.IntegrationTests
             using (var transaction = db.BeginTransaction())
             {
                 var query = new Query("child") { Filter = Filter.HasAncestor(parentKey) };
-                var results = transaction.RunQuery(query);
+                var results = transaction.RunQueryLazily(query);
                 Assert.Equal(1, results.Count());
             }
         }

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3.Tests/AsyncLazyDatastoreQueryTest.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3.Tests/AsyncLazyDatastoreQueryTest.cs
@@ -95,7 +95,7 @@ namespace Google.Datastore.V1Beta3.Tests
         {
             var query = new AsyncLazyDatastoreQuery(_responses.Select(r => r.Clone()).ToAsyncEnumerable());
             var results = await query.GetAllResultsAsync();
-            Assert.Equal(_entities, results.Entities);
+            Assert.Equal(_entities, results.Entities.ToArray());
             Assert.Equal(MoreResultsType.MoreResultsAfterLimit, results.MoreResults);
             Assert.Equal(ByteString.CopyFromUtf8("after-batch-4"), results.EndCursor);
         }

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3.Tests/LazyDatastoreQueryTest.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3.Tests/LazyDatastoreQueryTest.cs
@@ -19,7 +19,7 @@ using static Google.Datastore.V1Beta3.QueryResultBatch.Types;
 
 namespace Google.Datastore.V1Beta3.Tests
 {
-    public class DatastoreQueryResultsTest
+    public class LazyDatastoreQueryTest
     {
         private static readonly Entity[] _entities = Enumerable
             .Range(0, 20)
@@ -78,34 +78,24 @@ namespace Google.Datastore.V1Beta3.Tests
         [Fact]
         public void AsEntities()
         {
-            var results = new DatastoreQueryResults(_responses.Select(r => r.Clone()));
-            Assert.Equal(_entities, results);
-        }
-
-        [Fact]
-        public void AsEntityResults()
-        {
-            var results = new DatastoreQueryResults(_responses.Select(r => r.Clone()));
-            var expected = _entityResults.ToList();
-            expected[4].Cursor = _responses[1].Batch.EndCursor;
-            expected[14].Cursor = _responses[2].Batch.EndCursor;
-            expected[19].Cursor = _responses[3].Batch.EndCursor;
-            Assert.Equal(expected, results.AsEntityResults());
-        }
-
-        [Fact]
-        public void AsBatches()
-        {
-            var results = new DatastoreQueryResults(_responses.Select(r => r.Clone()));
-            var expected = new[] { _responses[0].Batch, _responses[1].Batch, _responses[2].Batch, _responses[3].Batch };
-            Assert.Equal(expected, results.AsBatches());
+            var query = new LazyDatastoreQuery(_responses.Select(r => r.Clone()));
+            Assert.Equal(_entities, query);
         }
 
         [Fact]
         public void AsResponses()
         {
-            var results = new DatastoreQueryResults(_responses.Select(r => r.Clone()));
-            Assert.Equal(_responses, results.AsResponses());
+            var query = new LazyDatastoreQuery(_responses.Select(r => r.Clone()));
+            Assert.Equal(_responses, query.AsResponses());
+        }
+
+        [Fact]
+        public void GetAllResults()
+        {
+            var results = new LazyDatastoreQuery(_responses.Select(r => r.Clone())).GetAllResults();
+            Assert.Equal(_entities, results.Entities);
+            Assert.Equal(MoreResultsType.MoreResultsAfterLimit, results.MoreResults);
+            Assert.Equal(ByteString.CopyFromUtf8("after-batch-4"), results.EndCursor);
         }
     }
 }

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3.Tests/LazyDatastoreQueryTest.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3.Tests/LazyDatastoreQueryTest.cs
@@ -93,7 +93,7 @@ namespace Google.Datastore.V1Beta3.Tests
         public void GetAllResults()
         {
             var results = new LazyDatastoreQuery(_responses.Select(r => r.Clone())).GetAllResults();
-            Assert.Equal(_entities, results.Entities);
+            Assert.Equal(_entities, results.Entities.ToArray());
             Assert.Equal(MoreResultsType.MoreResultsAfterLimit, results.MoreResults);
             Assert.Equal(ByteString.CopyFromUtf8("after-batch-4"), results.EndCursor);
         }

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/AsyncLazyDatastoreQuery.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/AsyncLazyDatastoreQuery.cs
@@ -33,7 +33,7 @@ namespace Google.Datastore.V1Beta3
         /// <summary>
         /// Constructs a new instance from the given sequence of responses. This constructor
         /// is only present to facilitate testing; application code will normally obtain instances
-        /// of this class by calling <see cref="DatastoreDb.RunQuery"/>.
+        /// of this class by calling <see cref="DatastoreDb.RunQueryLazily"/>.
         /// </summary>
         /// <remarks>
         /// The sequence of responses will be returned directly from <see cref="AsResponses"/>, and

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/AsyncLazyDatastoreQuery.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/AsyncLazyDatastoreQuery.cs
@@ -1,0 +1,118 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Google.Datastore.V1Beta3
+{
+    /// <summary>
+    /// A Datastore query which is executed lazily. Iterating over this object will provide a sequence
+    /// of entities; alternatively, all the results can be fetched using <see cref="GetAllResultsAsync"/>,
+    /// or for diagnostic use cases the RPC responses can be viewed using <see cref="AsResponses"/>.
+    /// The lazy evaluation is important: if you iterate over the query multiple times, it will execute
+    /// multiple times, potentially returning different results each time.
+    /// </summary>
+    public sealed class AsyncLazyDatastoreQuery : IAsyncEnumerable<Entity>
+    {
+        private readonly IAsyncEnumerable<RunQueryResponse> _responses;
+
+        /// <summary>
+        /// Constructs a new instance from the given sequence of responses. This constructor
+        /// is only present to facilitate testing; application code will normally obtain instances
+        /// of this class by calling <see cref="DatastoreDb.RunQuery"/>.
+        /// </summary>
+        /// <remarks>
+        /// The sequence of responses will be returned directly from <see cref="AsResponses"/>, and
+        /// used to lazily construct the other sequences returned by this class. It should not
+        /// contain any null references.
+        /// </remarks>
+        /// <param name="responses">The responses to return.</param>
+        public AsyncLazyDatastoreQuery(IAsyncEnumerable<RunQueryResponse> responses)
+        {
+            _responses = GaxPreconditions.CheckNotNull(responses, nameof(responses));
+        }
+
+        /// <summary>
+        /// Reads all the results from this query, until either the query-specified limit or end cursor
+        /// is reached, or there is no more data to read. Note that all the entities are read into memory,
+        /// so this method is not appropriate for use cases where a query could return a very large number
+        /// of results. However, it is the simplest approach to use cases where the query is bounded, such
+        /// as displaying a page of results at a time in a web application.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation. When completed, the result of the task
+        /// is the complete set of query results.</returns>
+        public async Task<DatastoreQueryResults> GetAllResultsAsync()
+        {
+            // This takes slightly more memory than we really need, due to extra
+            // cursors etc, but that's likely to be insignificant compared with the
+            // entity data, and is immediately eligible for garbage collection.
+            var responses = await _responses.ToList().ConfigureAwait(false);
+            var entities = responses.SelectMany(r => r.Batch.EntityResults.Select(er => er.Entity)).ToList().AsReadOnly();
+            var lastBatch = responses.Last().Batch;
+            return new DatastoreQueryResults(entities, lastBatch.MoreResults, lastBatch.EndCursor);
+        }
+
+        /// <inheritdoc />
+        public IAsyncEnumerator<Entity> GetEnumerator() => AsEntities().GetEnumerator();
+
+        /// <summary>
+        /// Returns the results of this query as a sequence of <see cref="Entity"/> values.
+        /// </summary>
+        /// <remarks>
+        /// This method only exists for symmetry with the other "As*" methods, to make the fact that
+        /// the class implements IEnumerable{Entity} more incidental.
+        /// </remarks>
+        private IAsyncEnumerable<Entity> AsEntities() => AsEntityResults().Select(er => er.Entity);
+
+        /// <summary>
+        /// Returns the results of this query as a sequence of <see cref="EntityResult"/> values.
+        /// The final result from each batch is modified to use the batch's end cursor instead of
+        /// the original <see cref="EntityResult.Cursor"/> value.
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        /// <returns>A sequence of <see cref="EntityResult"/> values.</returns>
+        private IAsyncEnumerable<EntityResult> AsEntityResults() =>
+            AsBatches().SelectMany(batch =>
+            {
+                var lastResult = batch.EntityResults.LastOrDefault();
+                if (lastResult != null)
+                {
+                    lastResult.Cursor = batch.EndCursor;
+                }
+                return batch.EntityResults.ToAsyncEnumerable();
+            });
+
+        /// <summary>
+        /// Returns the results of this query as a sequence of <see cref="RunQueryResponse"/> values
+        /// exactly as returned by the Datastore API. This method is only useful if the application
+        /// wishes to examine the <see cref="RunQueryResponse.Query"/> property; otherwise, use
+        /// <see cref="AsBatches"/> to obtain the sequence of batches.
+        /// </summary>
+        /// <returns>A sequence of <see cref="RunQueryResponse"/> values.</returns>
+        public IAsyncEnumerable<RunQueryResponse> AsResponses() => _responses;
+
+        /// <summary>
+        /// Returns the results of this query as a sequence of <see cref="QueryResultBatch"/> values.
+        /// This method is only useful if the application wishes to process a batch at a time; if the
+        /// details of how the API splits the results into batches is not needed, use <see cref="AsEntityResults"/>
+        /// or simply iterate over the entities.
+        /// </summary>
+        /// <returns>A sequence of <see cref="QueryResultBatch"/> values.</returns>
+        public IAsyncEnumerable<QueryResultBatch> AsBatches() => _responses.Select(r => r.Batch);
+    }
+}

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/DatastoreDb.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/DatastoreDb.cs
@@ -93,23 +93,31 @@ namespace Google.Datastore.V1Beta3
         }
 
         /// <summary>
-        /// Lazily executes the given structured query.
+        /// Runs the given query eagerly, retrieving all results in memory and indicating whether more
+        /// results may be available beyond the query's limit. Use this method when your query has a limited
+        /// number of results, for example to build a web application which fetches results in pages.
         /// </summary>
-        /// <remarks>
-        /// The results are requested lazily: no API calls will be made until the application starts
-        /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
-        /// multiple times will execute the query again, potentially returning different results.
-        /// </remarks>
         /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the lazy query results.</returns>
-        public virtual LazyDatastoreQuery RunQuery(
-            Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+        /// <returns>The complete query results.</returns>
+        public virtual DatastoreQueryResults RunQuery(
+            Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null) =>
+            RunQueryLazily(query, readConsistency, callSettings).GetAllResults();
 
+        /// <summary>
+        /// Runs the given query eagerly and asynchronously, retrieving all results in memory and indicating whether more
+        /// results may be available beyond the query's limit. Use this method when your query has a limited
+        /// number of results, for example to build a web application which fetches results in pages.
+        /// </summary>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A task representing the asynchronous operation. The result of the task is the complete set of query results.</returns>
+        public virtual Task<DatastoreQueryResults> RunQueryAsync(
+            Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null) =>
+            RunQueryLazilyAsync(query, readConsistency, callSettings).GetAllResultsAsync();
+        
         /// <summary>
         /// Lazily executes the given structured query.
         /// </summary>
@@ -122,14 +130,58 @@ namespace Google.Datastore.V1Beta3
         /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A <see cref="LazyDatastoreQuery"/> representing the lazy query results.</returns>
-        public virtual AsyncLazyDatastoreQuery RunQueryAsync(
+        public virtual LazyDatastoreQuery RunQueryLazily(
             Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
 
         /// <summary>
-        /// Executes the given GQL query.
+        /// Lazily executes the given structured query for asynchronous consumption.
+        /// </summary>
+        /// <remarks>
+        /// The results are requested lazily: no API calls will be made until the application starts
+        /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
+        /// multiple times will execute the query again, potentially returning different results.
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>An <see cref="AsyncLazyDatastoreQuery"/> representing the lazy query results.</returns>
+        public virtual AsyncLazyDatastoreQuery RunQueryLazilyAsync(
+            Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Runs the given query eagerly, retrieving all results in memory and indicating whether more
+        /// results may be available beyond the query's limit. Use this method when your query has a limited
+        /// number of results, for example to build a web application which fetches results in pages.
+        /// </summary>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>The complete query results.</returns>
+        public virtual DatastoreQueryResults RunQuery(
+            GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null) =>
+            RunQueryLazily(query, readConsistency, callSettings).GetAllResults();
+
+        /// <summary>
+        /// Runs the given query eagerly and asynchronously, retrieving all results in memory and indicating whether more
+        /// results may be available beyond the query's limit. Use this method when your query has a limited
+        /// number of results, for example to build a web application which fetches results in pages.
+        /// </summary>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A task representing the asynchronous operation. The result of the task is the complete set of query results.</returns>
+        public virtual Task<DatastoreQueryResults> RunQueryAsync(
+            GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null) =>
+            RunQueryLazilyAsync(query, readConsistency, callSettings).GetAllResultsAsync();
+
+        /// <summary>
+        /// Lazily executes the given GQL query for asynchronous consumption.
         /// </summary>
         /// <remarks>
         /// The results are requested lazily: no API calls will be made until the application starts
@@ -140,14 +192,14 @@ namespace Google.Datastore.V1Beta3
         /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A <see cref="LazyDatastoreQuery"/> representing the lazy query results.</returns>
-        public virtual LazyDatastoreQuery RunQuery(
+        public virtual LazyDatastoreQuery RunQueryLazily(
             GqlQuery gqlQuery, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
 
         /// <summary>
-        /// Executes the given GQL query.
+        /// Lazily executes the given GQL query for asynchronous consumption.
         /// </summary>
         /// <remarks>
         /// The results are requested lazily: no API calls will be made until the application starts
@@ -157,8 +209,8 @@ namespace Google.Datastore.V1Beta3
         /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the lazy query results.</returns>
-        public virtual AsyncLazyDatastoreQuery RunQueryAsync(
+        /// <returns>An <see cref="AsyncLazyDatastoreQuery"/> representing the lazy query results.</returns>
+        public virtual AsyncLazyDatastoreQuery RunQueryLazilyAsync(
             GqlQuery gqlQuery, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/DatastoreDb.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/DatastoreDb.cs
@@ -93,76 +93,72 @@ namespace Google.Datastore.V1Beta3
         }
 
         /// <summary>
-        /// Executes the given structured query, returning a result set that can be viewed as a sequence of
-        /// entities, entity results (with cursors), batches, or raw API responses.
+        /// Lazily executes the given structured query.
         /// </summary>
         /// <remarks>
         /// The results are requested lazily: no API calls will be made until the application starts
-        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
+        /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
         /// multiple times will execute the query again, potentially returning different results.
         /// </remarks>
         /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
-        public virtual DatastoreQueryResults RunQuery(
+        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the lazy query results.</returns>
+        public virtual LazyDatastoreQuery RunQuery(
             Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
 
         /// <summary>
-        /// Executes the given structured query, returning a result set that can be viewed as an asynchronous
-        /// sequence of entities, entity results (with cursors), batches, or raw API responses.
+        /// Lazily executes the given structured query.
         /// </summary>
         /// <remarks>
         /// The results are requested lazily: no API calls will be made until the application starts
-        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
+        /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
         /// multiple times will execute the query again, potentially returning different results.
         /// </remarks>
         /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
-        public virtual DatastoreAsyncQueryResults RunQueryAsync(
+        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the lazy query results.</returns>
+        public virtual AsyncLazyDatastoreQuery RunQueryAsync(
             Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
-        
+
         /// <summary>
-        /// Executes the given GQL query, returning a result set that can be viewed as a sequence of
-        /// entities, entity results (with cursors), batches, or raw API responses.
+        /// Executes the given GQL query.
         /// </summary>
         /// <remarks>
         /// The results are requested lazily: no API calls will be made until the application starts
-        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
+        /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
         /// multiple times will execute the query again, potentially returning different results.
         /// </remarks>
         /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
-        public virtual DatastoreQueryResults RunQuery(
+        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the lazy query results.</returns>
+        public virtual LazyDatastoreQuery RunQuery(
             GqlQuery gqlQuery, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
 
         /// <summary>
-        /// Executes the given GQL query, returning a result set that can be viewed as an asynchronous
-        /// sequence of entities, entity results (with cursors), batches, or raw API responses.
+        /// Executes the given GQL query.
         /// </summary>
         /// <remarks>
         /// The results are requested lazily: no API calls will be made until the application starts
-        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
+        /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
         /// multiple times will execute the query again, potentially returning different results.
         /// </remarks>
         /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
-        public virtual DatastoreAsyncQueryResults RunQueryAsync(
+        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the lazy query results.</returns>
+        public virtual AsyncLazyDatastoreQuery RunQueryAsync(
             GqlQuery gqlQuery, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/DatastoreDbImpl.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/DatastoreDbImpl.cs
@@ -65,7 +65,7 @@ namespace Google.Datastore.V1Beta3
         public override KeyFactory CreateKeyFactory(string kind) => new KeyFactory(_partitionId, kind);
         
         /// <inheritdoc/>
-        public override LazyDatastoreQuery RunQuery(
+        public override LazyDatastoreQuery RunQueryLazily(
             Query query,
             ReadConsistency? readConsistency = null,
             CallSettings callSettings = null)
@@ -83,7 +83,7 @@ namespace Google.Datastore.V1Beta3
         }
 
         /// <inheritdoc/>
-        public override AsyncLazyDatastoreQuery RunQueryAsync(
+        public override AsyncLazyDatastoreQuery RunQueryLazilyAsync(
             Query query,
             ReadConsistency? readConsistency = null,
             CallSettings callSettings = null)
@@ -101,7 +101,7 @@ namespace Google.Datastore.V1Beta3
         }
 
         /// <inheritdoc/>
-        public override LazyDatastoreQuery RunQuery(
+        public override LazyDatastoreQuery RunQueryLazily(
             GqlQuery gqlQuery,
             ReadConsistency? readConsistency = null,
             CallSettings callSettings = null)
@@ -119,7 +119,7 @@ namespace Google.Datastore.V1Beta3
         }
 
         /// <inheritdoc/>
-        public override AsyncLazyDatastoreQuery RunQueryAsync(
+        public override AsyncLazyDatastoreQuery RunQueryLazilyAsync(
             GqlQuery gqlQuery,
             ReadConsistency? readConsistency = null,
             CallSettings callSettings = null)

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/DatastoreDbImpl.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/DatastoreDbImpl.cs
@@ -65,7 +65,7 @@ namespace Google.Datastore.V1Beta3
         public override KeyFactory CreateKeyFactory(string kind) => new KeyFactory(_partitionId, kind);
         
         /// <inheritdoc/>
-        public override DatastoreQueryResults RunQuery(
+        public override LazyDatastoreQuery RunQuery(
             Query query,
             ReadConsistency? readConsistency = null,
             CallSettings callSettings = null)
@@ -79,11 +79,11 @@ namespace Google.Datastore.V1Beta3
                 ReadOptions = GetReadOptions(readConsistency)
             };
             var streamer = new QueryStreamer(request, Client.RunQueryApiCall, callSettings);
-            return new DatastoreQueryResults(streamer.Sync());
+            return new LazyDatastoreQuery(streamer.Sync());
         }
 
         /// <inheritdoc/>
-        public override DatastoreAsyncQueryResults RunQueryAsync(
+        public override AsyncLazyDatastoreQuery RunQueryAsync(
             Query query,
             ReadConsistency? readConsistency = null,
             CallSettings callSettings = null)
@@ -97,11 +97,11 @@ namespace Google.Datastore.V1Beta3
                 ReadOptions = GetReadOptions(readConsistency)
             };
             var streamer = new QueryStreamer(request, Client.RunQueryApiCall, callSettings);
-            return new DatastoreAsyncQueryResults(streamer.Async());
+            return new AsyncLazyDatastoreQuery(streamer.Async());
         }
 
         /// <inheritdoc/>
-        public override DatastoreQueryResults RunQuery(
+        public override LazyDatastoreQuery RunQuery(
             GqlQuery gqlQuery,
             ReadConsistency? readConsistency = null,
             CallSettings callSettings = null)
@@ -115,11 +115,11 @@ namespace Google.Datastore.V1Beta3
                 ReadOptions = GetReadOptions(readConsistency)
             };
             var streamer = new QueryStreamer(request, Client.RunQueryApiCall, callSettings);
-            return new DatastoreQueryResults(streamer.Sync());
+            return new LazyDatastoreQuery(streamer.Sync());
         }
 
         /// <inheritdoc/>
-        public override DatastoreAsyncQueryResults RunQueryAsync(
+        public override AsyncLazyDatastoreQuery RunQueryAsync(
             GqlQuery gqlQuery,
             ReadConsistency? readConsistency = null,
             CallSettings callSettings = null)
@@ -133,7 +133,7 @@ namespace Google.Datastore.V1Beta3
                 ReadOptions = GetReadOptions(readConsistency)
             };
             var streamer = new QueryStreamer(request, Client.RunQueryApiCall, callSettings);
-            return new DatastoreAsyncQueryResults(streamer.Async());
+            return new AsyncLazyDatastoreQuery(streamer.Async());
         }
 
         /// <inheritdoc/>

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/DatastoreTransaction.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/DatastoreTransaction.cs
@@ -93,7 +93,7 @@ namespace Google.Datastore.V1Beta3
         /// </para>
         /// <para>
         /// The results are requested lazily: no API calls will be made until the application starts
-        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
+        /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
         /// multiple times will execute the query again, potentially returning different results.
         /// </para>
         /// </remarks>
@@ -101,8 +101,8 @@ namespace Google.Datastore.V1Beta3
         /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
         /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
-        public DatastoreQueryResults RunQuery(Query query, CallSettings callSettings = null)
+        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the result of the query.</returns>
+        public LazyDatastoreQuery RunQuery(Query query, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(query, nameof(query));
             var request = new RunQueryRequest
@@ -113,7 +113,7 @@ namespace Google.Datastore.V1Beta3
                 ReadOptions = _readOptions
             };
             var streamer = new QueryStreamer(request, _client.RunQueryApiCall, callSettings);
-            return new DatastoreQueryResults(streamer.Sync());
+            return new LazyDatastoreQuery(streamer.Sync());
         }
 
 
@@ -129,7 +129,7 @@ namespace Google.Datastore.V1Beta3
         /// </para>
         /// <para>
         /// The results are requested lazily: no API calls will be made until the application starts
-        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
+        /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
         /// multiple times will execute the query again, potentially returning different results.
         /// </para>
         /// </remarks>
@@ -137,8 +137,8 @@ namespace Google.Datastore.V1Beta3
         /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
         /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
-        public DatastoreAsyncQueryResults RunQueryAsync(Query query, CallSettings callSettings = null)
+        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the result of the query.</returns>
+        public AsyncLazyDatastoreQuery RunQueryAsync(Query query, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(query, nameof(query));
             var request = new RunQueryRequest
@@ -149,7 +149,7 @@ namespace Google.Datastore.V1Beta3
                 ReadOptions = _readOptions
             };
             var streamer = new QueryStreamer(request, _client.RunQueryApiCall, callSettings);
-            return new DatastoreAsyncQueryResults(streamer.Async());
+            return new AsyncLazyDatastoreQuery(streamer.Async());
         }
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace Google.Datastore.V1Beta3
         /// </para>
         /// <para>
         /// The results are requested lazily: no API calls will be made until the application starts
-        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
+        /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
         /// multiple times will execute the query again, potentially returning different results.
         /// </para>
         /// </remarks>
@@ -172,8 +172,8 @@ namespace Google.Datastore.V1Beta3
         /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
         /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
-        public DatastoreQueryResults RunQuery(GqlQuery gqlQuery, CallSettings callSettings = null)
+        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the result of the query.</returns>
+        public LazyDatastoreQuery RunQuery(GqlQuery gqlQuery, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(gqlQuery, nameof(gqlQuery));
             var request = new RunQueryRequest
@@ -184,7 +184,7 @@ namespace Google.Datastore.V1Beta3
                 ReadOptions = _readOptions
             };
             var streamer = new QueryStreamer(request, _client.RunQueryApiCall, callSettings);
-            return new DatastoreQueryResults(streamer.Sync());
+            return new LazyDatastoreQuery(streamer.Sync());
         }
 
         /// <summary>
@@ -199,7 +199,7 @@ namespace Google.Datastore.V1Beta3
         /// </para>
         /// <para>
         /// The results are requested lazily: no API calls will be made until the application starts
-        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
+        /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
         /// multiple times will execute the query again, potentially returning different results.
         /// </para>
         /// </remarks>
@@ -207,8 +207,8 @@ namespace Google.Datastore.V1Beta3
         /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
         /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
-        public DatastoreAsyncQueryResults RunQueryAsync(GqlQuery gqlQuery, PartitionId partitionId, CallSettings callSettings = null)
+        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the result of the query.</returns>
+        public AsyncLazyDatastoreQuery RunQueryAsync(GqlQuery gqlQuery, PartitionId partitionId, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(gqlQuery, nameof(gqlQuery));
             var request = new RunQueryRequest
@@ -219,7 +219,7 @@ namespace Google.Datastore.V1Beta3
                 ReadOptions = _readOptions
             };
             var streamer = new QueryStreamer(request, _client.RunQueryApiCall, callSettings);
-            return new DatastoreAsyncQueryResults(streamer.Async());
+            return new AsyncLazyDatastoreQuery(streamer.Async());
         }
 
         /// <summary>

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/DatastoreTransaction.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/DatastoreTransaction.cs
@@ -82,8 +82,43 @@ namespace Google.Datastore.V1Beta3
         }
 
         /// <summary>
-        /// Executes the given structured query in this transaction, returning a result set that can be viewed as a sequence of
-        /// entities, entity results (with cursors), batches, or raw API responses.
+        /// Runs the given query eagerly in this transaction, retrieving all results in memory and indicating whether more
+        /// results may be available beyond the query's limit. Use this method when your query has a limited
+        /// number of results, for example to build a web application which fetches results in pages.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Using a transaction ensures that a commit operation will fail if any of the entities returned
+        /// by this query have been modified while the transaction is active. Note that modifications performed
+        /// as part of this operation are not reflected in the query results.
+        /// </para>
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>The complete query results.</returns>
+        public DatastoreQueryResults RunQuery(Query query, CallSettings callSettings = null) =>
+            RunQueryLazily(query, callSettings).GetAllResults();
+
+        /// <summary>
+        /// Runs the given query eagerly and asynchronously in this transaction, retrieving all results in memory
+        /// and indicating whether more results may be available beyond the query's limit. Use this method when your query has a limited
+        /// number of results, for example to build a web application which fetches results in pages.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Using a transaction ensures that a commit operation will fail if any of the entities returned
+        /// by this query have been modified while the transaction is active. Note that modifications performed
+        /// as part of this operation are not reflected in the query results.
+        /// </para>
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A task representing the asynchronous operation. The result of the task is the complete set of query results.</returns>
+        public Task<DatastoreQueryResults> RunQueryAsync(Query query, CallSettings callSettings = null) =>
+            RunQueryLazilyAsync(query, callSettings).GetAllResultsAsync();
+
+        /// <summary>
+        /// Lazily executes the given structured query in this transaction.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -101,8 +136,8 @@ namespace Google.Datastore.V1Beta3
         /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
         /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the result of the query.</returns>
-        public LazyDatastoreQuery RunQuery(Query query, CallSettings callSettings = null)
+        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the the lazy query results.</returns>
+        public LazyDatastoreQuery RunQueryLazily(Query query, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(query, nameof(query));
             var request = new RunQueryRequest
@@ -116,10 +151,8 @@ namespace Google.Datastore.V1Beta3
             return new LazyDatastoreQuery(streamer.Sync());
         }
 
-
         /// <summary>
-        /// Executes the given structured query in this transaction, returning a result set that can be viewed as an asynchronous
-        /// sequence of entities, entity results (with cursors), batches, or raw API responses.
+        /// Lazily executes the given structured query in this transaction for asynchronous consumption.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -137,8 +170,8 @@ namespace Google.Datastore.V1Beta3
         /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
         /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the result of the query.</returns>
-        public AsyncLazyDatastoreQuery RunQueryAsync(Query query, CallSettings callSettings = null)
+        /// <returns>An <see cref="AsyncLazyDatastoreQuery"/> representing the result of the query.</returns>
+        public AsyncLazyDatastoreQuery RunQueryLazilyAsync(Query query, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(query, nameof(query));
             var request = new RunQueryRequest
@@ -153,8 +186,45 @@ namespace Google.Datastore.V1Beta3
         }
 
         /// <summary>
-        /// Executes the given GQL query in this transaction, returning a result set that can be viewed as a sequence of
-        /// entities, entity results (with cursors), batches, or raw API responses.
+        /// Runs the given query eagerly in this transaction, retrieving all results in memory and indicating whether more
+        /// results may be available beyond the query's limit. Use this method when your query has a limited
+        /// number of results, for example to build a web application which fetches results in pages.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Using a transaction ensures that a commit operation will fail if any of the entities returned
+        /// by this query have been modified while the transaction is active. Note that modifications performed
+        /// as part of this operation are not reflected in the query results.
+        /// </para>
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>The complete query results.</returns>
+        public DatastoreQueryResults RunQuery(GqlQuery query, CallSettings callSettings = null) =>
+            RunQueryLazily(query, callSettings).GetAllResults();
+
+        /// <summary>
+        /// Runs the given query eagerly and asynchronously in this transaction, retrieving all results in memory and indicating whether more
+        /// results may be available beyond the query's limit. Use this method when your query has a limited
+        /// number of results, for example to build a web application which fetches results in pages.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Using a transaction ensures that a commit operation will fail if any of the entities returned
+        /// by this query have been modified while the transaction is active. Note that modifications performed
+        /// as part of this operation are not reflected in the query results.
+        /// </para>
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A task representing the asynchronous operation. The result of the task is the complete set of query results.</returns>
+        public Task<DatastoreQueryResults> RunQueryAsync(GqlQuery query, CallSettings callSettings = null) =>
+            RunQueryLazilyAsync(query, callSettings).GetAllResultsAsync();
+
+        /// <summary>
+        /// Lazily executes the given GQL query in this transaction.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -173,7 +243,7 @@ namespace Google.Datastore.V1Beta3
         /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A <see cref="LazyDatastoreQuery"/> representing the result of the query.</returns>
-        public LazyDatastoreQuery RunQuery(GqlQuery gqlQuery, CallSettings callSettings = null)
+        public LazyDatastoreQuery RunQueryLazily(GqlQuery gqlQuery, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(gqlQuery, nameof(gqlQuery));
             var request = new RunQueryRequest
@@ -188,8 +258,7 @@ namespace Google.Datastore.V1Beta3
         }
 
         /// <summary>
-        /// Executes the given GQL query in this transaction, returning a result set that can be viewed as an asynchronous
-        /// sequence of entities, entity results (with cursors), batches, or raw API responses.
+        /// Lazily executes the given structured query in this transaction for asynchronous consumption.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -207,14 +276,14 @@ namespace Google.Datastore.V1Beta3
         /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
         /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the result of the query.</returns>
-        public AsyncLazyDatastoreQuery RunQueryAsync(GqlQuery gqlQuery, PartitionId partitionId, CallSettings callSettings = null)
+        /// <returns>An <see cref="AsyncLazyDatastoreQuery"/> representing the result of the query.</returns>
+        public AsyncLazyDatastoreQuery RunQueryLazilyAsync(GqlQuery gqlQuery, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(gqlQuery, nameof(gqlQuery));
             var request = new RunQueryRequest
             {
                 ProjectId = _projectId,
-                PartitionId = partitionId,
+                PartitionId = _partitionId,
                 GqlQuery = gqlQuery,
                 ReadOptions = _readOptions
             };

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/LazyDatastoreQuery.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/LazyDatastoreQuery.cs
@@ -33,7 +33,7 @@ namespace Google.Datastore.V1Beta3
         /// <summary>
         /// Constructs a new instance from the given sequence of responses. This constructor
         /// is only present to facilitate testing; application code will normally obtain instances
-        /// of this class by calling <see cref="DatastoreDb.RunQuery"/>.
+        /// of this class by calling <see cref="DatastoreDb.RunQueryLazily"/>.
         /// </summary>
         /// <remarks>
         /// The sequence of responses will be returned directly from <see cref="AsResponses"/>, and

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/LazyDatastoreQuery.cs
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/LazyDatastoreQuery.cs
@@ -1,0 +1,87 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Datastore.V1Beta3
+{
+    /// <summary>
+    /// A Datastore query which is executed lazily. Iterating over this object will provide a sequence
+    /// of entities; alternatively, all the results can be fetched using <see cref="GetAllResults"/>,
+    /// or for diagnostic use cases the RPC responses can be viewed using <see cref="AsResponses"/>.
+    /// The lazy evaluation is important: if you iterate over the query multiple times, it will execute
+    /// multiple times, potentially returning different results each time.
+    /// </summary>
+    public sealed class LazyDatastoreQuery : IEnumerable<Entity>
+    {
+        private readonly IEnumerable<RunQueryResponse> _responses;
+
+        /// <summary>
+        /// Constructs a new instance from the given sequence of responses. This constructor
+        /// is only present to facilitate testing; application code will normally obtain instances
+        /// of this class by calling <see cref="DatastoreDb.RunQuery"/>.
+        /// </summary>
+        /// <remarks>
+        /// The sequence of responses will be returned directly from <see cref="AsResponses"/>, and
+        /// used to lazily construct the other sequences returned by this class. It should not
+        /// contain any null references.
+        /// </remarks>
+        /// <param name="responses">The responses to return.</param>
+        public LazyDatastoreQuery(IEnumerable<RunQueryResponse> responses)
+        {
+            _responses = GaxPreconditions.CheckNotNull(responses, nameof(responses));
+        }
+
+        /// <summary>
+        /// Reads all the results from this query, until either the query-specified limit or end cursor
+        /// is reached, or there is no more data to read. Note that all the entities are read into memory,
+        /// so this method is not appropriate for use cases where a query could return a very large number
+        /// of results. However, it is the simplest approach to use cases where the query is bounded, such
+        /// as displaying a page of results at a time in a web application.
+        /// </summary>
+        /// <returns>The complete set of query results.</returns>
+        public DatastoreQueryResults GetAllResults()
+        {
+            // This takes slightly more memory than we really need, due to extra
+            // cursors etc, but that's likely to be insignificant compared with the
+            // entity data, and is immediately eligible for garbage collection.
+            var responses = _responses.ToList();
+            var entities = responses.SelectMany(r => r.Batch.EntityResults.Select(er => er.Entity)).ToList().AsReadOnly();
+            var lastBatch = responses.Last().Batch;
+            return new DatastoreQueryResults(entities, lastBatch.MoreResults, lastBatch.EndCursor);
+        }
+
+        /// <inheritdoc />
+        public IEnumerator<Entity> GetEnumerator() =>
+            _responses.SelectMany(r => r.Batch.EntityResults.Select(er => er.Entity)).GetEnumerator();
+
+        /// <summary>
+        /// This method is for advanced use cases only, where more diagnostic information is required;
+        /// most application code should merely iterate over the query results as <see cref="Entity"/>
+        /// values, or call <see cref="GetAllResults()"/>.
+        /// The results of this query are returned as a sequence of <see cref="RunQueryResponse"/> values
+        /// exactly as returned by the Datastore API. This method is only useful if the application
+        /// wishes to examine the <see cref="RunQueryResponse.Query"/> property; otherwise, use
+        /// <see cref="AsBatches"/> to obtain the sequence of batches.
+        /// </summary>
+        /// <returns>A sequence of <see cref="RunQueryResponse"/> values.</returns>
+        public IEnumerable<RunQueryResponse> AsResponses() => _responses;
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/LazyDatastoreQuery.cs~RF1e39a47c.TMP
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/LazyDatastoreQuery.cs~RF1e39a47c.TMP
@@ -13,17 +13,20 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Google.Datastore.V1Beta3
 {
     /// <summary>
-    /// An asynchronous Datastore query which is executed lazily and which be viewed in multiple ways.
+    /// A Datastore query which is executed lazily and which be viewed in multiple ways.
+    /// The lazy evaluation is important: if you iterate over the query multiple times, it will execute
+    /// multiple times, potentially returning different results each time.
     /// </summary>
-    public sealed class DatastoreAsyncQueryResults : IAsyncEnumerable<Entity>
+    public sealed class LazyDatastoreQuery : IEnumerable<Entity>
     {
-        private readonly IAsyncEnumerable<RunQueryResponse> _responses;
+        private readonly IEnumerable<RunQueryResponse> _responses;
 
         /// <summary>
         /// Constructs a new instance from the given sequence of responses. This constructor
@@ -36,13 +39,32 @@ namespace Google.Datastore.V1Beta3
         /// contain any null references.
         /// </remarks>
         /// <param name="responses">The responses to return.</param>
-        public DatastoreAsyncQueryResults(IAsyncEnumerable<RunQueryResponse> responses)
+        public LazyDatastoreQuery(IEnumerable<RunQueryResponse> responses)
         {
             _responses = GaxPreconditions.CheckNotNull(responses, nameof(responses));
         }
 
+        /// <summary>
+        /// Reads all the results from this query, until either the query-specified limit or end cursor
+        /// is reached, or there is no more data to read. Note that all the entities are read into memory,
+        /// so this method is not appropriate for use cases where a query could return a very large number
+        /// of results. However, it is the simplest approach to use cases where the query is bounded, such
+        /// as displaying a page of results at a time in a web application.
+        /// </summary>
+        /// <returns>The complete set of query results.</returns>
+        public DatastoreQueryResults GetAllResults()
+        {
+            // This takes slightly more memory than we really need, due to extra
+            // cursors etc, but that's likely to be insignificant compared with the
+            // entity data, and is immediately eligible for garbage collection.
+            var responses = _responses.ToList();
+            var entities = responses.SelectMany(r => r.Batch.EntityResults.Select(er => er.Entity)).ToList().AsReadOnly();
+            var lastBatch = responses.Last().Batch;
+            return new DatastoreQueryResults(entities, lastBatch.MoreResults, lastBatch.EndCursor);
+        }
+
         /// <inheritdoc />
-        public IAsyncEnumerator<Entity> GetEnumerator() => AsEntities().GetEnumerator();
+        public IEnumerator<Entity> GetEnumerator() => AsEntities().GetEnumerator();
 
         /// <summary>
         /// Returns the results of this query as a sequence of <see cref="Entity"/> values.
@@ -51,7 +73,7 @@ namespace Google.Datastore.V1Beta3
         /// This method only exists for symmetry with the other "As*" methods, to make the fact that
         /// the class implements IEnumerable{Entity} more incidental.
         /// </remarks>
-        private IAsyncEnumerable<Entity> AsEntities() => AsEntityResults().Select(er => er.Entity);
+        private IEnumerable<Entity> AsEntities() => AsEntityResults().Select(er => er.Entity);
 
         /// <summary>
         /// Returns the results of this query as a sequence of <see cref="EntityResult"/> values.
@@ -61,33 +83,31 @@ namespace Google.Datastore.V1Beta3
         /// <remarks>
         /// </remarks>
         /// <returns>A sequence of <see cref="EntityResult"/> values.</returns>
-        public IAsyncEnumerable<EntityResult> AsEntityResults() =>
-            AsBatches().SelectMany(batch =>
+        public IEnumerable<EntityResult> AsEntityResults() =>
+            AsResponses().SelectMany(response =>
             {
+                var batch = response.Batch;
                 var lastResult = batch.EntityResults.LastOrDefault();
                 if (lastResult != null)
                 {
                     lastResult.Cursor = batch.EndCursor;
                 }
-                return batch.EntityResults.ToAsyncEnumerable();
+                return batch.EntityResults;
             });
 
         /// <summary>
-        /// Returns the results of this query as a sequence of <see cref="RunQueryResponse"/> values
+        /// This method is for advanced use cases only, where more diagnostic information is required;
+        /// most application code should merely iterate over the query results as <see cref="Entity"/>
+        /// values, or call <see cref="GetAllResults()"/>.
+        /// The results of this query are returned as a sequence of <see cref="RunQueryResponse"/> values
         /// exactly as returned by the Datastore API. This method is only useful if the application
         /// wishes to examine the <see cref="RunQueryResponse.Query"/> property; otherwise, use
         /// <see cref="AsBatches"/> to obtain the sequence of batches.
         /// </summary>
         /// <returns>A sequence of <see cref="RunQueryResponse"/> values.</returns>
-        public IAsyncEnumerable<RunQueryResponse> AsResponses() => _responses;
+        public IEnumerable<RunQueryResponse> AsResponses() => _responses;
 
-        /// <summary>
-        /// Returns the results of this query as a sequence of <see cref="QueryResultBatch"/> values.
-        /// This method is only useful if the application wishes to process a batch at a time; if the
-        /// details of how the API splits the results into batches is not needed, use <see cref="AsEntityResults"/>
-        /// or simply iterate over the entities.
-        /// </summary>
-        /// <returns>A sequence of <see cref="QueryResultBatch"/> values.</returns>
-        public IAsyncEnumerable<QueryResultBatch> AsBatches() => _responses.Select(r => r.Batch);
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }


### PR DESCRIPTION
This is a second attempt at improving the query experience for Datastore, building on the comments received on #292. I think it's now much simpler to use for web applications - Jeff, I'm happy to create a PR to show how it would change your sample code, although I guess one good test would be to see whether it's discoverable enough for you to do it :)

I'm much happier with this version.

Commit message:

- Rename DatastoreQueryResults to LazyDatastoreQuery
  for clarity
- Add DatastoreQueryResults which is just an in-memory
  set of results, a cursor and an end condition
- Add LazyDatastoreQuery.GetAllResults() to fetch
  everything (ideal for web apps)
- Remove AsEntityResults() as it's rarely useful now
- Remove AsBatches() as it's rarely useful now
- Reword documentation for AsResponses() to indicate
  that it's a pretty niche use case.
- Remove details from DatastoreDb method calls, as
  there's now more documentation in LazyDatastoreQuery
  and the name is more appropriate.
- Ditto everything async

Basically, most use cases will fall into "stream all
results, I don't care about cursors" (just iterate
over LazyDatastoreQuery) or "I'm setting the limit
myself, get all the results" (call GetAllResults()).