### PR TITLE
Update all production binary project.json files

### DIFF
--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/project.json
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/project.json
@@ -1,13 +1,13 @@
 {
-  "version": "1.0.0-beta01-*",
-  "description": "Wrapper library for Google.Apis.Bigquery.v2, making common operations simpler in client code.",
+  "version": "1.0.0-beta02-*",
+  "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
   "authors": [ "Google Inc." ],
 
   "packOptions": {
-    "summary": "Wrapper library for Google.Apis.Bigquery.v2",
-    "owners": [ "google-apis-packages" ],
-    "tags": [ "Google" ],
-    "iconUrl": "https://cloud.google.com/images/devtools-icon-64x64.png",
+    "summary": "Recommended Google client library to access the BigQuery API.",
+    "owners": [ "google-cloud" ],
+    "tags": [ "Google", "Cloud", "BigQuery" ],
+    "iconUrl": "https://cloud.google.com/images/gcp-icon-64x64.png",
     "projectUrl": "https://github.com/GoogleCloudPlatform/google-cloud-dotnet",
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
     "requireLicenseAcceptance": false
@@ -18,7 +18,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Rest": "1.0.0-beta01-CI00081",
+    "Google.Api.Gax.Rest": "1.0.0-beta02",
     "Google.Apis": "1.16.0",
     "Google.Apis.Auth": "1.16.0",
     "Google.Apis.Bigquery.v2": "1.16.0.591",

--- a/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1/project.json
+++ b/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1/project.json
@@ -1,13 +1,13 @@
 ﻿{
-  "version": "0.1.0-*",
-  "description": "Google Cloud Natural Language API v1beta1 client library",
+  "version": "0.2.0-*",
+  "description": "Recommended Google client library to access the Google Cloud Natural Language API, which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.",
   "authors": [ "Google Inc." ],
 
   "packOptions": {
-    "summary": "Google Cloud Natural Language API v1beta1 client library",
-    "owners": [ "google-apis-packages" ],
-    "tags": [ "Google" ],
-    "iconUrl": "https://cloud.google.com/images/devtools-icon-64x64.png",
+    "summary": "Recommended Google client library to access the Google Cloud Natural Language API.",
+    "owners": [ "google-cloud" ],
+    "tags": [ "Google", "Cloud", "Language" ],
+    "iconUrl": "https://cloud.google.com/images/gcp-icon-64x64.png",
     "projectUrl": "https://github.com/GoogleCloudPlatform/google-cloud-dotnet",
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
     "requireLicenseAcceptance": false
@@ -18,8 +18,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00076",
-    "Google.Api.Gax": "1.0.0-CI00076",
+    "Google.Api.CommonProtos": "1.0.0-beta02",
+    "Google.Api.Gax": "1.0.0-beta02",
     "Google.Apis.Auth": "1.16.0",
     "Google.Protobuf": "3.0.0",
     "Grpc.Auth": "1.0.0",

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
@@ -1,13 +1,13 @@
 ﻿{
-  "version": "0.1.0-*",
-  "description": "Google Cloud Speech API v1beta1 client library",
+  "version": "0.2.0-*",
+  "description": "Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.",
   "authors": [ "Google Inc." ],
 
   "packOptions": {
-    "summary": "Google Cloud Speech API v1beta1 client library",
-    "owners": [ "google-apis-packages" ],
-    "tags": [ "Google" ],
-    "iconUrl": "https://cloud.google.com/images/devtools-icon-64x64.png",
+    "summary": "Recommended Google client library to access the Google Cloud Speech API.",
+    "owners": [ "google-cloud" ],
+    "tags": [ "Google", "Cloud", "Speech" ],
+    "iconUrl": "https://cloud.google.com/images/gcp-icon-64x64.png",
     "projectUrl": "https://github.com/GoogleCloudPlatform/google-cloud-dotnet",
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
     "requireLicenseAcceptance": false
@@ -18,8 +18,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00076",
-    "Google.Api.Gax": "1.0.0-CI00076",
+    "Google.Api.CommonProtos": "1.0.0-beta02",
+    "Google.Api.Gax": "1.0.0-beta02",
     "Google.Apis.Auth": "1.16.0",
     "Google.Protobuf": "3.0.0",
     "Grpc.Auth": "1.0.0",

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
@@ -1,13 +1,13 @@
 ﻿{
-  "version": "0.1.0-*",
-  "description": "Google Cloud Vision API v1 client library",
+  "version": "0.2.0-*",
+  "description": "Recommended Google client library to access the Google Cloud Vision API, which integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.",
   "authors": [ "Google Inc." ],
 
   "packOptions": {
     "summary": "Google Cloud Vision API v1 client library",
-    "owners": [ "google-apis-packages" ],
-    "tags": [ "Google" ],
-    "iconUrl": "https://cloud.google.com/images/devtools-icon-64x64.png",
+    "owners": [ "google-cloud" ],
+    "tags": [ "Google", "Cloud", "Vision" ],
+    "iconUrl": "https://cloud.google.com/images/gcp-icon-64x64.png",
     "projectUrl": "https://github.com/GoogleCloudPlatform/google-cloud-dotnet",
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
     "requireLicenseAcceptance": false
@@ -18,8 +18,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00076",
-    "Google.Api.Gax": "1.0.0-CI00076",
+    "Google.Api.CommonProtos": "1.0.0-beta02",
+    "Google.Api.Gax": "1.0.0-beta02",
     "Google.Apis.Auth": "1.16.0",
     "Google.Protobuf": "3.0.0",
     "Grpc.Auth": "1.0.0",

--- a/apis/Google.Datastore.V1/Google.Datastore.V1/project.json
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1/project.json
@@ -1,13 +1,13 @@
 ﻿{
-  "version": "1.0.0-beta01-*",
-  "description": "Google Cloud Datastore v1 client library",
+  "version": "1.0.0-beta02-*",
+  "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",
   "authors": [ "Google Inc." ],
 
   "packOptions": {
-    "summary": "Google Cloud Datastore v1 client library",
-    "owners": [ "google-apis-packages" ],
-    "tags": [ "Google" ],
-    "iconUrl": "https://cloud.google.com/images/devtools-icon-64x64.png",
+    "summary": "Recommended Google client library to access the Google Cloud Datastore API.",
+    "owners": [ "google-cloud" ],
+    "tags": [ "Google", "Cloud", "Datastore" ],
+    "iconUrl": "https://cloud.google.com/images/gcp-icon-64x64.png",
     "projectUrl": "https://github.com/GoogleCloudPlatform/google-cloud-dotnet",
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
     "requireLicenseAcceptance": false
@@ -18,8 +18,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00076",
-    "Google.Api.Gax": "1.0.0-CI00076",
+    "Google.Api.CommonProtos": "1.0.0-beta02",
+    "Google.Api.Gax": "1.0.0-beta02",
     "Google.Apis.Auth": "1.16.0",
     "Google.Protobuf": "3.0.0",
     "Grpc.Auth": "1.0.0",

--- a/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/project.json
+++ b/apis/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3/project.json
@@ -7,7 +7,7 @@
     "summary": "Google Cloud Datastore v1beta3 client library",
     "owners": [ "google-apis-packages" ],
     "tags": [ "Google" ],
-    "iconUrl": "https://cloud.google.com/images/devtools-icon-64x64.png",
+    "iconUrl": "https://cloud.google.com/images/gcp-icon-64x64.png",
     "projectUrl": "https://github.com/GoogleCloudPlatform/google-cloud-dotnet",
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
     "requireLicenseAcceptance": false
@@ -18,8 +18,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00076",
-    "Google.Api.Gax": "1.0.0-CI00076",
+    "Google.Api.CommonProtos": "1.0.0-beta02",
+    "Google.Api.Gax": "1.0.0-beta02",
     "Google.Apis.Auth": "1.16.0",
     "Google.Protobuf": "3.0.0",
     "Grpc.Auth": "1.0.0",

--- a/apis/Google.Iam.V1/Google.Iam.V1/project.json
+++ b/apis/Google.Iam.V1/Google.Iam.V1/project.json
@@ -1,13 +1,13 @@
 ﻿{
-  "version": "1.0.0-beta01",
-  "description": "Google IAM v1 client library",
+  "version": "1.0.0-beta02",
+  "description": "gRPC services for the Google Identity and Access Management API. This library is typically used as a dependency for other API client libraries.",
   "authors": [ "Google Inc." ],
 
   "packOptions": {
-    "summary": "Google IAM v1",
-    "owners": [ "google-apis-packages" ],
-    "tags": [ "Google" ],
-    "iconUrl": "https://cloud.google.com/images/devtools-icon-64x64.png",
+    "summary": "gRPC services for the Google Identity and Access Management API.",
+    "owners": [ "google-cloud" ],
+    "tags": [ "Google", "Cloud", "IAM", "Identity", "Access" ],
+    "iconUrl": "https://cloud.google.com/images/gcp-icon-64x64.png",
     "projectUrl": "https://github.com/GoogleCloudPlatform/google-cloud-dotnet",
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
     "requireLicenseAcceptance": false

--- a/apis/Google.Logging.V2/Google.Logging.Log4Net.Tests/project.json
+++ b/apis/Google.Logging.V2/Google.Logging.Log4Net.Tests/project.json
@@ -7,7 +7,7 @@
 
   "dependencies": {
     "Google.Logging.Log4Net": { "target": "project" },
-    "Google.Api.Gax.Testing": "1.0.0-CI00076",
+    "Google.Api.Gax.Testing": "1.0.0-beta02",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Moq": "4.6.36-alpha"

--- a/apis/Google.Logging.V2/Google.Logging.Log4Net/project.json
+++ b/apis/Google.Logging.V2/Google.Logging.Log4Net/project.json
@@ -1,13 +1,13 @@
 ﻿{
-  "version": "1.0.0-beta01-*",
-  "description": "Google StackdriverLogging Log4Net client Library",
+  "version": "1.0.0-beta02-*",
+  "description": "Log4Net client library for the Google Stackdriver Logging API.",
   "authors": [ "Google Inc." ],
 
   "packOptions": {
-    "summary": "Google Stackdriver Logging Log4Net client Library",
-    "owners": [ "google-apis-packages" ],
-    "tags": [ "Google", "log4net", "logging" ],
-    "iconUrl": "https://cloud.google.com/images/devtools-icon-64x64.png",
+    "summary": "Log4Net client library for the Google Stackdriver Logging API.",
+    "owners": [ "google-cloud" ],
+    "tags": [ "Google", "Cloud", "Logging", "log4net", "Stackdriver" ],
+    "iconUrl": "https://cloud.google.com/images/gcp-icon-64x64.png",
     "projectUrl": "https://github.com/GoogleCloudPlatform/google-cloud-dotnet",
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
     "requireLicenseAcceptance": false
@@ -18,8 +18,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00076",
-    "Google.Api.Gax": "1.0.0-CI00076",
+    "Google.Api.CommonProtos": "1.0.0-beta02",
+    "Google.Api.Gax": "1.0.0-beta02",
     "Google.Logging.V2": { "target": "project" },
     "log4net": "2.0.5"
   },

--- a/apis/Google.Logging.V2/Google.Logging.Type/project.json
+++ b/apis/Google.Logging.V2/Google.Logging.Type/project.json
@@ -1,13 +1,13 @@
 {
-  "version": "1.0.0-beta01-*",
-  "description": "Google Logging version-agnostic types",
+  "version": "1.0.0-beta02-*",
+  "description": "Version-agnostic types for the Google Stackdriver Logging API.",
   "authors": [ "Google Inc." ],
 
   "packOptions": {
-    "summary": "Google Logging version-agnostic types",
-    "owners": [ "google-apis-packages" ],
-    "tags": [ "Google" ],
-    "iconUrl": "https://cloud.google.com/images/devtools-icon-64x64.png",
+    "summary": "Version-agnostic types for the Google Stackdriver Logging API.",
+    "owners": [ "google-cloud" ],
+    "tags": [ "Google", "Cloud", "Logging", "Stackdriver" ],
+    "iconUrl": "https://cloud.google.com/images/gcp-icon-64x64.png",
     "projectUrl": "https://github.com/GoogleCloudPlatform/google-cloud-dotnet",
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
     "requireLicenseAcceptance": false
@@ -18,7 +18,7 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00076",
+    "Google.Api.CommonProtos": "1.0.0-beta02",
     "Google.Protobuf": "3.0.0"
   },
 

--- a/apis/Google.Logging.V2/Google.Logging.V2/project.json
+++ b/apis/Google.Logging.V2/Google.Logging.V2/project.json
@@ -1,13 +1,13 @@
 {
-  "version": "1.0.0-beta01-*",
-  "description": "Google Logging v2 client library",
+  "version": "1.0.0-beta02-*",
+  "description": "Recommended Google client library to access the Google Stackdriver Logging API, which writes log entries and manages your logs, log sinks, and logs-based metrics.",
   "authors": [ "Google Inc." ],
 
   "packOptions": {
-    "summary": "Google Logging v2 client library",
-    "owners": [ "google-apis-packages" ],
-    "tags": [ "Google" ],
-    "iconUrl": "https://cloud.google.com/images/devtools-icon-64x64.png",
+    "summary": "Recommended Google client library to access the Google Stackdriver Logging API.",
+    "owners": [ "google-cloud" ],
+    "tags": [ "Google", "Cloud", "Logging", "Stackdriver" ],
+    "iconUrl": "https://cloud.google.com/images/gcp-icon-64x64.png",
     "projectUrl": "https://github.com/GoogleCloudPlatform/google-cloud-dotnet",
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
     "requireLicenseAcceptance": false
@@ -18,8 +18,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00076",
-    "Google.Api.Gax": "1.0.0-CI00076",
+    "Google.Api.CommonProtos": "1.0.0-beta02",
+    "Google.Api.Gax": "1.0.0-beta02",
     "Google.Apis.Auth": "1.16.0",
     "Google.Logging.Type": { "target": "project" },
     "Google.Protobuf": "3.0.0",

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1/project.json
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1/project.json
@@ -1,13 +1,13 @@
 ﻿{
-  "version": "1.0.0-beta01-*",
-  "description": "Google Pubsub v1 client library",
+  "version": "1.0.0-beta02-*",
+  "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",
   "authors": [ "Google Inc." ],
 
   "packOptions": {
-    "summary": "Google Pubsub v1 client library",
-    "owners": [ "google-apis-packages" ],
-    "tags": [ "Google" ],
-    "iconUrl": "https://cloud.google.com/images/devtools-icon-64x64.png",
+    "summary": "Recommended Google client library to access the Google Cloud Pub/Sub API.",
+    "owners": [ "google-cloud" ],
+    "tags": [ "Google", "Cloud", "PubSub" ],
+    "iconUrl": "https://cloud.google.com/images/gcp-icon-64x64.png",
     "projectUrl": "https://github.com/GoogleCloudPlatform/google-cloud-dotnet",
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
     "requireLicenseAcceptance": false
@@ -18,8 +18,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-CI00076",
-    "Google.Api.Gax": "1.0.0-CI00076",
+    "Google.Api.CommonProtos": "1.0.0-beta02",
+    "Google.Api.Gax": "1.0.0-beta02",
     "Google.Apis.Auth": "1.16.0",
     "Google.Protobuf": "3.0.0",
     "Grpc.Auth": "1.0.0",

--- a/apis/Google.Storage.V1/Google.Storage.V1/project.json
+++ b/apis/Google.Storage.V1/Google.Storage.V1/project.json
@@ -1,13 +1,13 @@
 {
-  "version": "1.0.0-beta01-*",
-  "description": "Wrapper library for Google.Apis.Storage.v1, making common operations simpler in client code.",
+  "version": "1.0.0-beta02-*",
+  "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
   "authors": [ "Google Inc." ],
 
   "packOptions": {
-    "summary": "Wrapper library for Google.Apis.Storage.v1",
-    "owners": [ "google-apis-packages" ],
-    "tags": [ "Google" ],
-    "iconUrl": "https://cloud.google.com/images/devtools-icon-64x64.png",
+    "summary": "Recommended Google client library to access the Google Cloud Storage API.",
+    "owners": [ "google-cloud" ],
+    "tags": [ "Google", "Cloud", "Storage" ],
+    "iconUrl": "https://cloud.google.com/images/gcp-icon-64x64.png",
     "projectUrl": "https://github.com/GoogleCloudPlatform/google-cloud-dotnet",
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
     "requireLicenseAcceptance": false
@@ -18,7 +18,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Rest": "1.0.0-beta01-CI00081",
+    "Google.Api.Gax.Rest": "1.0.0-beta02",
     "Google.Apis": "1.16.0",
     "Google.Apis.Auth": "1.16.0",
     "Google.Apis.Core": "1.16.0",


### PR DESCRIPTION
Changes:
- Update to 1.0.0-beta02 or 0.2.0 (depending on current version)
- Update GAX dependencies to 1.0.0-beta02
- Update owner to google-cloud
- Update summaries and descriptions
- Update icons to https://cloud.google.com/images/gcp-icon-64x64.png

Notes on quirks:

- I've updated the Google.Datastore.V1Beta3 project.json in terms of
  depenencies but *not* its version or summary/description. We don't
  intend to ship a new version of this package.
- The IAM package never had a beta01, but in order to get a sensible
  starting point to kick off from, it makes sense to create a new tag
  etc.
- Ditto the 0.1.0->0.2.0 APIs. In future we should probably use 0.0.0
  for initial commits.