### PR TITLE
NOT FOR SUBMISSION First pass at what the IAM mix-in might look like.

### DIFF
--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1.Snippets/SubscriberClientSnippets.cs
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1.Snippets/SubscriberClientSnippets.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using Google.Iam.V1;
 using Google.Protobuf;
 using System;
 using System.Collections.Generic;
@@ -247,6 +248,37 @@ namespace Google.Pubsub.V1.Snippets
             // successfully-pulled messages before they will be redelivered.
             var ackIds = pullResponse.ReceivedMessages.Select(rm => rm.AckId);
             await client.AcknowledgeAsync(subscriptionName, ackIds);
+            // End snippet
+        }
+
+        [Fact]
+        public void GetIamPolicy()
+        {
+            string projectId = _fixture.ProjectId;
+            string topicId = _fixture.CreateTopicId();
+            string subscriptionId = _fixture.CreateSubscriptionId();
+
+            PublisherClient publisher = PublisherClient.Create();
+            string topicName = PublisherClient.FormatTopicName(projectId, topicId);
+            publisher.CreateTopic(topicName);
+            SubscriberClient.Create().CreateSubscription(SubscriberClient.FormatSubscriptionName(projectId, subscriptionId), topicName, null, 60);
+
+            // Snippet: GetIamPolicy
+            SubscriberClient client = SubscriberClient.Create();
+
+            // Alternative: use an existing subscription resource name:
+            // "projects/{PROJECT_ID}/subscriptions/{SUBSCRIPTION_ID}"
+            string subscriptionName = SubscriberClient.FormatSubscriptionName(projectId, subscriptionId);
+
+            Policy subscriptionPolicy = client.SetIamPolicy(subscriptionName, new Policy
+            {
+                Bindings =
+                {
+                    new Binding { Members = { "allUsers" }, Role = "roles/viewer" }
+                }
+            });
+            Policy fetchedPolicy = client.GetIamPolicy(subscriptionName);
+            Console.WriteLine(subscriptionPolicy);
             // End snippet
         }
     }

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1.sln
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1.sln
@@ -7,6 +7,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Pubsub.V1", "Google.
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Pubsub.V1.Snippets", "Google.Pubsub.V1.Snippets\Google.Pubsub.V1.Snippets.xproj", "{60E5F4C2-7A10-41F1-A247-14C346A8E33A}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Iam.V1", "..\Google.Iam.V1\Google.Iam.V1\Google.Iam.V1.xproj", "{8BF4C91C-5611-444B-8550-D67DEBAF72F1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{60E5F4C2-7A10-41F1-A247-14C346A8E33A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{60E5F4C2-7A10-41F1-A247-14C346A8E33A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{60E5F4C2-7A10-41F1-A247-14C346A8E33A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BF4C91C-5611-444B-8550-D67DEBAF72F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BF4C91C-5611-444B-8550-D67DEBAF72F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BF4C91C-5611-444B-8550-D67DEBAF72F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BF4C91C-5611-444B-8550-D67DEBAF72F1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1/SubscriberClient.cs
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1/SubscriberClient.cs
@@ -15,6 +15,7 @@
 // Generated code. DO NOT EDIT!
 
 using Google.Api.Gax;
+using Google.Iam.V1;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -26,27 +27,6 @@ using System.Threading.Tasks;
 
 namespace Google.Pubsub.V1
 {
-
-    /// <summary>
-    /// Extension methods to assist with using <see cref="SubscriberClient"/>.
-    /// </summary>
-    public static partial class SubscriberExtensions
-    {
-        /// <summary>
-        /// Wrap a GRPC Subscriber client for more convenient use.
-        /// </summary>
-        /// <param name="grpcClient">A GRPC client to wrap.</param>
-        /// <param name="settings">
-        /// An optional <see cref="SubscriberSettings"/> to configure this wrapper.
-        /// If null or not specified, then the default settings are used.
-        /// </param>
-        /// <returns>A <see cref="SubscriberClient"/> that wraps the specified GRPC client.</returns>
-        public static SubscriberClient ToClient(
-            this Subscriber.SubscriberClient grpcClient,
-            SubscriberSettings settings = null
-        ) => new SubscriberClientImpl(grpcClient, settings);
-    }
-
     /// <summary>
     /// Settings for a Subscriber wrapper.
     /// </summary>
@@ -436,6 +416,41 @@ namespace Google.Pubsub.V1
             }),
         };
 
+        // TODO:
+        // - Populate more sensibly. (These settings are taken from ModifyPushConfigSettings.)
+        // - Consider having a separate IAM settings 
+        public CallSettings GetIamPolicySettings { get; set; } = new CallSettings
+        {
+            Timing = CallTiming.FromRetry(new RetrySettings
+            {
+                RetryBackoff = GetDefaultRetryBackoff(),
+                TimeoutBackoff = GetDefaultTimeoutBackoff(),
+                RetryFilter = NonIdempotentRetryFilter,
+                TotalExpiration = Expiration.FromTimeout(TimeSpan.FromMilliseconds(600000)),
+            }),
+        };
+
+        public CallSettings SetIamPolicySettings { get; set; } = new CallSettings
+        {
+            Timing = CallTiming.FromRetry(new RetrySettings
+            {
+                RetryBackoff = GetDefaultRetryBackoff(),
+                TimeoutBackoff = GetDefaultTimeoutBackoff(),
+                RetryFilter = NonIdempotentRetryFilter,
+                TotalExpiration = Expiration.FromTimeout(TimeSpan.FromMilliseconds(600000)),
+            }),
+        };
+
+        public CallSettings TestIamPermissionSettings { get; set; } = new CallSettings
+        {
+            Timing = CallTiming.FromRetry(new RetrySettings
+            {
+                RetryBackoff = GetDefaultRetryBackoff(),
+                TimeoutBackoff = GetDefaultTimeoutBackoff(),
+                RetryFilter = NonIdempotentRetryFilter,
+                TotalExpiration = Expiration.FromTimeout(TimeSpan.FromMilliseconds(600000)),
+            }),
+        };
 
         /// <summary>
         /// Creates a deep clone of this object, with all the same property values.
@@ -565,7 +580,8 @@ namespace Google.Pubsub.V1
         {
             GaxPreconditions.CheckNotNull(channel, nameof(channel));
             Subscriber.SubscriberClient grpcClient = new Subscriber.SubscriberClient(channel);
-            return new SubscriberClientImpl(grpcClient, settings);
+            IAMPolicy.IAMPolicyClient iamGrpcClient = new IAMPolicy.IAMPolicyClient(channel);
+            return new SubscriberClientImpl(grpcClient, iamGrpcClient, settings);
         }
 
         /// <summary>
@@ -583,6 +599,14 @@ namespace Google.Pubsub.V1
         /// The underlying GRPC Subscriber client.
         /// </summary>
         public virtual Subscriber.SubscriberClient GrpcClient
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        /// <summary>
+        /// The underlying GRPC IAMPolicy client.
+        /// </summary>
+        public virtual IAMPolicy.IAMPolicyClient IamGrpcClient
         {
             get { throw new NotImplementedException(); }
         }
@@ -1211,6 +1235,75 @@ namespace Google.Pubsub.V1
             throw new NotImplementedException();
         }
 
+
+        // Mix-in methods
+        public virtual Task<Policy> SetIamPolicyAsync(
+            string resource,
+            Policy policy,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual Task<Policy> SetIamPolicyAsync(
+            string resource,
+            Policy policy,
+            CancellationToken cancellationToken) => SetIamPolicyAsync(
+                resource,
+                policy,
+                new CallSettings { CancellationToken = cancellationToken });
+
+        public virtual Policy SetIamPolicy(
+            string resource,
+            Policy policy,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual Task<Policy> GetIamPolicyAsync(
+            string resource,
+            CancellationToken cancellationToken) => GetIamPolicyAsync(
+                resource,
+                new CallSettings { CancellationToken = cancellationToken });
+
+        public virtual Task<Policy> GetIamPolicyAsync(
+            string resource,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual Policy GetIamPolicy(
+            string resource,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
+            string resource,
+            IEnumerable<string> permissions,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
+            string resource,
+            IEnumerable<string> permissions,
+            CancellationToken cancellationToken) => TestIamPermissionsAsync(
+                resource,
+                permissions,
+                new CallSettings { CancellationToken = cancellationToken });
+
+        public virtual TestIamPermissionsResponse TestIamPermissions(
+            string resource,
+            IEnumerable<string> permissions,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public sealed partial class SubscriberClientImpl : SubscriberClient
@@ -1224,10 +1317,14 @@ namespace Google.Pubsub.V1
         private readonly ApiCall<AcknowledgeRequest, Empty> _callAcknowledge;
         private readonly ApiCall<PullRequest, PullResponse> _callPull;
         private readonly ApiCall<ModifyPushConfigRequest, Empty> _callModifyPushConfig;
+        private readonly ApiCall<GetIamPolicyRequest, Policy> _callGetIamPolicy;
+        private readonly ApiCall<SetIamPolicyRequest, Policy> _callSetIamPolicy;
+        private readonly ApiCall<TestIamPermissionsRequest, TestIamPermissionsResponse> _callTestIamPermissions;
 
-        public SubscriberClientImpl(Subscriber.SubscriberClient grpcClient, SubscriberSettings settings)
+        public SubscriberClientImpl(Subscriber.SubscriberClient grpcClient, IAMPolicy.IAMPolicyClient iamGrpcClient, SubscriberSettings settings)
         {
             this.GrpcClient = grpcClient;
+            this.IamGrpcClient = iamGrpcClient;
             SubscriberSettings effectiveSettings = settings ?? SubscriberSettings.GetDefault();
             _clientHelper = new ClientHelper(effectiveSettings);
             _callCreateSubscription = _clientHelper.BuildApiCall<Subscription, Subscription>(
@@ -1246,9 +1343,17 @@ namespace Google.Pubsub.V1
                 GrpcClient.PullAsync, GrpcClient.Pull, effectiveSettings.PullSettings);
             _callModifyPushConfig = _clientHelper.BuildApiCall<ModifyPushConfigRequest, Empty>(
                 GrpcClient.ModifyPushConfigAsync, GrpcClient.ModifyPushConfig, effectiveSettings.ModifyPushConfigSettings);
+            _callGetIamPolicy = _clientHelper.BuildApiCall<GetIamPolicyRequest, Policy>(
+                IamGrpcClient.GetIamPolicyAsync, IamGrpcClient.GetIamPolicy, effectiveSettings.GetIamPolicySettings);
+            _callSetIamPolicy = _clientHelper.BuildApiCall<SetIamPolicyRequest, Policy>(
+                IamGrpcClient.SetIamPolicyAsync, IamGrpcClient.SetIamPolicy, effectiveSettings.SetIamPolicySettings);
+            _callTestIamPermissions = _clientHelper.BuildApiCall<TestIamPermissionsRequest, TestIamPermissionsResponse>(
+                IamGrpcClient.TestIamPermissionsAsync, IamGrpcClient.TestIamPermissions, effectiveSettings.TestIamPermissionSettings);
         }
 
         public override Subscriber.SubscriberClient GrpcClient { get; }
+
+        public override IAMPolicy.IAMPolicyClient IamGrpcClient { get; }
 
         /// <summary>
         /// Creates a subscription to a given topic for a given subscriber.
@@ -1734,6 +1839,67 @@ namespace Google.Pubsub.V1
                 },
                 callSettings);
 
+        public override Task<Policy> GetIamPolicyAsync(
+            string resource,
+            CallSettings callSettings = null) => _callGetIamPolicy.Async(
+                new GetIamPolicyRequest
+                {
+                    Resource = resource,
+                },
+                callSettings);
+
+        public override Policy GetIamPolicy(
+            string resource,
+            CallSettings callSettings = null) => _callGetIamPolicy.Sync(
+                new GetIamPolicyRequest
+                {
+                    Resource = resource,
+                },
+                callSettings);
+
+        public override Task<Policy> SetIamPolicyAsync(
+            string resource,
+            Policy policy,
+            CallSettings callSettings = null) => _callSetIamPolicy.Async(
+                new SetIamPolicyRequest
+                {
+                    Resource = resource,
+                    Policy = policy,
+                },
+                callSettings);
+
+        public override Policy SetIamPolicy(
+            string resource,
+            Policy policy,
+            CallSettings callSettings = null) => _callSetIamPolicy.Sync(
+                new SetIamPolicyRequest
+                {
+                    Resource = resource,
+                    Policy = policy,
+                },
+                callSettings);
+
+        public override Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
+            string resource,
+            IEnumerable<string> permissions,
+            CallSettings callSettings = null) => _callTestIamPermissions.Async(
+                new TestIamPermissionsRequest
+                {
+                    Resource = resource,
+                    Permissions = { permissions },
+                },
+                callSettings);
+
+        public override TestIamPermissionsResponse TestIamPermissions(
+            string resource,
+            IEnumerable<string> permissions,
+            CallSettings callSettings = null) => _callTestIamPermissions.Sync(
+                new TestIamPermissionsRequest
+                {
+                    Resource = resource,
+                    Permissions = { permissions },
+                },
+                callSettings);
     }
 
     // Partial classes to enable page-streaming

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1/project.json
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1/project.json
@@ -24,7 +24,8 @@
     "Google.Protobuf": "3.0.0",
     "Grpc.Auth": "1.0.0",
     "Grpc.Core": "1.0.0",
-    "System.Interactive.Async": "3.0.0"
+    "System.Interactive.Async": "3.0.0",
+    "Google.Iam.V1": { "target": "project" }
   },
 
   "frameworks": {

--- a/apis/global.json
+++ b/apis/global.json
@@ -1,6 +1,7 @@
 ﻿{
   "projects": [
     "Google.Storage.V1",
+    "Google.Iam.V1",
     "Google.Longrunning",
     "../tools"
   ],


### PR DESCRIPTION
Only the SubscriberClient has it implemented at the moment, but I
believe the PublisherClient would look the same.

If we think multiple APIs may want the same set of settings,
we could potentially have an IamSettings object, and make that a
property of PublisherSettings / SubscriberSettings.