### PR TITLE
Add metadata filtering, to remove bits of protobuf messages which aren't really needed

### DIFF
--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -26,7 +26,7 @@ build_api_docs() {
   
   docfx.cmd metadata -f output/$api/docfx.json
   dotnet run -p ../tools/Google.Cloud.Tools.GenerateSnippetMarkdown -- $api
-  docfx.cmd output/$api/docfx.json
+  docfx.cmd build output/$api/docfx.json
 
   # Special case root: that should end up in the root of the assembled
   # site.
@@ -55,6 +55,8 @@ mkdir output/assembled
 fetch gax-dotnet googleapis/gax-dotnet
 # For Google.Protobuf
 fetch protobuf google/protobuf
+# Remove // comments in project.json; dotnet cli is fine with it, but docfx isn't.
+sed -i -r 's/\s+\/\/.*//g' external/protobuf/csharp/src/Google.Protobuf/project.json
 # For Grpc.Core etc
 fetch grpc google/grpc
 

--- a/docs/filterConfig.yml
+++ b/docs/filterConfig.yml
@@ -1,0 +1,39 @@
+apiRules:
+- exclude:
+    uidRegex: \.Google#Protobuf#IMessage#Descriptor$
+- exclude:
+    type: Field
+    uidRegex: FieldNumber$
+- exclude:
+    type: Property
+    uidRegex: Parser$
+- exclude:
+    type: Property
+    uidRegex: Descriptor$
+- exclude:
+    type: Method
+    uidRegex: Equals\(
+- exclude:
+    type: Method
+    uidRegex: WriteTo\(
+- exclude:
+    type: Method
+    uidRegex: MergeFrom\(
+- exclude:
+    type: Method
+    uidRegex: GetHashCode$
+- exclude:
+    type: Method
+    uidRegex: Clone$
+- exclude:
+    type: Method
+    uidRegex: CalculateSize$
+- exclude:
+    type: Method
+    uidRegex: ToString$
+- exclude:
+    type: Type
+    uidRegex: \.Types$
+- exclude:
+    type: Type
+    uidRegex: Reflection$

--- a/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
+++ b/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
@@ -34,7 +34,6 @@ namespace Google.Cloud.Tools.GenerateDocfxSources
             { "Grpc.Core", "grpc/src/csharp/Grpc.Core/Grpc.Core.csproj" },
         };
 
-
         private static int Main(string[] args)
         {
             try
@@ -105,7 +104,8 @@ namespace Google.Cloud.Tools.GenerateDocfxSources
                     new JObject
                     {
                         ["src"] = src,
-                        ["dest"] = "obj/api"
+                        ["dest"] = "obj/api",
+                        ["filter"] = "filterConfig.yml"
                     }
                 },
                 ["build"] = new JObject {


### PR DESCRIPTION
Also fixes issue with protobuf's project.json which was preventing it from generating metadata before.

See https://jskeet.github.io/google-cloud-dotnet/ for sample output - for example, see 

http://jskeet.github.io/google-cloud-dotnet/docs/Google.Cloud.Language.V1Beta1/api/Google.Cloud.Language.V1Beta1.Token.html
vs
http://GoogleCloudPlatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Language.V1Beta1/api/Google.Cloud.Language.V1Beta1.Token.html


Fixes #305.