### PR TITLE
Update dependencies around speech and LRO.

### DIFF
--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.sln
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.sln
@@ -7,6 +7,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Cloud.Speech.V1Beta1
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Cloud.Speech.V1Beta1.Snippets", "Google.Cloud.Speech.V1Beta1.Snippets\Google.Cloud.Speech.V1Beta1.Snippets.xproj", "{25D98E51-33AF-455B-B5DD-C0E17F65EA0F}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Longrunning", "..\Google.Longrunning\Google.Longrunning\Google.Longrunning.xproj", "{2DA31819-9094-49EC-96B6-744A481EB4F9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{25D98E51-33AF-455B-B5DD-C0E17F65EA0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{25D98E51-33AF-455B-B5DD-C0E17F65EA0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{25D98E51-33AF-455B-B5DD-C0E17F65EA0F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2DA31819-9094-49EC-96B6-744A481EB4F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2DA31819-9094-49EC-96B6-744A481EB4F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2DA31819-9094-49EC-96B6-744A481EB4F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2DA31819-9094-49EC-96B6-744A481EB4F9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.2.0-*",
+  "version": "0.2.1-*",
   "description": "Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.",
   "authors": [ "Google Inc." ],
 
@@ -18,9 +18,10 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta02",
+    "Google.Api.CommonProtos": "1.0.0-beta03",
     "Google.Api.Gax": "1.0.0-beta02",
     "Google.Apis.Auth": "1.16.0",
+    "Google.Longrunning": { "target": "project" },
     "Google.Protobuf": "3.0.0",
     "Grpc.Auth": "1.0.0",
     "Grpc.Core": "1.0.0",

--- a/apis/Google.LongRunning/Google.LongRunning/project.json
+++ b/apis/Google.LongRunning/Google.LongRunning/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0-beta02-*",
+  "version": "1.0.0-beta01-*",
   "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",
   "authors": [ "Google Inc." ],
 
@@ -18,7 +18,7 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta02",
+    "Google.Api.CommonProtos": "1.0.0-beta03",
     "Google.Api.Gax": "1.0.0-beta02",
     "Google.Protobuf": "3.0.0",
     "Grpc.Core": "1.0.0",

--- a/apis/global.json
+++ b/apis/global.json
@@ -1,6 +1,7 @@
 ﻿{
   "projects": [
-    "Google.Storage.V1"
+    "Google.Storage.V1",
+    "Google.Longrunning"
   ],
   "sdk": {
     "version": "1.0.0-preview2-003121"


### PR DESCRIPTION
Google.Longrunning is now the sole source of Operation,
which means the Speech API needs to depend on that... and the latest
version of Google.Api.CommonProtos.

We will release Google.Longrunning-1.0.0-beta01 and Google.Cloud.Speech.V1Beta1-0.2.1 on nuget.org when this has been merged.