### PR TITLE
First part of adding coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ external
 output
 *~
 .cr
+packages
+coverage


### PR DESCRIPTION
This doesn't include it in CI - we can do that using coveralls.io once we've got an AppVeyor build (as OpenCover only works on Windows). This is a starting point though.