### PR TITLE
Upload coverage data from Appveyor to coveralls.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![Travis build Status](https://travis-ci.org/GoogleCloudPlatform/google-cloud-dotnet.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/google-cloud-dotnet)
 [![Appveyor build status](https://ci.appveyor.com/api/projects/status/d25hbwksdu6y9v5t?svg=true)](https://ci.appveyor.com/project/GoogleCloudPlatform/google-cloud-dotnet)
+[![Coverage Status](https://coveralls.io/repos/github/GoogleCloudPlatform/google-cloud-dotnet/badge.svg)](https://coveralls.io/github/GoogleCloudPlatform/google-cloud-dotnet)
 
 * [Homepage][language-landing-dotnet]
 * [API Documentation][api-reference-dotnet]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,10 @@ branches:
   only:
     - master
 
+environment:
+  COVERALLS_REPO_TOKEN:
+    secure: 0F41/ccYgoYS098AEpBDGjBToFMvBsrjGLRzOW+ViyY4QrIzVIUmMlKiuNXDDeAs
+
 # Install the pre-requisites for the build.
 install:
   # Download the installer for dotnet.
@@ -24,6 +28,8 @@ install:
 build_script:
   - dotnet --info
   - bash build.sh
+  - nuget install -OutputDirectory packages -Version 0.7.0 coveralls.net
+  - packages\coveralls.net.0.7.0\tools\csmacnz.Coveralls.exe --opencover -i coverage\coverage.xml
 
 # The tests are run as part of the build.
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,7 @@ install:
 build_script:
   - dotnet --info
   - bash build.sh
-  - nuget install -OutputDirectory packages -Version 0.7.0 coveralls.net
-  - packages\coveralls.net.0.7.0\tools\csmacnz.Coveralls.exe --opencover -i coverage\coverage.xml
+  - bash coveralls.sh
 
 # The tests are run as part of the build.
 test: off

--- a/build.sh
+++ b/build.sh
@@ -64,11 +64,16 @@ do
       # OpenCover is picky about how it finds the excluded files. There may be a better approach than this,
       # but it'll do for now.
       generatedFiles=`find $api/$api -name '*.cs' | xargs grep -l "// Generated" | sed 's/.*\/.*\//*\\\\*\\\\/g' | tr '\n' ';'`
-
+      
+      # TODO: We still end up with output lines for the service and client, but with nothing
+      # available to be covered or uncovered. Protobuf messages don't appear (which is right!)
+      # so excludebyfile appears to be working. Odd.
       $OPENCOVER \
         -target:"c:\Program Files\dotnet\dotnet.exe" \
         -targetargs:"test -f net451 $DOTNET_TEST_ARGS $testdir" \
-        -output:$coverage/$api.xml \
+        -mergeoutput \
+        -hideskipped:File \
+        -output:$coverage/coverage.xml \
         -oldStyle \
         -filter:"+[$api]*" \
         -searchdirs:$testdir/bin/$CONFIG/net451/win7-x64 \
@@ -85,7 +90,7 @@ done
 if [ -n "$OPENCOVER" -a -n "REPORTGENERATOR" ]
 then
   $REPORTGENERATOR \
-    -reports:$coverage/*.xml \
+    -reports:$coverage/coverage.xml \
     -targetdir:$coverage \
     -verbosity:Error
 fi

--- a/coveralls.sh
+++ b/coveralls.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Only push to coveralls when code is committed; secure variables
+# aren't decoded in pull requests.
+if [ -n "$COVERALLS_REPO_TOKEN" ]
+then
+  nuget install -OutputDirectory packages -Version 0.7.0 coveralls.net
+  packages/coveralls.net.0.7.0/tools/csmacnz.Coveralls.exe --opencover -i coverage/coverage.xml
+fi


### PR DESCRIPTION
This requires us having a single coverage output file, so
we use mergeoutput in OpenCover. At the same time, we can hide
skipped files, so we do that now too.

The coverage reported still isn't really right, but getting it
flowing is a good start.