### PR TITLE
Call dotnet restore suitably when fetching external libraries

### DIFF
--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -3,6 +3,9 @@
 set -e
 
 fetch() {
+  # $1: directory
+  # $2: repo
+  # $3: path to call dotnet restore on
   if [ -d "external/$1" ]
   then
     echo Skipping $1
@@ -10,6 +13,7 @@ fetch() {
   fi
   echo Fetching $1
   git clone https://github.com/$2 external/$1 --quiet --depth=1
+  dotnet restore external/$1/$3
 }
 
 build_api_docs() {
@@ -52,13 +56,13 @@ mkdir output
 mkdir output/assembled
 
 # For Google.Api.Gax and Google.Api.Gax.Rest
-fetch gax-dotnet googleapis/gax-dotnet
+fetch gax-dotnet googleapis/gax-dotnet .
 # For Google.Protobuf
-fetch protobuf google/protobuf
+fetch protobuf google/protobuf .
 # Remove // comments in project.json; dotnet cli is fine with it, but docfx isn't.
 sed -i -r 's/\s+\/\/.*//g' external/protobuf/csharp/src/Google.Protobuf/project.json
 # For Grpc.Core etc
-fetch grpc google/grpc
+fetch grpc google/grpc src/csharp
 
 # TODO: google/google-api-dotnet-client, but those projects
 # don't work with docfx right now


### PR DESCRIPTION
This completes the fix for #327.