### PR TITLE
Add scripts to help with releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ output
 .cr
 packages
 coverage
+releasebuild

--- a/buildrelease.sh
+++ b/buildrelease.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Script to perform a release build for all APIs, based on
+# the tag for a single API version.
+# Sample: buildrelease.sh Google.Pubsub.V1 1.0.0-beta05
+
+# The repo is cloned into a fresh "releasebuild" directory.
+
+set -e
+
+if [ -z "$1" -o -z "$2" ]
+then
+  echo Please specify API name and version
+  exit 1
+fi
+
+tag=$1-$2
+
+# TODO: We don't really want a regex here... just a match.
+git fetch -v --dry-run --tags upstream 2>&1 \
+  | grep -e $tag > /dev/null \
+  || (echo "Tag $tag appears not to exist. Did you run tagrelease.sh?"; exit 1)
+
+# Do everything from the repository root for sanity.
+cd $(dirname $0)
+
+rm -rf releasebuild
+git clone https://github.com/GoogleCloudPlatform/google-cloud-dotnet.git releasebuild
+cd releasebuild
+git checkout $tag
+NOVERSIONSUFFIX=yes ./build.sh
+
+# TODO: Make builddocs.sh cope with being run from any directory.
+cd docs
+./builddocs.sh

--- a/pushrelease.sh
+++ b/pushrelease.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Script to push a release to nuget or myget.
+# Prerequisites:
+# - myget_api_key or nuget_api_key is set appropriately
+# - The release has been created and built (see tagrelease.sh and
+#   buildrelease.sh)
+#
+# Note that buildrelease.sh doesn't have to have been invoked with
+# the same API name and version, so long as the tag is for the same
+# commit.
+
+# Sample: pushrelease.sh Google.Pubsub.V1 1.0.0-beta05
+
+set -e
+
+if [ -z "$1" -o -z "$2" ]
+then
+  echo Please specify API name and version
+  exit 1
+fi
+
+# Start from the repository root for sanity.
+cd $(dirname $0)
+
+if [ ! -d "releasebuild" ]
+then
+  echo Please run the release build first
+  exit 1
+fi
+
+api=$1
+version=$2
+tag="$api"-"$version"
+
+cd releasebuild
+
+git tag | grep -x "$tag" \
+  || (echo "Tag $tag appears not to exist. Did you run tagrelease.sh?"; exit 1)
+
+# Check that they're the same commit...
+tagcommit=`git rev-parse $tag`
+headcommit=`git rev-parse HEAD`
+
+if [ "$tagcommit" != "$headcommit" ]
+then
+  echo "Tag commit ($tagcommit) is not the same as the HEAD commit ($headcommit)"
+  exit 1
+fi
+
+packagefile="apis/$api/$api/bin/Release/$api.$version.nupkg"
+
+if [ ! -e "$packagefile" ]
+then
+  echo "Package file $packagefile not found. Bad build?"
+  exit 1
+fi
+
+# TODO: Do these two in a single block
+[[ $version =~ ^0\..*$ ]] && \
+  nuget_source="https://www.myget.org/F/google-dotnet-public/api/v2/package" || \
+  nuget_source="https://www.nuget.org/api/v2/package"
+
+[[ $version =~ ^0\..*$ ]] && \
+  api_key="$myget_api_key" || \
+  api_key="$nuget_api_key"
+
+if [ -z "$api_key" ]
+then
+  echo "Please set the relevant API key environment variable"
+  exit 1
+fi
+
+echo "Pushing $api version $version to $nuget_source"
+
+nuget push -Source "$nuget_source" -ApiKey "$api_key" "$packagefile"

--- a/tagrelease.sh
+++ b/tagrelease.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Script to create a release (with corresponding tag) on github.
+# Sample: tagrelease.sh Google.Pubsub.V1 1.0.0-beta05
+# Make sure github_access_token is set to a valid github personal
+# access token first.
+
+set -e
+
+if [ -z "$1" -o -z "$2" ]
+then
+  echo Please specify API name and version
+  exit 1
+fi
+
+if [ -z "$github_access_token" ]
+then
+  echo Please set github_access_token first
+  exit
+fi
+
+api=$1
+version=$2
+
+# Do everything from the repository root for sanity.
+cd $(dirname $0)
+
+# Check that the API exists
+if [ ! -d apis/$api ]
+then
+  echo Can\'t find apis/$api\; check for typos
+  exit 1
+fi
+
+# Check that our master is up-to-date with upstream.
+# This will exit with a non-zero error code if the line isn't found.
+# TODO: Is this the best way to do this?
+git fetch -v --dry-run upstream 2>&1 \
+  | grep -E '\[up to date\]\s+master\s+->\s+upstream/master' > /dev/null \
+  || (echo Please update your local git repo before creating a release; exit 1)
+
+echo Creating release for API $api version $version
+
+commit=`git rev-parse master`
+[[ $version =~ ^(0\..*)|(.*-.*)$ ]] && prerelease="true" || prerelease="false"
+
+api_json=`cat << EndOfJson
+{
+  "tag_name": "$api-$version",
+  "target_commitish": "$commit",
+  "name": "$version release of $api",
+  "body": "",
+  "draft": false,
+  "prerelease": $prerelease
+}
+EndOfJson`
+
+# TODO: Work out what to do with the output of this
+curl --data "$api_json" https://api.github.com/repos/GoogleCloudPlatform/google-cloud-dotnet/releases?access_token=$github_access_token
+
+echo Created release $api-$version.
+
+# Plan:
+# Accept API name and version, e.g. tagrelease.sh Google.Pubsub.V1 1.0.0-beta03
+# Check that the local repo is up to date, using git fetch -v --dry-run upstream
+# Check http://www.barrykooij.com/create-github-releases-via-command-line/


### PR DESCRIPTION
Often multiple packages will be released at the same time. The
workflow would be something like:

tagrelease PackageA 1.0.0-beta01
tagrelease PackageB 0.1.0
buildrelease PackageA 1.0.0-beta01
pushrelease PackageA 1.0.0-beta01
pushrelease PackageB 0.1.0

Note only one build step - but the push step will check that
PackageB 0.1.0 really was built.

Separately we may want to consider creating a scripts or build directory at some point...