### PR TITLE
Add favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
         <link rel="stylesheet" href="css/normalize.css">
         <link rel="stylesheet" href="css/github.min.css">
         <link rel="stylesheet" href="css/site.css">
+        <link rel="shortcut icon" href="https://cloud.google.com/images/gcp-favicon.ico">
         <script src="js/vendor/modernizr-2.6.2.min.js"></script>
         <link href='https://fonts.googleapis.com/css?family=Droid+Sans+Mono|Roboto:300,400,700,700italic,400italic|Open+Sans:300' rel='stylesheet' type='text/css'>
     </head>


### PR DESCRIPTION
Add a favicon to the GitHub Pages website. Fixes #422.

**Depending on how the website is built, this change might get blown away on the next update.**