### PR TITLE
Generate XML docs for all APIs

### DIFF
--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/project.json
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1/project.json
+++ b/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true    
   },
 
   "dependencies": {

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/project.json
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true    
   },
 
   "dependencies": {

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/apis/Google.Datastore.V1/Google.Datastore.V1/project.json
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/project.json
+++ b/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/apis/Google.Devtools.Cloudtrace.V1/Google.Devtools.Cloudtrace.V1/project.json
+++ b/apis/Google.Devtools.Cloudtrace.V1/Google.Devtools.Cloudtrace.V1/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/apis/Google.Iam.V1/Google.Iam.V1/project.json
+++ b/apis/Google.Iam.V1/Google.Iam.V1/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/apis/Google.Logging.V2/Google.Logging.Log4Net/project.json
+++ b/apis/Google.Logging.V2/Google.Logging.Log4Net/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/apis/Google.Logging.V2/Google.Logging.Type/project.json
+++ b/apis/Google.Logging.V2/Google.Logging.Type/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/apis/Google.Logging.V2/Google.Logging.V2/project.json
+++ b/apis/Google.Logging.V2/Google.Logging.V2/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/apis/Google.Longrunning/Google.Longrunning/project.json
+++ b/apis/Google.Longrunning/Google.Longrunning/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/apis/Google.Monitoring.V3/Google.Monitoring.V3/project.json
+++ b/apis/Google.Monitoring.V3/Google.Monitoring.V3/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1/project.json
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/apis/Google.Storage.V1/Google.Storage.V1/project.json
+++ b/apis/Google.Storage.V1/Google.Storage.V1/project.json
@@ -14,7 +14,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../GoogleApis.snk"
+    "keyFile": "../../GoogleApis.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {


### PR DESCRIPTION
This currently generates a *lot* of warnings, which will be fixed
in per-API follow-up PRs.