### PR TITLE
Fix Datastore XML docs for hand-written code.

### DIFF
--- a/apis/Google.Datastore.V1/Google.Datastore.V1.IntegrationTests/Google.Datastore.V1.IntegrationTests.xproj
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1.IntegrationTests/Google.Datastore.V1.IntegrationTests.xproj
@@ -11,9 +11,11 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/apis/Google.Datastore.V1/Google.Datastore.V1.Snippets/Google.Datastore.V1.Snippets.xproj
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1.Snippets/Google.Datastore.V1.Snippets.xproj
@@ -11,9 +11,11 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/apis/Google.Datastore.V1/Google.Datastore.V1.Tests/Google.Datastore.V1.Tests.xproj
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1.Tests/Google.Datastore.V1.Tests.xproj
@@ -11,9 +11,11 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/apis/Google.Datastore.V1/Google.Datastore.V1/AsyncLazyDatastoreQuery.cs
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1/AsyncLazyDatastoreQuery.cs
@@ -33,7 +33,7 @@ namespace Google.Datastore.V1
         /// <summary>
         /// Constructs a new instance from the given sequence of responses. This constructor
         /// is only present to facilitate testing; application code will normally obtain instances
-        /// of this class by calling <see cref="DatastoreDb.RunQueryLazily"/>.
+        /// of this class by calling <see cref="DatastoreDb.RunQueryLazilyAsync(Query, ReadOptions.Types.ReadConsistency?, CallSettings)"/>.
         /// </summary>
         /// <remarks>
         /// The sequence of responses will be returned directly from <see cref="AsResponses"/>, and
@@ -73,7 +73,7 @@ namespace Google.Datastore.V1
         /// <summary>
         /// This method is for advanced use cases only, where more diagnostic information is required;
         /// most application code should merely iterate over the query results as <see cref="Entity"/>
-        /// values, or call <see cref="GetAllResults()"/>.
+        /// values, or call <see cref="GetAllResultsAsync"/>.
         /// The results of this query are returned as a sequence of <see cref="RunQueryResponse"/> values
         /// exactly as returned by the Datastore API.
         /// </summary>

--- a/apis/Google.Datastore.V1/Google.Datastore.V1/DatastoreClient.cs
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1/DatastoreClient.cs
@@ -137,7 +137,8 @@ namespace Google.Datastore.V1
 
         /// <summary>
         /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
-        /// <see cref="DatastoreClient.Lookup"/> and <see cref="DatastoreClient.LookupAsync"/>.
+        /// <see cref="DatastoreClient.Lookup(string, ReadOptions, IEnumerable{Key}, CallSettings)"/> and
+        /// <see cref="DatastoreClient.LookupAsync(string, ReadOptions, IEnumerable{Key}, CallSettings)"/>.
         /// </summary>
         /// <remarks>
         /// The default <see cref="DatastoreClient.Lookup"/> and

--- a/apis/Google.Datastore.V1/Google.Datastore.V1/DatastoreDb.cs
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1/DatastoreDb.cs
@@ -188,7 +188,7 @@ namespace Google.Datastore.V1
         /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
         /// multiple times will execute the query again, potentially returning different results.
         /// </remarks>
-        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="gqlQuery">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A <see cref="LazyDatastoreQuery"/> representing the lazy query results.</returns>
@@ -206,7 +206,7 @@ namespace Google.Datastore.V1
         /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
         /// multiple times will execute the query again, potentially returning different results.
         /// </remarks>
-        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="gqlQuery">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>An <see cref="AsyncLazyDatastoreQuery"/> representing the lazy query results.</returns>

--- a/apis/Google.Datastore.V1/Google.Datastore.V1/DatastoreTransaction.cs
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1/DatastoreTransaction.cs
@@ -133,8 +133,6 @@ namespace Google.Datastore.V1
         /// </para>
         /// </remarks>
         /// <param name="query">The query to execute. Must not be null.</param>
-        /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
-        /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A <see cref="LazyDatastoreQuery"/> representing the the lazy query results.</returns>
         public LazyDatastoreQuery RunQueryLazily(Query query, CallSettings callSettings = null)
@@ -167,8 +165,6 @@ namespace Google.Datastore.V1
         /// </para>
         /// </remarks>
         /// <param name="query">The query to execute. Must not be null.</param>
-        /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
-        /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>An <see cref="AsyncLazyDatastoreQuery"/> representing the result of the query.</returns>
         public AsyncLazyDatastoreQuery RunQueryLazilyAsync(Query query, CallSettings callSettings = null)
@@ -198,7 +194,6 @@ namespace Google.Datastore.V1
         /// </para>
         /// </remarks>
         /// <param name="query">The query to execute. Must not be null.</param>
-        /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>The complete query results.</returns>
         public DatastoreQueryResults RunQuery(GqlQuery query, CallSettings callSettings = null) =>
@@ -217,7 +212,6 @@ namespace Google.Datastore.V1
         /// </para>
         /// </remarks>
         /// <param name="query">The query to execute. Must not be null.</param>
-        /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A task representing the asynchronous operation. The result of the task is the complete set of query results.</returns>
         public Task<DatastoreQueryResults> RunQueryAsync(GqlQuery query, CallSettings callSettings = null) =>
@@ -238,9 +232,7 @@ namespace Google.Datastore.V1
         /// multiple times will execute the query again, potentially returning different results.
         /// </para>
         /// </remarks>
-        /// <param name="query">The query to execute. Must not be null.</param>
-        /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
-        /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
+        /// <param name="gqlQuery">The query to execute. Must not be null.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A <see cref="LazyDatastoreQuery"/> representing the result of the query.</returns>
         public LazyDatastoreQuery RunQueryLazily(GqlQuery gqlQuery, CallSettings callSettings = null)
@@ -272,9 +264,7 @@ namespace Google.Datastore.V1
         /// multiple times will execute the query again, potentially returning different results.
         /// </para>
         /// </remarks>
-        /// <param name="query">The query to execute. Must not be null.</param>
-        /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
-        /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
+        /// <param name="gqlQuery">The query to execute. Must not be null.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>An <see cref="AsyncLazyDatastoreQuery"/> representing the result of the query.</returns>
         public AsyncLazyDatastoreQuery RunQueryLazilyAsync(GqlQuery gqlQuery, CallSettings callSettings = null)
@@ -296,7 +286,6 @@ namespace Google.Datastore.V1
         /// </summary>
         /// <remarks>This method simply delegates to <see cref="Lookup(IEnumerable{Key}, CallSettings)"/>.</remarks>
         /// <param name="key">The key to look up. Must not be null, and must be complete.</param>
-        /// <param name="readConsistency">The desired read consistency of the lookup, or null to use the default.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The entity with the specified key, or <c>null</c> if no such entity exists.</returns>
         public Entity Lookup(Key key, CallSettings callSettings = null) => Lookup(new[] { key }, callSettings)[0];
@@ -372,7 +361,6 @@ namespace Google.Datastore.V1
         /// This call may perform multiple RPC operations in order to look up all keys.
         /// </remarks>
         /// <param name="keys">The keys to look up. Must not be null, and every element must be non-null and refer to a complete key.</param>
-        /// <param name="readConsistency">The desired read consistency of the lookup, or null to use the default.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A collection of entities with the same size as <paramref name="keys"/>, containing corresponding entity
         /// references, or <c>null</c> where the key was not found.</returns>

--- a/apis/Google.Datastore.V1/Google.Datastore.V1/EntityPartial.cs
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1/EntityPartial.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using Google.Api.Gax;
+using System;
 
 namespace Google.Datastore.V1
 {

--- a/apis/Google.Datastore.V1/Google.Datastore.V1/LazyDatastoreQuery.cs
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1/LazyDatastoreQuery.cs
@@ -33,7 +33,7 @@ namespace Google.Datastore.V1
         /// <summary>
         /// Constructs a new instance from the given sequence of responses. This constructor
         /// is only present to facilitate testing; application code will normally obtain instances
-        /// of this class by calling <see cref="DatastoreDb.RunQueryLazily"/>.
+        /// of this class by calling <see cref="DatastoreDb.RunQueryLazily(Query, ReadOptions.Types.ReadConsistency?, CallSettings)"/>.
         /// </summary>
         /// <remarks>
         /// The sequence of responses will be returned directly from <see cref="AsResponses"/>, and


### PR DESCRIPTION
There are still warnings in DatastoreClient and DatastoreGrpc.

(Project changes are unrelated but harmless.)