### PR TITLE
Temporary fix for Monitoring generated code

### DIFF
--- a/apis/Google.Monitoring.V3/Google.Monitoring.V3/AgentTranslationServiceClient.cs
+++ b/apis/Google.Monitoring.V3/Google.Monitoring.V3/AgentTranslationServiceClient.cs
@@ -190,6 +190,7 @@ namespace Google.Monitoring.V3
         /// </list>
         /// </remarks>
         public static IReadOnlyList<string> DefaultScopes { get; } = new ReadOnlyCollection<string>(new string[] {
+            "https://www.googleapis.com/auth/cloud-platform"
         });
 
         private static readonly ChannelPool s_channelPool = new ChannelPool(DefaultScopes);

--- a/apis/Google.Monitoring.V3/Google.Monitoring.V3/GroupServiceClient.cs
+++ b/apis/Google.Monitoring.V3/Google.Monitoring.V3/GroupServiceClient.cs
@@ -361,6 +361,7 @@ namespace Google.Monitoring.V3
         /// </list>
         /// </remarks>
         public static IReadOnlyList<string> DefaultScopes { get; } = new ReadOnlyCollection<string>(new string[] {
+            "https://www.googleapis.com/auth/cloud-platform"
         });
 
         private static readonly ChannelPool s_channelPool = new ChannelPool(DefaultScopes);

--- a/apis/Google.Monitoring.V3/Google.Monitoring.V3/MetricServiceClient.cs
+++ b/apis/Google.Monitoring.V3/Google.Monitoring.V3/MetricServiceClient.cs
@@ -394,6 +394,7 @@ namespace Google.Monitoring.V3
         /// </list>
         /// </remarks>
         public static IReadOnlyList<string> DefaultScopes { get; } = new ReadOnlyCollection<string>(new string[] {
+            "https://www.googleapis.com/auth/cloud-platform"
         });
 
         private static readonly ChannelPool s_channelPool = new ChannelPool(DefaultScopes);


### PR DESCRIPTION
This adds a default scope for each of the services in Monitoring.V3,
allowing them to work with service accounts.
The ultimate fix will be in the monitoring.yaml file which is used
as the source when autogenerating code though.