### PR TITLE
Fix DeleteTable and add snippet tests

### DIFF
--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Snippets/BigqueryClientSnippets.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Snippets/BigqueryClientSnippets.cs
@@ -510,6 +510,46 @@ namespace Google.Bigquery.V2.Snippets
             Assert.Equal(originalRows, copiedRows);
         }
 
+        [Fact]
+        public void DeleteTable()
+        {
+            string projectId = _fixture.ProjectId;
+            string datasetId = _fixture.GameDatasetId;
+            string tableId = Guid.NewGuid().ToString().Replace("-", "_");
+            TableSchema schema = new TableSchemaBuilder
+            {
+                { "from_player", BigqueryDbType.String },
+                { "to_player", BigqueryDbType.String },
+                { "message", BigqueryDbType.String }
+            }.Build();
+            BigqueryClient.Create(projectId).CreateTable(datasetId, tableId, schema);
+
+            // Snippet: DeleteTable(string,string,*)
+            BigqueryClient client = BigqueryClient.Create(projectId);
+            client.DeleteTable(datasetId, tableId);
+            // End snippet
+
+            var tables = client.ListTables(datasetId);
+            var ids = tables.Select(ds => ds.Reference.TableId).ToList();
+            Assert.DoesNotContain(tableId, ids);
+        }
+
+        [Fact]
+        public void DeleteDataset()
+        {
+            string projectId = _fixture.ProjectId;
+            string datasetId = _fixture.GenerateDatasetId();
+            BigqueryClient.Create(projectId).CreateDataset(datasetId);
+            // Snippet: DeleteDataset(string,DeleteDatasetOptions)
+            BigqueryClient client = BigqueryClient.Create(projectId);
+            client.DeleteDataset(datasetId);
+            // End snippet
+
+            var datasets = client.ListDatasets();
+            var ids = datasets.Select(ds => ds.Reference.DatasetId).ToList();
+            Assert.DoesNotContain(datasetId, ids);
+        }
+
         private bool WaitForStreamingBufferToEmpty(string tableId)
         {
             var client = BigqueryClient.Create(_fixture.ProjectId);
@@ -521,9 +561,7 @@ namespace Google.Bigquery.V2.Snippets
             }
             return table.Resource.StreamingBuffer == null;
         }
-
-        // TODO: Snippets for DeleteTable and DeleteDataset; they fail with "still in use" at the moment (when just created).
-
+        
         // TODO: Repeated fields and record types.
 
         // TODO:

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryClientImpl.TableCrud.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryClientImpl.TableCrud.cs
@@ -100,7 +100,7 @@ namespace Google.Bigquery.V2
         public override void DeleteTable(TableReference tableReference, DeleteTableOptions options = null)
         {
             GaxRestPreconditions.CheckNotNull(tableReference, nameof(tableReference));
-            var request = Service.Tables.Delete(tableReference.ProjectId, tableReference.TableId, tableReference.TableId);
+            var request = Service.Tables.Delete(tableReference.ProjectId, tableReference.DatasetId, tableReference.TableId);
             options?.ModifyRequest(request);
             request.Execute();
         }


### PR DESCRIPTION
- Fix typo in DeleteTable call
- Use it in snippet tests, which now work for the tables

(I'll separately see if I can now do table/dataset cleanup in the fixture.)

Fixes issue #443