### PR TITLE
Enable Standard SQL by default

### DIFF
--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.IntegrationTests/InsertTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.IntegrationTests/InsertTest.cs
@@ -108,7 +108,7 @@ namespace Google.Bigquery.V2.IntegrationTests
             var queryResults = client.ExecuteQuery($"SELECT guid, position.x, position.y FROM {table} WHERE guid='{guid}'")
                 .PollUntilCompleted()
                 .GetRows()
-                .Select(r => new { Guid = (string)r["guid"], X = (long)r["position_x"], Y = (long)r["position_y"] })
+                .Select(r => new { Guid = (string)r["guid"], X = (long)r["x"], Y = (long)r["y"] })
                 .ToList();
             var expectedResults = new[]
             {
@@ -132,10 +132,10 @@ namespace Google.Bigquery.V2.IntegrationTests
             };
             table.Insert(row);
             // We know the format of Guid.ToString() is harmless. More care needed for arbitrary strings, of course!
-            var queryResults = client.ExecuteQuery($"SELECT guid, tags FROM {table} WHERE guid='{guid}' ORDER BY tags")
+            var queryResults = client.ExecuteQuery($"SELECT guid, tag FROM {table}, UNNEST(tags) AS tag WHERE guid='{guid}' ORDER BY tag")
                 .PollUntilCompleted()
                 .GetRows()
-                .Select(r => new { Guid = (string)r["guid"], Tag = (string)r["tags"] })
+                .Select(r => new { Guid = (string)r["guid"], Tag = (string)r["tag"] })
                 .ToList();
             var expectedResults = new[]
             {
@@ -162,10 +162,10 @@ namespace Google.Bigquery.V2.IntegrationTests
             };
             table.Insert(row);
             // We know the format of Guid.ToString() is harmless. More care needed for arbitrary strings, of course!
-            var queryResults = client.ExecuteQuery($"SELECT guid, names.first, names.last FROM {table} WHERE guid='{guid}' ORDER BY names.first")
+            var queryResults = client.ExecuteQuery($"SELECT guid, name.first, name.last FROM {table}, UNNEST(names) AS name WHERE guid='{guid}' ORDER BY name.first")
                 .PollUntilCompleted()
                 .GetRows()
-                .Select(r => new { Guid = (string)r["guid"], FirstName = (string)r["names_first"], LastName = (string)r["names_last"] })
+                .Select(r => new { Guid = (string)r["guid"], FirstName = (string)r["first"], LastName = (string)r["last"] })
                 .ToList();
             var expectedResults = new[]
             {

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.IntegrationTests/MetadataExplorationTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.IntegrationTests/MetadataExplorationTest.cs
@@ -66,7 +66,7 @@ namespace Google.Bigquery.V2.IntegrationTests
             var dataset = client.GetDataset(PublicDatasetsDataset);
 
             var table = dataset.GetTable("wikipedia");
-            Assert.Equal("bigquery-public-data:samples.wikipedia", table.FullyQualifiedId);
+            Assert.Equal("bigquery-public-data.samples.wikipedia", table.FullyQualifiedId);
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace Google.Bigquery.V2.IntegrationTests
             var client = BigqueryClient.Create(PublicDatasetsProject);
             var table = client.GetTable(PublicDatasetsDataset, "wikipedia");
 
-            Assert.Equal("bigquery-public-data:samples.wikipedia", table.FullyQualifiedId);
+            Assert.Equal("bigquery-public-data.samples.wikipedia", table.FullyQualifiedId);
         }
     }
 }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.IntegrationTests/UploadTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.IntegrationTests/UploadTest.cs
@@ -84,7 +84,7 @@ namespace Google.Bigquery.V2.IntegrationTests
             var afterRows = table.ListRows().ToList();
             Assert.Equal(beforeRowCount + 2, afterRows.Count);
 
-            var sql = $"SELECT player, score FROM {table} WHERE player CONTAINS 'UploadJsonTest' ORDER BY player";
+            var sql = $"SELECT player, score FROM {table} WHERE STARTS_WITH(player, 'UploadJsonTest') ORDER BY player";
             var rows = client.ExecuteQuery(sql).GetRows().ToList();
             Assert.Equal(2, rows.Count);
             Assert.Equal("UploadJsonTest1", (string)rows[0]["player"]);

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Snippets/BigqueryClientSnippets.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Snippets/BigqueryClientSnippets.cs
@@ -44,8 +44,27 @@ namespace Google.Bigquery.V2.Snippets
             var client = BigqueryClient.Create(projectId);
             var table = client.GetTable("bigquery-public-data", "samples", "shakespeare");
 
-            string sql = $"SELECT TOP(corpus, 10) as title, COUNT(*) as unique_words FROM {table}";
+            string sql = $"SELECT corpus AS title, COUNT(word) AS unique_words FROM {table} GROUP BY title ORDER BY unique_words DESC LIMIT 10";
             BigqueryQueryJob query = client.ExecuteQuery(sql).PollUntilCompleted();
+
+            foreach (BigqueryRow row in query.GetRows())
+            {
+                Console.WriteLine($"{row["title"]}: {row["unique_words"]}");
+            }
+            // End sample
+        }
+
+        [Fact]
+        public void LegacySqlOverview()
+        {
+            string projectId = _fixture.ProjectId;
+
+            // Sample: LegacySql
+            var client = BigqueryClient.Create(projectId);
+            var table = client.GetTable("bigquery-public-data", "samples", "shakespeare");
+
+            string sql = $"SELECT TOP(corpus, 10) AS title, COUNT(*) AS unique_words FROM {table:legacy}";
+            BigqueryQueryJob query = client.ExecuteQuery(sql, new ExecuteQueryOptions { UseLegacySql = true }).PollUntilCompleted();
 
             foreach (BigqueryRow row in query.GetRows())
             {

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryTableTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryTableTest.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2.Data;
+using Moq;
+using Xunit;
+
+namespace Google.Bigquery.V2.Tests
+{
+    public class BigqueryTableTest
+    {
+        [Fact]
+        public void StringConversions()
+        {
+            var table = CreateTable("project", "dataset", "table");
+            var legacy = "[project:dataset.table]";
+            var standard = "`project.dataset.table`";
+            Assert.Equal(standard, table.ToString());
+            Assert.Equal(legacy, table.ToLegacySqlFormat());
+            Assert.Equal(standard, table.ToString(null, null));
+            Assert.Equal(standard, table.ToString("not legacy", null));
+            Assert.Equal(legacy, table.ToString("legacy", null));
+        }
+
+        /// <summary>
+        /// Creates a BigqueryTable with just the ID populated.
+        /// </summary>
+        private static BigqueryTable CreateTable(string projectId, string datasetId, string tableId)
+        {
+            var table = new Table
+            {
+                TableReference = new TableReference { ProjectId = projectId, DatasetId = datasetId, TableId = tableId }
+            };
+            return new BigqueryTable(new Mock<BigqueryClient>().Object, table);
+        }
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/CreateQueryJobOptionsTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/CreateQueryJobOptionsTest.cs
@@ -30,9 +30,11 @@ namespace Google.Bigquery.V2.Tests
                 DestinationTable = new TableReference { ProjectId = "a", DatasetId = "b", TableId = "c" },
                 FlattenResults = false,
                 MaximumBillingTier = 10,
+                MaximumBytesBilled = 1000,
                 Priority = QueryPriority.Batch, 
                 UseQueryCache = false,
-                WriteDisposition = WriteDisposition.WriteIfEmpty
+                WriteDisposition = WriteDisposition.WriteIfEmpty,
+                UseLegacySql = true
             };
 
             JobConfigurationQuery query = new JobConfigurationQuery();
@@ -43,9 +45,11 @@ namespace Google.Bigquery.V2.Tests
             Assert.Equal("c", query.DestinationTable.TableId);
             Assert.Equal(false, query.FlattenResults);
             Assert.Equal(10, query.MaximumBillingTier);
+            Assert.Equal(1000, query.MaximumBytesBilled);
             Assert.Equal("BATCH", query.Priority);
             Assert.Equal(false, query.UseQueryCache);
             Assert.Equal("WRITE_EMPTY", query.WriteDisposition);
+            Assert.Equal(true, query.UseLegacySql);
         }
     }
 }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/ExecuteQueryOptionsTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/ExecuteQueryOptionsTest.cs
@@ -26,13 +26,15 @@ namespace Google.Bigquery.V2.Tests
             {
                 DefaultDataset = new DatasetReference { ProjectId = "a", DatasetId = "b" },
                 PageSize = 25,
-                UseQueryCache = false
+                UseQueryCache = false,
+                UseLegacySql = true
             };
             var request = new QueryRequest();
             options.ModifyRequest(request);
             Assert.Equal(25, request.MaxResults);
             Assert.Equal("a", request.DefaultDataset.ProjectId);
             Assert.Equal(false, request.UseQueryCache);
+            Assert.Equal(true, request.UseLegacySql);
         }
     }
 }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/project.json
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/project.json
@@ -9,6 +9,7 @@
     "Google.Bigquery.V2": { "target": "project" },
     "Google.Cloud.ClientTesting": { "target": "project" },
     "xunit": "2.2.0-beta2-build3300",
+    "Moq": "4.6.36-alpha",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryClientImpl.Queries.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryClientImpl.Queries.cs
@@ -46,7 +46,7 @@ namespace Google.Bigquery.V2
         {
             GaxRestPreconditions.CheckNotNull(sql, nameof(sql));
 
-            var queryRequest = new Apis.Bigquery.v2.Data.QueryRequest { Query = sql };
+            var queryRequest = new QueryRequest { Query = sql, UseLegacySql = false };
             options?.ModifyRequest(queryRequest);
             var request = Service.Jobs.Query(queryRequest, ProjectId);
             var queryResponse = request.Execute();
@@ -57,7 +57,7 @@ namespace Google.Bigquery.V2
         public override BigqueryJob CreateQueryJob(string sql, CreateQueryJobOptions options = null)
         {
             GaxRestPreconditions.CheckNotNull(sql, nameof(sql));
-            var query = new JobConfigurationQuery { Query = sql };
+            var query = new JobConfigurationQuery { Query = sql, UseLegacySql = false };
             options?.ModifyRequest(query);
             var job = Service.Jobs.Insert(new Job
             {

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/CreateQueryJobOptions.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/CreateQueryJobOptions.cs
@@ -75,9 +75,23 @@ namespace Google.Bigquery.V2
         public int? MaximumBillingTier { get; set; }
 
         /// <summary>
+        /// Limits the bytes billed for this job. Queries that will have bytes billed beyond this limit will fail (without incurring a charge).
+        /// If not set, this is effectively the project default.
+        /// </summary>
+        public long? MaximumBytesBilled { get; set; }
+
+        /// <summary>
         /// The priority of the query.
         /// </summary>
         public QueryPriority? Priority { get; set; }
+
+        // Note: we default the JobConfigurationQuery to set UseLegacySql to false
+        // in BigqueryClientImpl. This option is nullable for potential merging purposes.
+
+        /// <summary>
+        /// Set to true to use legacy SQL instead of standard SQL.
+        /// </summary>
+        public bool? UseLegacySql { get; set; }
 
         internal void ModifyRequest(JobConfigurationQuery query)
         {
@@ -107,6 +121,10 @@ namespace Google.Bigquery.V2
             {
                 query.MaximumBillingTier = MaximumBillingTier;
             }
+            if (MaximumBytesBilled != null)
+            {
+                query.MaximumBytesBilled = MaximumBytesBilled;
+            }
             if (Priority != null)
             {
                 query.Priority = EnumMap<QueryPriority>.ToApiValue(Priority.Value);
@@ -118,6 +136,10 @@ namespace Google.Bigquery.V2
             if (WriteDisposition != null)
             {
                 query.WriteDisposition = EnumMap<WriteDisposition>.ToApiValue(WriteDisposition.Value);
+            }
+            if (UseLegacySql != null)
+            {
+                query.UseLegacySql = UseLegacySql;
             }
         }
     }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/ExecuteQueryOptions.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/ExecuteQueryOptions.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Google.Apis.Bigquery.v2.Data;
-using System;
 
 namespace Google.Bigquery.V2
 {
@@ -40,6 +39,14 @@ namespace Google.Bigquery.V2
         /// </summary>
         public DatasetReference DefaultDataset { get; set; }
 
+        // Note: we default the QueryRequest to set UseLegacySql to false
+        // in BigqueryClientImpl. This option is nullable for potential merging purposes.
+
+        /// <summary>
+        /// Set to true to use legacy SQL instead of standard SQL.
+        /// </summary>
+        public bool? UseLegacySql { get; set; }
+
         internal void ModifyRequest(QueryRequest request)
         {
             if (PageSize != null)
@@ -54,6 +61,10 @@ namespace Google.Bigquery.V2
             {
                 request.DefaultDataset = DefaultDataset;
             }
+            if (UseLegacySql != null)
+            {
+                request.UseLegacySql = UseLegacySql;
+            }
 
             // TODO: more options. DryRun would be useful, but we have no way of returning the results...
         }
@@ -65,7 +76,7 @@ namespace Google.Bigquery.V2
         internal GetQueryResultsOptions ToGetQueryResultsOptions() =>
             new GetQueryResultsOptions
             {
-                PageSize = PageSize                
+                PageSize = PageSize
             };
     }
 }

--- a/apis/Google.Bigquery.V2/docs/index.md
+++ b/apis/Google.Bigquery.V2/docs/index.md
@@ -33,10 +33,21 @@ with datasets, tables and query results simpler.
 
 # Sample code
 
-Querying:
+## Querying
 
 [!code-cs[](obj/snippets/Google.Bigquery.V2.BigqueryClient.txt#QueryOverview)]
 
-Data insertion:
+## Using legacy SQL
+
+By default, [BigqueryClient](obj/api/Google.Bigquery.V2.BigqueryClient.yml)
+uses [Standard SQL](https://cloud.google.com/bigquery/sql-reference/). To
+use [Legacy SQL](https://cloud.google.com/bigquery/query-reference),
+simply set `UseLegacySql` to true in the query options, and make
+sure that you use the legacy format for the table name, as shown
+below.
+
+[!code-cs[](obj/snippets/Google.Bigquery.V2.BigqueryClient.txt#LegacySql)]
+
+## Data insertion
 
 [!code-cs[](obj/snippets/Google.Bigquery.V2.BigqueryClient.txt#InsertOverview)]


### PR DESCRIPTION
A new option allows Legacy SQL on an opt-in basis.

Fixes #459.