### PR TITLE
Expose new gRPC methods to create IAM clients.

### DIFF
--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1.sln
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1.sln
@@ -7,6 +7,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Pubsub.V1", "Google.
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Pubsub.V1.Snippets", "Google.Pubsub.V1.Snippets\Google.Pubsub.V1.Snippets.xproj", "{60E5F4C2-7A10-41F1-A247-14C346A8E33A}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Iam.V1", "..\Google.Iam.V1\Google.Iam.V1\Google.Iam.V1.xproj", "{8BF4C91C-5611-444B-8550-D67DEBAF72F1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{60E5F4C2-7A10-41F1-A247-14C346A8E33A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{60E5F4C2-7A10-41F1-A247-14C346A8E33A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{60E5F4C2-7A10-41F1-A247-14C346A8E33A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BF4C91C-5611-444B-8550-D67DEBAF72F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BF4C91C-5611-444B-8550-D67DEBAF72F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BF4C91C-5611-444B-8550-D67DEBAF72F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BF4C91C-5611-444B-8550-D67DEBAF72F1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1/PubsubGrpc.cs
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1/PubsubGrpc.cs
@@ -21,6 +21,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
+using static Google.Iam.V1.IAMPolicy;
 
 namespace Google.Pubsub.V1 {
   /// <summary>
@@ -224,6 +225,15 @@ namespace Google.Pubsub.V1 {
       protected SubscriberClient(ClientBaseConfiguration configuration) : base(configuration)
       {
       }
+      
+      // IMPLEMENTATION NOTE: This will be in a partial class eventually.
+
+      /// <summary>
+      /// Creates a new instance of <see cref="IAMPolicyClient"/> using the same call invoker
+      /// as this client.
+      /// </summary>
+      /// <returns>A new IAM client for the same target as this client.</returns>
+      public virtual IAMPolicyClient CreateIAMPolicyClient() => new IAMPolicyClient(CallInvoker);
 
       /// <summary>
       ///  Creates a subscription to a given topic.
@@ -730,6 +740,15 @@ namespace Google.Pubsub.V1 {
       protected PublisherClient(ClientBaseConfiguration configuration) : base(configuration)
       {
       }
+
+      // IMPLEMENTATION NOTE: This will be in a partial class eventually.
+
+      /// <summary>
+      /// Creates a new instance of <see cref="IAMPolicyClient"/> using the same call invoker
+      /// as this client.
+      /// </summary>
+      /// <returns>A new IAM client for the same target as this client.</returns>
+      public virtual IAMPolicyClient CreateIAMPolicyClient() => new IAMPolicyClient(CallInvoker);
 
       /// <summary>
       ///  Creates the given topic with the given name.

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1/project.json
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1/project.json
@@ -22,6 +22,7 @@
     "Google.Api.CommonProtos": "1.0.0-beta02",
     "Google.Api.Gax.Grpc": "1.0.0-beta03",
     "Google.Apis.Auth": "1.16.0",
+    "Google.Iam.V1": { "target": "project" },
     "Google.Protobuf": "3.0.0",
     "Grpc.Auth": "1.0.1-pre1",
     "Grpc.Core": "1.0.1-pre1",

--- a/apis/global.json
+++ b/apis/global.json
@@ -2,6 +2,7 @@
   "projects": [
     "Google.Storage.V1",
     "Google.Longrunning",
+    "Google.Iam.V1",
     "../tools"
   ],
   "sdk": {


### PR DESCRIPTION
This is ugly at the moment, modifying generated code. We have filed
https://github.com/grpc/grpc/issues/8506 to allow gRPC to generate
partial classes, at which point the change can be in a separate file.

The purpose of these methods is to allow for toolkit code to
create a gRPC client appropriately to expose IAM methods on both
PublisherClient and SubscriberClient.