### PR TITLE
Improve unit test coverage of BigQuery

### DIFF
--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryClientImplTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryClientImplTest.cs
@@ -1,0 +1,208 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2.Data;
+using System.Linq;
+using Xunit;
+using static Google.Apis.Bigquery.v2.Data.DatasetList;
+using static Google.Apis.Bigquery.v2.Data.JobList;
+using static Google.Apis.Bigquery.v2.Data.ProjectList;
+
+namespace Google.Bigquery.V2.Tests
+{
+    public class BigqueryClientImplTest
+    {
+        [Fact]
+        public void ListProjects()
+        {
+            var projectId = "project";
+            var service = new FakeBigqueryService();
+            var client = new BigqueryClientImpl(projectId, service);
+            var reference = client.GetProjectReference(projectId);
+            service.ExpectRequest(
+                service.Projects.List(),
+                new ProjectList { Projects = new[] { new ProjectsData { ProjectReference = reference } } });
+            var result = client.ListProjects();
+            var dataset = result.Single();
+            Assert.Equal(projectId, dataset.Reference.ProjectId);
+        }
+
+        [Fact]
+        public void CreateDataset()
+        {
+            var projectId = "project";
+            var datasetId = "dataset";
+            var service = new FakeBigqueryService();
+            var client = new BigqueryClientImpl(projectId, service);
+            var reference = client.GetDatasetReference(projectId, datasetId);
+            service.ExpectRequest(
+                service.Datasets.Insert(new Dataset { DatasetReference = reference }, projectId),
+                new Dataset { DatasetReference = reference });
+            var result = client.CreateDataset(reference);
+            Assert.Equal(projectId, result.Reference.ProjectId);
+            Assert.Equal(datasetId, result.Reference.DatasetId);
+        }
+
+        [Fact]
+        public void GetDataset()
+        {
+            var projectId = "project";
+            var datasetId = "dataset";
+            var service = new FakeBigqueryService();
+            var client = new BigqueryClientImpl(projectId, service);
+            var reference = client.GetDatasetReference(projectId, datasetId);
+            service.ExpectRequest(
+                service.Datasets.Get(projectId, datasetId),
+                new Dataset { DatasetReference = reference });
+            var result = client.GetDataset(reference);
+            Assert.Equal(projectId, result.Reference.ProjectId);
+            Assert.Equal(datasetId, result.Reference.DatasetId);
+        }
+
+        [Fact]
+        public void ListDatasets()
+        {
+            var projectId = "project";
+            var datasetId = "dataset";
+            var service = new FakeBigqueryService();
+            var client = new BigqueryClientImpl(projectId, service);
+            var projectReference = client.GetProjectReference(projectId);
+            var datasetReference = client.GetDatasetReference(projectId, datasetId);
+            service.ExpectRequest(
+                service.Datasets.List(projectId),
+                new DatasetList { Datasets = new[] { new DatasetsData { DatasetReference = datasetReference } } });
+            var result = client.ListDatasets(projectReference);
+            var dataset = result.Single();
+            Assert.Equal(projectId, dataset.Reference.ProjectId);
+            Assert.Equal(datasetId, dataset.Reference.DatasetId);
+        }
+
+        [Fact]
+        public void DeleteDataset()
+        {
+            var projectId = "project";
+            var datasetId = "dataset";
+            var service = new FakeBigqueryService();
+            var client = new BigqueryClientImpl(projectId, service);
+            var reference = client.GetDatasetReference(projectId, datasetId);
+            service.ExpectRequest(
+                service.Datasets.Delete(projectId, datasetId),
+                "OK");
+            client.DeleteDataset(reference);
+        }
+
+        [Fact]
+        public void CreateTable()
+        {
+            var projectId = "project";
+            var datasetId = "dataset";
+            var tableId = "table";
+            var service = new FakeBigqueryService();
+            var client = new BigqueryClientImpl(projectId, service);
+            var reference = client.GetTableReference(projectId, datasetId, tableId);
+            var schema = new TableSchemaBuilder { { "column", BigqueryDbType.Integer } }.Build();
+            service.ExpectRequest(
+                service.Tables.Insert(new Table { TableReference = reference, Schema = schema }, projectId, datasetId),
+                new Table { TableReference = reference, Schema = schema });
+            var result = client.CreateTable(reference, schema);
+            Assert.Equal(projectId, result.Reference.ProjectId);
+            Assert.Equal(datasetId, result.Reference.DatasetId);
+            Assert.Equal(tableId, result.Reference.TableId);
+            Assert.Equal("column", result.Schema.Fields[0].Name);
+        }
+
+        [Fact]
+        public void GetTable()
+        {
+            var projectId = "project";
+            var datasetId = "dataset";
+            var tableId = "table";
+            var service = new FakeBigqueryService();
+            var client = new BigqueryClientImpl(projectId, service);
+            var reference = client.GetTableReference(projectId, datasetId, tableId);
+            service.ExpectRequest(
+                service.Tables.Get(projectId, datasetId, tableId),
+                new Table { TableReference = reference });
+            var result = client.GetTable(reference);
+            Assert.Equal(projectId, result.Reference.ProjectId);
+            Assert.Equal(datasetId, result.Reference.DatasetId);
+            Assert.Equal(tableId, result.Reference.TableId);
+        }
+
+        [Fact]
+        public void DeleteTable()
+        {
+            var projectId = "project";
+            var datasetId = "dataset";
+            var tableId = "table";
+            var service = new FakeBigqueryService();
+            var client = new BigqueryClientImpl(projectId, service);
+            var reference = client.GetTableReference(projectId, datasetId, tableId);
+            service.ExpectRequest(
+                service.Tables.Delete(projectId, datasetId, tableId),
+                "OK");
+            client.DeleteTable(reference);
+        }
+
+        [Fact]
+        public void GetJob()
+        {
+            var projectId = "project";
+            var jobId = "job";
+            var service = new FakeBigqueryService();
+            var client = new BigqueryClientImpl(projectId, service);
+            var reference = client.GetJobReference(projectId, jobId);
+            service.ExpectRequest(
+                service.Jobs.Get(projectId, jobId),
+                new Job { JobReference = reference });
+            var result = client.GetJob(reference);
+            Assert.Equal(projectId, result.Reference.ProjectId);
+            Assert.Equal(jobId, result.Reference.JobId);
+        }
+
+        [Fact]
+        public void ListJobs()
+        {
+            var projectId = "project";
+            var jobId = "job";
+            var service = new FakeBigqueryService();
+            var client = new BigqueryClientImpl(projectId, service);
+            var projectReference = client.GetProjectReference(projectId);
+            var jobReference = client.GetJobReference(projectId, jobId);
+            service.ExpectRequest(
+                service.Jobs.List(projectId),
+                new JobList { Jobs = new[] { new JobsData { JobReference = jobReference } } });
+            var result = client.ListJobs(projectReference);
+            var job = result.Single();
+            Assert.Equal(projectId, job.Reference.ProjectId);
+            Assert.Equal(jobId, job.Reference.JobId);
+        }
+
+        [Fact]
+        public void CancelJob()
+        {
+            var projectId = "project";
+            var jobId = "job";
+            var service = new FakeBigqueryService();
+            var client = new BigqueryClientImpl(projectId, service);
+            var reference = client.GetJobReference(projectId, jobId);
+            service.ExpectRequest(
+                service.Jobs.Cancel(projectId, jobId),
+                new JobCancelResponse { Job = new Job { JobReference = reference } });
+            var result = client.CancelJob(reference);
+            Assert.Equal(projectId, result.Reference.ProjectId);
+            Assert.Equal(jobId, result.Reference.JobId);
+        }
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryClientTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryClientTest.cs
@@ -12,27 +12,48 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax;
+using Google.Api.Gax.Rest;
+using Google.Apis.Bigquery.v2.Data;
 using Google.Cloud.ClientTesting;
+using Moq;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
+using System.Collections;
+using System.IO;
 
 namespace Google.Bigquery.V2.Tests
 {
     public class BigqueryClientTest : AbstractClientTester<BigqueryClient, BigqueryClientTest.DerivedBigqueryClient>
     {
-        // The Get*Reference methods are actually implemented...
+        private const string ProjectId = "sample-project";
+
         public static IEnumerable<object[]> NotImplementedMethods => AllInstanceMethods
             .Where(array =>
             {
                 var method = (MethodInfo)array[0];
-                return !(method.Name.StartsWith("Get") && method.Name.EndsWith("Reference"));
+                // The Get*Reference methods are actually implemented...
+                if (method.Name.StartsWith("Get") && method.Name.EndsWith("Reference"))
+                {
+                    return false;
+                }
+                // For methods with overloads, where there's a "core" overload accepting a *Reference type,
+                // only check that that one is not implemented - the others should be tested for delegation
+                // separately. (Testing them here creates confusing coverage.)
+                var overloads = typeof(BigqueryClient).GetTypeInfo().GetDeclaredMethods(method.Name);
+                var referenceAcceptingOverload = overloads.FirstOrDefault(
+                    o => o.GetParameters().FirstOrDefault()?.ParameterType.Name.EndsWith("Reference") == true);
+                return referenceAcceptingOverload == null || referenceAcceptingOverload == method;
             });
 
         public class DerivedBigqueryClient : BigqueryClient
         {
-            public override string ProjectId => "project";
+            public override string ProjectId => BigqueryClientTest.ProjectId;
         }
 
         [Theory]
@@ -56,7 +77,7 @@ namespace Google.Bigquery.V2.Tests
         {
             var reference = new DerivedBigqueryClient().GetJobReference("jobid");
             Assert.Equal("jobid", reference.JobId);
-            Assert.Equal("project", reference.ProjectId);
+            Assert.Equal(ProjectId, reference.ProjectId);
         }
 
         [Fact]
@@ -73,7 +94,7 @@ namespace Google.Bigquery.V2.Tests
             var reference = new DerivedBigqueryClient().GetTableReference("datasetid", "tableid");
             Assert.Equal("datasetid", reference.DatasetId);
             Assert.Equal("tableid", reference.TableId);
-            Assert.Equal("project", reference.ProjectId);
+            Assert.Equal(ProjectId, reference.ProjectId);
         }
 
         [Fact]
@@ -90,7 +111,7 @@ namespace Google.Bigquery.V2.Tests
         {
             var reference = new DerivedBigqueryClient().GetDatasetReference("datasetid");
             Assert.Equal("datasetid", reference.DatasetId);
-            Assert.Equal("project", reference.ProjectId);
+            Assert.Equal(ProjectId, reference.ProjectId);
         }
 
         [Fact]
@@ -106,6 +127,381 @@ namespace Google.Bigquery.V2.Tests
         {
             var reference = new DerivedBigqueryClient().GetProjectReference("p");
             Assert.Equal("p", reference.ProjectId);
+        }
+
+        [Fact]
+        public void CreateDatasetEquivalents()
+        {
+            var datasetId = "dataset";
+            var reference = GetDatasetReference(datasetId);
+            var options = new CreateDatasetOptions();
+            VerifyEquivalent(new BigqueryDataset(new DerivedBigqueryClient(), GetDataset(reference)),
+                client => client.CreateDataset(MatchesWhenSerialized(reference), options),
+                client => client.CreateDataset(datasetId, options),
+                client => client.CreateDataset(ProjectId, datasetId, options));
+        }
+
+        [Fact]
+        public void DeleteDatasetEquivalents()
+        {
+            var datasetId = "dataset";
+            var reference = GetDatasetReference(datasetId);
+            var options = new DeleteDatasetOptions();
+            VerifyEquivalent(
+                client => client.DeleteDataset(MatchesWhenSerialized(reference), options),
+                client => client.DeleteDataset(datasetId, options),
+                client => client.DeleteDataset(ProjectId, datasetId, options));
+        }
+
+        [Fact]
+        public void GetDatasetEquivalents()
+        {
+            var datasetId = "dataset";
+            var reference = GetDatasetReference(datasetId);
+            var options = new GetDatasetOptions();
+            VerifyEquivalent(new BigqueryDataset(new DerivedBigqueryClient(), GetDataset(reference)),
+                client => client.GetDataset(MatchesWhenSerialized(reference), options),
+                client => client.GetDataset(datasetId, options),
+                client => client.GetDataset(ProjectId, datasetId, options));
+        }
+
+        [Fact]
+        public void GetOrCreateDatasetEquivalents()
+        {
+            var datasetId = "dataset";
+            var reference = GetDatasetReference(datasetId);
+            var getOptions = new GetDatasetOptions();
+            var createOptions = new CreateDatasetOptions();
+            VerifyEquivalent(new BigqueryDataset(new DerivedBigqueryClient(), GetDataset(reference)),
+                client => client.GetOrCreateDataset(MatchesWhenSerialized(reference), getOptions, createOptions),
+                client => client.GetOrCreateDataset(datasetId, getOptions, createOptions),
+                client => client.GetOrCreateDataset(ProjectId, datasetId, getOptions, createOptions));
+        }
+
+        [Fact]
+        public void ListDatasetsEquivalents()
+        {
+            var reference = new ProjectReference { ProjectId = ProjectId };
+            var options = new ListDatasetsOptions();
+            VerifyEquivalent(new UnimplementedPagedEnumerable<DatasetList, BigqueryDataset>(),
+                client => client.ListDatasets(MatchesWhenSerialized(reference), options),
+                client => client.ListDatasets(options),
+                client => client.ListDatasets(ProjectId, options));
+        }
+
+        [Fact]
+        public void CreateTableEquivalents()
+        {
+            var datasetId = "dataset";
+            var tableId = "table";
+            var schema = new TableSchemaBuilder().Build();
+            var reference = GetTableReference(datasetId, tableId);
+            var options = new CreateTableOptions();
+            VerifyEquivalent(new BigqueryTable(new DerivedBigqueryClient(), GetTable(reference)),
+                client => client.CreateTable(MatchesWhenSerialized(reference), schema, options),
+                client => client.CreateTable(datasetId, tableId, schema, options),
+                client => client.CreateTable(ProjectId, datasetId, tableId, schema, options),
+                client => new BigqueryDataset(client, GetDataset(datasetId)).CreateTable(tableId, schema, options));
+        }
+
+        [Fact]
+        public void DeleteTableEquivalents()
+        {
+            var datasetId = "dataset";
+            var tableId = "table";
+            var schema = new TableSchemaBuilder().Build();
+            var reference = GetTableReference(datasetId, tableId);
+            var options = new DeleteTableOptions();
+            VerifyEquivalent(
+                client => client.DeleteTable(MatchesWhenSerialized(reference), options),
+                client => client.DeleteTable(datasetId, tableId, options),
+                client => client.DeleteTable(ProjectId, datasetId, tableId, options),
+                client => new BigqueryTable(client, new Table { TableReference = reference }).Delete(options));
+        }
+
+        [Fact]
+        public void GetTableEquivalents()
+        {
+            var datasetId = "dataset";
+            var tableId = "table";
+            var reference = GetTableReference(datasetId, tableId);
+            var options = new GetTableOptions();
+            VerifyEquivalent(new BigqueryTable(new DerivedBigqueryClient(), GetTable(reference)),
+                client => client.GetTable(MatchesWhenSerialized(reference), options),
+                client => client.GetTable(datasetId, tableId, options),
+                client => client.GetTable(ProjectId, datasetId, tableId, options),
+                client => new BigqueryDataset(client, GetDataset(datasetId)).GetTable(tableId, options));
+        }
+
+        [Fact]
+        public void GetOrCreateTableEquivalents()
+        {
+            var datasetId = "dataset";
+            var tableId = "table";
+            var schema = new TableSchemaBuilder().Build();
+            var reference = GetTableReference(datasetId, tableId);
+            var getOptions = new GetTableOptions();
+            var createOptions = new CreateTableOptions();
+            VerifyEquivalent(new BigqueryTable(new DerivedBigqueryClient(), GetTable(reference)),
+                client => client.GetOrCreateTable(MatchesWhenSerialized(reference), schema, getOptions, createOptions),
+                client => client.GetOrCreateTable(datasetId, tableId, schema, getOptions, createOptions),
+                client => client.GetOrCreateTable(ProjectId, datasetId, tableId, schema, getOptions, createOptions),
+                client => new BigqueryDataset(client, GetDataset(datasetId)).GetOrCreateTable(tableId, schema, getOptions, createOptions));
+        }
+
+        [Fact]
+        public void ListTablesEquivalents()
+        {
+            var datasetId = "dataset";
+            var reference = GetDatasetReference(datasetId);
+            var options = new ListTablesOptions();
+            VerifyEquivalent(new UnimplementedPagedEnumerable<TableList, BigqueryTable>(),
+                client => client.ListTables(MatchesWhenSerialized(reference), options),
+                client => client.ListTables(datasetId, options),
+                client => client.ListTables(ProjectId, datasetId, options),
+                client => new BigqueryDataset(client, GetDataset(datasetId)).ListTables(options));
+        }
+
+        [Fact]
+        public void GetJobEquivalents()
+        {
+            var jobId = "job";
+            var reference = GetJobReference(jobId);
+            var options = new GetJobOptions();
+            VerifyEquivalent(new BigqueryJob(new DerivedBigqueryClient(), GetJob(reference)),
+                client => client.GetJob(MatchesWhenSerialized(reference), options),
+                client => client.GetJob(jobId, options),
+                client => client.GetJob(ProjectId, jobId, options));
+        }
+
+        [Fact]
+        public void CancelJobEquivalents()
+        {
+            var jobId = "job";
+            var reference = GetJobReference(jobId);
+            var options = new CancelJobOptions();
+            VerifyEquivalent(new BigqueryJob(new DerivedBigqueryClient(), GetJob(reference)),
+                client => client.CancelJob(MatchesWhenSerialized(reference), options),
+                client => client.CancelJob(jobId, options),
+                client => client.CancelJob(ProjectId, jobId, options),
+                client => new BigqueryJob(client, GetJob(reference)).Cancel(options));
+        }
+
+        [Fact]
+        public void PollJobUntilCompletedEquivalents()
+        {
+            var jobId = "job";
+            var reference = GetJobReference(jobId);
+            var options = new PollJobOptions();
+            VerifyEquivalent(new BigqueryJob(new DerivedBigqueryClient(), GetJob(reference)),
+                client => client.PollJobUntilCompleted(MatchesWhenSerialized(reference), options),
+                client => client.PollJobUntilCompleted(jobId, options),
+                client => client.PollJobUntilCompleted(ProjectId, jobId, options),
+                client => new BigqueryJob(client, GetJob(reference)).PollUntilCompleted(options));
+        }
+
+        [Fact]
+        public void PollQueryUntilCompletedEquivalents()
+        {
+            var jobId = "job";
+            var reference = GetJobReference(jobId);
+            var getQueryResultsOptions = new GetQueryResultsOptions();
+            var pollOptions = new PollJobOptions();
+            VerifyEquivalent(
+                new BigqueryQueryJob(new DerivedBigqueryClient(), new GetQueryResultsResponse { JobReference = reference }, getQueryResultsOptions),
+                client => client.PollQueryUntilCompleted(MatchesWhenSerialized(reference), getQueryResultsOptions, pollOptions),
+                client => client.PollQueryUntilCompleted(jobId, getQueryResultsOptions, pollOptions),
+                client => client.PollQueryUntilCompleted(ProjectId, jobId, getQueryResultsOptions, pollOptions),
+                client => new BigqueryJob(client, GetJob(reference)).PollQueryUntilCompleted(getQueryResultsOptions, pollOptions),
+                client => new BigqueryQueryJob(client, new GetQueryResultsResponse { JobReference = reference }, getQueryResultsOptions).PollUntilCompleted(pollOptions));
+        }
+
+        [Fact]
+        public void ListJobsEquivalents()
+        {
+            var reference = new ProjectReference { ProjectId = ProjectId };
+            var options = new ListJobsOptions();
+            VerifyEquivalent(new UnimplementedPagedEnumerable<JobList, BigqueryJob>(),
+                client => client.ListJobs(MatchesWhenSerialized(reference), options),
+                client => client.ListJobs(options),
+                client => client.ListJobs(ProjectId, options));
+        }
+
+        [Fact]
+        public void ListRowsEquivalents()
+        {
+            var datasetId = "dataset";
+            var tableId = "table";
+            var reference = GetTableReference(datasetId, tableId);
+            var schema = new TableSchemaBuilder().Build();
+            var options = new ListRowsOptions();
+            VerifyEquivalent(new UnimplementedPagedEnumerable<TableDataList, BigqueryRow>(),
+                client => client.ListRows(MatchesWhenSerialized(reference), schema, options),
+                client => client.ListRows(datasetId, tableId, schema, options),
+                client => client.ListRows(ProjectId, datasetId, tableId, schema, options),
+                client => new BigqueryTable(client, GetTable(reference, schema)).ListRows(options));
+        }
+
+        [Fact]
+        public void UploadCsvEquivalents()
+        {
+            var datasetId = "dataset";
+            var tableId = "table";
+            var jobReference = GetJobReference("job");
+            var tableReference = GetTableReference(datasetId, tableId);
+            var schema = new TableSchemaBuilder().Build();
+            var options = new UploadCsvOptions();
+            var stream = new MemoryStream();
+            VerifyEquivalent(new BigqueryJob(new DerivedBigqueryClient(), new Job { JobReference = jobReference }),
+                client => client.UploadCsv(MatchesWhenSerialized(tableReference), schema, stream, options),
+                client => client.UploadCsv(datasetId, tableId, schema, stream, options),
+                client => client.UploadCsv(ProjectId, datasetId, tableId, schema, stream, options),
+                client => new BigqueryTable(client, GetTable(tableReference, schema)).UploadCsv(stream, options));
+        }
+
+        [Fact]
+        public void UploadJsonEquivalents()
+        {
+            var datasetId = "dataset";
+            var tableId = "table";
+            var jobReference = GetJobReference("job");
+            var tableReference = GetTableReference(datasetId, tableId);
+            var schema = new TableSchemaBuilder().Build();
+            var options = new UploadJsonOptions();
+            var stream = new MemoryStream();
+            VerifyEquivalent(new BigqueryJob(new DerivedBigqueryClient(), new Job { JobReference = jobReference }),
+                client => client.UploadJson(MatchesWhenSerialized(tableReference), schema, stream, options),
+                client => client.UploadJson(datasetId, tableId, schema, stream, options),
+                client => client.UploadJson(ProjectId, datasetId, tableId, schema, stream, options),
+                client => new BigqueryTable(client, GetTable(tableReference, schema)).UploadJson(stream, options));
+        }
+
+        [Fact]
+        public void InsertEquivalents_SingleRow()
+        {
+            var datasetId = "dataset";
+            var tableId = "table";
+            var reference = new TableReference { ProjectId = ProjectId, DatasetId = datasetId, TableId = tableId };
+            var schema = new TableSchemaBuilder().Build();
+            var options = new InsertOptions();
+            var stream = new MemoryStream();
+            var row = new InsertRow();
+            VerifyEquivalent(
+                client => client.Insert(MatchesWhenSerialized(reference), new[] { row }, options),
+                client => client.Insert(datasetId, tableId, row, options),
+                client => client.Insert(ProjectId, datasetId, tableId, row, options),
+                client => new BigqueryTable(client, GetTable(reference)).Insert(row, options));
+        }
+
+        [Fact]
+        public void InsertEquivalents_RowCollection()
+        {
+            var datasetId = "dataset";
+            var tableId = "table";
+            var reference = new TableReference { ProjectId = ProjectId, DatasetId = datasetId, TableId = tableId };
+            var schema = new TableSchemaBuilder().Build();
+            var options = new InsertOptions();
+            var stream = new MemoryStream();
+            var rows = new[] { new InsertRow(), new InsertRow() };
+            VerifyEquivalent(
+                client => client.Insert(MatchesWhenSerialized(reference), rows, options),
+                client => client.Insert(datasetId, tableId, rows, options),
+                client => client.Insert(ProjectId, datasetId, tableId, rows, options),
+                client => new BigqueryTable(client, GetTable(reference)).Insert(rows, options));
+        }
+
+        [Fact]
+        public void InsertEquivalents_ParamsRows()
+        {
+            var datasetId = "dataset";
+            var tableId = "table";
+            var reference = new TableReference { ProjectId = ProjectId, DatasetId = datasetId, TableId = tableId };
+            var schema = new TableSchemaBuilder().Build();
+            var options = new InsertOptions();
+            var stream = new MemoryStream();
+            var rows = new[] { new InsertRow(), new InsertRow() };
+            VerifyEquivalent(
+                client => client.Insert(MatchesWhenSerialized(reference), rows, null),
+                client => client.Insert(datasetId, tableId, rows[0], rows[1]),
+                client => client.Insert(ProjectId, datasetId, tableId, rows[0], rows[1]),
+                client => new BigqueryTable(client, GetTable(reference)).Insert(rows[0], rows[1]));
+        }
+
+        private T MatchesWhenSerialized<T>(T expected)
+        {
+            string serialized = JsonConvert.SerializeObject(expected);
+            return It.Is<T>(actual => JsonConvert.SerializeObject(actual) == serialized);
+        }
+
+        private void VerifyEquivalent<TResult>(
+            TResult result,
+            Expression<Func<DerivedBigqueryClient, TResult>> underlyingCall,
+            params Func<BigqueryClient, TResult>[] equivalentCalls) where TResult : class
+        {
+            foreach (var call in equivalentCalls)
+            {
+                var mock = new Mock<DerivedBigqueryClient>();
+                mock.CallBase = true;
+                mock.Setup(underlyingCall).Returns(result);
+                Assert.Same(result, call(mock.Object));
+                mock.VerifyAll();
+            }
+        }
+
+        private void VerifyEquivalent(
+            Expression<Action<DerivedBigqueryClient>> underlyingCall,
+            params Action<BigqueryClient>[] equivalentCalls)
+        {
+            foreach (var call in equivalentCalls)
+            {
+                var mock = new Mock<DerivedBigqueryClient>();
+                mock.CallBase = true;
+                mock.Setup(underlyingCall);
+                call(mock.Object);
+                mock.VerifyAll();
+            }
+        }
+
+        private static Table GetTable(string datasetId, string tableId, TableSchema schema = null) =>
+            GetTable(GetTableReference(datasetId, tableId), schema);
+
+        private static Table GetTable(TableReference reference, TableSchema schema = null) =>
+            new Table { TableReference = reference, Schema = schema };
+
+        private static TableReference GetTableReference(string datasetId, string tableId) =>
+            new TableReference { ProjectId = ProjectId, DatasetId = datasetId, TableId = tableId };
+
+        private static Dataset GetDataset(string datasetId) => GetDataset(GetDatasetReference(datasetId));
+
+        private static Dataset GetDataset(DatasetReference reference) => new Dataset { DatasetReference = reference };
+
+        private static DatasetReference GetDatasetReference(string datasetId) =>
+            new DatasetReference { ProjectId = ProjectId, DatasetId = datasetId };
+
+        private static Job GetJob(string jobId) => GetJob(GetJobReference(jobId));
+
+        private static Job GetJob(JobReference reference) => new Job { JobReference = reference };
+
+        private static JobReference GetJobReference(string JobId) =>
+            new JobReference { ProjectId = ProjectId, JobId = JobId };
+
+        // TODO: Create a simple implementation in Google.Api.Gax.Testing, after the planned refactoring.
+        private class UnimplementedPagedEnumerable<TResponse, TResource> : IPagedEnumerable<TResponse, TResource>
+        {
+            public IResponseEnumerable<TResponse, TResource> AsPages()
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerator<TResource> GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryRowTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryRowTest.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2.Data;
+using System;
+using Xunit;
+
+namespace Google.Bigquery.V2.Tests
+{
+    public class BigqueryRowTest
+    {
+        [Fact]
+        public void Scalars()
+        {
+            var schema = new TableSchemaBuilder
+            {
+                { "integer", BigqueryDbType.Integer },
+                { "bool", BigqueryDbType.Boolean },
+                { "bytes", BigqueryDbType.Bytes },
+                { "float", BigqueryDbType.Float },
+                { "string", BigqueryDbType.String },
+                { "timestamp", BigqueryDbType.Timestamp },
+            }.Build();
+            var rawRow = new TableRow
+            {
+                F = new[]
+                {
+                    new TableCell { V = "10" },
+                    new TableCell { V = "true" },
+                    new TableCell { V = "AQI=" }, // 1, 2
+                    new TableCell { V = "2.5" },
+                    new TableCell { V = "text" },
+                    new TableCell { V = "1477566580.5" }, // 2016-10-27T11:09:40.500Z
+                }
+            };
+            var row = new BigqueryRow(rawRow, schema);
+            Assert.Equal(10, (long)row["integer"]);
+            Assert.Equal(true, (bool)row["bool"]);
+            Assert.Equal(new byte[] { 1, 2 }, (byte[])row["bytes"]);
+            Assert.Equal(2.5d, (double)row["float"]);
+            Assert.Equal("text", (string)row["string"]);
+            Assert.Equal(new DateTime(2016, 10, 27, 11, 9, 40, 500, DateTimeKind.Utc), (DateTime)row["timestamp"]);
+        }
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/CloudProjectTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/CloudProjectTest.cs
@@ -1,0 +1,45 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2.Data;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Apis.Bigquery.v2.Data.ProjectList;
+
+namespace Google.Bigquery.V2.Tests
+{
+    public class CloudProjectTest
+    {
+        [Fact]
+        public void Properties()
+        {
+            string id = "hard-to-remember";
+            string name = "Fluffy";
+            var data = new ProjectsData
+            {
+                FriendlyName = name,
+                Id = id,
+                ProjectReference = new ProjectReference { ProjectId = id }
+            };
+            var project = new CloudProject(new Mock<BigqueryClient>().Object, data);
+            Assert.Equal(name, project.FriendlyName);
+            Assert.Equal(id, project.ProjectId);
+            Assert.Equal(id, project.Reference.ProjectId);
+        }
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/ExecuteQueryOptionsTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/ExecuteQueryOptionsTest.cs
@@ -36,5 +36,19 @@ namespace Google.Bigquery.V2.Tests
             Assert.Equal(false, request.UseQueryCache);
             Assert.Equal(true, request.UseLegacySql);
         }
+
+        [Fact]
+        public void ToGetQueryResultsOptions()
+        {
+            var options = new ExecuteQueryOptions
+            {
+                DefaultDataset = new DatasetReference { ProjectId = "a", DatasetId = "b" },
+                PageSize = 25,
+                UseQueryCache = false,
+                UseLegacySql = true
+            };
+            var getQueryResultsOptions = options.ToGetQueryResultsOptions();
+            Assert.Equal(25, getQueryResultsOptions.PageSize);
+        }
     }
 }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/FakeBigqueryService.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/FakeBigqueryService.cs
@@ -1,0 +1,64 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2;
+using Google.Apis.Http;
+using Google.Apis.Requests;
+
+namespace Google.Bigquery.V2.Tests
+{
+    /// <summary>
+    /// A fake service allowing request/response expect/replay.
+    /// </summary>
+    public class FakeBigqueryService : BigqueryService
+    {
+        private readonly ReplayingMessageHandler handler;
+
+        public FakeBigqueryService() : base(new Initializer
+        {
+            HttpClientFactory = new FakeHttpClientFactory(new ReplayingMessageHandler()),
+            ApplicationName = "Fake",
+            GZipEnabled = false
+        })
+        {
+            handler = (ReplayingMessageHandler) HttpClient.MessageHandler;
+            var client = new ConfigurableHttpClient(handler);
+        }
+
+        public void ExpectRequest<TResponse>(ClientServiceRequest<TResponse> request, TResponse response)
+        {
+            string requestContent = SerializeObject(request);
+            var httpRequest = request.CreateRequest();
+            string responseContent = SerializeObject(response);            
+            handler.ExpectRequest(httpRequest.RequestUri, httpRequest.Content?.ReadAsStringAsync()?.Result, responseContent);
+        }
+
+        /// <summary>
+        /// HTTP client factory which gets a specific message handler (for mocking) and use for creating the HTTP
+        /// client.
+        /// </summary>
+        private class FakeHttpClientFactory : IHttpClientFactory
+        {
+            private readonly ConfigurableMessageHandler _handler;
+
+            public FakeHttpClientFactory(ConfigurableMessageHandler handler)
+            {
+                _handler = handler;
+            }
+
+            public ConfigurableHttpClient CreateHttpClient(CreateHttpClientArgs args) =>
+                new ConfigurableHttpClient(_handler);
+        }
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/GetQueryResultsOptionsTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/GetQueryResultsOptionsTest.cs
@@ -22,19 +22,59 @@ namespace Google.Bigquery.V2.Tests
     public class GetQueryResultsOptionsTest
     {
         [Fact]
-        public void ModifyRequest()
+        public void ModifyRequest_NoneSet()
+        {
+            var options = new GetQueryResultsOptions();
+            GetQueryResultsRequest request = new GetQueryResultsRequest(new BigqueryService(), "project", "job");
+            options.ModifyRequest(request);
+            Assert.Equal(null, request.StartIndex);
+            Assert.Equal(null, request.PageToken);
+            Assert.Equal(null, request.MaxResults);
+            Assert.Equal(null, request.TimeoutMs);
+        }
+
+        [Fact]
+        public void ModifyRequest_AllSetExceptStartIndex()
+        {
+            var options = new GetQueryResultsOptions
+            {
+                PageSize = 25,
+                PageToken = "foo",
+                Timeout = TimeSpan.FromSeconds(5),
+            };
+            GetQueryResultsRequest request = new GetQueryResultsRequest(new BigqueryService(), "project", "job");
+            options.ModifyRequest(request);
+            Assert.Equal("foo", request.PageToken);
+            Assert.Equal(25, request.MaxResults);
+            Assert.Equal(5 * 1000, request.TimeoutMs);
+        }
+
+        [Fact]
+        public void ModifyRequest_AllSetExceptPageToken()
         {
             var options = new GetQueryResultsOptions
             {
                 StartIndex = 10,
                 PageSize = 25,
-                Timeout = TimeSpan.FromSeconds(5)
+                Timeout = TimeSpan.FromSeconds(5),
             };
             GetQueryResultsRequest request = new GetQueryResultsRequest(new BigqueryService(), "project", "job");
             options.ModifyRequest(request);
             Assert.Equal(10UL, request.StartIndex);
             Assert.Equal(25, request.MaxResults);
             Assert.Equal(5 * 1000, request.TimeoutMs);
+        }
+
+        [Fact]
+        public void ModifyRequest_BothPageTokenAndStartIndexSet()
+        {
+            var options = new GetQueryResultsOptions
+            {
+                StartIndex = 10,
+                PageToken = "foo"
+            };
+            GetQueryResultsRequest request = new GetQueryResultsRequest(new BigqueryService(), "project", "job");
+            Assert.Throws<ArgumentException>(() => options.ModifyRequest(request));
         }
     }
 }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/InsertRowTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/InsertRowTest.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using Xunit;
@@ -20,6 +21,13 @@ namespace Google.Bigquery.V2.Tests
 {
     public class InsertRowTest
     {
+        [Fact]
+        public void InsertId()
+        {
+            var row = new InsertRow("id");
+            Assert.Equal("id", row.InsertId);
+        }
+
         [Fact]
         public void InvalidFieldName()
         {
@@ -48,6 +56,14 @@ namespace Google.Bigquery.V2.Tests
             Assert.Equal("value1", rowData.Json["field1"]);
             Assert.Null(rowData.Json["field2"]);
             Assert.Equal(2, rowData.Json["field3"]);
+        }
+
+        [Fact]
+        public void AddDictionary()
+        {
+            var dictionary = new Dictionary<string, object> { { "field1", "value1" } };
+            var row = new InsertRow { dictionary };
+            Assert.Equal("value1", row["field1"]);
         }
 
         [Theory]
@@ -99,6 +115,24 @@ namespace Google.Bigquery.V2.Tests
             };
             var rowData = row.ToRowsData();
             Assert.Equal("2000-01-01 05:00:00Z", rowData.Json["field"]);
+        }
+
+        [Fact]
+        public void NestedRecordFormatting()
+        {
+            var nested = new InsertRow { { "inner", "value" } };
+            var outer = new InsertRow { { "outer", nested } };
+            var rowData = outer.ToRowsData();
+            var obj = (IDictionary<string, object>)rowData.Json["outer"];
+            Assert.Equal("value", obj["inner"]);
+        }
+
+        [Fact]
+        public void RepeatedValue()
+        {
+            var row = new InsertRow { { "numbers", new[] { 1, 2 } } };
+            var rowData = row.ToRowsData();
+            Assert.Equal(new object[] { 1, 2 }, rowData.Json["numbers"]);
         }
     }
 }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/ReplayingMessageHandler.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/ReplayingMessageHandler.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Http;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Bigquery.V2.Tests
+{
+    /// <summary>
+    /// Test helper class effectively acting as an HTTP mock.
+    /// We may well want to put this into Google.Api.Gax.Rest.Testing at some point.
+    /// Additionally, it could do with being able to return non-OK results...
+    /// </summary>
+    public class ReplayingMessageHandler : ConfigurableMessageHandler
+    {
+        private readonly Queue<Tuple<Uri, string, string>> _requestResponses = new Queue<Tuple<Uri, string, string>>();
+
+        public ReplayingMessageHandler() : base(new HttpClientHandler())
+        {
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Assert.NotEmpty(_requestResponses);
+
+            var requestResponse = _requestResponses.Dequeue();
+            Uri expectedRequestUri = requestResponse.Item1;
+            string expectedRequestContent = requestResponse.Item2;
+            string providedResponse = requestResponse.Item3;
+            Assert.Equal(expectedRequestUri, request.RequestUri);
+            string body = await (request.Content?.ReadAsStringAsync() ?? Task.FromResult<string>(null));
+            Assert.Equal(expectedRequestContent, body);
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(providedResponse) };
+        }
+
+        public void ExpectRequest(Uri requestUri, string requestContent, string responseContent)
+        {
+            _requestResponses.Enqueue(Tuple.Create(requestUri, requestContent, responseContent));
+        }
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/TableFieldSchemaExtensionsTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/TableFieldSchemaExtensionsTest.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2.Data;
+using Xunit;
+
+namespace Google.Bigquery.V2.Tests
+{
+    public class TableFieldSchemaExtensionsTest
+    {
+        [Fact]
+        public void GetFieldType()
+        {
+            var field = new TableFieldSchema { Type = "INTEGER" };
+            Assert.Equal(BigqueryDbType.Integer, field.GetFieldType());
+        }
+
+        [Fact]
+        public void GetFieldMode()
+        {
+            var field = new TableFieldSchema { Mode = "REPEATED" };
+            Assert.Equal(FieldMode.Repeated, field.GetFieldMode());
+        }
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryJob.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryJob.cs
@@ -107,7 +107,8 @@ namespace Google.Bigquery.V2
         /// Cancels this job.
         /// </summary>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
-        public void Cancel(CancelJobOptions options = null) => _client.CancelJob(Reference, options);
+        /// <returns>The final state of the job.</returns>
+        public BigqueryJob Cancel(CancelJobOptions options = null) => _client.CancelJob(Reference, options);
 
         // TODO: Refresh? Could easily call GetJob, but can't easily modify *this* job...
     }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/FieldMode.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/FieldMode.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-
 namespace Google.Bigquery.V2
 {
     /// <summary>


### PR DESCRIPTION
In particular:

- Start faking out the service for simple cases (much more to do)
- Check the equivalence of various calls that end up on "core"
  client ones