### PR TITLE
Bring Google.Devtools.AspNet versions up to date

### DIFF
--- a/apis/Google.Devtools.AspNet/Google.Devtools.AspNet.sln
+++ b/apis/Google.Devtools.AspNet/Google.Devtools.AspNet.sln
@@ -7,6 +7,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Devtools.AspNet", "G
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Devtools.AspNet.Tests", "Google.Devtools.AspNet.Tests\Google.Devtools.AspNet.Tests.xproj", "{575CD5C0-C69D-495E-90FD-028BE94178E4}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Devtools.Clouderrorreporting.V1Beta1", "..\Google.Devtools.Clouderrorreporting.V1Beta1\Google.Devtools.Clouderrorreporting.V1Beta1\Google.Devtools.Clouderrorreporting.V1Beta1.xproj", "{4AB959C8-953B-41BA-9C8F-392002F6A4F6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{575CD5C0-C69D-495E-90FD-028BE94178E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{575CD5C0-C69D-495E-90FD-028BE94178E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{575CD5C0-C69D-495E-90FD-028BE94178E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4AB959C8-953B-41BA-9C8F-392002F6A4F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4AB959C8-953B-41BA-9C8F-392002F6A4F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4AB959C8-953B-41BA-9C8F-392002F6A4F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4AB959C8-953B-41BA-9C8F-392002F6A4F6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Devtools.AspNet/Google.Devtools.AspNet/project.json
+++ b/apis/Google.Devtools.AspNet/Google.Devtools.AspNet/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0-*",
+  "version": "0.1.1-*",
   "description": "ExceptionLogger for the Google Stackdriver Error Reporting API.",
   "authors": [ "Google Inc." ],
 
@@ -19,8 +19,8 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax": "1.0.0-beta02-CI00094",
-    "Google.Devtools.Clouderrorreporting.V1Beta1": "0.1.0",
+    "Google.Api.Gax": "1.0.0-beta03",
+    "Google.Devtools.Clouderrorreporting.V1Beta1": { "target": "project" },
     "Microsoft.AspNet.WebApi.Core": "5.2.3"
   },
 

--- a/apis/global.json
+++ b/apis/global.json
@@ -3,6 +3,7 @@
     "Google.Storage.V1",
     "Google.Longrunning",
     "Google.Iam.V1",
+    "Google.Devtools.Clouderrorreporting.V1Beta1",
     "../tools"
   ],
   "sdk": {


### PR DESCRIPTION
- Explicitly pull in GAX beta03
- Always bring in the latest Error Reporting API as a project
  reference. When the library goes GA, we'll want to pin this to
  a specific version, but until then, we'll keep it as current
- Up the version number to 0.1.1