### PR TITLE
Revert change to skip sentiment analysis test.

### DIFF
--- a/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1.Snippets/LanguageServiceClientSnippets.cs
+++ b/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1.Snippets/LanguageServiceClientSnippets.cs
@@ -41,7 +41,7 @@ namespace Google.Cloud.Language.V1Beta1.Snippets
             Assert.Equal("Richard of York", response.Entities[0].Name);
         }
 
-        [Fact(Skip = "Polarity is 0 at the moment; need to investigate")]
+        [Fact]
         public void AnalyzeSentiment()
         {
             // Snippet: AnalyzeSentiment


### PR DESCRIPTION
Looks like the Language service temporarily removed polarity, but
that it's back now.

(Have run this locally, and it works. Will self-merge.)