### PR TITLE
Integration test updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ releasebuild
 tmp
 googleapis
 toolkit
+
+# Testing
+integrationprogress.txt
+results.xml

--- a/apis/Google.Storage.V1/Google.Storage.V1.Snippets/project.json
+++ b/apis/Google.Storage.V1/Google.Storage.V1.Snippets/project.json
@@ -13,6 +13,14 @@
   "testRunner": "xunit",
 
   "frameworks": {
-    "net451": {}
+    "net451": {},
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0",
+          "type": "platform"
+        }
+      }
+    }
   }
 }

--- a/runintegrationtests.sh
+++ b/runintegrationtests.sh
@@ -3,8 +3,10 @@
 # Assumption: everything has been built already.
 
 set -e
+PROGRESS_FILE=`realpath integrationprogress.txt`
 
-[[ $(dotnet --info | grep "OS Platform" | grep -c Windows) -ne 0 ]] && OS=Windows || OS=Linux
+[[ "$1" == "--continue" ]] || rm $PROGRESS_FILE
+touch $PROGRESS_FILE
 
 cd apis
 
@@ -13,8 +15,12 @@ for testdir in */*.IntegrationTests */*.Snippets
 do
   if [[ "$testdir" =~ (Metadata|AspNet|Log4Net) ]]
   then
-    echo Skipping $testdir
+    echo "Skipping $testdir; test not supported yet."
+  elif echo "$testdir" | grep --quiet -F -f $PROGRESS_FILE
+  then
+    echo "Skipping $testdir; test already run"
   else
-    dotnet test -f netcoreapp1.0 $DOTNET_TEST_ARGS $testdir
+    dotnet test -c Release --no-build -f netcoreapp1.0 $DOTNET_TEST_ARGS $testdir -xml $testdir/results.xml
+    echo "$testdir" >> $PROGRESS_FILE
   fi
 done


### PR DESCRIPTION
- New --continue option for runintegrationtests.sh, to continue from where it left off
- Generate a results.xml file so it's easy to find out which tests are slow
- Make Google.Storage.V1.Snippets work in core