### PR TITLE
API regeneration

### DIFF
--- a/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1.Snippets/LanguageServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1.Snippets/LanguageServiceClientSnippets.g.cs
@@ -15,8 +15,6 @@
 // Generated code. DO NOT EDIT!
 
 using Google.Api.Gax.Grpc;
-using Google.Cloud.Language.V1beta1;
-using Google.Cloud.Language.V1beta1.AnnotateTextRequest.Types;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -27,6 +25,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using static Google.Cloud.Language.V1Beta1.AnnotateTextRequest.Types;
 
 namespace Google.Cloud.Language.V1Beta1.Snippets
 {

--- a/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1.Snippets/LanguageServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1.Snippets/LanguageServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 // Generated code. DO NOT EDIT!
 
 using Google.Api.Gax.Grpc;
+using Google.Cloud.Language.V1beta1;
+using Google.Cloud.Language.V1beta1.AnnotateTextRequest.Types;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -25,7 +27,6 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using static Google.Cloud.Language.V1Beta1.AnnotateTextRequest.Types;
 
 namespace Google.Cloud.Language.V1Beta1.Snippets
 {

--- a/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1/LanguageServiceClient.cs
+++ b/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1/LanguageServiceClient.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
 
 // Generated code. DO NOT EDIT!
 
-using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Cloud.Language.V1beta1;
+using Google.Cloud.Language.V1beta1.AnnotateTextRequest.Types;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -24,7 +25,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
-using static Google.Cloud.Language.V1Beta1.AnnotateTextRequest.Types;
 
 namespace Google.Cloud.Language.V1Beta1
 {
@@ -308,10 +308,11 @@ namespace Google.Cloud.Language.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Analyzes the sentiment of the provided text.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document. Currently, `analyzeSentiment` only supports English text
+        /// ([Document.language][google.cloud.language.v1beta1.Document.language]="EN").
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -327,10 +328,11 @@ namespace Google.Cloud.Language.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Analyzes the sentiment of the provided text.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document. Currently, `analyzeSentiment` only supports English text
+        /// ([Document.language][google.cloud.language.v1beta1.Document.language]="EN").
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -345,10 +347,11 @@ namespace Google.Cloud.Language.V1Beta1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Analyzes the sentiment of the provided text.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document. Currently, `analyzeSentiment` only supports English text
+        /// ([Document.language][google.cloud.language.v1beta1.Document.language]="EN").
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -364,13 +367,14 @@ namespace Google.Cloud.Language.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Finds named entities (currently finds proper names) in the text,
+        /// entity types, salience, mentions for each entity, and other properties.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document.
         /// </param>
         /// <param name="encodingType">
-        ///
+        /// The encoding type used by the API to calculate offsets.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -387,13 +391,14 @@ namespace Google.Cloud.Language.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Finds named entities (currently finds proper names) in the text,
+        /// entity types, salience, mentions for each entity, and other properties.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document.
         /// </param>
         /// <param name="encodingType">
-        ///
+        /// The encoding type used by the API to calculate offsets.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -410,13 +415,14 @@ namespace Google.Cloud.Language.V1Beta1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Finds named entities (currently finds proper names) in the text,
+        /// entity types, salience, mentions for each entity, and other properties.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document.
         /// </param>
         /// <param name="encodingType">
-        ///
+        /// The encoding type used by the API to calculate offsets.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -433,16 +439,19 @@ namespace Google.Cloud.Language.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Advanced API that analyzes the document and provides a full set of text
+        /// annotations, including semantic, syntactic, and sentiment information. This
+        /// API is intended for users who are familiar with machine learning and need
+        /// in-depth text features to build upon.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document.
         /// </param>
         /// <param name="features">
-        ///
+        /// The enabled features.
         /// </param>
         /// <param name="encodingType">
-        ///
+        /// The encoding type used by the API to calculate offsets.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -460,16 +469,19 @@ namespace Google.Cloud.Language.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Advanced API that analyzes the document and provides a full set of text
+        /// annotations, including semantic, syntactic, and sentiment information. This
+        /// API is intended for users who are familiar with machine learning and need
+        /// in-depth text features to build upon.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document.
         /// </param>
         /// <param name="features">
-        ///
+        /// The enabled features.
         /// </param>
         /// <param name="encodingType">
-        ///
+        /// The encoding type used by the API to calculate offsets.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -488,16 +500,19 @@ namespace Google.Cloud.Language.V1Beta1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Advanced API that analyzes the document and provides a full set of text
+        /// annotations, including semantic, syntactic, and sentiment information. This
+        /// API is intended for users who are familiar with machine learning and need
+        /// in-depth text features to build upon.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document.
         /// </param>
         /// <param name="features">
-        ///
+        /// The enabled features.
         /// </param>
         /// <param name="encodingType">
-        ///
+        /// The encoding type used by the API to calculate offsets.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -550,10 +565,11 @@ namespace Google.Cloud.Language.V1Beta1
         public override LanguageService.LanguageServiceClient GrpcClient { get; }
 
         /// <summary>
-        ///
+        /// Analyzes the sentiment of the provided text.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document. Currently, `analyzeSentiment` only supports English text
+        /// ([Document.language][google.cloud.language.v1beta1.Document.language]="EN").
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -571,10 +587,11 @@ namespace Google.Cloud.Language.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Analyzes the sentiment of the provided text.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document. Currently, `analyzeSentiment` only supports English text
+        /// ([Document.language][google.cloud.language.v1beta1.Document.language]="EN").
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -592,13 +609,14 @@ namespace Google.Cloud.Language.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Finds named entities (currently finds proper names) in the text,
+        /// entity types, salience, mentions for each entity, and other properties.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document.
         /// </param>
         /// <param name="encodingType">
-        ///
+        /// The encoding type used by the API to calculate offsets.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -618,13 +636,14 @@ namespace Google.Cloud.Language.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Finds named entities (currently finds proper names) in the text,
+        /// entity types, salience, mentions for each entity, and other properties.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document.
         /// </param>
         /// <param name="encodingType">
-        ///
+        /// The encoding type used by the API to calculate offsets.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -644,16 +663,19 @@ namespace Google.Cloud.Language.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Advanced API that analyzes the document and provides a full set of text
+        /// annotations, including semantic, syntactic, and sentiment information. This
+        /// API is intended for users who are familiar with machine learning and need
+        /// in-depth text features to build upon.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document.
         /// </param>
         /// <param name="features">
-        ///
+        /// The enabled features.
         /// </param>
         /// <param name="encodingType">
-        ///
+        /// The encoding type used by the API to calculate offsets.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -675,16 +697,19 @@ namespace Google.Cloud.Language.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Advanced API that analyzes the document and provides a full set of text
+        /// annotations, including semantic, syntactic, and sentiment information. This
+        /// API is intended for users who are familiar with machine learning and need
+        /// in-depth text features to build upon.
         /// </summary>
         /// <param name="document">
-        ///
+        /// Input document.
         /// </param>
         /// <param name="features">
-        ///
+        /// The enabled features.
         /// </param>
         /// <param name="encodingType">
-        ///
+        /// The encoding type used by the API to calculate offsets.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.

--- a/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1/LanguageServiceClient.cs
+++ b/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1/LanguageServiceClient.cs
@@ -14,9 +14,8 @@
 
 // Generated code. DO NOT EDIT!
 
+using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
-using Google.Cloud.Language.V1beta1;
-using Google.Cloud.Language.V1beta1.AnnotateTextRequest.Types;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -25,6 +24,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
+using static Google.Cloud.Language.V1Beta1.AnnotateTextRequest.Types;
 
 namespace Google.Cloud.Language.V1Beta1
 {

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.Snippets/SpeechClientSnippets.g.cs
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.Snippets/SpeechClientSnippets.g.cs
@@ -15,7 +15,6 @@
 // Generated code. DO NOT EDIT!
 
 using Google.Api.Gax.Grpc;
-using Google.Cloud.Speech.V1beta1;
 using Google.Longrunning;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.Snippets/SpeechClientSnippets.g.cs
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.Snippets/SpeechClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 // Generated code. DO NOT EDIT!
 
 using Google.Api.Gax.Grpc;
+using Google.Cloud.Speech.V1beta1;
 using Google.Longrunning;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/SpeechClient.cs
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/SpeechClient.cs
@@ -14,8 +14,8 @@
 
 // Generated code. DO NOT EDIT!
 
+using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
-using Google.Cloud.Speech.V1beta1;
 using Google.Longrunning;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/SpeechClient.cs
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/SpeechClient.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 
 // Generated code. DO NOT EDIT!
 
-using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Cloud.Speech.V1beta1;
 using Google.Longrunning;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -277,13 +277,15 @@ namespace Google.Cloud.Speech.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Perform synchronous speech-recognition: receive results after all audio
+        /// has been sent and processed.
         /// </summary>
         /// <param name="config">
-        ///
+        /// [Required] The `config` message provides information to the recognizer
+        /// that specifies how to process the request.
         /// </param>
         /// <param name="audio">
-        ///
+        /// [Required] The audio data to be recognized.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -300,13 +302,15 @@ namespace Google.Cloud.Speech.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Perform synchronous speech-recognition: receive results after all audio
+        /// has been sent and processed.
         /// </summary>
         /// <param name="config">
-        ///
+        /// [Required] The `config` message provides information to the recognizer
+        /// that specifies how to process the request.
         /// </param>
         /// <param name="audio">
-        ///
+        /// [Required] The audio data to be recognized.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -323,13 +327,15 @@ namespace Google.Cloud.Speech.V1Beta1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Perform synchronous speech-recognition: receive results after all audio
+        /// has been sent and processed.
         /// </summary>
         /// <param name="config">
-        ///
+        /// [Required] The `config` message provides information to the recognizer
+        /// that specifies how to process the request.
         /// </param>
         /// <param name="audio">
-        ///
+        /// [Required] The audio data to be recognized.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -346,13 +352,17 @@ namespace Google.Cloud.Speech.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Perform asynchronous speech-recognition: receive results via the
+        /// google.longrunning.Operations interface. Returns either an
+        /// `Operation.error` or an `Operation.response` which contains
+        /// an `AsyncRecognizeResponse` message.
         /// </summary>
         /// <param name="config">
-        ///
+        /// [Required] The `config` message provides information to the recognizer
+        /// that specifies how to process the request.
         /// </param>
         /// <param name="audio">
-        ///
+        /// [Required] The audio data to be recognized.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -369,13 +379,17 @@ namespace Google.Cloud.Speech.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Perform asynchronous speech-recognition: receive results via the
+        /// google.longrunning.Operations interface. Returns either an
+        /// `Operation.error` or an `Operation.response` which contains
+        /// an `AsyncRecognizeResponse` message.
         /// </summary>
         /// <param name="config">
-        ///
+        /// [Required] The `config` message provides information to the recognizer
+        /// that specifies how to process the request.
         /// </param>
         /// <param name="audio">
-        ///
+        /// [Required] The audio data to be recognized.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -392,13 +406,17 @@ namespace Google.Cloud.Speech.V1Beta1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Perform asynchronous speech-recognition: receive results via the
+        /// google.longrunning.Operations interface. Returns either an
+        /// `Operation.error` or an `Operation.response` which contains
+        /// an `AsyncRecognizeResponse` message.
         /// </summary>
         /// <param name="config">
-        ///
+        /// [Required] The `config` message provides information to the recognizer
+        /// that specifies how to process the request.
         /// </param>
         /// <param name="audio">
-        ///
+        /// [Required] The audio data to be recognized.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -447,13 +465,15 @@ namespace Google.Cloud.Speech.V1Beta1
         public override Speech.SpeechClient GrpcClient { get; }
 
         /// <summary>
-        ///
+        /// Perform synchronous speech-recognition: receive results after all audio
+        /// has been sent and processed.
         /// </summary>
         /// <param name="config">
-        ///
+        /// [Required] The `config` message provides information to the recognizer
+        /// that specifies how to process the request.
         /// </param>
         /// <param name="audio">
-        ///
+        /// [Required] The audio data to be recognized.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -473,13 +493,15 @@ namespace Google.Cloud.Speech.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Perform synchronous speech-recognition: receive results after all audio
+        /// has been sent and processed.
         /// </summary>
         /// <param name="config">
-        ///
+        /// [Required] The `config` message provides information to the recognizer
+        /// that specifies how to process the request.
         /// </param>
         /// <param name="audio">
-        ///
+        /// [Required] The audio data to be recognized.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -499,13 +521,17 @@ namespace Google.Cloud.Speech.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Perform asynchronous speech-recognition: receive results via the
+        /// google.longrunning.Operations interface. Returns either an
+        /// `Operation.error` or an `Operation.response` which contains
+        /// an `AsyncRecognizeResponse` message.
         /// </summary>
         /// <param name="config">
-        ///
+        /// [Required] The `config` message provides information to the recognizer
+        /// that specifies how to process the request.
         /// </param>
         /// <param name="audio">
-        ///
+        /// [Required] The audio data to be recognized.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -525,13 +551,17 @@ namespace Google.Cloud.Speech.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Perform asynchronous speech-recognition: receive results via the
+        /// google.longrunning.Operations interface. Returns either an
+        /// `Operation.error` or an `Operation.response` which contains
+        /// an `AsyncRecognizeResponse` message.
         /// </summary>
         /// <param name="config">
-        ///
+        /// [Required] The `config` message provides information to the recognizer
+        /// that specifies how to process the request.
         /// </param>
         /// <param name="audio">
-        ///
+        /// [Required] The audio data to be recognized.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 // Generated code. DO NOT EDIT!
 
 using Google.Api.Gax.Grpc;
+using Google.Cloud.Vision.V1;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.cs
@@ -14,6 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
+using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Cloud.Vision.V1;
 using Google.Protobuf.WellKnownTypes;

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 
 // Generated code. DO NOT EDIT!
 
-using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Cloud.Vision.V1;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -245,10 +245,10 @@ namespace Google.Cloud.Vision.V1
         }
 
         /// <summary>
-        ///
+        /// Run image detection and annotation for a batch of images.
         /// </summary>
         /// <param name="requests">
-        ///
+        /// Individual image annotation requests for this batch.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -264,10 +264,10 @@ namespace Google.Cloud.Vision.V1
         }
 
         /// <summary>
-        ///
+        /// Run image detection and annotation for a batch of images.
         /// </summary>
         /// <param name="requests">
-        ///
+        /// Individual image annotation requests for this batch.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -282,10 +282,10 @@ namespace Google.Cloud.Vision.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Run image detection and annotation for a batch of images.
         /// </summary>
         /// <param name="requests">
-        ///
+        /// Individual image annotation requests for this batch.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -330,10 +330,10 @@ namespace Google.Cloud.Vision.V1
         public override ImageAnnotator.ImageAnnotatorClient GrpcClient { get; }
 
         /// <summary>
-        ///
+        /// Run image detection and annotation for a batch of images.
         /// </summary>
         /// <param name="requests">
-        ///
+        /// Individual image annotation requests for this batch.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -351,10 +351,10 @@ namespace Google.Cloud.Vision.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Run image detection and annotation for a batch of images.
         /// </summary>
         /// <param name="requests">
-        ///
+        /// Individual image annotation requests for this batch.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.

--- a/apis/Google.Datastore.V1/Google.Datastore.V1.Snippets/DatastoreClientSnippets.g.cs
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1.Snippets/DatastoreClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 // Generated code. DO NOT EDIT!
 
 using Google.Api.Gax.Grpc;
+using Google.Datastore.V1;
+using Google.Datastore.V1.CommitRequest.Types;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -25,7 +27,6 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using static Google.Datastore.V1.CommitRequest.Types;
 
 namespace Google.Datastore.V1.Snippets
 {

--- a/apis/Google.Datastore.V1/Google.Datastore.V1.Snippets/DatastoreClientSnippets.g.cs
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1.Snippets/DatastoreClientSnippets.g.cs
@@ -16,7 +16,6 @@
 
 using Google.Api.Gax.Grpc;
 using Google.Datastore.V1;
-using Google.Datastore.V1.CommitRequest.Types;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -27,6 +26,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using static Google.Datastore.V1.CommitRequest.Types;
 
 namespace Google.Datastore.V1.Snippets
 {

--- a/apis/Google.Datastore.V1/Google.Datastore.V1/DatastoreClient.cs
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1/DatastoreClient.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
 
 // Generated code. DO NOT EDIT!
 
-using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Datastore.V1;
+using Google.Datastore.V1.CommitRequest.Types;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -25,7 +26,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
-using static Google.Datastore.V1.CommitRequest.Types;
 
 namespace Google.Datastore.V1
 {
@@ -400,16 +400,16 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Looks up entities by key.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this lookup request.
         /// </param>
         /// <param name="keys">
-        ///
+        /// Keys of entities to look up.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -427,16 +427,16 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Looks up entities by key.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this lookup request.
         /// </param>
         /// <param name="keys">
-        ///
+        /// Keys of entities to look up.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -455,16 +455,16 @@ namespace Google.Datastore.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Looks up entities by key.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this lookup request.
         /// </param>
         /// <param name="keys">
-        ///
+        /// Keys of entities to look up.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -482,19 +482,22 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Queries for entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="partitionId">
-        ///
+        /// Entities are partitioned into subsets, identified by a partition ID.
+        /// Queries are scoped to a single partition.
+        /// This partition ID is normalized with the standard default context
+        /// partition ID.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this query.
         /// </param>
         /// <param name="query">
-        ///
+        /// The query to run.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -513,19 +516,22 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Queries for entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="partitionId">
-        ///
+        /// Entities are partitioned into subsets, identified by a partition ID.
+        /// Queries are scoped to a single partition.
+        /// This partition ID is normalized with the standard default context
+        /// partition ID.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this query.
         /// </param>
         /// <param name="query">
-        ///
+        /// The query to run.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -546,19 +552,22 @@ namespace Google.Datastore.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Queries for entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="partitionId">
-        ///
+        /// Entities are partitioned into subsets, identified by a partition ID.
+        /// Queries are scoped to a single partition.
+        /// This partition ID is normalized with the standard default context
+        /// partition ID.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this query.
         /// </param>
         /// <param name="query">
-        ///
+        /// The query to run.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -577,19 +586,22 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Queries for entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="partitionId">
-        ///
+        /// Entities are partitioned into subsets, identified by a partition ID.
+        /// Queries are scoped to a single partition.
+        /// This partition ID is normalized with the standard default context
+        /// partition ID.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this query.
         /// </param>
         /// <param name="gqlQuery">
-        ///
+        /// The GQL query to run.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -608,19 +620,22 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Queries for entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="partitionId">
-        ///
+        /// Entities are partitioned into subsets, identified by a partition ID.
+        /// Queries are scoped to a single partition.
+        /// This partition ID is normalized with the standard default context
+        /// partition ID.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this query.
         /// </param>
         /// <param name="gqlQuery">
-        ///
+        /// The GQL query to run.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -641,19 +656,22 @@ namespace Google.Datastore.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Queries for entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="partitionId">
-        ///
+        /// Entities are partitioned into subsets, identified by a partition ID.
+        /// Queries are scoped to a single partition.
+        /// This partition ID is normalized with the standard default context
+        /// partition ID.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this query.
         /// </param>
         /// <param name="gqlQuery">
-        ///
+        /// The GQL query to run.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -672,10 +690,10 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Begins a new transaction.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -691,10 +709,10 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Begins a new transaction.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -709,10 +727,10 @@ namespace Google.Datastore.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Begins a new transaction.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -728,19 +746,34 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Commits a transaction, optionally creating, deleting or modifying some
+        /// entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="mode">
-        ///
+        /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
         /// </param>
         /// <param name="transaction">
-        ///
+        /// The identifier of the transaction associated with the commit. A
+        /// transaction identifier is returned by a call to
+        /// [Datastore.BeginTransaction][google.datastore.v1.Datastore.BeginTransaction].
         /// </param>
         /// <param name="mutations">
+        /// The mutations to perform.
         ///
+        /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
+        /// applied in order. The following sequences of mutations affecting a single
+        /// entity are not permitted in a single `Commit` request:
+        ///
+        /// - `insert` followed by `insert`
+        /// - `update` followed by `insert`
+        /// - `upsert` followed by `insert`
+        /// - `delete` followed by `update`
+        ///
+        /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
+        /// entity.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -759,19 +792,34 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Commits a transaction, optionally creating, deleting or modifying some
+        /// entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="mode">
-        ///
+        /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
         /// </param>
         /// <param name="transaction">
-        ///
+        /// The identifier of the transaction associated with the commit. A
+        /// transaction identifier is returned by a call to
+        /// [Datastore.BeginTransaction][google.datastore.v1.Datastore.BeginTransaction].
         /// </param>
         /// <param name="mutations">
+        /// The mutations to perform.
         ///
+        /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
+        /// applied in order. The following sequences of mutations affecting a single
+        /// entity are not permitted in a single `Commit` request:
+        ///
+        /// - `insert` followed by `insert`
+        /// - `update` followed by `insert`
+        /// - `upsert` followed by `insert`
+        /// - `delete` followed by `update`
+        ///
+        /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
+        /// entity.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -792,19 +840,34 @@ namespace Google.Datastore.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Commits a transaction, optionally creating, deleting or modifying some
+        /// entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="mode">
-        ///
+        /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
         /// </param>
         /// <param name="transaction">
-        ///
+        /// The identifier of the transaction associated with the commit. A
+        /// transaction identifier is returned by a call to
+        /// [Datastore.BeginTransaction][google.datastore.v1.Datastore.BeginTransaction].
         /// </param>
         /// <param name="mutations">
+        /// The mutations to perform.
         ///
+        /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
+        /// applied in order. The following sequences of mutations affecting a single
+        /// entity are not permitted in a single `Commit` request:
+        ///
+        /// - `insert` followed by `insert`
+        /// - `update` followed by `insert`
+        /// - `upsert` followed by `insert`
+        /// - `delete` followed by `update`
+        ///
+        /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
+        /// entity.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -823,16 +886,29 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Commits a transaction, optionally creating, deleting or modifying some
+        /// entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="mode">
-        ///
+        /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
         /// </param>
         /// <param name="mutations">
+        /// The mutations to perform.
         ///
+        /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
+        /// applied in order. The following sequences of mutations affecting a single
+        /// entity are not permitted in a single `Commit` request:
+        ///
+        /// - `insert` followed by `insert`
+        /// - `update` followed by `insert`
+        /// - `upsert` followed by `insert`
+        /// - `delete` followed by `update`
+        ///
+        /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
+        /// entity.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -850,16 +926,29 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Commits a transaction, optionally creating, deleting or modifying some
+        /// entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="mode">
-        ///
+        /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
         /// </param>
         /// <param name="mutations">
+        /// The mutations to perform.
         ///
+        /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
+        /// applied in order. The following sequences of mutations affecting a single
+        /// entity are not permitted in a single `Commit` request:
+        ///
+        /// - `insert` followed by `insert`
+        /// - `update` followed by `insert`
+        /// - `upsert` followed by `insert`
+        /// - `delete` followed by `update`
+        ///
+        /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
+        /// entity.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -878,16 +967,29 @@ namespace Google.Datastore.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Commits a transaction, optionally creating, deleting or modifying some
+        /// entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="mode">
-        ///
+        /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
         /// </param>
         /// <param name="mutations">
+        /// The mutations to perform.
         ///
+        /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
+        /// applied in order. The following sequences of mutations affecting a single
+        /// entity are not permitted in a single `Commit` request:
+        ///
+        /// - `insert` followed by `insert`
+        /// - `update` followed by `insert`
+        /// - `upsert` followed by `insert`
+        /// - `delete` followed by `update`
+        ///
+        /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
+        /// entity.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -905,13 +1007,14 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Rolls back a transaction.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="transaction">
-        ///
+        /// The transaction identifier, returned by a call to
+        /// [Datastore.BeginTransaction][google.datastore.v1.Datastore.BeginTransaction].
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -928,13 +1031,14 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Rolls back a transaction.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="transaction">
-        ///
+        /// The transaction identifier, returned by a call to
+        /// [Datastore.BeginTransaction][google.datastore.v1.Datastore.BeginTransaction].
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -951,13 +1055,14 @@ namespace Google.Datastore.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Rolls back a transaction.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="transaction">
-        ///
+        /// The transaction identifier, returned by a call to
+        /// [Datastore.BeginTransaction][google.datastore.v1.Datastore.BeginTransaction].
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -974,13 +1079,15 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Allocates IDs for the given keys, which is useful for referencing an entity
+        /// before it is inserted.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="keys">
-        ///
+        /// A list of keys with incomplete key paths for which to allocate IDs.
+        /// No key may be reserved/read-only.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -997,13 +1104,15 @@ namespace Google.Datastore.V1
         }
 
         /// <summary>
-        ///
+        /// Allocates IDs for the given keys, which is useful for referencing an entity
+        /// before it is inserted.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="keys">
-        ///
+        /// A list of keys with incomplete key paths for which to allocate IDs.
+        /// No key may be reserved/read-only.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -1020,13 +1129,15 @@ namespace Google.Datastore.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Allocates IDs for the given keys, which is useful for referencing an entity
+        /// before it is inserted.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="keys">
-        ///
+        /// A list of keys with incomplete key paths for which to allocate IDs.
+        /// No key may be reserved/read-only.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1087,16 +1198,16 @@ namespace Google.Datastore.V1
         public override Datastore.DatastoreClient GrpcClient { get; }
 
         /// <summary>
-        ///
+        /// Looks up entities by key.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this lookup request.
         /// </param>
         /// <param name="keys">
-        ///
+        /// Keys of entities to look up.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1118,16 +1229,16 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Looks up entities by key.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this lookup request.
         /// </param>
         /// <param name="keys">
-        ///
+        /// Keys of entities to look up.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1149,19 +1260,22 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Queries for entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="partitionId">
-        ///
+        /// Entities are partitioned into subsets, identified by a partition ID.
+        /// Queries are scoped to a single partition.
+        /// This partition ID is normalized with the standard default context
+        /// partition ID.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this query.
         /// </param>
         /// <param name="query">
-        ///
+        /// The query to run.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1185,19 +1299,22 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Queries for entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="partitionId">
-        ///
+        /// Entities are partitioned into subsets, identified by a partition ID.
+        /// Queries are scoped to a single partition.
+        /// This partition ID is normalized with the standard default context
+        /// partition ID.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this query.
         /// </param>
         /// <param name="query">
-        ///
+        /// The query to run.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1221,19 +1338,22 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Queries for entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="partitionId">
-        ///
+        /// Entities are partitioned into subsets, identified by a partition ID.
+        /// Queries are scoped to a single partition.
+        /// This partition ID is normalized with the standard default context
+        /// partition ID.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this query.
         /// </param>
         /// <param name="gqlQuery">
-        ///
+        /// The GQL query to run.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1257,19 +1377,22 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Queries for entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="partitionId">
-        ///
+        /// Entities are partitioned into subsets, identified by a partition ID.
+        /// Queries are scoped to a single partition.
+        /// This partition ID is normalized with the standard default context
+        /// partition ID.
         /// </param>
         /// <param name="readOptions">
-        ///
+        /// The options for this query.
         /// </param>
         /// <param name="gqlQuery">
-        ///
+        /// The GQL query to run.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1293,10 +1416,10 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Begins a new transaction.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1314,10 +1437,10 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Begins a new transaction.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1335,19 +1458,34 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Commits a transaction, optionally creating, deleting or modifying some
+        /// entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="mode">
-        ///
+        /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
         /// </param>
         /// <param name="transaction">
-        ///
+        /// The identifier of the transaction associated with the commit. A
+        /// transaction identifier is returned by a call to
+        /// [Datastore.BeginTransaction][google.datastore.v1.Datastore.BeginTransaction].
         /// </param>
         /// <param name="mutations">
+        /// The mutations to perform.
         ///
+        /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
+        /// applied in order. The following sequences of mutations affecting a single
+        /// entity are not permitted in a single `Commit` request:
+        ///
+        /// - `insert` followed by `insert`
+        /// - `update` followed by `insert`
+        /// - `upsert` followed by `insert`
+        /// - `delete` followed by `update`
+        ///
+        /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
+        /// entity.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1371,19 +1509,34 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Commits a transaction, optionally creating, deleting or modifying some
+        /// entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="mode">
-        ///
+        /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
         /// </param>
         /// <param name="transaction">
-        ///
+        /// The identifier of the transaction associated with the commit. A
+        /// transaction identifier is returned by a call to
+        /// [Datastore.BeginTransaction][google.datastore.v1.Datastore.BeginTransaction].
         /// </param>
         /// <param name="mutations">
+        /// The mutations to perform.
         ///
+        /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
+        /// applied in order. The following sequences of mutations affecting a single
+        /// entity are not permitted in a single `Commit` request:
+        ///
+        /// - `insert` followed by `insert`
+        /// - `update` followed by `insert`
+        /// - `upsert` followed by `insert`
+        /// - `delete` followed by `update`
+        ///
+        /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
+        /// entity.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1407,16 +1560,29 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Commits a transaction, optionally creating, deleting or modifying some
+        /// entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="mode">
-        ///
+        /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
         /// </param>
         /// <param name="mutations">
+        /// The mutations to perform.
         ///
+        /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
+        /// applied in order. The following sequences of mutations affecting a single
+        /// entity are not permitted in a single `Commit` request:
+        ///
+        /// - `insert` followed by `insert`
+        /// - `update` followed by `insert`
+        /// - `upsert` followed by `insert`
+        /// - `delete` followed by `update`
+        ///
+        /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
+        /// entity.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1438,16 +1604,29 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Commits a transaction, optionally creating, deleting or modifying some
+        /// entities.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="mode">
-        ///
+        /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
         /// </param>
         /// <param name="mutations">
+        /// The mutations to perform.
         ///
+        /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
+        /// applied in order. The following sequences of mutations affecting a single
+        /// entity are not permitted in a single `Commit` request:
+        ///
+        /// - `insert` followed by `insert`
+        /// - `update` followed by `insert`
+        /// - `upsert` followed by `insert`
+        /// - `delete` followed by `update`
+        ///
+        /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
+        /// entity.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1469,13 +1648,14 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Rolls back a transaction.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="transaction">
-        ///
+        /// The transaction identifier, returned by a call to
+        /// [Datastore.BeginTransaction][google.datastore.v1.Datastore.BeginTransaction].
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1495,13 +1675,14 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Rolls back a transaction.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="transaction">
-        ///
+        /// The transaction identifier, returned by a call to
+        /// [Datastore.BeginTransaction][google.datastore.v1.Datastore.BeginTransaction].
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1521,13 +1702,15 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Allocates IDs for the given keys, which is useful for referencing an entity
+        /// before it is inserted.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="keys">
-        ///
+        /// A list of keys with incomplete key paths for which to allocate IDs.
+        /// No key may be reserved/read-only.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1547,13 +1730,15 @@ namespace Google.Datastore.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Allocates IDs for the given keys, which is useful for referencing an entity
+        /// before it is inserted.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// The ID of the project against which to make the request.
         /// </param>
         /// <param name="keys">
-        ///
+        /// A list of keys with incomplete key paths for which to allocate IDs.
+        /// No key may be reserved/read-only.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.

--- a/apis/Google.Datastore.V1/Google.Datastore.V1/DatastoreClient.cs
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1/DatastoreClient.cs
@@ -14,9 +14,9 @@
 
 // Generated code. DO NOT EDIT!
 
+using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Datastore.V1;
-using Google.Datastore.V1.CommitRequest.Types;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
+using static Google.Datastore.V1.CommitRequest.Types;
 
 namespace Google.Datastore.V1
 {

--- a/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1.Snippets/ErrorGroupServiceClientSnippets.g.cs
+++ b/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1.Snippets/ErrorGroupServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 // Generated code. DO NOT EDIT!
 
 using Google.Api.Gax.Grpc;
+using Google.Devtools.Clouderrorreporting.V1beta1;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;

--- a/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1.Snippets/ErrorGroupServiceClientSnippets.g.cs
+++ b/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1.Snippets/ErrorGroupServiceClientSnippets.g.cs
@@ -15,7 +15,6 @@
 // Generated code. DO NOT EDIT!
 
 using Google.Api.Gax.Grpc;
-using Google.Devtools.Clouderrorreporting.V1beta1;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;

--- a/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1.Snippets/ErrorStatsServiceClientSnippets.g.cs
+++ b/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1.Snippets/ErrorStatsServiceClientSnippets.g.cs
@@ -16,7 +16,6 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
-using Google.Devtools.Clouderrorreporting.V1beta1;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;

--- a/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1.Snippets/ErrorStatsServiceClientSnippets.g.cs
+++ b/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1.Snippets/ErrorStatsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Devtools.Clouderrorreporting.V1beta1;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -34,7 +35,6 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1.Snippets
         public async Task ListGroupStatsAsync()
         {
             // Snippet: ListGroupStatsAsync(string,QueryTimeRange,string,int?,CallSettings)
-            // Additional: ListGroupStatsAsync(string,QueryTimeRange,string,int?,CancellationToken)
             // Create client
             ErrorStatsServiceClient errorStatsServiceClient = ErrorStatsServiceClient.Create();
             // Initialize request argument(s)
@@ -102,7 +102,6 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1.Snippets
         public async Task ListEventsAsync()
         {
             // Snippet: ListEventsAsync(string,string,string,int?,CallSettings)
-            // Additional: ListEventsAsync(string,string,string,int?,CancellationToken)
             // Create client
             ErrorStatsServiceClient errorStatsServiceClient = ErrorStatsServiceClient.Create();
             // Initialize request argument(s)

--- a/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1.Snippets/ReportErrorsServiceClientSnippets.g.cs
+++ b/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1.Snippets/ReportErrorsServiceClientSnippets.g.cs
@@ -15,7 +15,6 @@
 // Generated code. DO NOT EDIT!
 
 using Google.Api.Gax.Grpc;
-using Google.Devtools.Clouderrorreporting.V1beta1;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -39,9 +38,9 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1.Snippets
             ReportErrorsServiceClient reportErrorsServiceClient = ReportErrorsServiceClient.Create();
             // Initialize request argument(s)
             string formattedProjectName = ReportErrorsServiceClient.FormatProjectName("[PROJECT]");
-            ReportedErrorEvent event = new ReportedErrorEvent();
+            ReportedErrorEvent @event = new ReportedErrorEvent();
             // Make the request
-            ReportErrorEventResponse response = await reportErrorsServiceClient.ReportErrorEventAsync(formattedProjectName, event);
+            ReportErrorEventResponse response = await reportErrorsServiceClient.ReportErrorEventAsync(formattedProjectName, @event);
             // End snippet
         }
 
@@ -52,9 +51,9 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1.Snippets
             ReportErrorsServiceClient reportErrorsServiceClient = ReportErrorsServiceClient.Create();
             // Initialize request argument(s)
             string formattedProjectName = ReportErrorsServiceClient.FormatProjectName("[PROJECT]");
-            ReportedErrorEvent event = new ReportedErrorEvent();
+            ReportedErrorEvent @event = new ReportedErrorEvent();
             // Make the request
-            ReportErrorEventResponse response = reportErrorsServiceClient.ReportErrorEvent(formattedProjectName, event);
+            ReportErrorEventResponse response = reportErrorsServiceClient.ReportErrorEvent(formattedProjectName, @event);
             // End snippet
         }
 

--- a/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1.Snippets/ReportErrorsServiceClientSnippets.g.cs
+++ b/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1.Snippets/ReportErrorsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 // Generated code. DO NOT EDIT!
 
 using Google.Api.Gax.Grpc;
+using Google.Devtools.Clouderrorreporting.V1beta1;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -38,9 +39,9 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1.Snippets
             ReportErrorsServiceClient reportErrorsServiceClient = ReportErrorsServiceClient.Create();
             // Initialize request argument(s)
             string formattedProjectName = ReportErrorsServiceClient.FormatProjectName("[PROJECT]");
-            ReportedErrorEvent @event = new ReportedErrorEvent();
+            ReportedErrorEvent event = new ReportedErrorEvent();
             // Make the request
-            ReportErrorEventResponse response = await reportErrorsServiceClient.ReportErrorEventAsync(formattedProjectName, @event);
+            ReportErrorEventResponse response = await reportErrorsServiceClient.ReportErrorEventAsync(formattedProjectName, event);
             // End snippet
         }
 
@@ -51,9 +52,9 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1.Snippets
             ReportErrorsServiceClient reportErrorsServiceClient = ReportErrorsServiceClient.Create();
             // Initialize request argument(s)
             string formattedProjectName = ReportErrorsServiceClient.FormatProjectName("[PROJECT]");
-            ReportedErrorEvent @event = new ReportedErrorEvent();
+            ReportedErrorEvent event = new ReportedErrorEvent();
             // Make the request
-            ReportErrorEventResponse response = reportErrorsServiceClient.ReportErrorEvent(formattedProjectName, @event);
+            ReportErrorEventResponse response = reportErrorsServiceClient.ReportErrorEvent(formattedProjectName, event);
             // End snippet
         }
 

--- a/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/ErrorGroupServiceClient.cs
+++ b/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/ErrorGroupServiceClient.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 
 // Generated code. DO NOT EDIT!
 
-using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Devtools.Clouderrorreporting.V1beta1;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -295,10 +295,17 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Get the specified group.
         /// </summary>
         /// <param name="groupName">
+        /// [Required] The group resource name. Written as
+        /// <code>projects/<var>projectID</var>/groups/<var>group_name</var></code>.
+        /// Call
+        /// <a href="/error-reporting/reference/rest/v1beta1/projects.groupStats/list">
+        /// <code>groupStats.list</code></a> to return a list of groups belonging to
+        /// this project.
         ///
+        /// Example: <code>projects/my-project-123/groups/my-group</code>
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -314,10 +321,17 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Get the specified group.
         /// </summary>
         /// <param name="groupName">
+        /// [Required] The group resource name. Written as
+        /// <code>projects/<var>projectID</var>/groups/<var>group_name</var></code>.
+        /// Call
+        /// <a href="/error-reporting/reference/rest/v1beta1/projects.groupStats/list">
+        /// <code>groupStats.list</code></a> to return a list of groups belonging to
+        /// this project.
         ///
+        /// Example: <code>projects/my-project-123/groups/my-group</code>
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -332,10 +346,17 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Get the specified group.
         /// </summary>
         /// <param name="groupName">
+        /// [Required] The group resource name. Written as
+        /// <code>projects/<var>projectID</var>/groups/<var>group_name</var></code>.
+        /// Call
+        /// <a href="/error-reporting/reference/rest/v1beta1/projects.groupStats/list">
+        /// <code>groupStats.list</code></a> to return a list of groups belonging to
+        /// this project.
         ///
+        /// Example: <code>projects/my-project-123/groups/my-group</code>
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -351,10 +372,11 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Replace the data for the specified group.
+        /// Fails if the group does not exist.
         /// </summary>
         /// <param name="group">
-        ///
+        /// [Required] The group which replaces the resource on the server.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -370,10 +392,11 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Replace the data for the specified group.
+        /// Fails if the group does not exist.
         /// </summary>
         /// <param name="group">
-        ///
+        /// [Required] The group which replaces the resource on the server.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -388,10 +411,11 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Replace the data for the specified group.
+        /// Fails if the group does not exist.
         /// </summary>
         /// <param name="group">
-        ///
+        /// [Required] The group which replaces the resource on the server.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -439,10 +463,17 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         public override ErrorGroupService.ErrorGroupServiceClient GrpcClient { get; }
 
         /// <summary>
-        ///
+        /// Get the specified group.
         /// </summary>
         /// <param name="groupName">
+        /// [Required] The group resource name. Written as
+        /// <code>projects/<var>projectID</var>/groups/<var>group_name</var></code>.
+        /// Call
+        /// <a href="/error-reporting/reference/rest/v1beta1/projects.groupStats/list">
+        /// <code>groupStats.list</code></a> to return a list of groups belonging to
+        /// this project.
         ///
+        /// Example: <code>projects/my-project-123/groups/my-group</code>
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -460,10 +491,17 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Get the specified group.
         /// </summary>
         /// <param name="groupName">
+        /// [Required] The group resource name. Written as
+        /// <code>projects/<var>projectID</var>/groups/<var>group_name</var></code>.
+        /// Call
+        /// <a href="/error-reporting/reference/rest/v1beta1/projects.groupStats/list">
+        /// <code>groupStats.list</code></a> to return a list of groups belonging to
+        /// this project.
         ///
+        /// Example: <code>projects/my-project-123/groups/my-group</code>
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -481,10 +519,11 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Replace the data for the specified group.
+        /// Fails if the group does not exist.
         /// </summary>
         /// <param name="group">
-        ///
+        /// [Required] The group which replaces the resource on the server.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -502,10 +541,11 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Replace the data for the specified group.
+        /// Fails if the group does not exist.
         /// </summary>
         /// <param name="group">
-        ///
+        /// [Required] The group which replaces the resource on the server.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.

--- a/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/ErrorGroupServiceClient.cs
+++ b/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/ErrorGroupServiceClient.cs
@@ -14,8 +14,8 @@
 
 // Generated code. DO NOT EDIT!
 
+using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
-using Google.Devtools.Clouderrorreporting.V1beta1;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;

--- a/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/ErrorStatsServiceClient.cs
+++ b/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/ErrorStatsServiceClient.cs
@@ -16,7 +16,6 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
-using Google.Devtools.Clouderrorreporting.V1beta1;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;

--- a/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/ErrorStatsServiceClient.cs
+++ b/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/ErrorStatsServiceClient.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Devtools.Clouderrorreporting.V1beta1;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -324,13 +325,22 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Lists the specified groups.
         /// </summary>
         /// <param name="projectName">
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as <code>projects/</code> plus the
+        /// <a href="https://support.google.com/cloud/answer/6158840">Google Cloud
+        /// Platform project ID</a>.
         ///
+        /// Example: <code>projects/my-project-123</code>.
         /// </param>
         /// <param name="timeRange">
-        ///
+        /// [Required] List data for the given time range.
+        /// Only <code>ErrorGroupStats</code> with a non-zero count in the given time
+        /// range are returned, unless the request contains an explicit group_id list.
+        /// If a group_id list is given, also <code>ErrorGroupStats</code> with zero
+        /// occurrences are returned.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -357,13 +367,22 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Lists the specified groups.
         /// </summary>
         /// <param name="projectName">
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as <code>projects/</code> plus the
+        /// <a href="https://support.google.com/cloud/answer/6158840">Google Cloud
+        /// Platform project ID</a>.
         ///
+        /// Example: <code>projects/my-project-123</code>.
         /// </param>
         /// <param name="timeRange">
-        ///
+        /// [Required] List data for the given time range.
+        /// Only <code>ErrorGroupStats</code> with a non-zero count in the given time
+        /// range are returned, unless the request contains an explicit group_id list.
+        /// If a group_id list is given, also <code>ErrorGroupStats</code> with zero
+        /// occurrences are returned.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -390,13 +409,16 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Lists the specified events.
         /// </summary>
         /// <param name="projectName">
-        ///
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as `projects/` plus the
+        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="groupId">
-        ///
+        /// [Required] The group for which events shall be returned.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -423,13 +445,16 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Lists the specified events.
         /// </summary>
         /// <param name="projectName">
-        ///
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as `projects/` plus the
+        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="groupId">
-        ///
+        /// [Required] The group for which events shall be returned.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -456,10 +481,13 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Deletes all error events of a given project.
         /// </summary>
         /// <param name="projectName">
-        ///
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as `projects/` plus the
+        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -475,10 +503,13 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         }
 
         /// <summary>
-        ///
+        /// Deletes all error events of a given project.
         /// </summary>
         /// <param name="projectName">
-        ///
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as `projects/` plus the
+        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -493,10 +524,13 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Deletes all error events of a given project.
         /// </summary>
         /// <param name="projectName">
-        ///
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as `projects/` plus the
+        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -547,13 +581,22 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         public override ErrorStatsService.ErrorStatsServiceClient GrpcClient { get; }
 
         /// <summary>
-        ///
+        /// Lists the specified groups.
         /// </summary>
         /// <param name="projectName">
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as <code>projects/</code> plus the
+        /// <a href="https://support.google.com/cloud/answer/6158840">Google Cloud
+        /// Platform project ID</a>.
         ///
+        /// Example: <code>projects/my-project-123</code>.
         /// </param>
         /// <param name="timeRange">
-        ///
+        /// [Required] List data for the given time range.
+        /// Only <code>ErrorGroupStats</code> with a non-zero count in the given time
+        /// range are returned, unless the request contains an explicit group_id list.
+        /// If a group_id list is given, also <code>ErrorGroupStats</code> with zero
+        /// occurrences are returned.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -586,13 +629,22 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists the specified groups.
         /// </summary>
         /// <param name="projectName">
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as <code>projects/</code> plus the
+        /// <a href="https://support.google.com/cloud/answer/6158840">Google Cloud
+        /// Platform project ID</a>.
         ///
+        /// Example: <code>projects/my-project-123</code>.
         /// </param>
         /// <param name="timeRange">
-        ///
+        /// [Required] List data for the given time range.
+        /// Only <code>ErrorGroupStats</code> with a non-zero count in the given time
+        /// range are returned, unless the request contains an explicit group_id list.
+        /// If a group_id list is given, also <code>ErrorGroupStats</code> with zero
+        /// occurrences are returned.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -625,13 +677,16 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists the specified events.
         /// </summary>
         /// <param name="projectName">
-        ///
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as `projects/` plus the
+        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="groupId">
-        ///
+        /// [Required] The group for which events shall be returned.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -664,13 +719,16 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists the specified events.
         /// </summary>
         /// <param name="projectName">
-        ///
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as `projects/` plus the
+        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="groupId">
-        ///
+        /// [Required] The group for which events shall be returned.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -703,10 +761,13 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes all error events of a given project.
         /// </summary>
         /// <param name="projectName">
-        ///
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as `projects/` plus the
+        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -724,10 +785,13 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes all error events of a given project.
         /// </summary>
         /// <param name="projectName">
-        ///
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as `projects/` plus the
+        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.

--- a/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/ReportErrorsServiceClient.cs
+++ b/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/ReportErrorsServiceClient.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 
 // Generated code. DO NOT EDIT!
 
-using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Devtools.Clouderrorreporting.V1beta1;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -261,13 +261,23 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         }
 
         /// <summary>
+        /// Report an individual error event.
         ///
+        /// This endpoint accepts <strong>either</strong> an OAuth token,
+        /// <strong>or</strong> an
+        /// <a href="https://support.google.com/cloud/answer/6158862">API key</a>
+        /// for authentication. To use an API key, append it to the URL as the value of
+        /// a `key` parameter. For example:
+        /// <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>
         /// </summary>
         /// <param name="projectName">
-        ///
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as `projects/` plus the
+        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="event">
-        ///
+        /// [Required] The error event to be reported.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -277,20 +287,30 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         /// </returns>
         public virtual Task<ReportErrorEventResponse> ReportErrorEventAsync(
             string projectName,
-            ReportedErrorEvent @event,
+            ReportedErrorEvent event,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
 
         /// <summary>
+        /// Report an individual error event.
         ///
+        /// This endpoint accepts <strong>either</strong> an OAuth token,
+        /// <strong>or</strong> an
+        /// <a href="https://support.google.com/cloud/answer/6158862">API key</a>
+        /// for authentication. To use an API key, append it to the URL as the value of
+        /// a `key` parameter. For example:
+        /// <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>
         /// </summary>
         /// <param name="projectName">
-        ///
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as `projects/` plus the
+        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="event">
-        ///
+        /// [Required] The error event to be reported.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -300,20 +320,30 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         /// </returns>
         public virtual Task<ReportErrorEventResponse> ReportErrorEventAsync(
             string projectName,
-            ReportedErrorEvent @event,
+            ReportedErrorEvent event,
             CancellationToken cancellationToken) => ReportErrorEventAsync(
                 projectName,
-                @event,
+                event,
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
+        /// Report an individual error event.
         ///
+        /// This endpoint accepts <strong>either</strong> an OAuth token,
+        /// <strong>or</strong> an
+        /// <a href="https://support.google.com/cloud/answer/6158862">API key</a>
+        /// for authentication. To use an API key, append it to the URL as the value of
+        /// a `key` parameter. For example:
+        /// <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>
         /// </summary>
         /// <param name="projectName">
-        ///
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as `projects/` plus the
+        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="event">
-        ///
+        /// [Required] The error event to be reported.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -323,7 +353,7 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         /// </returns>
         public virtual ReportErrorEventResponse ReportErrorEvent(
             string projectName,
-            ReportedErrorEvent @event,
+            ReportedErrorEvent event,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -359,13 +389,23 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         public override ReportErrorsService.ReportErrorsServiceClient GrpcClient { get; }
 
         /// <summary>
+        /// Report an individual error event.
         ///
+        /// This endpoint accepts <strong>either</strong> an OAuth token,
+        /// <strong>or</strong> an
+        /// <a href="https://support.google.com/cloud/answer/6158862">API key</a>
+        /// for authentication. To use an API key, append it to the URL as the value of
+        /// a `key` parameter. For example:
+        /// <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>
         /// </summary>
         /// <param name="projectName">
-        ///
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as `projects/` plus the
+        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="event">
-        ///
+        /// [Required] The error event to be reported.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -375,23 +415,33 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         /// </returns>
         public override Task<ReportErrorEventResponse> ReportErrorEventAsync(
             string projectName,
-            ReportedErrorEvent @event,
+            ReportedErrorEvent event,
             CallSettings callSettings = null) => _callReportErrorEvent.Async(
                 new ReportErrorEventRequest
                 {
                     ProjectName = projectName,
-                    Event = @event,
+                    Event = event,
                 },
                 callSettings);
 
         /// <summary>
+        /// Report an individual error event.
         ///
+        /// This endpoint accepts <strong>either</strong> an OAuth token,
+        /// <strong>or</strong> an
+        /// <a href="https://support.google.com/cloud/answer/6158862">API key</a>
+        /// for authentication. To use an API key, append it to the URL as the value of
+        /// a `key` parameter. For example:
+        /// <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>
         /// </summary>
         /// <param name="projectName">
-        ///
+        /// [Required] The resource name of the Google Cloud Platform project. Written
+        /// as `projects/` plus the
+        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="event">
-        ///
+        /// [Required] The error event to be reported.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -401,12 +451,12 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         /// </returns>
         public override ReportErrorEventResponse ReportErrorEvent(
             string projectName,
-            ReportedErrorEvent @event,
+            ReportedErrorEvent event,
             CallSettings callSettings = null) => _callReportErrorEvent.Sync(
                 new ReportErrorEventRequest
                 {
                     ProjectName = projectName,
-                    Event = @event,
+                    Event = event,
                 },
                 callSettings);
 

--- a/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/ReportErrorsServiceClient.cs
+++ b/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/ReportErrorsServiceClient.cs
@@ -14,8 +14,8 @@
 
 // Generated code. DO NOT EDIT!
 
+using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
-using Google.Devtools.Clouderrorreporting.V1beta1;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -287,7 +287,7 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         /// </returns>
         public virtual Task<ReportErrorEventResponse> ReportErrorEventAsync(
             string projectName,
-            ReportedErrorEvent event,
+            ReportedErrorEvent @event,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -320,10 +320,10 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         /// </returns>
         public virtual Task<ReportErrorEventResponse> ReportErrorEventAsync(
             string projectName,
-            ReportedErrorEvent event,
+            ReportedErrorEvent @event,
             CancellationToken cancellationToken) => ReportErrorEventAsync(
                 projectName,
-                event,
+                @event,
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
@@ -353,7 +353,7 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         /// </returns>
         public virtual ReportErrorEventResponse ReportErrorEvent(
             string projectName,
-            ReportedErrorEvent event,
+            ReportedErrorEvent @event,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -415,12 +415,12 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         /// </returns>
         public override Task<ReportErrorEventResponse> ReportErrorEventAsync(
             string projectName,
-            ReportedErrorEvent event,
+            ReportedErrorEvent @event,
             CallSettings callSettings = null) => _callReportErrorEvent.Async(
                 new ReportErrorEventRequest
                 {
                     ProjectName = projectName,
-                    Event = event,
+                    Event = @event,
                 },
                 callSettings);
 
@@ -451,12 +451,12 @@ namespace Google.Devtools.Clouderrorreporting.V1Beta1
         /// </returns>
         public override ReportErrorEventResponse ReportErrorEvent(
             string projectName,
-            ReportedErrorEvent event,
+            ReportedErrorEvent @event,
             CallSettings callSettings = null) => _callReportErrorEvent.Sync(
                 new ReportErrorEventRequest
                 {
                     ProjectName = projectName,
-                    Event = event,
+                    Event = @event,
                 },
                 callSettings);
 

--- a/apis/Google.Devtools.Cloudtrace.V1/Google.Devtools.Cloudtrace.V1.Snippets/TraceServiceClientSnippets.g.cs
+++ b/apis/Google.Devtools.Cloudtrace.V1/Google.Devtools.Cloudtrace.V1.Snippets/TraceServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Devtools.Cloudtrace.V1;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -88,7 +89,6 @@ namespace Google.Devtools.Cloudtrace.V1.Snippets
         public async Task ListTracesAsync()
         {
             // Snippet: ListTracesAsync(string,string,int?,CallSettings)
-            // Additional: ListTracesAsync(string,string,int?,CancellationToken)
             // Create client
             TraceServiceClient traceServiceClient = TraceServiceClient.Create();
             // Initialize request argument(s)

--- a/apis/Google.Devtools.Cloudtrace.V1/Google.Devtools.Cloudtrace.V1/TraceServiceClient.cs
+++ b/apis/Google.Devtools.Cloudtrace.V1/Google.Devtools.Cloudtrace.V1/TraceServiceClient.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Devtools.Cloudtrace.V1;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -134,7 +136,8 @@ namespace Google.Devtools.Cloudtrace.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description>No status codes</description></item>
+        /// <item><description><see cref="StatusCode.DeadlineExceeded"/></description></item>
+        /// <item><description><see cref="StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 45000 milliseconds.
         /// </remarks>
@@ -143,7 +146,7 @@ namespace Google.Devtools.Cloudtrace.V1
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
                 totalExpiration: Expiration.FromTimeout(TimeSpan.FromMilliseconds(45000)),
-                retryFilter: NonIdempotentRetryFilter
+                retryFilter: IdempotentRetryFilter
             )));
 
         /// <summary>
@@ -310,13 +313,17 @@ namespace Google.Devtools.Cloudtrace.V1
         }
 
         /// <summary>
-        ///
+        /// Sends new traces to Stackdriver Trace or updates existing traces. If the ID
+        /// of a trace that you send matches that of an existing trace, any fields
+        /// in the existing trace and its spans are overwritten by the provided values,
+        /// and any new fields provided are merged with the existing trace data. If the
+        /// ID does not match, a new trace is created.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// ID of the Cloud project where the trace data is stored.
         /// </param>
         /// <param name="traces">
-        ///
+        /// The body of the message.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -333,13 +340,17 @@ namespace Google.Devtools.Cloudtrace.V1
         }
 
         /// <summary>
-        ///
+        /// Sends new traces to Stackdriver Trace or updates existing traces. If the ID
+        /// of a trace that you send matches that of an existing trace, any fields
+        /// in the existing trace and its spans are overwritten by the provided values,
+        /// and any new fields provided are merged with the existing trace data. If the
+        /// ID does not match, a new trace is created.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// ID of the Cloud project where the trace data is stored.
         /// </param>
         /// <param name="traces">
-        ///
+        /// The body of the message.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -356,13 +367,17 @@ namespace Google.Devtools.Cloudtrace.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Sends new traces to Stackdriver Trace or updates existing traces. If the ID
+        /// of a trace that you send matches that of an existing trace, any fields
+        /// in the existing trace and its spans are overwritten by the provided values,
+        /// and any new fields provided are merged with the existing trace data. If the
+        /// ID does not match, a new trace is created.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// ID of the Cloud project where the trace data is stored.
         /// </param>
         /// <param name="traces">
-        ///
+        /// The body of the message.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -379,13 +394,13 @@ namespace Google.Devtools.Cloudtrace.V1
         }
 
         /// <summary>
-        ///
+        /// Gets a single trace by its ID.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// ID of the Cloud project where the trace data is stored.
         /// </param>
         /// <param name="traceId">
-        ///
+        /// ID of the trace to return.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -402,13 +417,13 @@ namespace Google.Devtools.Cloudtrace.V1
         }
 
         /// <summary>
-        ///
+        /// Gets a single trace by its ID.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// ID of the Cloud project where the trace data is stored.
         /// </param>
         /// <param name="traceId">
-        ///
+        /// ID of the trace to return.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -425,13 +440,13 @@ namespace Google.Devtools.Cloudtrace.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Gets a single trace by its ID.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// ID of the Cloud project where the trace data is stored.
         /// </param>
         /// <param name="traceId">
-        ///
+        /// ID of the trace to return.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -448,10 +463,10 @@ namespace Google.Devtools.Cloudtrace.V1
         }
 
         /// <summary>
-        ///
+        /// Returns of a list of traces that match the specified filter conditions.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// ID of the Cloud project where the trace data is stored.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -477,10 +492,10 @@ namespace Google.Devtools.Cloudtrace.V1
         }
 
         /// <summary>
-        ///
+        /// Returns of a list of traces that match the specified filter conditions.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// ID of the Cloud project where the trace data is stored.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -541,13 +556,17 @@ namespace Google.Devtools.Cloudtrace.V1
         public override TraceService.TraceServiceClient GrpcClient { get; }
 
         /// <summary>
-        ///
+        /// Sends new traces to Stackdriver Trace or updates existing traces. If the ID
+        /// of a trace that you send matches that of an existing trace, any fields
+        /// in the existing trace and its spans are overwritten by the provided values,
+        /// and any new fields provided are merged with the existing trace data. If the
+        /// ID does not match, a new trace is created.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// ID of the Cloud project where the trace data is stored.
         /// </param>
         /// <param name="traces">
-        ///
+        /// The body of the message.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -567,13 +586,17 @@ namespace Google.Devtools.Cloudtrace.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Sends new traces to Stackdriver Trace or updates existing traces. If the ID
+        /// of a trace that you send matches that of an existing trace, any fields
+        /// in the existing trace and its spans are overwritten by the provided values,
+        /// and any new fields provided are merged with the existing trace data. If the
+        /// ID does not match, a new trace is created.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// ID of the Cloud project where the trace data is stored.
         /// </param>
         /// <param name="traces">
-        ///
+        /// The body of the message.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -593,13 +616,13 @@ namespace Google.Devtools.Cloudtrace.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Gets a single trace by its ID.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// ID of the Cloud project where the trace data is stored.
         /// </param>
         /// <param name="traceId">
-        ///
+        /// ID of the trace to return.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -619,13 +642,13 @@ namespace Google.Devtools.Cloudtrace.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Gets a single trace by its ID.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// ID of the Cloud project where the trace data is stored.
         /// </param>
         /// <param name="traceId">
-        ///
+        /// ID of the trace to return.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -645,10 +668,10 @@ namespace Google.Devtools.Cloudtrace.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Returns of a list of traces that match the specified filter conditions.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// ID of the Cloud project where the trace data is stored.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -679,10 +702,10 @@ namespace Google.Devtools.Cloudtrace.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Returns of a list of traces that match the specified filter conditions.
         /// </summary>
         /// <param name="projectId">
-        ///
+        /// ID of the Cloud project where the trace data is stored.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.

--- a/apis/Google.Logging.V2/Google.Logging.V2.Snippets/ConfigServiceV2ClientSnippets.g.cs
+++ b/apis/Google.Logging.V2/Google.Logging.V2.Snippets/ConfigServiceV2ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Logging.V2;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -34,7 +35,6 @@ namespace Google.Logging.V2.Snippets
         public async Task ListSinksAsync()
         {
             // Snippet: ListSinksAsync(string,string,int?,CallSettings)
-            // Additional: ListSinksAsync(string,string,int?,CancellationToken)
             // Create client
             ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
             // Initialize request argument(s)

--- a/apis/Google.Logging.V2/Google.Logging.V2.Snippets/LoggingServiceV2ClientSnippets.g.cs
+++ b/apis/Google.Logging.V2/Google.Logging.V2.Snippets/LoggingServiceV2ClientSnippets.g.cs
@@ -18,7 +18,6 @@ using Google.Api;
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Logging.V2;
-using Google.Logging.V2.WriteLogEntriesRequest.Types;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;

--- a/apis/Google.Logging.V2/Google.Logging.V2.Snippets/LoggingServiceV2ClientSnippets.g.cs
+++ b/apis/Google.Logging.V2/Google.Logging.V2.Snippets/LoggingServiceV2ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 using Google.Api;
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Logging.V2;
+using Google.Logging.V2.WriteLogEntriesRequest.Types;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -91,7 +93,6 @@ namespace Google.Logging.V2.Snippets
         public async Task ListLogEntriesAsync()
         {
             // Snippet: ListLogEntriesAsync(IEnumerable<string>,string,string,string,int?,CallSettings)
-            // Additional: ListLogEntriesAsync(IEnumerable<string>,string,string,string,int?,CancellationToken)
             // Create client
             LoggingServiceV2Client loggingServiceV2Client = LoggingServiceV2Client.Create();
             // Initialize request argument(s)

--- a/apis/Google.Logging.V2/Google.Logging.V2.Snippets/MetricsServiceV2ClientSnippets.g.cs
+++ b/apis/Google.Logging.V2/Google.Logging.V2.Snippets/MetricsServiceV2ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Logging.V2;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -34,7 +35,6 @@ namespace Google.Logging.V2.Snippets
         public async Task ListLogMetricsAsync()
         {
             // Snippet: ListLogMetricsAsync(string,string,int?,CallSettings)
-            // Additional: ListLogMetricsAsync(string,string,int?,CancellationToken)
             // Create client
             MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
             // Initialize request argument(s)

--- a/apis/Google.Logging.V2/Google.Logging.V2/ConfigServiceV2Client.cs
+++ b/apis/Google.Logging.V2/Google.Logging.V2/ConfigServiceV2Client.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Logging.V2;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -411,10 +413,11 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Lists sinks.
         /// </summary>
         /// <param name="parent">
-        ///
+        /// Required. The cloud resource containing the sinks.
+        /// Example: `"projects/my-logging-project"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -440,10 +443,11 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Lists sinks.
         /// </summary>
         /// <param name="parent">
-        ///
+        /// Required. The cloud resource containing the sinks.
+        /// Example: `"projects/my-logging-project"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -469,10 +473,11 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Gets a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to return.
+        /// Example: `"projects/my-project-id/sinks/my-sink-id"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -488,10 +493,11 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Gets a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to return.
+        /// Example: `"projects/my-project-id/sinks/my-sink-id"`.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -506,10 +512,11 @@ namespace Google.Logging.V2
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Gets a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to return.
+        /// Example: `"projects/my-project-id/sinks/my-sink-id"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -525,13 +532,16 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Creates a sink.
         /// </summary>
         /// <param name="parent">
-        ///
+        /// Required. The resource in which to create the sink.
+        /// Example: `"projects/my-project-id"`.
+        /// The new sink must be provided in the request.
         /// </param>
         /// <param name="sink">
-        ///
+        /// Required. The new sink, whose `name` parameter is a sink identifier that
+        /// is not already in use.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -548,13 +558,16 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Creates a sink.
         /// </summary>
         /// <param name="parent">
-        ///
+        /// Required. The resource in which to create the sink.
+        /// Example: `"projects/my-project-id"`.
+        /// The new sink must be provided in the request.
         /// </param>
         /// <param name="sink">
-        ///
+        /// Required. The new sink, whose `name` parameter is a sink identifier that
+        /// is not already in use.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -571,13 +584,16 @@ namespace Google.Logging.V2
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Creates a sink.
         /// </summary>
         /// <param name="parent">
-        ///
+        /// Required. The resource in which to create the sink.
+        /// Example: `"projects/my-project-id"`.
+        /// The new sink must be provided in the request.
         /// </param>
         /// <param name="sink">
-        ///
+        /// Required. The new sink, whose `name` parameter is a sink identifier that
+        /// is not already in use.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -594,13 +610,17 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Updates or creates a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to update, including the parent
+        /// resource and the sink identifier.  If the sink does not exist, this method
+        /// creates the sink.  Example: `"projects/my-project-id/sinks/my-sink-id"`.
         /// </param>
         /// <param name="sink">
-        ///
+        /// Required. The updated sink, whose name is the same identifier that appears
+        /// as part of `sinkName`.  If `sinkName` does not exist, then
+        /// this method creates a new sink.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -617,13 +637,17 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Updates or creates a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to update, including the parent
+        /// resource and the sink identifier.  If the sink does not exist, this method
+        /// creates the sink.  Example: `"projects/my-project-id/sinks/my-sink-id"`.
         /// </param>
         /// <param name="sink">
-        ///
+        /// Required. The updated sink, whose name is the same identifier that appears
+        /// as part of `sinkName`.  If `sinkName` does not exist, then
+        /// this method creates a new sink.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -640,13 +664,17 @@ namespace Google.Logging.V2
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Updates or creates a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to update, including the parent
+        /// resource and the sink identifier.  If the sink does not exist, this method
+        /// creates the sink.  Example: `"projects/my-project-id/sinks/my-sink-id"`.
         /// </param>
         /// <param name="sink">
-        ///
+        /// Required. The updated sink, whose name is the same identifier that appears
+        /// as part of `sinkName`.  If `sinkName` does not exist, then
+        /// this method creates a new sink.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -663,10 +691,13 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Deletes a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to delete, including the parent
+        /// resource and the sink identifier.  Example:
+        /// `"projects/my-project-id/sinks/my-sink-id"`.  It is an error if the sink
+        /// does not exist.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -682,10 +713,13 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Deletes a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to delete, including the parent
+        /// resource and the sink identifier.  Example:
+        /// `"projects/my-project-id/sinks/my-sink-id"`.  It is an error if the sink
+        /// does not exist.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -700,10 +734,13 @@ namespace Google.Logging.V2
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Deletes a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to delete, including the parent
+        /// resource and the sink identifier.  Example:
+        /// `"projects/my-project-id/sinks/my-sink-id"`.  It is an error if the sink
+        /// does not exist.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -760,10 +797,11 @@ namespace Google.Logging.V2
         public override ConfigServiceV2.ConfigServiceV2Client GrpcClient { get; }
 
         /// <summary>
-        ///
+        /// Lists sinks.
         /// </summary>
         /// <param name="parent">
-        ///
+        /// Required. The cloud resource containing the sinks.
+        /// Example: `"projects/my-logging-project"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -794,10 +832,11 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists sinks.
         /// </summary>
         /// <param name="parent">
-        ///
+        /// Required. The cloud resource containing the sinks.
+        /// Example: `"projects/my-logging-project"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -828,10 +867,11 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Gets a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to return.
+        /// Example: `"projects/my-project-id/sinks/my-sink-id"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -849,10 +889,11 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Gets a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to return.
+        /// Example: `"projects/my-project-id/sinks/my-sink-id"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -870,13 +911,16 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Creates a sink.
         /// </summary>
         /// <param name="parent">
-        ///
+        /// Required. The resource in which to create the sink.
+        /// Example: `"projects/my-project-id"`.
+        /// The new sink must be provided in the request.
         /// </param>
         /// <param name="sink">
-        ///
+        /// Required. The new sink, whose `name` parameter is a sink identifier that
+        /// is not already in use.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -896,13 +940,16 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Creates a sink.
         /// </summary>
         /// <param name="parent">
-        ///
+        /// Required. The resource in which to create the sink.
+        /// Example: `"projects/my-project-id"`.
+        /// The new sink must be provided in the request.
         /// </param>
         /// <param name="sink">
-        ///
+        /// Required. The new sink, whose `name` parameter is a sink identifier that
+        /// is not already in use.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -922,13 +969,17 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Updates or creates a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to update, including the parent
+        /// resource and the sink identifier.  If the sink does not exist, this method
+        /// creates the sink.  Example: `"projects/my-project-id/sinks/my-sink-id"`.
         /// </param>
         /// <param name="sink">
-        ///
+        /// Required. The updated sink, whose name is the same identifier that appears
+        /// as part of `sinkName`.  If `sinkName` does not exist, then
+        /// this method creates a new sink.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -948,13 +999,17 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Updates or creates a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to update, including the parent
+        /// resource and the sink identifier.  If the sink does not exist, this method
+        /// creates the sink.  Example: `"projects/my-project-id/sinks/my-sink-id"`.
         /// </param>
         /// <param name="sink">
-        ///
+        /// Required. The updated sink, whose name is the same identifier that appears
+        /// as part of `sinkName`.  If `sinkName` does not exist, then
+        /// this method creates a new sink.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -974,10 +1029,13 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to delete, including the parent
+        /// resource and the sink identifier.  Example:
+        /// `"projects/my-project-id/sinks/my-sink-id"`.  It is an error if the sink
+        /// does not exist.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -995,10 +1053,13 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes a sink.
         /// </summary>
         /// <param name="sinkName">
-        ///
+        /// Required. The resource name of the sink to delete, including the parent
+        /// resource and the sink identifier.  Example:
+        /// `"projects/my-project-id/sinks/my-sink-id"`.  It is an error if the sink
+        /// does not exist.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.

--- a/apis/Google.Logging.V2/Google.Logging.V2/LoggingServiceV2Client.cs
+++ b/apis/Google.Logging.V2/Google.Logging.V2/LoggingServiceV2Client.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,9 @@
 using Google.Api;
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Logging.V2;
+using Google.Logging.V2.WriteLogEntriesRequest.Types;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -422,10 +425,12 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Deletes a log and all its log entries.
+        /// The log will reappear if it receives new entries.
         /// </summary>
         /// <param name="logName">
-        ///
+        /// Required. The resource name of the log to delete.  Example:
+        /// `"projects/my-project/logs/syslog"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -441,10 +446,12 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Deletes a log and all its log entries.
+        /// The log will reappear if it receives new entries.
         /// </summary>
         /// <param name="logName">
-        ///
+        /// Required. The resource name of the log to delete.  Example:
+        /// `"projects/my-project/logs/syslog"`.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -459,10 +466,12 @@ namespace Google.Logging.V2
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Deletes a log and all its log entries.
+        /// The log will reappear if it receives new entries.
         /// </summary>
         /// <param name="logName">
-        ///
+        /// Required. The resource name of the log to delete.  Example:
+        /// `"projects/my-project/logs/syslog"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -478,19 +487,41 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Writes log entries to Stackdriver Logging.  All log entries are
+        /// written by this method.
         /// </summary>
         /// <param name="logName">
-        ///
+        /// Optional. A default log resource name that is assigned to all log entries
+        /// in `entries` that do not specify a value for `log_name`.  Example:
+        /// `"projects/my-project/logs/syslog"`.  See
+        /// [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="resource">
+        /// Optional. A default monitored resource object that is assigned to all log
+        /// entries in `entries` that do not specify a value for `resource`. Example:
         ///
+        ///     { "type": "gce_instance",
+        ///       "labels": {
+        ///         "zone": "us-central1-a", "instance_id": "00000000000000000000" }}
+        ///
+        /// See [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="labels">
-        ///
+        /// Optional. Default labels that are added to the `labels` field of all log
+        /// entries in `entries`. If a log entry already has a label with the same key
+        /// as a label in this parameter, then the log entry's label is not changed.
+        /// See [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="entries">
+        /// Required. The log entries to write. Values supplied for the fields
+        /// `log_name`, `resource`, and `labels` in this `entries.write` request are
+        /// added to those log entries that do not provide their own values for the
+        /// fields.
         ///
+        /// To improve throughput and to avoid exceeding the
+        /// [quota limit](/logging/quota-policy) for calls to `entries.write`,
+        /// you should write multiple log entries at once rather than
+        /// calling this method for each individual log entry.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -509,19 +540,41 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Writes log entries to Stackdriver Logging.  All log entries are
+        /// written by this method.
         /// </summary>
         /// <param name="logName">
-        ///
+        /// Optional. A default log resource name that is assigned to all log entries
+        /// in `entries` that do not specify a value for `log_name`.  Example:
+        /// `"projects/my-project/logs/syslog"`.  See
+        /// [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="resource">
+        /// Optional. A default monitored resource object that is assigned to all log
+        /// entries in `entries` that do not specify a value for `resource`. Example:
         ///
+        ///     { "type": "gce_instance",
+        ///       "labels": {
+        ///         "zone": "us-central1-a", "instance_id": "00000000000000000000" }}
+        ///
+        /// See [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="labels">
-        ///
+        /// Optional. Default labels that are added to the `labels` field of all log
+        /// entries in `entries`. If a log entry already has a label with the same key
+        /// as a label in this parameter, then the log entry's label is not changed.
+        /// See [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="entries">
+        /// Required. The log entries to write. Values supplied for the fields
+        /// `log_name`, `resource`, and `labels` in this `entries.write` request are
+        /// added to those log entries that do not provide their own values for the
+        /// fields.
         ///
+        /// To improve throughput and to avoid exceeding the
+        /// [quota limit](/logging/quota-policy) for calls to `entries.write`,
+        /// you should write multiple log entries at once rather than
+        /// calling this method for each individual log entry.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -542,19 +595,41 @@ namespace Google.Logging.V2
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Writes log entries to Stackdriver Logging.  All log entries are
+        /// written by this method.
         /// </summary>
         /// <param name="logName">
-        ///
+        /// Optional. A default log resource name that is assigned to all log entries
+        /// in `entries` that do not specify a value for `log_name`.  Example:
+        /// `"projects/my-project/logs/syslog"`.  See
+        /// [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="resource">
+        /// Optional. A default monitored resource object that is assigned to all log
+        /// entries in `entries` that do not specify a value for `resource`. Example:
         ///
+        ///     { "type": "gce_instance",
+        ///       "labels": {
+        ///         "zone": "us-central1-a", "instance_id": "00000000000000000000" }}
+        ///
+        /// See [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="labels">
-        ///
+        /// Optional. Default labels that are added to the `labels` field of all log
+        /// entries in `entries`. If a log entry already has a label with the same key
+        /// as a label in this parameter, then the log entry's label is not changed.
+        /// See [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="entries">
+        /// Required. The log entries to write. Values supplied for the fields
+        /// `log_name`, `resource`, and `labels` in this `entries.write` request are
+        /// added to those log entries that do not provide their own values for the
+        /// fields.
         ///
+        /// To improve throughput and to avoid exceeding the
+        /// [quota limit](/logging/quota-policy) for calls to `entries.write`,
+        /// you should write multiple log entries at once rather than
+        /// calling this method for each individual log entry.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -573,16 +648,29 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Lists log entries.  Use this method to retrieve log entries from Cloud
+        /// Logging.  For ways to export log entries, see
+        /// [Exporting Logs](/logging/docs/export).
         /// </summary>
         /// <param name="projectIds">
-        ///
+        /// Deprecated. One or more project identifiers or project numbers from which
+        /// to retrieve log entries.  Examples: `"my-project-1A"`, `"1234567890"`. If
+        /// present, these project identifiers are converted to resource format and
+        /// added to the list of resources in `resourceNames`. Callers should use
+        /// `resourceNames` rather than this parameter.
         /// </param>
         /// <param name="filter">
-        ///
+        /// Optional. A filter that chooses which log entries to return.  See [Advanced
+        /// Logs Filters](/logging/docs/view/advanced_filters).  Only log entries that
+        /// match the filter are returned.  An empty filter matches all log entries.
         /// </param>
         /// <param name="orderBy">
-        ///
+        /// Optional. How the results should be sorted.  Presently, the only permitted
+        /// values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
+        /// option returns entries in order of increasing values of
+        /// `LogEntry.timestamp` (oldest first), and the second option returns entries
+        /// in order of decreasing timestamps (newest first).  Entries with equal
+        /// timestamps are returned in order of `LogEntry.insertId`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -610,16 +698,29 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Lists log entries.  Use this method to retrieve log entries from Cloud
+        /// Logging.  For ways to export log entries, see
+        /// [Exporting Logs](/logging/docs/export).
         /// </summary>
         /// <param name="projectIds">
-        ///
+        /// Deprecated. One or more project identifiers or project numbers from which
+        /// to retrieve log entries.  Examples: `"my-project-1A"`, `"1234567890"`. If
+        /// present, these project identifiers are converted to resource format and
+        /// added to the list of resources in `resourceNames`. Callers should use
+        /// `resourceNames` rather than this parameter.
         /// </param>
         /// <param name="filter">
-        ///
+        /// Optional. A filter that chooses which log entries to return.  See [Advanced
+        /// Logs Filters](/logging/docs/view/advanced_filters).  Only log entries that
+        /// match the filter are returned.  An empty filter matches all log entries.
         /// </param>
         /// <param name="orderBy">
-        ///
+        /// Optional. How the results should be sorted.  Presently, the only permitted
+        /// values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
+        /// option returns entries in order of increasing values of
+        /// `LogEntry.timestamp` (oldest first), and the second option returns entries
+        /// in order of decreasing timestamps (newest first).  Entries with equal
+        /// timestamps are returned in order of `LogEntry.insertId`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -685,10 +786,12 @@ namespace Google.Logging.V2
         public override LoggingServiceV2.LoggingServiceV2Client GrpcClient { get; }
 
         /// <summary>
-        ///
+        /// Deletes a log and all its log entries.
+        /// The log will reappear if it receives new entries.
         /// </summary>
         /// <param name="logName">
-        ///
+        /// Required. The resource name of the log to delete.  Example:
+        /// `"projects/my-project/logs/syslog"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -706,10 +809,12 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes a log and all its log entries.
+        /// The log will reappear if it receives new entries.
         /// </summary>
         /// <param name="logName">
-        ///
+        /// Required. The resource name of the log to delete.  Example:
+        /// `"projects/my-project/logs/syslog"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -727,19 +832,41 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Writes log entries to Stackdriver Logging.  All log entries are
+        /// written by this method.
         /// </summary>
         /// <param name="logName">
-        ///
+        /// Optional. A default log resource name that is assigned to all log entries
+        /// in `entries` that do not specify a value for `log_name`.  Example:
+        /// `"projects/my-project/logs/syslog"`.  See
+        /// [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="resource">
+        /// Optional. A default monitored resource object that is assigned to all log
+        /// entries in `entries` that do not specify a value for `resource`. Example:
         ///
+        ///     { "type": "gce_instance",
+        ///       "labels": {
+        ///         "zone": "us-central1-a", "instance_id": "00000000000000000000" }}
+        ///
+        /// See [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="labels">
-        ///
+        /// Optional. Default labels that are added to the `labels` field of all log
+        /// entries in `entries`. If a log entry already has a label with the same key
+        /// as a label in this parameter, then the log entry's label is not changed.
+        /// See [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="entries">
+        /// Required. The log entries to write. Values supplied for the fields
+        /// `log_name`, `resource`, and `labels` in this `entries.write` request are
+        /// added to those log entries that do not provide their own values for the
+        /// fields.
         ///
+        /// To improve throughput and to avoid exceeding the
+        /// [quota limit](/logging/quota-policy) for calls to `entries.write`,
+        /// you should write multiple log entries at once rather than
+        /// calling this method for each individual log entry.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -757,25 +884,47 @@ namespace Google.Logging.V2
                 {
                     LogName = logName,
                     Resource = resource,
-                    Labels = { labels },
+                    Labels = labels,
                     Entries = { entries },
                 },
                 callSettings);
 
         /// <summary>
-        ///
+        /// Writes log entries to Stackdriver Logging.  All log entries are
+        /// written by this method.
         /// </summary>
         /// <param name="logName">
-        ///
+        /// Optional. A default log resource name that is assigned to all log entries
+        /// in `entries` that do not specify a value for `log_name`.  Example:
+        /// `"projects/my-project/logs/syslog"`.  See
+        /// [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="resource">
+        /// Optional. A default monitored resource object that is assigned to all log
+        /// entries in `entries` that do not specify a value for `resource`. Example:
         ///
+        ///     { "type": "gce_instance",
+        ///       "labels": {
+        ///         "zone": "us-central1-a", "instance_id": "00000000000000000000" }}
+        ///
+        /// See [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="labels">
-        ///
+        /// Optional. Default labels that are added to the `labels` field of all log
+        /// entries in `entries`. If a log entry already has a label with the same key
+        /// as a label in this parameter, then the log entry's label is not changed.
+        /// See [LogEntry][google.logging.v2.LogEntry].
         /// </param>
         /// <param name="entries">
+        /// Required. The log entries to write. Values supplied for the fields
+        /// `log_name`, `resource`, and `labels` in this `entries.write` request are
+        /// added to those log entries that do not provide their own values for the
+        /// fields.
         ///
+        /// To improve throughput and to avoid exceeding the
+        /// [quota limit](/logging/quota-policy) for calls to `entries.write`,
+        /// you should write multiple log entries at once rather than
+        /// calling this method for each individual log entry.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -793,22 +942,35 @@ namespace Google.Logging.V2
                 {
                     LogName = logName,
                     Resource = resource,
-                    Labels = { labels },
+                    Labels = labels,
                     Entries = { entries },
                 },
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists log entries.  Use this method to retrieve log entries from Cloud
+        /// Logging.  For ways to export log entries, see
+        /// [Exporting Logs](/logging/docs/export).
         /// </summary>
         /// <param name="projectIds">
-        ///
+        /// Deprecated. One or more project identifiers or project numbers from which
+        /// to retrieve log entries.  Examples: `"my-project-1A"`, `"1234567890"`. If
+        /// present, these project identifiers are converted to resource format and
+        /// added to the list of resources in `resourceNames`. Callers should use
+        /// `resourceNames` rather than this parameter.
         /// </param>
         /// <param name="filter">
-        ///
+        /// Optional. A filter that chooses which log entries to return.  See [Advanced
+        /// Logs Filters](/logging/docs/view/advanced_filters).  Only log entries that
+        /// match the filter are returned.  An empty filter matches all log entries.
         /// </param>
         /// <param name="orderBy">
-        ///
+        /// Optional. How the results should be sorted.  Presently, the only permitted
+        /// values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
+        /// option returns entries in order of increasing values of
+        /// `LogEntry.timestamp` (oldest first), and the second option returns entries
+        /// in order of decreasing timestamps (newest first).  Entries with equal
+        /// timestamps are returned in order of `LogEntry.insertId`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -843,16 +1005,29 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists log entries.  Use this method to retrieve log entries from Cloud
+        /// Logging.  For ways to export log entries, see
+        /// [Exporting Logs](/logging/docs/export).
         /// </summary>
         /// <param name="projectIds">
-        ///
+        /// Deprecated. One or more project identifiers or project numbers from which
+        /// to retrieve log entries.  Examples: `"my-project-1A"`, `"1234567890"`. If
+        /// present, these project identifiers are converted to resource format and
+        /// added to the list of resources in `resourceNames`. Callers should use
+        /// `resourceNames` rather than this parameter.
         /// </param>
         /// <param name="filter">
-        ///
+        /// Optional. A filter that chooses which log entries to return.  See [Advanced
+        /// Logs Filters](/logging/docs/view/advanced_filters).  Only log entries that
+        /// match the filter are returned.  An empty filter matches all log entries.
         /// </param>
         /// <param name="orderBy">
-        ///
+        /// Optional. How the results should be sorted.  Presently, the only permitted
+        /// values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
+        /// option returns entries in order of increasing values of
+        /// `LogEntry.timestamp` (oldest first), and the second option returns entries
+        /// in order of decreasing timestamps (newest first).  Entries with equal
+        /// timestamps are returned in order of `LogEntry.insertId`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.

--- a/apis/Google.Logging.V2/Google.Logging.V2/LoggingServiceV2Client.cs
+++ b/apis/Google.Logging.V2/Google.Logging.V2/LoggingServiceV2Client.cs
@@ -17,8 +17,6 @@
 using Google.Api;
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
-using Google.Logging.V2;
-using Google.Logging.V2.WriteLogEntriesRequest.Types;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -884,7 +882,7 @@ namespace Google.Logging.V2
                 {
                     LogName = logName,
                     Resource = resource,
-                    Labels = labels,
+                    Labels = { labels },
                     Entries = { entries },
                 },
                 callSettings);
@@ -942,7 +940,7 @@ namespace Google.Logging.V2
                 {
                     LogName = logName,
                     Resource = resource,
-                    Labels = labels,
+                    Labels = { labels },
                     Entries = { entries },
                 },
                 callSettings);

--- a/apis/Google.Logging.V2/Google.Logging.V2/MetricsServiceV2Client.cs
+++ b/apis/Google.Logging.V2/Google.Logging.V2/MetricsServiceV2Client.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Logging.V2;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -411,10 +413,11 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Lists logs-based metrics.
         /// </summary>
         /// <param name="parent">
-        ///
+        /// Required. The resource name containing the metrics.
+        /// Example: `"projects/my-project-id"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -440,10 +443,11 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Lists logs-based metrics.
         /// </summary>
         /// <param name="parent">
-        ///
+        /// Required. The resource name containing the metrics.
+        /// Example: `"projects/my-project-id"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -469,10 +473,11 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Gets a logs-based metric.
         /// </summary>
         /// <param name="metricName">
-        ///
+        /// The resource name of the desired metric.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -488,10 +493,11 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Gets a logs-based metric.
         /// </summary>
         /// <param name="metricName">
-        ///
+        /// The resource name of the desired metric.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -506,10 +512,11 @@ namespace Google.Logging.V2
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Gets a logs-based metric.
         /// </summary>
         /// <param name="metricName">
-        ///
+        /// The resource name of the desired metric.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -525,13 +532,17 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Creates a logs-based metric.
         /// </summary>
         /// <param name="parent">
+        /// The resource name of the project in which to create the metric.
+        /// Example: `"projects/my-project-id"`.
         ///
+        /// The new metric must be provided in the request.
         /// </param>
         /// <param name="metric">
-        ///
+        /// The new logs-based metric, which must not have an identifier that
+        /// already exists.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -548,13 +559,17 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Creates a logs-based metric.
         /// </summary>
         /// <param name="parent">
+        /// The resource name of the project in which to create the metric.
+        /// Example: `"projects/my-project-id"`.
         ///
+        /// The new metric must be provided in the request.
         /// </param>
         /// <param name="metric">
-        ///
+        /// The new logs-based metric, which must not have an identifier that
+        /// already exists.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -571,13 +586,17 @@ namespace Google.Logging.V2
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Creates a logs-based metric.
         /// </summary>
         /// <param name="parent">
+        /// The resource name of the project in which to create the metric.
+        /// Example: `"projects/my-project-id"`.
         ///
+        /// The new metric must be provided in the request.
         /// </param>
         /// <param name="metric">
-        ///
+        /// The new logs-based metric, which must not have an identifier that
+        /// already exists.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -594,13 +613,20 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Creates or updates a logs-based metric.
         /// </summary>
         /// <param name="metricName">
+        /// The resource name of the metric to update.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         ///
+        /// The updated metric must be provided in the request and have the
+        /// same identifier that is specified in `metricName`.
+        /// If the metric does not exist, it is created.
         /// </param>
         /// <param name="metric">
-        ///
+        /// The updated metric, whose name must be the same as the
+        /// metric identifier in `metricName`. If `metricName` does not
+        /// exist, then a new metric is created.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -617,13 +643,20 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Creates or updates a logs-based metric.
         /// </summary>
         /// <param name="metricName">
+        /// The resource name of the metric to update.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         ///
+        /// The updated metric must be provided in the request and have the
+        /// same identifier that is specified in `metricName`.
+        /// If the metric does not exist, it is created.
         /// </param>
         /// <param name="metric">
-        ///
+        /// The updated metric, whose name must be the same as the
+        /// metric identifier in `metricName`. If `metricName` does not
+        /// exist, then a new metric is created.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -640,13 +673,20 @@ namespace Google.Logging.V2
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Creates or updates a logs-based metric.
         /// </summary>
         /// <param name="metricName">
+        /// The resource name of the metric to update.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         ///
+        /// The updated metric must be provided in the request and have the
+        /// same identifier that is specified in `metricName`.
+        /// If the metric does not exist, it is created.
         /// </param>
         /// <param name="metric">
-        ///
+        /// The updated metric, whose name must be the same as the
+        /// metric identifier in `metricName`. If `metricName` does not
+        /// exist, then a new metric is created.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -663,10 +703,11 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Deletes a logs-based metric.
         /// </summary>
         /// <param name="metricName">
-        ///
+        /// The resource name of the metric to delete.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -682,10 +723,11 @@ namespace Google.Logging.V2
         }
 
         /// <summary>
-        ///
+        /// Deletes a logs-based metric.
         /// </summary>
         /// <param name="metricName">
-        ///
+        /// The resource name of the metric to delete.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -700,10 +742,11 @@ namespace Google.Logging.V2
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Deletes a logs-based metric.
         /// </summary>
         /// <param name="metricName">
-        ///
+        /// The resource name of the metric to delete.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -760,10 +803,11 @@ namespace Google.Logging.V2
         public override MetricsServiceV2.MetricsServiceV2Client GrpcClient { get; }
 
         /// <summary>
-        ///
+        /// Lists logs-based metrics.
         /// </summary>
         /// <param name="parent">
-        ///
+        /// Required. The resource name containing the metrics.
+        /// Example: `"projects/my-project-id"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -794,10 +838,11 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists logs-based metrics.
         /// </summary>
         /// <param name="parent">
-        ///
+        /// Required. The resource name containing the metrics.
+        /// Example: `"projects/my-project-id"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -828,10 +873,11 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Gets a logs-based metric.
         /// </summary>
         /// <param name="metricName">
-        ///
+        /// The resource name of the desired metric.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -849,10 +895,11 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Gets a logs-based metric.
         /// </summary>
         /// <param name="metricName">
-        ///
+        /// The resource name of the desired metric.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -870,13 +917,17 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Creates a logs-based metric.
         /// </summary>
         /// <param name="parent">
+        /// The resource name of the project in which to create the metric.
+        /// Example: `"projects/my-project-id"`.
         ///
+        /// The new metric must be provided in the request.
         /// </param>
         /// <param name="metric">
-        ///
+        /// The new logs-based metric, which must not have an identifier that
+        /// already exists.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -896,13 +947,17 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Creates a logs-based metric.
         /// </summary>
         /// <param name="parent">
+        /// The resource name of the project in which to create the metric.
+        /// Example: `"projects/my-project-id"`.
         ///
+        /// The new metric must be provided in the request.
         /// </param>
         /// <param name="metric">
-        ///
+        /// The new logs-based metric, which must not have an identifier that
+        /// already exists.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -922,13 +977,20 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Creates or updates a logs-based metric.
         /// </summary>
         /// <param name="metricName">
+        /// The resource name of the metric to update.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         ///
+        /// The updated metric must be provided in the request and have the
+        /// same identifier that is specified in `metricName`.
+        /// If the metric does not exist, it is created.
         /// </param>
         /// <param name="metric">
-        ///
+        /// The updated metric, whose name must be the same as the
+        /// metric identifier in `metricName`. If `metricName` does not
+        /// exist, then a new metric is created.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -948,13 +1010,20 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Creates or updates a logs-based metric.
         /// </summary>
         /// <param name="metricName">
+        /// The resource name of the metric to update.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         ///
+        /// The updated metric must be provided in the request and have the
+        /// same identifier that is specified in `metricName`.
+        /// If the metric does not exist, it is created.
         /// </param>
         /// <param name="metric">
-        ///
+        /// The updated metric, whose name must be the same as the
+        /// metric identifier in `metricName`. If `metricName` does not
+        /// exist, then a new metric is created.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -974,10 +1043,11 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes a logs-based metric.
         /// </summary>
         /// <param name="metricName">
-        ///
+        /// The resource name of the metric to delete.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -995,10 +1065,11 @@ namespace Google.Logging.V2
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes a logs-based metric.
         /// </summary>
         /// <param name="metricName">
-        ///
+        /// The resource name of the metric to delete.
+        /// Example: `"projects/my-project-id/metrics/my-metric-id"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.

--- a/apis/Google.Longrunning/Google.Longrunning.Snippets/OperationsClientSnippets.g.cs
+++ b/apis/Google.Longrunning/Google.Longrunning.Snippets/OperationsClientSnippets.g.cs
@@ -1,21 +1,36 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Generated code. DO NOT EDIT!
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Longrunning;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -59,7 +74,6 @@ namespace Google.Longrunning.Snippets
         public async Task ListOperationsAsync()
         {
             // Snippet: ListOperationsAsync(string,string,string,int?,CallSettings)
-            // Additional: ListOperationsAsync(string,string,string,int?,CancellationToken)
             // Create client
             OperationsClient operationsClient = OperationsClient.Create();
             // Initialize request argument(s)

--- a/apis/Google.Longrunning/Google.Longrunning/OperationsClient.cs
+++ b/apis/Google.Longrunning/Google.Longrunning/OperationsClient.cs
@@ -1,21 +1,37 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Generated code. DO NOT EDIT!
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Longrunning;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -353,10 +369,12 @@ namespace Google.Longrunning
         }
 
         /// <summary>
-        ///
+        /// Gets the latest state of a long-running operation.  Clients can use this
+        /// method to poll the operation result at intervals as recommended by the API
+        /// service.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -372,10 +390,12 @@ namespace Google.Longrunning
         }
 
         /// <summary>
-        ///
+        /// Gets the latest state of a long-running operation.  Clients can use this
+        /// method to poll the operation result at intervals as recommended by the API
+        /// service.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -390,10 +410,12 @@ namespace Google.Longrunning
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Gets the latest state of a long-running operation.  Clients can use this
+        /// method to poll the operation result at intervals as recommended by the API
+        /// service.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -409,13 +431,17 @@ namespace Google.Longrunning
         }
 
         /// <summary>
+        /// Lists operations that match the specified filter in the request. If the
+        /// server doesn't support this method, it returns `UNIMPLEMENTED`.
         ///
+        /// NOTE: the `name` binding below allows API services to override the binding
+        /// to use different resource name schemes, such as `users/*/operations`.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation collection.
         /// </param>
         /// <param name="filter">
-        ///
+        /// The standard list filter.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -442,13 +468,17 @@ namespace Google.Longrunning
         }
 
         /// <summary>
+        /// Lists operations that match the specified filter in the request. If the
+        /// server doesn't support this method, it returns `UNIMPLEMENTED`.
         ///
+        /// NOTE: the `name` binding below allows API services to override the binding
+        /// to use different resource name schemes, such as `users/*/operations`.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation collection.
         /// </param>
         /// <param name="filter">
-        ///
+        /// The standard list filter.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -475,10 +505,19 @@ namespace Google.Longrunning
         }
 
         /// <summary>
-        ///
+        /// Starts asynchronous cancellation on a long-running operation.  The server
+        /// makes a best effort to cancel the operation, but success is not
+        /// guaranteed.  If the server doesn't support this method, it returns
+        /// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+        /// [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+        /// other methods to check whether the cancellation succeeded or whether the
+        /// operation completed despite cancellation. On successful cancellation,
+        /// the operation is not deleted; instead, it becomes an operation with
+        /// an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+        /// corresponding to `Code.CANCELLED`.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource to be cancelled.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -494,10 +533,19 @@ namespace Google.Longrunning
         }
 
         /// <summary>
-        ///
+        /// Starts asynchronous cancellation on a long-running operation.  The server
+        /// makes a best effort to cancel the operation, but success is not
+        /// guaranteed.  If the server doesn't support this method, it returns
+        /// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+        /// [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+        /// other methods to check whether the cancellation succeeded or whether the
+        /// operation completed despite cancellation. On successful cancellation,
+        /// the operation is not deleted; instead, it becomes an operation with
+        /// an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+        /// corresponding to `Code.CANCELLED`.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource to be cancelled.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -512,10 +560,19 @@ namespace Google.Longrunning
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Starts asynchronous cancellation on a long-running operation.  The server
+        /// makes a best effort to cancel the operation, but success is not
+        /// guaranteed.  If the server doesn't support this method, it returns
+        /// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+        /// [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+        /// other methods to check whether the cancellation succeeded or whether the
+        /// operation completed despite cancellation. On successful cancellation,
+        /// the operation is not deleted; instead, it becomes an operation with
+        /// an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+        /// corresponding to `Code.CANCELLED`.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource to be cancelled.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -531,10 +588,13 @@ namespace Google.Longrunning
         }
 
         /// <summary>
-        ///
+        /// Deletes a long-running operation. This method indicates that the client is
+        /// no longer interested in the operation result. It does not cancel the
+        /// operation. If the server doesn't support this method, it returns
+        /// `google.rpc.Code.UNIMPLEMENTED`.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource to be deleted.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -550,10 +610,13 @@ namespace Google.Longrunning
         }
 
         /// <summary>
-        ///
+        /// Deletes a long-running operation. This method indicates that the client is
+        /// no longer interested in the operation result. It does not cancel the
+        /// operation. If the server doesn't support this method, it returns
+        /// `google.rpc.Code.UNIMPLEMENTED`.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource to be deleted.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -568,10 +631,13 @@ namespace Google.Longrunning
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Deletes a long-running operation. This method indicates that the client is
+        /// no longer interested in the operation result. It does not cancel the
+        /// operation. If the server doesn't support this method, it returns
+        /// `google.rpc.Code.UNIMPLEMENTED`.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource to be deleted.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -625,10 +691,12 @@ namespace Google.Longrunning
         public override Operations.OperationsClient GrpcClient { get; }
 
         /// <summary>
-        ///
+        /// Gets the latest state of a long-running operation.  Clients can use this
+        /// method to poll the operation result at intervals as recommended by the API
+        /// service.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -646,10 +714,12 @@ namespace Google.Longrunning
                 callSettings);
 
         /// <summary>
-        ///
+        /// Gets the latest state of a long-running operation.  Clients can use this
+        /// method to poll the operation result at intervals as recommended by the API
+        /// service.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -667,13 +737,17 @@ namespace Google.Longrunning
                 callSettings);
 
         /// <summary>
+        /// Lists operations that match the specified filter in the request. If the
+        /// server doesn't support this method, it returns `UNIMPLEMENTED`.
         ///
+        /// NOTE: the `name` binding below allows API services to override the binding
+        /// to use different resource name schemes, such as `users/*/operations`.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation collection.
         /// </param>
         /// <param name="filter">
-        ///
+        /// The standard list filter.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -706,13 +780,17 @@ namespace Google.Longrunning
                 callSettings);
 
         /// <summary>
+        /// Lists operations that match the specified filter in the request. If the
+        /// server doesn't support this method, it returns `UNIMPLEMENTED`.
         ///
+        /// NOTE: the `name` binding below allows API services to override the binding
+        /// to use different resource name schemes, such as `users/*/operations`.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation collection.
         /// </param>
         /// <param name="filter">
-        ///
+        /// The standard list filter.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -745,10 +823,19 @@ namespace Google.Longrunning
                 callSettings);
 
         /// <summary>
-        ///
+        /// Starts asynchronous cancellation on a long-running operation.  The server
+        /// makes a best effort to cancel the operation, but success is not
+        /// guaranteed.  If the server doesn't support this method, it returns
+        /// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+        /// [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+        /// other methods to check whether the cancellation succeeded or whether the
+        /// operation completed despite cancellation. On successful cancellation,
+        /// the operation is not deleted; instead, it becomes an operation with
+        /// an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+        /// corresponding to `Code.CANCELLED`.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource to be cancelled.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -766,10 +853,19 @@ namespace Google.Longrunning
                 callSettings);
 
         /// <summary>
-        ///
+        /// Starts asynchronous cancellation on a long-running operation.  The server
+        /// makes a best effort to cancel the operation, but success is not
+        /// guaranteed.  If the server doesn't support this method, it returns
+        /// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+        /// [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+        /// other methods to check whether the cancellation succeeded or whether the
+        /// operation completed despite cancellation. On successful cancellation,
+        /// the operation is not deleted; instead, it becomes an operation with
+        /// an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+        /// corresponding to `Code.CANCELLED`.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource to be cancelled.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -787,10 +883,13 @@ namespace Google.Longrunning
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes a long-running operation. This method indicates that the client is
+        /// no longer interested in the operation result. It does not cancel the
+        /// operation. If the server doesn't support this method, it returns
+        /// `google.rpc.Code.UNIMPLEMENTED`.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource to be deleted.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -808,10 +907,13 @@ namespace Google.Longrunning
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes a long-running operation. This method indicates that the client is
+        /// no longer interested in the operation result. It does not cancel the
+        /// operation. If the server doesn't support this method, it returns
+        /// `google.rpc.Code.UNIMPLEMENTED`.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The name of the operation resource to be deleted.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.

--- a/apis/Google.Monitoring.V3/Google.Monitoring.V3.Snippets/GroupServiceClientSnippets.g.cs
+++ b/apis/Google.Monitoring.V3/Google.Monitoring.V3.Snippets/GroupServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 using Google.Api;
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Monitoring.V3;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -137,7 +138,6 @@ namespace Google.Monitoring.V3.Snippets
         public async Task ListGroupMembersAsync()
         {
             // Snippet: ListGroupMembersAsync(string,string,int?,CallSettings)
-            // Additional: ListGroupMembersAsync(string,string,int?,CancellationToken)
             // Create client
             GroupServiceClient groupServiceClient = GroupServiceClient.Create();
             // Initialize request argument(s)

--- a/apis/Google.Monitoring.V3/Google.Monitoring.V3.Snippets/MetricServiceClientSnippets.g.cs
+++ b/apis/Google.Monitoring.V3/Google.Monitoring.V3.Snippets/MetricServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 using Google.Api;
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Monitoring.V3;
+using Google.Monitoring.V3.ListTimeSeriesRequest.Types;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -27,7 +29,6 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using static Google.Monitoring.V3.ListTimeSeriesRequest.Types;
 
 namespace Google.Monitoring.V3.Snippets
 {
@@ -36,7 +37,6 @@ namespace Google.Monitoring.V3.Snippets
         public async Task ListMonitoredResourceDescriptorsAsync()
         {
             // Snippet: ListMonitoredResourceDescriptorsAsync(string,string,int?,CallSettings)
-            // Additional: ListMonitoredResourceDescriptorsAsync(string,string,int?,CancellationToken)
             // Create client
             MetricServiceClient metricServiceClient = MetricServiceClient.Create();
             // Initialize request argument(s)
@@ -127,7 +127,6 @@ namespace Google.Monitoring.V3.Snippets
         public async Task ListMetricDescriptorsAsync()
         {
             // Snippet: ListMetricDescriptorsAsync(string,string,int?,CallSettings)
-            // Additional: ListMetricDescriptorsAsync(string,string,int?,CancellationToken)
             // Create client
             MetricServiceClient metricServiceClient = MetricServiceClient.Create();
             // Initialize request argument(s)
@@ -270,7 +269,6 @@ namespace Google.Monitoring.V3.Snippets
         public async Task ListTimeSeriesAsync()
         {
             // Snippet: ListTimeSeriesAsync(string,string,TimeInterval,TimeSeriesView,string,int?,CallSettings)
-            // Additional: ListTimeSeriesAsync(string,string,TimeInterval,TimeSeriesView,string,int?,CancellationToken)
             // Create client
             MetricServiceClient metricServiceClient = MetricServiceClient.Create();
             // Initialize request argument(s)

--- a/apis/Google.Monitoring.V3/Google.Monitoring.V3.Snippets/MetricServiceClientSnippets.g.cs
+++ b/apis/Google.Monitoring.V3/Google.Monitoring.V3.Snippets/MetricServiceClientSnippets.g.cs
@@ -18,7 +18,6 @@ using Google.Api;
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Monitoring.V3;
-using Google.Monitoring.V3.ListTimeSeriesRequest.Types;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -29,6 +28,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using static Google.Monitoring.V3.ListTimeSeriesRequest.Types;
 
 namespace Google.Monitoring.V3.Snippets
 {

--- a/apis/Google.Monitoring.V3/Google.Monitoring.V3/GroupServiceClient.cs
+++ b/apis/Google.Monitoring.V3/Google.Monitoring.V3/GroupServiceClient.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 using Google.Api;
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Monitoring.V3;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -326,7 +328,6 @@ namespace Google.Monitoring.V3
         /// </list>
         /// </remarks>
         public static IReadOnlyList<string> DefaultScopes { get; } = new ReadOnlyCollection<string>(new string[] {
-            "https://www.googleapis.com/auth/cloud-platform"
         });
 
         private static readonly ChannelPool s_channelPool = new ChannelPool(DefaultScopes);
@@ -435,10 +436,11 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Gets a single group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The group to retrieve. The format is
+        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -454,10 +456,11 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Gets a single group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The group to retrieve. The format is
+        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -472,10 +475,11 @@ namespace Google.Monitoring.V3
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Gets a single group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The group to retrieve. The format is
+        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -491,13 +495,15 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Creates a new group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project in which to create the group. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="group">
-        ///
+        /// A group definition. It is an error to define the `name` field because
+        /// the system assigns the name.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -514,13 +520,15 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Creates a new group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project in which to create the group. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="group">
-        ///
+        /// A group definition. It is an error to define the `name` field because
+        /// the system assigns the name.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -537,13 +545,15 @@ namespace Google.Monitoring.V3
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Creates a new group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project in which to create the group. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="group">
-        ///
+        /// A group definition. It is an error to define the `name` field because
+        /// the system assigns the name.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -560,10 +570,12 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Updates an existing group.
+        /// You can change any group attributes except `name`.
         /// </summary>
         /// <param name="group">
-        ///
+        /// The new definition of the group.  All fields of the existing group,
+        /// excepting `name`, are replaced with the corresponding fields of this group.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -579,10 +591,12 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Updates an existing group.
+        /// You can change any group attributes except `name`.
         /// </summary>
         /// <param name="group">
-        ///
+        /// The new definition of the group.  All fields of the existing group,
+        /// excepting `name`, are replaced with the corresponding fields of this group.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -597,10 +611,12 @@ namespace Google.Monitoring.V3
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Updates an existing group.
+        /// You can change any group attributes except `name`.
         /// </summary>
         /// <param name="group">
-        ///
+        /// The new definition of the group.  All fields of the existing group,
+        /// excepting `name`, are replaced with the corresponding fields of this group.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -616,10 +632,11 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Deletes an existing group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The group to delete. The format is
+        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -635,10 +652,11 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Deletes an existing group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The group to delete. The format is
+        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -653,10 +671,11 @@ namespace Google.Monitoring.V3
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Deletes an existing group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The group to delete. The format is
+        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -672,10 +691,11 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Lists the monitored resources that are members of a group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The group whose members are listed. The format is
+        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -701,10 +721,11 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Lists the monitored resources that are members of a group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The group whose members are listed. The format is
+        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -774,10 +795,11 @@ namespace Google.Monitoring.V3
         public override GroupService.GroupServiceClient GrpcClient { get; }
 
         /// <summary>
-        ///
+        /// Gets a single group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The group to retrieve. The format is
+        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -795,10 +817,11 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Gets a single group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The group to retrieve. The format is
+        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -816,13 +839,15 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Creates a new group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project in which to create the group. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="group">
-        ///
+        /// A group definition. It is an error to define the `name` field because
+        /// the system assigns the name.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -842,13 +867,15 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Creates a new group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project in which to create the group. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="group">
-        ///
+        /// A group definition. It is an error to define the `name` field because
+        /// the system assigns the name.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -868,10 +895,12 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Updates an existing group.
+        /// You can change any group attributes except `name`.
         /// </summary>
         /// <param name="group">
-        ///
+        /// The new definition of the group.  All fields of the existing group,
+        /// excepting `name`, are replaced with the corresponding fields of this group.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -889,10 +918,12 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Updates an existing group.
+        /// You can change any group attributes except `name`.
         /// </summary>
         /// <param name="group">
-        ///
+        /// The new definition of the group.  All fields of the existing group,
+        /// excepting `name`, are replaced with the corresponding fields of this group.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -910,10 +941,11 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes an existing group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The group to delete. The format is
+        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -931,10 +963,11 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes an existing group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The group to delete. The format is
+        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -952,10 +985,11 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists the monitored resources that are members of a group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The group whose members are listed. The format is
+        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -986,10 +1020,11 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists the monitored resources that are members of a group.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The group whose members are listed. The format is
+        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.

--- a/apis/Google.Monitoring.V3/Google.Monitoring.V3/MetricServiceClient.cs
+++ b/apis/Google.Monitoring.V3/Google.Monitoring.V3/MetricServiceClient.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,9 @@
 using Google.Api;
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Monitoring.V3;
+using Google.Monitoring.V3.ListTimeSeriesRequest.Types;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
@@ -25,7 +28,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
-using static Google.Monitoring.V3.ListTimeSeriesRequest.Types;
 
 namespace Google.Monitoring.V3
 {
@@ -388,7 +390,6 @@ namespace Google.Monitoring.V3
         /// </list>
         /// </remarks>
         public static IReadOnlyList<string> DefaultScopes { get; } = new ReadOnlyCollection<string>(new string[] {
-            "https://www.googleapis.com/auth/cloud-platform"
         });
 
         private static readonly ChannelPool s_channelPool = new ChannelPool(DefaultScopes);
@@ -519,7 +520,8 @@ namespace Google.Monitoring.V3
         /// Lists monitored resource descriptors that match a filter. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -548,7 +550,8 @@ namespace Google.Monitoring.V3
         /// Lists monitored resource descriptors that match a filter. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -577,7 +580,10 @@ namespace Google.Monitoring.V3
         /// Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The monitored resource descriptor to get.  The format is
+        /// `"projects/{project_id_or_number}/monitoredResourceDescriptors/{resource_type}"`.
+        /// The `{resource_type}` is a predefined type, such as
+        /// `cloudsql_database`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -596,7 +602,10 @@ namespace Google.Monitoring.V3
         /// Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The monitored resource descriptor to get.  The format is
+        /// `"projects/{project_id_or_number}/monitoredResourceDescriptors/{resource_type}"`.
+        /// The `{resource_type}` is a predefined type, such as
+        /// `cloudsql_database`.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -614,7 +623,10 @@ namespace Google.Monitoring.V3
         /// Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The monitored resource descriptor to get.  The format is
+        /// `"projects/{project_id_or_number}/monitoredResourceDescriptors/{resource_type}"`.
+        /// The `{resource_type}` is a predefined type, such as
+        /// `cloudsql_database`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -633,7 +645,8 @@ namespace Google.Monitoring.V3
         /// Lists metric descriptors that match a filter. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -662,7 +675,8 @@ namespace Google.Monitoring.V3
         /// Lists metric descriptors that match a filter. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -691,7 +705,10 @@ namespace Google.Monitoring.V3
         /// Gets a single metric descriptor. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The metric descriptor on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
+        /// An example value of `{metric_id}` is
+        /// `"compute.googleapis.com/instance/disk/read_bytes_count"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -710,7 +727,10 @@ namespace Google.Monitoring.V3
         /// Gets a single metric descriptor. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The metric descriptor on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
+        /// An example value of `{metric_id}` is
+        /// `"compute.googleapis.com/instance/disk/read_bytes_count"`.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -728,7 +748,10 @@ namespace Google.Monitoring.V3
         /// Gets a single metric descriptor. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The metric descriptor on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
+        /// An example value of `{metric_id}` is
+        /// `"compute.googleapis.com/instance/disk/read_bytes_count"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -744,13 +767,17 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Creates a new metric descriptor.
+        /// User-created metric descriptors define
+        /// [custom metrics](/monitoring/custom-metrics).
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="metricDescriptor">
-        ///
+        /// The new [custom metric](/monitoring/custom-metrics)
+        /// descriptor.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -767,13 +794,17 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Creates a new metric descriptor.
+        /// User-created metric descriptors define
+        /// [custom metrics](/monitoring/custom-metrics).
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="metricDescriptor">
-        ///
+        /// The new [custom metric](/monitoring/custom-metrics)
+        /// descriptor.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -790,13 +821,17 @@ namespace Google.Monitoring.V3
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Creates a new metric descriptor.
+        /// User-created metric descriptors define
+        /// [custom metrics](/monitoring/custom-metrics).
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="metricDescriptor">
-        ///
+        /// The new [custom metric](/monitoring/custom-metrics)
+        /// descriptor.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -813,10 +848,14 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Deletes a metric descriptor. Only user-created
+        /// [custom metrics](/monitoring/custom-metrics) can be deleted.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The metric descriptor on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
+        /// An example of `{metric_id}` is:
+        /// `"custom.googleapis.com/my_test_metric"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -832,10 +871,14 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Deletes a metric descriptor. Only user-created
+        /// [custom metrics](/monitoring/custom-metrics) can be deleted.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The metric descriptor on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
+        /// An example of `{metric_id}` is:
+        /// `"custom.googleapis.com/my_test_metric"`.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -850,10 +893,14 @@ namespace Google.Monitoring.V3
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Deletes a metric descriptor. Only user-created
+        /// [custom metrics](/monitoring/custom-metrics) can be deleted.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The metric descriptor on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
+        /// An example of `{metric_id}` is:
+        /// `"custom.googleapis.com/my_test_metric"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -872,16 +919,25 @@ namespace Google.Monitoring.V3
         /// Lists time series that match a filter. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// "projects/{project_id_or_number}".
         /// </param>
         /// <param name="filter">
+        /// A [monitoring filter](/monitoring/api/v3/filters) that specifies which time
+        /// series should be returned.  The filter must specify a single metric type,
+        /// and can additionally specify metric labels and other information. For
+        /// example:
         ///
+        ///     metric.type = "compute.googleapis.com/instance/cpu/usage_time" AND
+        ///         metric.label.instance_name = "my-instance-name"
         /// </param>
         /// <param name="interval">
-        ///
+        /// The time interval for which results should be returned. Only time series
+        /// that contain data points in the specified interval are included
+        /// in the response.
         /// </param>
         /// <param name="view">
-        ///
+        /// Specifies which information is returned about the time series.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -913,16 +969,25 @@ namespace Google.Monitoring.V3
         /// Lists time series that match a filter. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// "projects/{project_id_or_number}".
         /// </param>
         /// <param name="filter">
+        /// A [monitoring filter](/monitoring/api/v3/filters) that specifies which time
+        /// series should be returned.  The filter must specify a single metric type,
+        /// and can additionally specify metric labels and other information. For
+        /// example:
         ///
+        ///     metric.type = "compute.googleapis.com/instance/cpu/usage_time" AND
+        ///         metric.label.instance_name = "my-instance-name"
         /// </param>
         /// <param name="interval">
-        ///
+        /// The time interval for which results should be returned. Only time series
+        /// that contain data points in the specified interval are included
+        /// in the response.
         /// </param>
         /// <param name="view">
-        ///
+        /// Specifies which information is returned about the time series.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -951,13 +1016,21 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Creates or adds data to one or more time series.
+        /// The response is empty if all time series in the request were written.
+        /// If any time series could not be written, a corresponding failure message is
+        /// included in the error response.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="timeSeries">
-        ///
+        /// The new data to be added to a list of time series.
+        /// Adds at most one data point to each of several time series.  The new data
+        /// point must be more recent than any other point in its time series.  Each
+        /// `TimeSeries` value must fully specify a unique time series by supplying
+        /// all label values for the metric and the monitored resource.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -974,13 +1047,21 @@ namespace Google.Monitoring.V3
         }
 
         /// <summary>
-        ///
+        /// Creates or adds data to one or more time series.
+        /// The response is empty if all time series in the request were written.
+        /// If any time series could not be written, a corresponding failure message is
+        /// included in the error response.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="timeSeries">
-        ///
+        /// The new data to be added to a list of time series.
+        /// Adds at most one data point to each of several time series.  The new data
+        /// point must be more recent than any other point in its time series.  Each
+        /// `TimeSeries` value must fully specify a unique time series by supplying
+        /// all label values for the metric and the monitored resource.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -997,13 +1078,21 @@ namespace Google.Monitoring.V3
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Creates or adds data to one or more time series.
+        /// The response is empty if all time series in the request were written.
+        /// If any time series could not be written, a corresponding failure message is
+        /// included in the error response.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="timeSeries">
-        ///
+        /// The new data to be added to a list of time series.
+        /// Adds at most one data point to each of several time series.  The new data
+        /// point must be more recent than any other point in its time series.  Each
+        /// `TimeSeries` value must fully specify a unique time series by supplying
+        /// all label values for the metric and the monitored resource.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1073,7 +1162,8 @@ namespace Google.Monitoring.V3
         /// Lists monitored resource descriptors that match a filter. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1107,7 +1197,8 @@ namespace Google.Monitoring.V3
         /// Lists monitored resource descriptors that match a filter. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1141,7 +1232,10 @@ namespace Google.Monitoring.V3
         /// Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The monitored resource descriptor to get.  The format is
+        /// `"projects/{project_id_or_number}/monitoredResourceDescriptors/{resource_type}"`.
+        /// The `{resource_type}` is a predefined type, such as
+        /// `cloudsql_database`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1162,7 +1256,10 @@ namespace Google.Monitoring.V3
         /// Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The monitored resource descriptor to get.  The format is
+        /// `"projects/{project_id_or_number}/monitoredResourceDescriptors/{resource_type}"`.
+        /// The `{resource_type}` is a predefined type, such as
+        /// `cloudsql_database`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1183,7 +1280,8 @@ namespace Google.Monitoring.V3
         /// Lists metric descriptors that match a filter. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1217,7 +1315,8 @@ namespace Google.Monitoring.V3
         /// Lists metric descriptors that match a filter. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1251,7 +1350,10 @@ namespace Google.Monitoring.V3
         /// Gets a single metric descriptor. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The metric descriptor on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
+        /// An example value of `{metric_id}` is
+        /// `"compute.googleapis.com/instance/disk/read_bytes_count"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1272,7 +1374,10 @@ namespace Google.Monitoring.V3
         /// Gets a single metric descriptor. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The metric descriptor on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
+        /// An example value of `{metric_id}` is
+        /// `"compute.googleapis.com/instance/disk/read_bytes_count"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1290,13 +1395,17 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Creates a new metric descriptor.
+        /// User-created metric descriptors define
+        /// [custom metrics](/monitoring/custom-metrics).
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="metricDescriptor">
-        ///
+        /// The new [custom metric](/monitoring/custom-metrics)
+        /// descriptor.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1316,13 +1425,17 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Creates a new metric descriptor.
+        /// User-created metric descriptors define
+        /// [custom metrics](/monitoring/custom-metrics).
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="metricDescriptor">
-        ///
+        /// The new [custom metric](/monitoring/custom-metrics)
+        /// descriptor.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1342,10 +1455,14 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes a metric descriptor. Only user-created
+        /// [custom metrics](/monitoring/custom-metrics) can be deleted.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The metric descriptor on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
+        /// An example of `{metric_id}` is:
+        /// `"custom.googleapis.com/my_test_metric"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1363,10 +1480,14 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes a metric descriptor. Only user-created
+        /// [custom metrics](/monitoring/custom-metrics) can be deleted.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The metric descriptor on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
+        /// An example of `{metric_id}` is:
+        /// `"custom.googleapis.com/my_test_metric"`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1387,16 +1508,25 @@ namespace Google.Monitoring.V3
         /// Lists time series that match a filter. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// "projects/{project_id_or_number}".
         /// </param>
         /// <param name="filter">
+        /// A [monitoring filter](/monitoring/api/v3/filters) that specifies which time
+        /// series should be returned.  The filter must specify a single metric type,
+        /// and can additionally specify metric labels and other information. For
+        /// example:
         ///
+        ///     metric.type = "compute.googleapis.com/instance/cpu/usage_time" AND
+        ///         metric.label.instance_name = "my-instance-name"
         /// </param>
         /// <param name="interval">
-        ///
+        /// The time interval for which results should be returned. Only time series
+        /// that contain data points in the specified interval are included
+        /// in the response.
         /// </param>
         /// <param name="view">
-        ///
+        /// Specifies which information is returned about the time series.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1436,16 +1566,25 @@ namespace Google.Monitoring.V3
         /// Lists time series that match a filter. This method does not require a Stackdriver account.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// "projects/{project_id_or_number}".
         /// </param>
         /// <param name="filter">
+        /// A [monitoring filter](/monitoring/api/v3/filters) that specifies which time
+        /// series should be returned.  The filter must specify a single metric type,
+        /// and can additionally specify metric labels and other information. For
+        /// example:
         ///
+        ///     metric.type = "compute.googleapis.com/instance/cpu/usage_time" AND
+        ///         metric.label.instance_name = "my-instance-name"
         /// </param>
         /// <param name="interval">
-        ///
+        /// The time interval for which results should be returned. Only time series
+        /// that contain data points in the specified interval are included
+        /// in the response.
         /// </param>
         /// <param name="view">
-        ///
+        /// Specifies which information is returned about the time series.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1482,13 +1621,21 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Creates or adds data to one or more time series.
+        /// The response is empty if all time series in the request were written.
+        /// If any time series could not be written, a corresponding failure message is
+        /// included in the error response.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="timeSeries">
-        ///
+        /// The new data to be added to a list of time series.
+        /// Adds at most one data point to each of several time series.  The new data
+        /// point must be more recent than any other point in its time series.  Each
+        /// `TimeSeries` value must fully specify a unique time series by supplying
+        /// all label values for the metric and the monitored resource.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1508,13 +1655,21 @@ namespace Google.Monitoring.V3
                 callSettings);
 
         /// <summary>
-        ///
+        /// Creates or adds data to one or more time series.
+        /// The response is empty if all time series in the request were written.
+        /// If any time series could not be written, a corresponding failure message is
+        /// included in the error response.
         /// </summary>
         /// <param name="name">
-        ///
+        /// The project on which to execute the request. The format is
+        /// `"projects/{project_id_or_number}"`.
         /// </param>
         /// <param name="timeSeries">
-        ///
+        /// The new data to be added to a list of time series.
+        /// Adds at most one data point to each of several time series.  The new data
+        /// point must be more recent than any other point in its time series.  Each
+        /// `TimeSeries` value must fully specify a unique time series by supplying
+        /// all label values for the metric and the monitored resource.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.

--- a/apis/Google.Monitoring.V3/Google.Monitoring.V3/MetricServiceClient.cs
+++ b/apis/Google.Monitoring.V3/Google.Monitoring.V3/MetricServiceClient.cs
@@ -18,7 +18,6 @@ using Google.Api;
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Monitoring.V3;
-using Google.Monitoring.V3.ListTimeSeriesRequest.Types;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -28,6 +27,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
+using static Google.Monitoring.V3.ListTimeSeriesRequest.Types;
 
 namespace Google.Monitoring.V3
 {

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1.Snippets/PublisherClientSnippets.g.cs
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1.Snippets/PublisherClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Iam.V1;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using Google.Pubsub.V1;
 using Grpc.Core;
 using System;
 using System.Collections;
@@ -123,7 +125,6 @@ namespace Google.Pubsub.V1.Snippets
         public async Task ListTopicsAsync()
         {
             // Snippet: ListTopicsAsync(string,string,int?,CallSettings)
-            // Additional: ListTopicsAsync(string,string,int?,CancellationToken)
             // Create client
             PublisherClient publisherClient = PublisherClient.Create();
             // Initialize request argument(s)
@@ -189,7 +190,6 @@ namespace Google.Pubsub.V1.Snippets
         public async Task ListTopicSubscriptionsAsync()
         {
             // Snippet: ListTopicSubscriptionsAsync(string,string,int?,CallSettings)
-            // Additional: ListTopicSubscriptionsAsync(string,string,int?,CancellationToken)
             // Create client
             PublisherClient publisherClient = PublisherClient.Create();
             // Initialize request argument(s)
@@ -274,6 +274,85 @@ namespace Google.Pubsub.V1.Snippets
             string formattedTopic = PublisherClient.FormatTopicName("[PROJECT]", "[TOPIC]");
             // Make the request
             publisherClient.DeleteTopic(formattedTopic);
+            // End snippet
+        }
+
+        public async Task SetIamPolicyAsync()
+        {
+            // Snippet: SetIamPolicyAsync(string,Policy,CallSettings)
+            // Additional: SetIamPolicyAsync(string,Policy,CancellationToken)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            string formattedResource = PublisherClient.FormatTopicName("[PROJECT]", "[TOPIC]");
+            Policy policy = new Policy();
+            // Make the request
+            Policy response = await publisherClient.SetIamPolicyAsync(formattedResource, policy);
+            // End snippet
+        }
+
+        public void SetIamPolicy()
+        {
+            // Snippet: SetIamPolicy(string,Policy,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            string formattedResource = PublisherClient.FormatTopicName("[PROJECT]", "[TOPIC]");
+            Policy policy = new Policy();
+            // Make the request
+            Policy response = publisherClient.SetIamPolicy(formattedResource, policy);
+            // End snippet
+        }
+
+        public async Task GetIamPolicyAsync()
+        {
+            // Snippet: GetIamPolicyAsync(string,CallSettings)
+            // Additional: GetIamPolicyAsync(string,CancellationToken)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            string formattedResource = PublisherClient.FormatTopicName("[PROJECT]", "[TOPIC]");
+            // Make the request
+            Policy response = await publisherClient.GetIamPolicyAsync(formattedResource);
+            // End snippet
+        }
+
+        public void GetIamPolicy()
+        {
+            // Snippet: GetIamPolicy(string,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            string formattedResource = PublisherClient.FormatTopicName("[PROJECT]", "[TOPIC]");
+            // Make the request
+            Policy response = publisherClient.GetIamPolicy(formattedResource);
+            // End snippet
+        }
+
+        public async Task TestIamPermissionsAsync()
+        {
+            // Snippet: TestIamPermissionsAsync(string,IEnumerable<string>,CallSettings)
+            // Additional: TestIamPermissionsAsync(string,IEnumerable<string>,CancellationToken)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            string formattedResource = PublisherClient.FormatTopicName("[PROJECT]", "[TOPIC]");
+            IEnumerable<string> permissions = new List<string>();
+            // Make the request
+            TestIamPermissionsResponse response = await publisherClient.TestIamPermissionsAsync(formattedResource, permissions);
+            // End snippet
+        }
+
+        public void TestIamPermissions()
+        {
+            // Snippet: TestIamPermissions(string,IEnumerable<string>,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            string formattedResource = PublisherClient.FormatTopicName("[PROJECT]", "[TOPIC]");
+            IEnumerable<string> permissions = new List<string>();
+            // Make the request
+            TestIamPermissionsResponse response = publisherClient.TestIamPermissions(formattedResource, permissions);
             // End snippet
         }
 

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1.Snippets/SubscriberClientSnippets.g.cs
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1.Snippets/SubscriberClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Iam.V1;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using Google.Pubsub.V1;
 using Grpc.Core;
 using System;
 using System.Collections;
@@ -90,7 +92,6 @@ namespace Google.Pubsub.V1.Snippets
         public async Task ListSubscriptionsAsync()
         {
             // Snippet: ListSubscriptionsAsync(string,string,int?,CallSettings)
-            // Additional: ListSubscriptionsAsync(string,string,int?,CancellationToken)
             // Create client
             SubscriberClient subscriberClient = SubscriberClient.Create();
             // Initialize request argument(s)
@@ -287,6 +288,85 @@ namespace Google.Pubsub.V1.Snippets
             PushConfig pushConfig = new PushConfig();
             // Make the request
             subscriberClient.ModifyPushConfig(formattedSubscription, pushConfig);
+            // End snippet
+        }
+
+        public async Task SetIamPolicyAsync()
+        {
+            // Snippet: SetIamPolicyAsync(string,Policy,CallSettings)
+            // Additional: SetIamPolicyAsync(string,Policy,CancellationToken)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            string formattedResource = SubscriberClient.FormatSubscriptionName("[PROJECT]", "[SUBSCRIPTION]");
+            Policy policy = new Policy();
+            // Make the request
+            Policy response = await subscriberClient.SetIamPolicyAsync(formattedResource, policy);
+            // End snippet
+        }
+
+        public void SetIamPolicy()
+        {
+            // Snippet: SetIamPolicy(string,Policy,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            string formattedResource = SubscriberClient.FormatSubscriptionName("[PROJECT]", "[SUBSCRIPTION]");
+            Policy policy = new Policy();
+            // Make the request
+            Policy response = subscriberClient.SetIamPolicy(formattedResource, policy);
+            // End snippet
+        }
+
+        public async Task GetIamPolicyAsync()
+        {
+            // Snippet: GetIamPolicyAsync(string,CallSettings)
+            // Additional: GetIamPolicyAsync(string,CancellationToken)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            string formattedResource = SubscriberClient.FormatSubscriptionName("[PROJECT]", "[SUBSCRIPTION]");
+            // Make the request
+            Policy response = await subscriberClient.GetIamPolicyAsync(formattedResource);
+            // End snippet
+        }
+
+        public void GetIamPolicy()
+        {
+            // Snippet: GetIamPolicy(string,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            string formattedResource = SubscriberClient.FormatSubscriptionName("[PROJECT]", "[SUBSCRIPTION]");
+            // Make the request
+            Policy response = subscriberClient.GetIamPolicy(formattedResource);
+            // End snippet
+        }
+
+        public async Task TestIamPermissionsAsync()
+        {
+            // Snippet: TestIamPermissionsAsync(string,IEnumerable<string>,CallSettings)
+            // Additional: TestIamPermissionsAsync(string,IEnumerable<string>,CancellationToken)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            string formattedResource = SubscriberClient.FormatSubscriptionName("[PROJECT]", "[SUBSCRIPTION]");
+            IEnumerable<string> permissions = new List<string>();
+            // Make the request
+            TestIamPermissionsResponse response = await subscriberClient.TestIamPermissionsAsync(formattedResource, permissions);
+            // End snippet
+        }
+
+        public void TestIamPermissions()
+        {
+            // Snippet: TestIamPermissions(string,IEnumerable<string>,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            string formattedResource = SubscriberClient.FormatSubscriptionName("[PROJECT]", "[SUBSCRIPTION]");
+            IEnumerable<string> permissions = new List<string>();
+            // Make the request
+            TestIamPermissionsResponse response = subscriberClient.TestIamPermissions(formattedResource, permissions);
             // End snippet
         }
 

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1/PublisherClient.cs
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1/PublisherClient.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,10 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Iam.V1;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using Google.Pubsub.V1;
 using Grpc.Core;
 using System;
 using System.Collections;
@@ -54,6 +57,9 @@ namespace Google.Pubsub.V1
             ListTopicsSettings = existing.ListTopicsSettings;
             ListTopicSubscriptionsSettings = existing.ListTopicSubscriptionsSettings;
             DeleteTopicSettings = existing.DeleteTopicSettings;
+            SetIamPolicySettings = existing.SetIamPolicySettings;
+            GetIamPolicySettings = existing.GetIamPolicySettings;
+            TestIamPermissionsSettings = existing.TestIamPermissionsSettings;
         }
 
         /// <summary>
@@ -355,6 +361,94 @@ namespace Google.Pubsub.V1
             )));
 
         /// <summary>
+        /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>PublisherClient.SetIamPolicy</c> and <c>PublisherClient.SetIamPolicyAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>PublisherClient.SetIamPolicy</c> and
+        /// <c>PublisherClient.SetIamPolicyAsync</c> <see cref="RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.3</description></item>
+        /// <item><description>Retry maximum delay: 60000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 60000 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.0</description></item>
+        /// <item><description>Timeout maximum delay: 60000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 600000 milliseconds.
+        /// </remarks>
+        public CallSettings SetIamPolicySettings { get; set; } = CallSettings.FromCallTiming(
+            CallTiming.FromRetry(new RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: Expiration.FromTimeout(TimeSpan.FromMilliseconds(600000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>PublisherClient.GetIamPolicy</c> and <c>PublisherClient.GetIamPolicyAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>PublisherClient.GetIamPolicy</c> and
+        /// <c>PublisherClient.GetIamPolicyAsync</c> <see cref="RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.3</description></item>
+        /// <item><description>Retry maximum delay: 60000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 60000 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.0</description></item>
+        /// <item><description>Timeout maximum delay: 60000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description><see cref="StatusCode.DeadlineExceeded"/></description></item>
+        /// <item><description><see cref="StatusCode.Unavailable"/></description></item>
+        /// </list>
+        /// Default RPC expiration is 600000 milliseconds.
+        /// </remarks>
+        public CallSettings GetIamPolicySettings { get; set; } = CallSettings.FromCallTiming(
+            CallTiming.FromRetry(new RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: Expiration.FromTimeout(TimeSpan.FromMilliseconds(600000)),
+                retryFilter: IdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>PublisherClient.TestIamPermissions</c> and <c>PublisherClient.TestIamPermissionsAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>PublisherClient.TestIamPermissions</c> and
+        /// <c>PublisherClient.TestIamPermissionsAsync</c> <see cref="RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.3</description></item>
+        /// <item><description>Retry maximum delay: 60000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 60000 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.0</description></item>
+        /// <item><description>Timeout maximum delay: 60000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 600000 milliseconds.
+        /// </remarks>
+        public CallSettings TestIamPermissionsSettings { get; set; } = CallSettings.FromCallTiming(
+            CallTiming.FromRetry(new RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: Expiration.FromTimeout(TimeSpan.FromMilliseconds(600000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
         /// Creates a deep clone of this object, with all the same property values.
         /// </summary>
         /// <returns>A deep clone of this <see cref="PublisherSettings"/> object.</returns>
@@ -492,7 +586,7 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Creates the given topic with the given name.
         /// </summary>
         /// <param name="name">
         /// The name of the topic. It must have the format
@@ -516,7 +610,7 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Creates the given topic with the given name.
         /// </summary>
         /// <param name="name">
         /// The name of the topic. It must have the format
@@ -539,7 +633,7 @@ namespace Google.Pubsub.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Creates the given topic with the given name.
         /// </summary>
         /// <param name="name">
         /// The name of the topic. It must have the format
@@ -563,13 +657,15 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
+        /// does not exist. The message payload must not be empty; it must contain
+        ///  either a non-empty data field, or at least one attribute.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// The messages in the request will be published on this topic.
         /// </param>
         /// <param name="messages">
-        ///
+        /// The messages to publish.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -586,13 +682,15 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
+        /// does not exist. The message payload must not be empty; it must contain
+        ///  either a non-empty data field, or at least one attribute.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// The messages in the request will be published on this topic.
         /// </param>
         /// <param name="messages">
-        ///
+        /// The messages to publish.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -609,13 +707,15 @@ namespace Google.Pubsub.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
+        /// does not exist. The message payload must not be empty; it must contain
+        ///  either a non-empty data field, or at least one attribute.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// The messages in the request will be published on this topic.
         /// </param>
         /// <param name="messages">
-        ///
+        /// The messages to publish.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -632,10 +732,10 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Gets the configuration of a topic.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// The name of the topic to get.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -651,10 +751,10 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Gets the configuration of a topic.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// The name of the topic to get.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -669,10 +769,10 @@ namespace Google.Pubsub.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Gets the configuration of a topic.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// The name of the topic to get.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -688,10 +788,10 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Lists matching topics.
         /// </summary>
         /// <param name="project">
-        ///
+        /// The name of the cloud project that topics belong to.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -717,10 +817,10 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Lists matching topics.
         /// </summary>
         /// <param name="project">
-        ///
+        /// The name of the cloud project that topics belong to.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -746,10 +846,10 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Lists the name of the subscriptions for this topic.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// The name of the topic that subscriptions are attached to.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -775,10 +875,10 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Lists the name of the subscriptions for this topic.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// The name of the topic that subscriptions are attached to.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -804,10 +904,14 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
+        /// does not exist. After a topic is deleted, a new topic may be created with
+        /// the same name; this is an entirely new topic with none of the old
+        /// configuration or subscriptions. Existing subscriptions to this topic are
+        /// not deleted, but their `topic` field is set to `_deleted-topic_`.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// Name of the topic to delete.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -823,10 +927,14 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
+        /// does not exist. After a topic is deleted, a new topic may be created with
+        /// the same name; this is an entirely new topic with none of the old
+        /// configuration or subscriptions. Existing subscriptions to this topic are
+        /// not deleted, but their `topic` field is set to `_deleted-topic_`.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// Name of the topic to delete.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -841,10 +949,14 @@ namespace Google.Pubsub.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
+        /// does not exist. After a topic is deleted, a new topic may be created with
+        /// the same name; this is an entirely new topic with none of the old
+        /// configuration or subscriptions. Existing subscriptions to this topic are
+        /// not deleted, but their `topic` field is set to `_deleted-topic_`.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// Name of the topic to delete.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -854,6 +966,245 @@ namespace Google.Pubsub.V1
         /// </returns>
         public virtual void DeleteTopic(
             string topic,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Sets the access control policy on the specified resource. Replaces any
+        /// existing policy.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being specified.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="policy">
+        /// REQUIRED: The complete policy to be applied to the `resource`. The size of
+        /// the policy is limited to a few 10s of KB. An empty policy is a
+        /// valid policy but certain Cloud Platform services (such as Projects)
+        /// might reject them.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Policy> SetIamPolicyAsync(
+            string resource,
+            Policy policy,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Sets the access control policy on the specified resource. Replaces any
+        /// existing policy.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being specified.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="policy">
+        /// REQUIRED: The complete policy to be applied to the `resource`. The size of
+        /// the policy is limited to a few 10s of KB. An empty policy is a
+        /// valid policy but certain Cloud Platform services (such as Projects)
+        /// might reject them.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Policy> SetIamPolicyAsync(
+            string resource,
+            Policy policy,
+            CancellationToken cancellationToken) => SetIamPolicyAsync(
+                resource,
+                policy,
+                CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Sets the access control policy on the specified resource. Replaces any
+        /// existing policy.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being specified.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="policy">
+        /// REQUIRED: The complete policy to be applied to the `resource`. The size of
+        /// the policy is limited to a few 10s of KB. An empty policy is a
+        /// valid policy but certain Cloud Platform services (such as Projects)
+        /// might reject them.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Policy SetIamPolicy(
+            string resource,
+            Policy policy,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets the access control policy for a resource.
+        /// Returns an empty policy if the resource exists and does not have a policy
+        /// set.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Policy> GetIamPolicyAsync(
+            string resource,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets the access control policy for a resource.
+        /// Returns an empty policy if the resource exists and does not have a policy
+        /// set.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Policy> GetIamPolicyAsync(
+            string resource,
+            CancellationToken cancellationToken) => GetIamPolicyAsync(
+                resource,
+                CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Gets the access control policy for a resource.
+        /// Returns an empty policy if the resource exists and does not have a policy
+        /// set.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Policy GetIamPolicy(
+            string resource,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns permissions that a caller has on the specified resource.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy detail is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="permissions">
+        /// The set of permissions to check for the `resource`. Permissions with
+        /// wildcards (such as '*' or 'storage.*') are not allowed. For more
+        /// information see
+        /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
+            string resource,
+            IEnumerable<string> permissions,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns permissions that a caller has on the specified resource.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy detail is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="permissions">
+        /// The set of permissions to check for the `resource`. Permissions with
+        /// wildcards (such as '*' or 'storage.*') are not allowed. For more
+        /// information see
+        /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
+            string resource,
+            IEnumerable<string> permissions,
+            CancellationToken cancellationToken) => TestIamPermissionsAsync(
+                resource,
+                permissions,
+                CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Returns permissions that a caller has on the specified resource.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy detail is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="permissions">
+        /// The set of permissions to check for the `resource`. Permissions with
+        /// wildcards (such as '*' or 'storage.*') are not allowed. For more
+        /// information see
+        /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual TestIamPermissionsResponse TestIamPermissions(
+            string resource,
+            IEnumerable<string> permissions,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -873,6 +1224,9 @@ namespace Google.Pubsub.V1
         private readonly ApiCall<ListTopicsRequest, ListTopicsResponse> _callListTopics;
         private readonly ApiCall<ListTopicSubscriptionsRequest, ListTopicSubscriptionsResponse> _callListTopicSubscriptions;
         private readonly ApiCall<DeleteTopicRequest, Empty> _callDeleteTopic;
+        private readonly ApiCall<SetIamPolicyRequest, Policy> _callSetIamPolicy;
+        private readonly ApiCall<GetIamPolicyRequest, Policy> _callGetIamPolicy;
+        private readonly ApiCall<TestIamPermissionsRequest, TestIamPermissionsResponse> _callTestIamPermissions;
 
         /// <summary>
         /// Constructs a client wrapper for the Publisher service, with the specified gRPC client and settings.
@@ -884,6 +1238,7 @@ namespace Google.Pubsub.V1
             this.GrpcClient = grpcClient;
             PublisherSettings effectiveSettings = settings ?? PublisherSettings.GetDefault();
             _clientHelper = new ClientHelper(effectiveSettings);
+            var grpcIAMPolicyClient = grpcClient.CreateIAMPolicyClient();
             _callCreateTopic = _clientHelper.BuildApiCall<Topic, Topic>(
                 GrpcClient.CreateTopicAsync, GrpcClient.CreateTopic, effectiveSettings.CreateTopicSettings);
             _callPublish = _clientHelper.BuildApiCall<PublishRequest, PublishResponse>(
@@ -896,6 +1251,12 @@ namespace Google.Pubsub.V1
                 GrpcClient.ListTopicSubscriptionsAsync, GrpcClient.ListTopicSubscriptions, effectiveSettings.ListTopicSubscriptionsSettings);
             _callDeleteTopic = _clientHelper.BuildApiCall<DeleteTopicRequest, Empty>(
                 GrpcClient.DeleteTopicAsync, GrpcClient.DeleteTopic, effectiveSettings.DeleteTopicSettings);
+            _callSetIamPolicy = _clientHelper.BuildApiCall<SetIamPolicyRequest, Policy>(
+                grpcIAMPolicyClient.SetIamPolicyAsync, grpcIAMPolicyClient.SetIamPolicy, effectiveSettings.SetIamPolicySettings);
+            _callGetIamPolicy = _clientHelper.BuildApiCall<GetIamPolicyRequest, Policy>(
+                grpcIAMPolicyClient.GetIamPolicyAsync, grpcIAMPolicyClient.GetIamPolicy, effectiveSettings.GetIamPolicySettings);
+            _callTestIamPermissions = _clientHelper.BuildApiCall<TestIamPermissionsRequest, TestIamPermissionsResponse>(
+                grpcIAMPolicyClient.TestIamPermissionsAsync, grpcIAMPolicyClient.TestIamPermissions, effectiveSettings.TestIamPermissionsSettings);
         }
 
         /// <summary>
@@ -904,7 +1265,7 @@ namespace Google.Pubsub.V1
         public override Publisher.PublisherClient GrpcClient { get; }
 
         /// <summary>
-        ///
+        /// Creates the given topic with the given name.
         /// </summary>
         /// <param name="name">
         /// The name of the topic. It must have the format
@@ -930,7 +1291,7 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Creates the given topic with the given name.
         /// </summary>
         /// <param name="name">
         /// The name of the topic. It must have the format
@@ -956,13 +1317,15 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
+        /// does not exist. The message payload must not be empty; it must contain
+        ///  either a non-empty data field, or at least one attribute.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// The messages in the request will be published on this topic.
         /// </param>
         /// <param name="messages">
-        ///
+        /// The messages to publish.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -982,13 +1345,15 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
+        /// does not exist. The message payload must not be empty; it must contain
+        ///  either a non-empty data field, or at least one attribute.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// The messages in the request will be published on this topic.
         /// </param>
         /// <param name="messages">
-        ///
+        /// The messages to publish.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1008,10 +1373,10 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Gets the configuration of a topic.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// The name of the topic to get.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1029,10 +1394,10 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Gets the configuration of a topic.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// The name of the topic to get.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1050,10 +1415,10 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists matching topics.
         /// </summary>
         /// <param name="project">
-        ///
+        /// The name of the cloud project that topics belong to.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1084,10 +1449,10 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists matching topics.
         /// </summary>
         /// <param name="project">
-        ///
+        /// The name of the cloud project that topics belong to.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1118,10 +1483,10 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists the name of the subscriptions for this topic.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// The name of the topic that subscriptions are attached to.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1152,10 +1517,10 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists the name of the subscriptions for this topic.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// The name of the topic that subscriptions are attached to.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1186,10 +1551,14 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
+        /// does not exist. After a topic is deleted, a new topic may be created with
+        /// the same name; this is an entirely new topic with none of the old
+        /// configuration or subscriptions. Existing subscriptions to this topic are
+        /// not deleted, but their `topic` field is set to `_deleted-topic_`.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// Name of the topic to delete.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1207,10 +1576,14 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
+        /// does not exist. After a topic is deleted, a new topic may be created with
+        /// the same name; this is an entirely new topic with none of the old
+        /// configuration or subscriptions. Existing subscriptions to this topic are
+        /// not deleted, but their `topic` field is set to `_deleted-topic_`.
         /// </summary>
         /// <param name="topic">
-        ///
+        /// Name of the topic to delete.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1224,6 +1597,182 @@ namespace Google.Pubsub.V1
                 new DeleteTopicRequest
                 {
                     Topic = topic,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Sets the access control policy on the specified resource. Replaces any
+        /// existing policy.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being specified.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="policy">
+        /// REQUIRED: The complete policy to be applied to the `resource`. The size of
+        /// the policy is limited to a few 10s of KB. An empty policy is a
+        /// valid policy but certain Cloud Platform services (such as Projects)
+        /// might reject them.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override Task<Policy> SetIamPolicyAsync(
+            string resource,
+            Policy policy,
+            CallSettings callSettings = null) => _callSetIamPolicy.Async(
+                new SetIamPolicyRequest
+                {
+                    Resource = resource,
+                    Policy = policy,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Sets the access control policy on the specified resource. Replaces any
+        /// existing policy.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being specified.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="policy">
+        /// REQUIRED: The complete policy to be applied to the `resource`. The size of
+        /// the policy is limited to a few 10s of KB. An empty policy is a
+        /// valid policy but certain Cloud Platform services (such as Projects)
+        /// might reject them.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override Policy SetIamPolicy(
+            string resource,
+            Policy policy,
+            CallSettings callSettings = null) => _callSetIamPolicy.Sync(
+                new SetIamPolicyRequest
+                {
+                    Resource = resource,
+                    Policy = policy,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets the access control policy for a resource.
+        /// Returns an empty policy if the resource exists and does not have a policy
+        /// set.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override Task<Policy> GetIamPolicyAsync(
+            string resource,
+            CallSettings callSettings = null) => _callGetIamPolicy.Async(
+                new GetIamPolicyRequest
+                {
+                    Resource = resource,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets the access control policy for a resource.
+        /// Returns an empty policy if the resource exists and does not have a policy
+        /// set.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override Policy GetIamPolicy(
+            string resource,
+            CallSettings callSettings = null) => _callGetIamPolicy.Sync(
+                new GetIamPolicyRequest
+                {
+                    Resource = resource,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Returns permissions that a caller has on the specified resource.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy detail is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="permissions">
+        /// The set of permissions to check for the `resource`. Permissions with
+        /// wildcards (such as '*' or 'storage.*') are not allowed. For more
+        /// information see
+        /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
+            string resource,
+            IEnumerable<string> permissions,
+            CallSettings callSettings = null) => _callTestIamPermissions.Async(
+                new TestIamPermissionsRequest
+                {
+                    Resource = resource,
+                    Permissions = { permissions },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Returns permissions that a caller has on the specified resource.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy detail is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="permissions">
+        /// The set of permissions to check for the `resource`. Permissions with
+        /// wildcards (such as '*' or 'storage.*') are not allowed. For more
+        /// information see
+        /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override TestIamPermissionsResponse TestIamPermissions(
+            string resource,
+            IEnumerable<string> permissions,
+            CallSettings callSettings = null) => _callTestIamPermissions.Sync(
+                new TestIamPermissionsRequest
+                {
+                    Resource = resource,
+                    Permissions = { permissions },
                 },
                 callSettings);
 

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1/PubsubGrpc.cs
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1/PubsubGrpc.cs
@@ -21,7 +21,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
-using static Google.Iam.V1.IAMPolicy;
 
 namespace Google.Pubsub.V1 {
   /// <summary>
@@ -225,15 +224,6 @@ namespace Google.Pubsub.V1 {
       protected SubscriberClient(ClientBaseConfiguration configuration) : base(configuration)
       {
       }
-      
-      // IMPLEMENTATION NOTE: This will be in a partial class eventually.
-
-      /// <summary>
-      /// Creates a new instance of <see cref="IAMPolicyClient"/> using the same call invoker
-      /// as this client.
-      /// </summary>
-      /// <returns>A new IAM client for the same target as this client.</returns>
-      public virtual IAMPolicyClient CreateIAMPolicyClient() => new IAMPolicyClient(CallInvoker);
 
       /// <summary>
       ///  Creates a subscription to a given topic.
@@ -740,15 +730,6 @@ namespace Google.Pubsub.V1 {
       protected PublisherClient(ClientBaseConfiguration configuration) : base(configuration)
       {
       }
-
-      // IMPLEMENTATION NOTE: This will be in a partial class eventually.
-
-      /// <summary>
-      /// Creates a new instance of <see cref="IAMPolicyClient"/> using the same call invoker
-      /// as this client.
-      /// </summary>
-      /// <returns>A new IAM client for the same target as this client.</returns>
-      public virtual IAMPolicyClient CreateIAMPolicyClient() => new IAMPolicyClient(CallInvoker);
 
       /// <summary>
       ///  Creates the given topic with the given name.

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1/PubsubGrpc.cs
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1/PubsubGrpc.cs
@@ -21,6 +21,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
+using static Google.Iam.V1.IAMPolicy;
 
 namespace Google.Pubsub.V1 {
   /// <summary>
@@ -224,6 +225,15 @@ namespace Google.Pubsub.V1 {
       protected SubscriberClient(ClientBaseConfiguration configuration) : base(configuration)
       {
       }
+      
+      // IMPLEMENTATION NOTE: This will be in a partial class eventually.
+
+      /// <summary>
+      /// Creates a new instance of <see cref="IAMPolicyClient"/> using the same call invoker
+      /// as this client.
+      /// </summary>
+      /// <returns>A new IAM client for the same target as this client.</returns>
+      public virtual IAMPolicyClient CreateIAMPolicyClient() => new IAMPolicyClient(CallInvoker);
 
       /// <summary>
       ///  Creates a subscription to a given topic.
@@ -730,6 +740,15 @@ namespace Google.Pubsub.V1 {
       protected PublisherClient(ClientBaseConfiguration configuration) : base(configuration)
       {
       }
+
+      // IMPLEMENTATION NOTE: This will be in a partial class eventually.
+
+      /// <summary>
+      /// Creates a new instance of <see cref="IAMPolicyClient"/> using the same call invoker
+      /// as this client.
+      /// </summary>
+      /// <returns>A new IAM client for the same target as this client.</returns>
+      public virtual IAMPolicyClient CreateIAMPolicyClient() => new IAMPolicyClient(CallInvoker);
 
       /// <summary>
       ///  Creates the given topic with the given name.

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1/SubscriberClient.cs
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1/SubscriberClient.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,10 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Iam.V1;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using Google.Pubsub.V1;
 using Grpc.Core;
 using System;
 using System.Collections;
@@ -56,6 +59,9 @@ namespace Google.Pubsub.V1
             AcknowledgeSettings = existing.AcknowledgeSettings;
             PullSettings = existing.PullSettings;
             ModifyPushConfigSettings = existing.ModifyPushConfigSettings;
+            SetIamPolicySettings = existing.SetIamPolicySettings;
+            GetIamPolicySettings = existing.GetIamPolicySettings;
+            TestIamPermissionsSettings = existing.TestIamPermissionsSettings;
         }
 
         /// <summary>
@@ -399,6 +405,94 @@ namespace Google.Pubsub.V1
             )));
 
         /// <summary>
+        /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>SubscriberClient.SetIamPolicy</c> and <c>SubscriberClient.SetIamPolicyAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>SubscriberClient.SetIamPolicy</c> and
+        /// <c>SubscriberClient.SetIamPolicyAsync</c> <see cref="RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.3</description></item>
+        /// <item><description>Retry maximum delay: 60000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 60000 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.0</description></item>
+        /// <item><description>Timeout maximum delay: 60000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 600000 milliseconds.
+        /// </remarks>
+        public CallSettings SetIamPolicySettings { get; set; } = CallSettings.FromCallTiming(
+            CallTiming.FromRetry(new RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: Expiration.FromTimeout(TimeSpan.FromMilliseconds(600000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>SubscriberClient.GetIamPolicy</c> and <c>SubscriberClient.GetIamPolicyAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>SubscriberClient.GetIamPolicy</c> and
+        /// <c>SubscriberClient.GetIamPolicyAsync</c> <see cref="RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.3</description></item>
+        /// <item><description>Retry maximum delay: 60000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 60000 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.0</description></item>
+        /// <item><description>Timeout maximum delay: 60000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description><see cref="StatusCode.DeadlineExceeded"/></description></item>
+        /// <item><description><see cref="StatusCode.Unavailable"/></description></item>
+        /// </list>
+        /// Default RPC expiration is 600000 milliseconds.
+        /// </remarks>
+        public CallSettings GetIamPolicySettings { get; set; } = CallSettings.FromCallTiming(
+            CallTiming.FromRetry(new RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: Expiration.FromTimeout(TimeSpan.FromMilliseconds(600000)),
+                retryFilter: IdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>SubscriberClient.TestIamPermissions</c> and <c>SubscriberClient.TestIamPermissionsAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>SubscriberClient.TestIamPermissions</c> and
+        /// <c>SubscriberClient.TestIamPermissionsAsync</c> <see cref="RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.3</description></item>
+        /// <item><description>Retry maximum delay: 60000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 60000 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.0</description></item>
+        /// <item><description>Timeout maximum delay: 60000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 600000 milliseconds.
+        /// </remarks>
+        public CallSettings TestIamPermissionsSettings { get; set; } = CallSettings.FromCallTiming(
+            CallTiming.FromRetry(new RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: Expiration.FromTimeout(TimeSpan.FromMilliseconds(600000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
         /// Creates a deep clone of this object, with all the same property values.
         /// </summary>
         /// <returns>A deep clone of this <see cref="SubscriberSettings"/> object.</returns>
@@ -555,7 +649,13 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
+        /// Creates a subscription to a given topic.
+        /// If the subscription already exists, returns `ALREADY_EXISTS`.
+        /// If the corresponding topic doesn't exist, returns `NOT_FOUND`.
         ///
+        /// If the name is not provided in the request, the server will assign a random
+        /// name for this subscription on the same project as the topic. Note that
+        /// for REST API requests, you must specify a name.
         /// </summary>
         /// <param name="name">
         /// The name of the subscription. It must have the format
@@ -566,13 +666,35 @@ namespace Google.Pubsub.V1
         /// in length, and it must not start with `"goog"`.
         /// </param>
         /// <param name="topic">
-        ///
+        /// The name of the topic from which this subscription is receiving messages.
+        /// The value of this field will be `_deleted-topic_` if the topic has been
+        /// deleted.
         /// </param>
         /// <param name="pushConfig">
-        ///
+        /// If push delivery is used with this subscription, this field is
+        /// used to configure it. An empty `pushConfig` signifies that the subscriber
+        /// will pull and ack messages using API methods.
         /// </param>
         /// <param name="ackDeadlineSeconds">
+        /// This value is the maximum time after a subscriber receives a message
+        /// before the subscriber should acknowledge the message. After message
+        /// delivery but before the ack deadline expires and before the message is
+        /// acknowledged, it is an outstanding message and will not be delivered
+        /// again during that time (on a best-effort basis).
         ///
+        /// For pull subscriptions, this value is used as the initial value for the ack
+        /// deadline. To override this value for a given message, call
+        /// `ModifyAckDeadline` with the corresponding `ack_id` if using
+        /// pull.
+        /// The maximum custom deadline you can specify is 600 seconds (10 minutes).
+        ///
+        /// For push delivery, this value is also used to set the request timeout for
+        /// the call to the push endpoint.
+        ///
+        /// If the subscriber never acknowledges the message, the Pub/Sub
+        /// system will eventually redeliver the message.
+        ///
+        /// If this parameter is 0, a default value of 10 seconds is used.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -591,7 +713,13 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
+        /// Creates a subscription to a given topic.
+        /// If the subscription already exists, returns `ALREADY_EXISTS`.
+        /// If the corresponding topic doesn't exist, returns `NOT_FOUND`.
         ///
+        /// If the name is not provided in the request, the server will assign a random
+        /// name for this subscription on the same project as the topic. Note that
+        /// for REST API requests, you must specify a name.
         /// </summary>
         /// <param name="name">
         /// The name of the subscription. It must have the format
@@ -602,13 +730,35 @@ namespace Google.Pubsub.V1
         /// in length, and it must not start with `"goog"`.
         /// </param>
         /// <param name="topic">
-        ///
+        /// The name of the topic from which this subscription is receiving messages.
+        /// The value of this field will be `_deleted-topic_` if the topic has been
+        /// deleted.
         /// </param>
         /// <param name="pushConfig">
-        ///
+        /// If push delivery is used with this subscription, this field is
+        /// used to configure it. An empty `pushConfig` signifies that the subscriber
+        /// will pull and ack messages using API methods.
         /// </param>
         /// <param name="ackDeadlineSeconds">
+        /// This value is the maximum time after a subscriber receives a message
+        /// before the subscriber should acknowledge the message. After message
+        /// delivery but before the ack deadline expires and before the message is
+        /// acknowledged, it is an outstanding message and will not be delivered
+        /// again during that time (on a best-effort basis).
         ///
+        /// For pull subscriptions, this value is used as the initial value for the ack
+        /// deadline. To override this value for a given message, call
+        /// `ModifyAckDeadline` with the corresponding `ack_id` if using
+        /// pull.
+        /// The maximum custom deadline you can specify is 600 seconds (10 minutes).
+        ///
+        /// For push delivery, this value is also used to set the request timeout for
+        /// the call to the push endpoint.
+        ///
+        /// If the subscriber never acknowledges the message, the Pub/Sub
+        /// system will eventually redeliver the message.
+        ///
+        /// If this parameter is 0, a default value of 10 seconds is used.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -629,7 +779,13 @@ namespace Google.Pubsub.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
+        /// Creates a subscription to a given topic.
+        /// If the subscription already exists, returns `ALREADY_EXISTS`.
+        /// If the corresponding topic doesn't exist, returns `NOT_FOUND`.
         ///
+        /// If the name is not provided in the request, the server will assign a random
+        /// name for this subscription on the same project as the topic. Note that
+        /// for REST API requests, you must specify a name.
         /// </summary>
         /// <param name="name">
         /// The name of the subscription. It must have the format
@@ -640,13 +796,35 @@ namespace Google.Pubsub.V1
         /// in length, and it must not start with `"goog"`.
         /// </param>
         /// <param name="topic">
-        ///
+        /// The name of the topic from which this subscription is receiving messages.
+        /// The value of this field will be `_deleted-topic_` if the topic has been
+        /// deleted.
         /// </param>
         /// <param name="pushConfig">
-        ///
+        /// If push delivery is used with this subscription, this field is
+        /// used to configure it. An empty `pushConfig` signifies that the subscriber
+        /// will pull and ack messages using API methods.
         /// </param>
         /// <param name="ackDeadlineSeconds">
+        /// This value is the maximum time after a subscriber receives a message
+        /// before the subscriber should acknowledge the message. After message
+        /// delivery but before the ack deadline expires and before the message is
+        /// acknowledged, it is an outstanding message and will not be delivered
+        /// again during that time (on a best-effort basis).
         ///
+        /// For pull subscriptions, this value is used as the initial value for the ack
+        /// deadline. To override this value for a given message, call
+        /// `ModifyAckDeadline` with the corresponding `ack_id` if using
+        /// pull.
+        /// The maximum custom deadline you can specify is 600 seconds (10 minutes).
+        ///
+        /// For push delivery, this value is also used to set the request timeout for
+        /// the call to the push endpoint.
+        ///
+        /// If the subscriber never acknowledges the message, the Pub/Sub
+        /// system will eventually redeliver the message.
+        ///
+        /// If this parameter is 0, a default value of 10 seconds is used.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -665,10 +843,10 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Gets the configuration details of a subscription.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription to get.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -684,10 +862,10 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Gets the configuration details of a subscription.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription to get.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -702,10 +880,10 @@ namespace Google.Pubsub.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Gets the configuration details of a subscription.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription to get.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -721,10 +899,10 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Lists matching subscriptions.
         /// </summary>
         /// <param name="project">
-        ///
+        /// The name of the cloud project that subscriptions belong to.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -750,10 +928,10 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Lists matching subscriptions.
         /// </summary>
         /// <param name="project">
-        ///
+        /// The name of the cloud project that subscriptions belong to.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -779,10 +957,14 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Deletes an existing subscription. All pending messages in the subscription
+        /// are immediately dropped. Calls to `Pull` after deletion will return
+        /// `NOT_FOUND`. After a subscription is deleted, a new one may be created with
+        /// the same name, but the new one has no association with the old
+        /// subscription, or its topic unless the same topic is specified.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription to delete.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -798,10 +980,14 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Deletes an existing subscription. All pending messages in the subscription
+        /// are immediately dropped. Calls to `Pull` after deletion will return
+        /// `NOT_FOUND`. After a subscription is deleted, a new one may be created with
+        /// the same name, but the new one has no association with the old
+        /// subscription, or its topic unless the same topic is specified.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription to delete.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -816,10 +1002,14 @@ namespace Google.Pubsub.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Deletes an existing subscription. All pending messages in the subscription
+        /// are immediately dropped. Calls to `Pull` after deletion will return
+        /// `NOT_FOUND`. After a subscription is deleted, a new one may be created with
+        /// the same name, but the new one has no association with the old
+        /// subscription, or its topic unless the same topic is specified.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription to delete.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -835,16 +1025,24 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Modifies the ack deadline for a specific message. This method is useful
+        /// to indicate that more time is needed to process a message by the
+        /// subscriber, or to make the message available for redelivery if the
+        /// processing was interrupted. Note that this does not modify the
+        /// subscription-level `ackDeadlineSeconds` used for subsequent messages.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription.
         /// </param>
         /// <param name="ackIds">
-        ///
+        /// List of acknowledgment IDs.
         /// </param>
         /// <param name="ackDeadlineSeconds">
-        ///
+        /// The new ack deadline with respect to the time this request was sent to
+        /// the Pub/Sub system. Must be >= 0. For example, if the value is 10, the new
+        /// ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
+        /// was made. Specifying zero may immediately make the message available for
+        /// another pull request.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -862,16 +1060,24 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Modifies the ack deadline for a specific message. This method is useful
+        /// to indicate that more time is needed to process a message by the
+        /// subscriber, or to make the message available for redelivery if the
+        /// processing was interrupted. Note that this does not modify the
+        /// subscription-level `ackDeadlineSeconds` used for subsequent messages.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription.
         /// </param>
         /// <param name="ackIds">
-        ///
+        /// List of acknowledgment IDs.
         /// </param>
         /// <param name="ackDeadlineSeconds">
-        ///
+        /// The new ack deadline with respect to the time this request was sent to
+        /// the Pub/Sub system. Must be >= 0. For example, if the value is 10, the new
+        /// ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
+        /// was made. Specifying zero may immediately make the message available for
+        /// another pull request.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -890,16 +1096,24 @@ namespace Google.Pubsub.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Modifies the ack deadline for a specific message. This method is useful
+        /// to indicate that more time is needed to process a message by the
+        /// subscriber, or to make the message available for redelivery if the
+        /// processing was interrupted. Note that this does not modify the
+        /// subscription-level `ackDeadlineSeconds` used for subsequent messages.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription.
         /// </param>
         /// <param name="ackIds">
-        ///
+        /// List of acknowledgment IDs.
         /// </param>
         /// <param name="ackDeadlineSeconds">
-        ///
+        /// The new ack deadline with respect to the time this request was sent to
+        /// the Pub/Sub system. Must be >= 0. For example, if the value is 10, the new
+        /// ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
+        /// was made. Specifying zero may immediately make the message available for
+        /// another pull request.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -917,13 +1131,20 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
+        /// Acknowledges the messages associated with the `ack_ids` in the
+        /// `AcknowledgeRequest`. The Pub/Sub system can remove the relevant messages
+        /// from the subscription.
         ///
+        /// Acknowledging a message whose ack deadline has expired may succeed,
+        /// but such a message may be redelivered later. Acknowledging a message more
+        /// than once will not result in an error.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription whose message is being acknowledged.
         /// </param>
         /// <param name="ackIds">
-        ///
+        /// The acknowledgment ID for the messages being acknowledged that was returned
+        /// by the Pub/Sub system in the `Pull` response. Must not be empty.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -940,13 +1161,20 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
+        /// Acknowledges the messages associated with the `ack_ids` in the
+        /// `AcknowledgeRequest`. The Pub/Sub system can remove the relevant messages
+        /// from the subscription.
         ///
+        /// Acknowledging a message whose ack deadline has expired may succeed,
+        /// but such a message may be redelivered later. Acknowledging a message more
+        /// than once will not result in an error.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription whose message is being acknowledged.
         /// </param>
         /// <param name="ackIds">
-        ///
+        /// The acknowledgment ID for the messages being acknowledged that was returned
+        /// by the Pub/Sub system in the `Pull` response. Must not be empty.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -963,13 +1191,20 @@ namespace Google.Pubsub.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
+        /// Acknowledges the messages associated with the `ack_ids` in the
+        /// `AcknowledgeRequest`. The Pub/Sub system can remove the relevant messages
+        /// from the subscription.
         ///
+        /// Acknowledging a message whose ack deadline has expired may succeed,
+        /// but such a message may be redelivered later. Acknowledging a message more
+        /// than once will not result in an error.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription whose message is being acknowledged.
         /// </param>
         /// <param name="ackIds">
-        ///
+        /// The acknowledgment ID for the messages being acknowledged that was returned
+        /// by the Pub/Sub system in the `Pull` response. Must not be empty.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -986,16 +1221,24 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Pulls messages from the server. Returns an empty list if there are no
+        /// messages available in the backlog. The server may return `UNAVAILABLE` if
+        /// there are too many concurrent pull requests pending for the given
+        /// subscription.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription from which messages should be pulled.
         /// </param>
         /// <param name="returnImmediately">
-        ///
+        /// If this is specified as true the system will respond immediately even if
+        /// it is not able to return a message in the `Pull` response. Otherwise the
+        /// system is allowed to wait until at least one message is available rather
+        /// than returning no messages. The client may cancel the request if it does
+        /// not wish to wait any longer for the response.
         /// </param>
         /// <param name="maxMessages">
-        ///
+        /// The maximum number of messages returned for this request. The Pub/Sub
+        /// system may return fewer than the number specified.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1013,16 +1256,24 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
-        ///
+        /// Pulls messages from the server. Returns an empty list if there are no
+        /// messages available in the backlog. The server may return `UNAVAILABLE` if
+        /// there are too many concurrent pull requests pending for the given
+        /// subscription.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription from which messages should be pulled.
         /// </param>
         /// <param name="returnImmediately">
-        ///
+        /// If this is specified as true the system will respond immediately even if
+        /// it is not able to return a message in the `Pull` response. Otherwise the
+        /// system is allowed to wait until at least one message is available rather
+        /// than returning no messages. The client may cancel the request if it does
+        /// not wish to wait any longer for the response.
         /// </param>
         /// <param name="maxMessages">
-        ///
+        /// The maximum number of messages returned for this request. The Pub/Sub
+        /// system may return fewer than the number specified.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -1041,16 +1292,24 @@ namespace Google.Pubsub.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        ///
+        /// Pulls messages from the server. Returns an empty list if there are no
+        /// messages available in the backlog. The server may return `UNAVAILABLE` if
+        /// there are too many concurrent pull requests pending for the given
+        /// subscription.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription from which messages should be pulled.
         /// </param>
         /// <param name="returnImmediately">
-        ///
+        /// If this is specified as true the system will respond immediately even if
+        /// it is not able to return a message in the `Pull` response. Otherwise the
+        /// system is allowed to wait until at least one message is available rather
+        /// than returning no messages. The client may cancel the request if it does
+        /// not wish to wait any longer for the response.
         /// </param>
         /// <param name="maxMessages">
-        ///
+        /// The maximum number of messages returned for this request. The Pub/Sub
+        /// system may return fewer than the number specified.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1068,13 +1327,23 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
+        /// Modifies the `PushConfig` for a specified subscription.
         ///
+        /// This may be used to change a push subscription to a pull one (signified by
+        /// an empty `PushConfig`) or vice versa, or change the endpoint URL and other
+        /// attributes of a push subscription. Messages will accumulate for delivery
+        /// continuously through the call regardless of changes to the `PushConfig`.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription.
         /// </param>
         /// <param name="pushConfig">
+        /// The push configuration for future deliveries.
         ///
+        /// An empty `pushConfig` indicates that the Pub/Sub system should
+        /// stop pushing messages from the given subscription and allow
+        /// messages to be pulled and acknowledged - effectively pausing
+        /// the subscription if `Pull` is not called.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1091,13 +1360,23 @@ namespace Google.Pubsub.V1
         }
 
         /// <summary>
+        /// Modifies the `PushConfig` for a specified subscription.
         ///
+        /// This may be used to change a push subscription to a pull one (signified by
+        /// an empty `PushConfig`) or vice versa, or change the endpoint URL and other
+        /// attributes of a push subscription. Messages will accumulate for delivery
+        /// continuously through the call regardless of changes to the `PushConfig`.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription.
         /// </param>
         /// <param name="pushConfig">
+        /// The push configuration for future deliveries.
         ///
+        /// An empty `pushConfig` indicates that the Pub/Sub system should
+        /// stop pushing messages from the given subscription and allow
+        /// messages to be pulled and acknowledged - effectively pausing
+        /// the subscription if `Pull` is not called.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -1114,13 +1393,23 @@ namespace Google.Pubsub.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
+        /// Modifies the `PushConfig` for a specified subscription.
         ///
+        /// This may be used to change a push subscription to a pull one (signified by
+        /// an empty `PushConfig`) or vice versa, or change the endpoint URL and other
+        /// attributes of a push subscription. Messages will accumulate for delivery
+        /// continuously through the call regardless of changes to the `PushConfig`.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription.
         /// </param>
         /// <param name="pushConfig">
+        /// The push configuration for future deliveries.
         ///
+        /// An empty `pushConfig` indicates that the Pub/Sub system should
+        /// stop pushing messages from the given subscription and allow
+        /// messages to be pulled and acknowledged - effectively pausing
+        /// the subscription if `Pull` is not called.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1131,6 +1420,245 @@ namespace Google.Pubsub.V1
         public virtual void ModifyPushConfig(
             string subscription,
             PushConfig pushConfig,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Sets the access control policy on the specified resource. Replaces any
+        /// existing policy.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being specified.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="policy">
+        /// REQUIRED: The complete policy to be applied to the `resource`. The size of
+        /// the policy is limited to a few 10s of KB. An empty policy is a
+        /// valid policy but certain Cloud Platform services (such as Projects)
+        /// might reject them.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Policy> SetIamPolicyAsync(
+            string resource,
+            Policy policy,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Sets the access control policy on the specified resource. Replaces any
+        /// existing policy.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being specified.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="policy">
+        /// REQUIRED: The complete policy to be applied to the `resource`. The size of
+        /// the policy is limited to a few 10s of KB. An empty policy is a
+        /// valid policy but certain Cloud Platform services (such as Projects)
+        /// might reject them.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Policy> SetIamPolicyAsync(
+            string resource,
+            Policy policy,
+            CancellationToken cancellationToken) => SetIamPolicyAsync(
+                resource,
+                policy,
+                CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Sets the access control policy on the specified resource. Replaces any
+        /// existing policy.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being specified.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="policy">
+        /// REQUIRED: The complete policy to be applied to the `resource`. The size of
+        /// the policy is limited to a few 10s of KB. An empty policy is a
+        /// valid policy but certain Cloud Platform services (such as Projects)
+        /// might reject them.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Policy SetIamPolicy(
+            string resource,
+            Policy policy,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets the access control policy for a resource.
+        /// Returns an empty policy if the resource exists and does not have a policy
+        /// set.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Policy> GetIamPolicyAsync(
+            string resource,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets the access control policy for a resource.
+        /// Returns an empty policy if the resource exists and does not have a policy
+        /// set.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Policy> GetIamPolicyAsync(
+            string resource,
+            CancellationToken cancellationToken) => GetIamPolicyAsync(
+                resource,
+                CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Gets the access control policy for a resource.
+        /// Returns an empty policy if the resource exists and does not have a policy
+        /// set.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Policy GetIamPolicy(
+            string resource,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns permissions that a caller has on the specified resource.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy detail is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="permissions">
+        /// The set of permissions to check for the `resource`. Permissions with
+        /// wildcards (such as '*' or 'storage.*') are not allowed. For more
+        /// information see
+        /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
+            string resource,
+            IEnumerable<string> permissions,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns permissions that a caller has on the specified resource.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy detail is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="permissions">
+        /// The set of permissions to check for the `resource`. Permissions with
+        /// wildcards (such as '*' or 'storage.*') are not allowed. For more
+        /// information see
+        /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
+            string resource,
+            IEnumerable<string> permissions,
+            CancellationToken cancellationToken) => TestIamPermissionsAsync(
+                resource,
+                permissions,
+                CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Returns permissions that a caller has on the specified resource.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy detail is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="permissions">
+        /// The set of permissions to check for the `resource`. Permissions with
+        /// wildcards (such as '*' or 'storage.*') are not allowed. For more
+        /// information see
+        /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual TestIamPermissionsResponse TestIamPermissions(
+            string resource,
+            IEnumerable<string> permissions,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1152,6 +1680,9 @@ namespace Google.Pubsub.V1
         private readonly ApiCall<AcknowledgeRequest, Empty> _callAcknowledge;
         private readonly ApiCall<PullRequest, PullResponse> _callPull;
         private readonly ApiCall<ModifyPushConfigRequest, Empty> _callModifyPushConfig;
+        private readonly ApiCall<SetIamPolicyRequest, Policy> _callSetIamPolicy;
+        private readonly ApiCall<GetIamPolicyRequest, Policy> _callGetIamPolicy;
+        private readonly ApiCall<TestIamPermissionsRequest, TestIamPermissionsResponse> _callTestIamPermissions;
 
         /// <summary>
         /// Constructs a client wrapper for the Subscriber service, with the specified gRPC client and settings.
@@ -1163,6 +1694,7 @@ namespace Google.Pubsub.V1
             this.GrpcClient = grpcClient;
             SubscriberSettings effectiveSettings = settings ?? SubscriberSettings.GetDefault();
             _clientHelper = new ClientHelper(effectiveSettings);
+            var grpcIAMPolicyClient = grpcClient.CreateIAMPolicyClient();
             _callCreateSubscription = _clientHelper.BuildApiCall<Subscription, Subscription>(
                 GrpcClient.CreateSubscriptionAsync, GrpcClient.CreateSubscription, effectiveSettings.CreateSubscriptionSettings);
             _callGetSubscription = _clientHelper.BuildApiCall<GetSubscriptionRequest, Subscription>(
@@ -1179,6 +1711,12 @@ namespace Google.Pubsub.V1
                 GrpcClient.PullAsync, GrpcClient.Pull, effectiveSettings.PullSettings);
             _callModifyPushConfig = _clientHelper.BuildApiCall<ModifyPushConfigRequest, Empty>(
                 GrpcClient.ModifyPushConfigAsync, GrpcClient.ModifyPushConfig, effectiveSettings.ModifyPushConfigSettings);
+            _callSetIamPolicy = _clientHelper.BuildApiCall<SetIamPolicyRequest, Policy>(
+                grpcIAMPolicyClient.SetIamPolicyAsync, grpcIAMPolicyClient.SetIamPolicy, effectiveSettings.SetIamPolicySettings);
+            _callGetIamPolicy = _clientHelper.BuildApiCall<GetIamPolicyRequest, Policy>(
+                grpcIAMPolicyClient.GetIamPolicyAsync, grpcIAMPolicyClient.GetIamPolicy, effectiveSettings.GetIamPolicySettings);
+            _callTestIamPermissions = _clientHelper.BuildApiCall<TestIamPermissionsRequest, TestIamPermissionsResponse>(
+                grpcIAMPolicyClient.TestIamPermissionsAsync, grpcIAMPolicyClient.TestIamPermissions, effectiveSettings.TestIamPermissionsSettings);
         }
 
         /// <summary>
@@ -1187,7 +1725,13 @@ namespace Google.Pubsub.V1
         public override Subscriber.SubscriberClient GrpcClient { get; }
 
         /// <summary>
+        /// Creates a subscription to a given topic.
+        /// If the subscription already exists, returns `ALREADY_EXISTS`.
+        /// If the corresponding topic doesn't exist, returns `NOT_FOUND`.
         ///
+        /// If the name is not provided in the request, the server will assign a random
+        /// name for this subscription on the same project as the topic. Note that
+        /// for REST API requests, you must specify a name.
         /// </summary>
         /// <param name="name">
         /// The name of the subscription. It must have the format
@@ -1198,13 +1742,35 @@ namespace Google.Pubsub.V1
         /// in length, and it must not start with `"goog"`.
         /// </param>
         /// <param name="topic">
-        ///
+        /// The name of the topic from which this subscription is receiving messages.
+        /// The value of this field will be `_deleted-topic_` if the topic has been
+        /// deleted.
         /// </param>
         /// <param name="pushConfig">
-        ///
+        /// If push delivery is used with this subscription, this field is
+        /// used to configure it. An empty `pushConfig` signifies that the subscriber
+        /// will pull and ack messages using API methods.
         /// </param>
         /// <param name="ackDeadlineSeconds">
+        /// This value is the maximum time after a subscriber receives a message
+        /// before the subscriber should acknowledge the message. After message
+        /// delivery but before the ack deadline expires and before the message is
+        /// acknowledged, it is an outstanding message and will not be delivered
+        /// again during that time (on a best-effort basis).
         ///
+        /// For pull subscriptions, this value is used as the initial value for the ack
+        /// deadline. To override this value for a given message, call
+        /// `ModifyAckDeadline` with the corresponding `ack_id` if using
+        /// pull.
+        /// The maximum custom deadline you can specify is 600 seconds (10 minutes).
+        ///
+        /// For push delivery, this value is also used to set the request timeout for
+        /// the call to the push endpoint.
+        ///
+        /// If the subscriber never acknowledges the message, the Pub/Sub
+        /// system will eventually redeliver the message.
+        ///
+        /// If this parameter is 0, a default value of 10 seconds is used.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1228,7 +1794,13 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
+        /// Creates a subscription to a given topic.
+        /// If the subscription already exists, returns `ALREADY_EXISTS`.
+        /// If the corresponding topic doesn't exist, returns `NOT_FOUND`.
         ///
+        /// If the name is not provided in the request, the server will assign a random
+        /// name for this subscription on the same project as the topic. Note that
+        /// for REST API requests, you must specify a name.
         /// </summary>
         /// <param name="name">
         /// The name of the subscription. It must have the format
@@ -1239,13 +1811,35 @@ namespace Google.Pubsub.V1
         /// in length, and it must not start with `"goog"`.
         /// </param>
         /// <param name="topic">
-        ///
+        /// The name of the topic from which this subscription is receiving messages.
+        /// The value of this field will be `_deleted-topic_` if the topic has been
+        /// deleted.
         /// </param>
         /// <param name="pushConfig">
-        ///
+        /// If push delivery is used with this subscription, this field is
+        /// used to configure it. An empty `pushConfig` signifies that the subscriber
+        /// will pull and ack messages using API methods.
         /// </param>
         /// <param name="ackDeadlineSeconds">
+        /// This value is the maximum time after a subscriber receives a message
+        /// before the subscriber should acknowledge the message. After message
+        /// delivery but before the ack deadline expires and before the message is
+        /// acknowledged, it is an outstanding message and will not be delivered
+        /// again during that time (on a best-effort basis).
         ///
+        /// For pull subscriptions, this value is used as the initial value for the ack
+        /// deadline. To override this value for a given message, call
+        /// `ModifyAckDeadline` with the corresponding `ack_id` if using
+        /// pull.
+        /// The maximum custom deadline you can specify is 600 seconds (10 minutes).
+        ///
+        /// For push delivery, this value is also used to set the request timeout for
+        /// the call to the push endpoint.
+        ///
+        /// If the subscriber never acknowledges the message, the Pub/Sub
+        /// system will eventually redeliver the message.
+        ///
+        /// If this parameter is 0, a default value of 10 seconds is used.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1269,10 +1863,10 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Gets the configuration details of a subscription.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription to get.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1290,10 +1884,10 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Gets the configuration details of a subscription.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription to get.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1311,10 +1905,10 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists matching subscriptions.
         /// </summary>
         /// <param name="project">
-        ///
+        /// The name of the cloud project that subscriptions belong to.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1345,10 +1939,10 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Lists matching subscriptions.
         /// </summary>
         /// <param name="project">
-        ///
+        /// The name of the cloud project that subscriptions belong to.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1379,10 +1973,14 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes an existing subscription. All pending messages in the subscription
+        /// are immediately dropped. Calls to `Pull` after deletion will return
+        /// `NOT_FOUND`. After a subscription is deleted, a new one may be created with
+        /// the same name, but the new one has no association with the old
+        /// subscription, or its topic unless the same topic is specified.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription to delete.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1400,10 +1998,14 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Deletes an existing subscription. All pending messages in the subscription
+        /// are immediately dropped. Calls to `Pull` after deletion will return
+        /// `NOT_FOUND`. After a subscription is deleted, a new one may be created with
+        /// the same name, but the new one has no association with the old
+        /// subscription, or its topic unless the same topic is specified.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription to delete.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1421,16 +2023,24 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Modifies the ack deadline for a specific message. This method is useful
+        /// to indicate that more time is needed to process a message by the
+        /// subscriber, or to make the message available for redelivery if the
+        /// processing was interrupted. Note that this does not modify the
+        /// subscription-level `ackDeadlineSeconds` used for subsequent messages.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription.
         /// </param>
         /// <param name="ackIds">
-        ///
+        /// List of acknowledgment IDs.
         /// </param>
         /// <param name="ackDeadlineSeconds">
-        ///
+        /// The new ack deadline with respect to the time this request was sent to
+        /// the Pub/Sub system. Must be >= 0. For example, if the value is 10, the new
+        /// ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
+        /// was made. Specifying zero may immediately make the message available for
+        /// another pull request.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1452,16 +2062,24 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Modifies the ack deadline for a specific message. This method is useful
+        /// to indicate that more time is needed to process a message by the
+        /// subscriber, or to make the message available for redelivery if the
+        /// processing was interrupted. Note that this does not modify the
+        /// subscription-level `ackDeadlineSeconds` used for subsequent messages.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription.
         /// </param>
         /// <param name="ackIds">
-        ///
+        /// List of acknowledgment IDs.
         /// </param>
         /// <param name="ackDeadlineSeconds">
-        ///
+        /// The new ack deadline with respect to the time this request was sent to
+        /// the Pub/Sub system. Must be >= 0. For example, if the value is 10, the new
+        /// ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
+        /// was made. Specifying zero may immediately make the message available for
+        /// another pull request.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1483,13 +2101,20 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
+        /// Acknowledges the messages associated with the `ack_ids` in the
+        /// `AcknowledgeRequest`. The Pub/Sub system can remove the relevant messages
+        /// from the subscription.
         ///
+        /// Acknowledging a message whose ack deadline has expired may succeed,
+        /// but such a message may be redelivered later. Acknowledging a message more
+        /// than once will not result in an error.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription whose message is being acknowledged.
         /// </param>
         /// <param name="ackIds">
-        ///
+        /// The acknowledgment ID for the messages being acknowledged that was returned
+        /// by the Pub/Sub system in the `Pull` response. Must not be empty.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1509,13 +2134,20 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
+        /// Acknowledges the messages associated with the `ack_ids` in the
+        /// `AcknowledgeRequest`. The Pub/Sub system can remove the relevant messages
+        /// from the subscription.
         ///
+        /// Acknowledging a message whose ack deadline has expired may succeed,
+        /// but such a message may be redelivered later. Acknowledging a message more
+        /// than once will not result in an error.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription whose message is being acknowledged.
         /// </param>
         /// <param name="ackIds">
-        ///
+        /// The acknowledgment ID for the messages being acknowledged that was returned
+        /// by the Pub/Sub system in the `Pull` response. Must not be empty.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1535,16 +2167,24 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Pulls messages from the server. Returns an empty list if there are no
+        /// messages available in the backlog. The server may return `UNAVAILABLE` if
+        /// there are too many concurrent pull requests pending for the given
+        /// subscription.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription from which messages should be pulled.
         /// </param>
         /// <param name="returnImmediately">
-        ///
+        /// If this is specified as true the system will respond immediately even if
+        /// it is not able to return a message in the `Pull` response. Otherwise the
+        /// system is allowed to wait until at least one message is available rather
+        /// than returning no messages. The client may cancel the request if it does
+        /// not wish to wait any longer for the response.
         /// </param>
         /// <param name="maxMessages">
-        ///
+        /// The maximum number of messages returned for this request. The Pub/Sub
+        /// system may return fewer than the number specified.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1566,16 +2206,24 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
-        ///
+        /// Pulls messages from the server. Returns an empty list if there are no
+        /// messages available in the backlog. The server may return `UNAVAILABLE` if
+        /// there are too many concurrent pull requests pending for the given
+        /// subscription.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The subscription from which messages should be pulled.
         /// </param>
         /// <param name="returnImmediately">
-        ///
+        /// If this is specified as true the system will respond immediately even if
+        /// it is not able to return a message in the `Pull` response. Otherwise the
+        /// system is allowed to wait until at least one message is available rather
+        /// than returning no messages. The client may cancel the request if it does
+        /// not wish to wait any longer for the response.
         /// </param>
         /// <param name="maxMessages">
-        ///
+        /// The maximum number of messages returned for this request. The Pub/Sub
+        /// system may return fewer than the number specified.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1597,13 +2245,23 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
+        /// Modifies the `PushConfig` for a specified subscription.
         ///
+        /// This may be used to change a push subscription to a pull one (signified by
+        /// an empty `PushConfig`) or vice versa, or change the endpoint URL and other
+        /// attributes of a push subscription. Messages will accumulate for delivery
+        /// continuously through the call regardless of changes to the `PushConfig`.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription.
         /// </param>
         /// <param name="pushConfig">
+        /// The push configuration for future deliveries.
         ///
+        /// An empty `pushConfig` indicates that the Pub/Sub system should
+        /// stop pushing messages from the given subscription and allow
+        /// messages to be pulled and acknowledged - effectively pausing
+        /// the subscription if `Pull` is not called.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1623,13 +2281,23 @@ namespace Google.Pubsub.V1
                 callSettings);
 
         /// <summary>
+        /// Modifies the `PushConfig` for a specified subscription.
         ///
+        /// This may be used to change a push subscription to a pull one (signified by
+        /// an empty `PushConfig`) or vice versa, or change the endpoint URL and other
+        /// attributes of a push subscription. Messages will accumulate for delivery
+        /// continuously through the call regardless of changes to the `PushConfig`.
         /// </summary>
         /// <param name="subscription">
-        ///
+        /// The name of the subscription.
         /// </param>
         /// <param name="pushConfig">
+        /// The push configuration for future deliveries.
         ///
+        /// An empty `pushConfig` indicates that the Pub/Sub system should
+        /// stop pushing messages from the given subscription and allow
+        /// messages to be pulled and acknowledged - effectively pausing
+        /// the subscription if `Pull` is not called.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1645,6 +2313,182 @@ namespace Google.Pubsub.V1
                 {
                     Subscription = subscription,
                     PushConfig = pushConfig,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Sets the access control policy on the specified resource. Replaces any
+        /// existing policy.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being specified.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="policy">
+        /// REQUIRED: The complete policy to be applied to the `resource`. The size of
+        /// the policy is limited to a few 10s of KB. An empty policy is a
+        /// valid policy but certain Cloud Platform services (such as Projects)
+        /// might reject them.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override Task<Policy> SetIamPolicyAsync(
+            string resource,
+            Policy policy,
+            CallSettings callSettings = null) => _callSetIamPolicy.Async(
+                new SetIamPolicyRequest
+                {
+                    Resource = resource,
+                    Policy = policy,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Sets the access control policy on the specified resource. Replaces any
+        /// existing policy.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being specified.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="policy">
+        /// REQUIRED: The complete policy to be applied to the `resource`. The size of
+        /// the policy is limited to a few 10s of KB. An empty policy is a
+        /// valid policy but certain Cloud Platform services (such as Projects)
+        /// might reject them.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override Policy SetIamPolicy(
+            string resource,
+            Policy policy,
+            CallSettings callSettings = null) => _callSetIamPolicy.Sync(
+                new SetIamPolicyRequest
+                {
+                    Resource = resource,
+                    Policy = policy,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets the access control policy for a resource.
+        /// Returns an empty policy if the resource exists and does not have a policy
+        /// set.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override Task<Policy> GetIamPolicyAsync(
+            string resource,
+            CallSettings callSettings = null) => _callGetIamPolicy.Async(
+                new GetIamPolicyRequest
+                {
+                    Resource = resource,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets the access control policy for a resource.
+        /// Returns an empty policy if the resource exists and does not have a policy
+        /// set.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override Policy GetIamPolicy(
+            string resource,
+            CallSettings callSettings = null) => _callGetIamPolicy.Sync(
+                new GetIamPolicyRequest
+                {
+                    Resource = resource,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Returns permissions that a caller has on the specified resource.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy detail is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="permissions">
+        /// The set of permissions to check for the `resource`. Permissions with
+        /// wildcards (such as '*' or 'storage.*') are not allowed. For more
+        /// information see
+        /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
+            string resource,
+            IEnumerable<string> permissions,
+            CallSettings callSettings = null) => _callTestIamPermissions.Async(
+                new TestIamPermissionsRequest
+                {
+                    Resource = resource,
+                    Permissions = { permissions },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Returns permissions that a caller has on the specified resource.
+        /// </summary>
+        /// <param name="resource">
+        /// REQUIRED: The resource for which the policy detail is being requested.
+        /// `resource` is usually specified as a path. For example, a Project
+        /// resource is specified as `projects/{project}`.
+        /// </param>
+        /// <param name="permissions">
+        /// The set of permissions to check for the `resource`. Permissions with
+        /// wildcards (such as '*' or 'storage.*') are not allowed. For more
+        /// information see
+        /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override TestIamPermissionsResponse TestIamPermissions(
+            string resource,
+            IEnumerable<string> permissions,
+            CallSettings callSettings = null) => _callTestIamPermissions.Sync(
+                new TestIamPermissionsRequest
+                {
+                    Resource = resource,
+                    Permissions = { permissions },
                 },
                 callSettings);
 

--- a/generateapis.sh
+++ b/generateapis.sh
@@ -115,6 +115,7 @@ mkdir $OUTDIR
 $PROTOC \
   -I googleapis \
   -I $CORE_PROTOS_ROOT \
+  --include_source_info \
   -o $OUTDIR/protos.desc \
   $CORE_PROTOS_ROOT/google/protobuf/*.proto \
   `find googleapis -name '*.proto'`


### PR DESCRIPTION
- Fixes the generation script to include comments
- Reruns generation, resulting in:
  - Comments appearing again
  - Tiny changes in copyright statements (commas and casing)
  - The new Pubsub IAM mixin
  - Fixes around snippets for listing methods