### PR TITLE
Fix log4net local-time -> UTC

### DIFF
--- a/apis/Google.Logging.V2/Google.Logging.Log4Net.Tests/Log4NetTest.cs
+++ b/apis/Google.Logging.V2/Google.Logging.Log4Net.Tests/Log4NetTest.cs
@@ -238,7 +238,7 @@ namespace Google.Logging.Log4Net.Tests
             Assert.Equal(2, uploadedEntries.Count);
             // Check the "lost-entries" payload text and timestamp are correct
             Assert.Equal(string.Format(s_lostMsg, TimeOfs(0), TimeOfs(3)), uploadedEntries[0].TextPayload);
-            Assert.Equal(fakeClock.GetCurrentDateTimeUtc(), uploadedEntries[0].Timestamp());
+            Assert.Equal(fakeClock.GetCurrentDateTimeUtc(), uploadedEntries[0].Timestamp.ToDateTime());
             // Check the single successfully logged message is correct
             Assert.Equal("Message4", uploadedEntries[1].TextPayload.Trim());
         }

--- a/apis/Google.Logging.V2/Google.Logging.Log4Net/Extensions.cs
+++ b/apis/Google.Logging.V2/Google.Logging.Log4Net/Extensions.cs
@@ -20,24 +20,18 @@ namespace Google.Logging.Log4Net
 {
     internal static class Extensions
     {
-        private static readonly DateTime s_epochZero = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
-        public static DateTime Timestamp(this LogEntry entry) =>
-            s_epochZero
-                + TimeSpan.FromSeconds(entry.Timestamp.Seconds)
-                + TimeSpan.FromTicks(entry.Timestamp.Nanos / 100);
-
         public static Timestamp ToTimestamp(this DateTime dt)
         {
-            TimeSpan sinceEpoch = dt - s_epochZero;
-            return new Timestamp
+            switch (dt.Kind)
             {
-                Seconds = sinceEpoch.Ticks / TimeSpan.TicksPerSecond,
-                Nanos = (int)((sinceEpoch.Ticks % TimeSpan.TicksPerSecond) * (1000000000L / TimeSpan.TicksPerSecond))
-            };
+                case DateTimeKind.Local:
+                    dt = dt.ToUniversalTime();
+                    break;
+                case DateTimeKind.Unspecified:
+                    dt = DateTime.SpecifyKind(dt, DateTimeKind.Utc);
+                    break;
+            }
+            return Timestamp.FromDateTime(dt);
         }
-
-        public static TimeSpan Scale(this TimeSpan dt, double scale) =>
-            new TimeSpan((long)(dt.Ticks * scale));
     }
 }

--- a/apis/Google.Logging.V2/Google.Logging.Log4Net/GoogleStackdriverAppender_Configuration.cs
+++ b/apis/Google.Logging.V2/Google.Logging.Log4Net/GoogleStackdriverAppender_Configuration.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/apis/Google.Logging.V2/Google.Logging.Log4Net/LogUploader.cs
+++ b/apis/Google.Logging.V2/Google.Logging.Log4Net/LogUploader.cs
@@ -133,7 +133,7 @@ namespace Google.Logging.Log4Net
                 {
                     // Always retry, regardless of error, as there's nothing much else to be done.
                     await _scheduler.Delay(errorDelay);
-                    errorDelay = errorDelay.Scale(_serverErrorBackoffSettings.DelayMultiplier);
+                    errorDelay = new TimeSpan((long)(errorDelay.Ticks * _serverErrorBackoffSettings.DelayMultiplier));
                     if (errorDelay > _serverErrorBackoffSettings.MaxDelay)
                     {
                         errorDelay = _serverErrorBackoffSettings.MaxDelay;

--- a/apis/Google.Logging.V2/Google.Logging.Log4Net/MemoryLogQueue.cs
+++ b/apis/Google.Logging.V2/Google.Logging.Log4Net/MemoryLogQueue.cs
@@ -59,11 +59,11 @@ namespace Google.Logging.Log4Net
                         _currentMemorySize -= lostEntry.Size;
                         if (lostRange == null)
                         {
-                            lostRange = new DateTimeRange(lostEntry.LogEntryExtra.Entry.Timestamp(), lostEntry.LogEntryExtra.Entry.Timestamp());
+                            lostRange = new DateTimeRange(lostEntry.LogEntryExtra.Entry.Timestamp.ToDateTime(), lostEntry.LogEntryExtra.Entry.Timestamp.ToDateTime());
                         }
                         else
                         {
-                            lostRange = lostRange.WithTo(lostEntry.LogEntryExtra.Entry.Timestamp());
+                            lostRange = lostRange.WithTo(lostEntry.LogEntryExtra.Entry.Timestamp.ToDateTime());
                         }
                     }
                     var sizedEntry = new LogEntryExtraSize(entry, _maxMemorySize > 0 ? entry.Entry.CalculateSize() : 0);


### PR DESCRIPTION
log4net timestamps are local, whereas cloud logging requires UTC.
And add missing copyright header.