### PR TITLE
First pass at parameterized queries

### DIFF
--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.IntegrationTests/BigqueryFixture.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.IntegrationTests/BigqueryFixture.cs
@@ -84,6 +84,11 @@ namespace Google.Bigquery.V2.IntegrationTests
                     { "player", "Angela" },
                     { "score", 95 },
                     { "gameStarted", new DateTime(2002, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
+                },
+                new InsertRow {
+                    { "player", null }, // Unnamed player...
+                    { "score", 1 },
+                    { "gameStarted", new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
                 }
             });
         }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.IntegrationTests/BigqueryParameterTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.IntegrationTests/BigqueryParameterTest.cs
@@ -1,0 +1,120 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Google.Bigquery.V2.IntegrationTests
+{
+    [Collection(nameof(BigqueryFixture))]
+    public class BigqueryParameterTest
+    {
+        private readonly BigqueryFixture _fixture;
+
+        public BigqueryParameterTest(BigqueryFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public void IntegerParameter()
+        {
+            var client = BigqueryClient.Create(_fixture.ProjectId);
+            var command = new BigqueryCommand("SELECT value FROM UNNEST([0, 1, 2, 3, 4]) AS value WHERE value > @value")
+            {
+                Parameters = { { "value", BigqueryParameterType.Int64, 2 } }
+            };
+            var results = client.ExecuteQuery(command).PollUntilCompleted().GetResultSet(10);
+            Assert.Equal(new[] { 3L, 4L }, results.Rows.Select(r => (long) r["value"]));
+        }
+
+        [Fact]
+        public void IntegerArrayParameter()
+        {
+            var client = BigqueryClient.Create(_fixture.ProjectId);
+            var command = new BigqueryCommand("SELECT value FROM UNNEST([0, 1, 2, 3, 4]) AS value WHERE value IN UNNEST(@p)")
+            {
+                Parameters = { { "p", BigqueryParameterType.Array, new[] { 1, 3, 5 } } }
+            };
+            var results = client.ExecuteQuery(command).PollUntilCompleted().GetResultSet(10);
+            Assert.Equal(new[] { 1L, 3L }, results.Rows.Select(r => (long)r["value"]));
+        }
+
+        [Fact]
+        public void TimestampParameter()
+        {
+            var client = BigqueryClient.Create(_fixture.ProjectId);
+            var table = client.GetTable(_fixture.DatasetId, _fixture.HighScoreTableId);
+            var command = new BigqueryCommand($"SELECT score FROM {table} WHERE player=@player AND gameStarted > @start")
+            {
+                Parameters =
+                {
+                    { "player", BigqueryParameterType.String, "Angela" },
+                    { "start", BigqueryParameterType.Timestamp, new DateTime(2001, 12, 31, 23, 59, 59, DateTimeKind.Utc) },
+                }
+            };
+            // Find the value when we've provided a timestamp smaller than the actual value
+            var results = client.ExecuteQuery(command).PollUntilCompleted().GetResultSet(10);
+            Assert.Equal(1, results.Rows.Count);
+
+            // We shouldn't find it now. (Angela's game started at 2002-01-01T00:00:00Z)
+            command.Parameters[1].Value = new DateTime(2002, 1, 1, 0, 0, 1, DateTimeKind.Utc);
+            results = client.ExecuteQuery(command).PollUntilCompleted().GetResultSet(10);
+            Assert.Equal(0, results.Rows.Count);
+        }
+
+        [Fact]
+        public void NullParameter()
+        {
+            var client = BigqueryClient.Create(_fixture.ProjectId);
+            var table = client.GetTable(_fixture.DatasetId, _fixture.HighScoreTableId);
+            var parameter = new BigqueryParameter("player", BigqueryParameterType.String, "Angela");
+            var command = new BigqueryCommand($"SELECT score FROM {table} WHERE player=@player") { Parameters = { parameter } };
+            var resultSet = client.ExecuteQuery(command).PollUntilCompleted().GetResultSet(5);
+            Assert.Equal(1, resultSet.Rows.Count);
+            Assert.Equal(95, (long)resultSet.Rows[0]["score"]);
+
+            // SQL rules: nothing equals null
+            parameter.Value = null;
+            resultSet = client.ExecuteQuery(command).PollUntilCompleted().GetResultSet(5);
+            Assert.Equal(0, resultSet.Rows.Count);
+
+            // But we should be able to find the null value this way.
+            command.Sql = $"SELECT score FROM {table} WHERE player=@player OR (player IS NULL AND @player IS NULL)";
+            resultSet = client.ExecuteQuery(command).PollUntilCompleted().GetResultSet(5);
+            Assert.Equal(1, resultSet.Rows.Count);
+            Assert.Equal(1, (long)resultSet.Rows[0]["score"]);
+        }
+
+        [Fact]
+        public void BytesParameter()
+        {
+            var command = new BigqueryCommand($"SELECT BYTE_LENGTH(@p) AS length")
+            {
+                Parameters = { { "p", BigqueryParameterType.Bytes, new byte[] { 1, 3 } } }
+            };
+            var row = GetSingleRow(command);
+            Assert.Equal(2, (long)row["length"]);
+        }
+
+        private BigqueryRow GetSingleRow(BigqueryCommand command)
+        {
+            var client = BigqueryClient.Create(_fixture.ProjectId);
+            var results = client.ExecuteQuery(command).PollUntilCompleted().GetResultSet(10);
+            Assert.Equal(1, results.Rows.Count);
+            return results.Rows[0];
+        }
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Snippets/BigquerySnippetFixture.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Snippets/BigquerySnippetFixture.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Threading;
 using Xunit;
 
 namespace Google.Bigquery.V2.Snippets

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryCommandTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryCommandTest.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2.Data;
+using System;
+using Xunit;
+
+namespace Google.Bigquery.V2.Tests
+{
+    public class BigqueryCommandTest
+    {
+        [Fact]
+        public void ParameterModeIsVerified()
+        {
+            var command = new BigqueryCommand();
+            Assert.Throws<ArgumentException>(() => command.ParameterMode = (BigqueryParameterMode)3);
+        }
+
+        [Fact]
+        public void ConstructionSample()
+        {
+            var command = new BigqueryCommand("sql here")
+            {
+                Parameters = { { BigqueryParameterType.Int64, 10 } }
+            };
+            Assert.Equal("sql here", command.Sql);
+            Assert.Equal(1, command.Parameters.Count);
+            Assert.Equal(10, command.Parameters[0].Value);
+            Assert.Equal(BigqueryParameterType.Int64, command.Parameters[0].Type);
+        }
+
+        [Fact]
+        public void PopulateQueryRequest()
+        {
+            var request = new QueryRequest();
+            var command = new BigqueryCommand("sql here")
+            {
+                Parameters = { { BigqueryParameterType.Int64, 10 } },
+                ParameterMode = BigqueryParameterMode.Positional
+            };
+            command.PopulateQueryRequest(request);
+            Assert.Equal("sql here", request.Query);
+            Assert.Equal("positional", request.ParameterMode);
+            Assert.Equal(1, request.QueryParameters.Count);
+            Assert.Equal("10", request.QueryParameters[0].ParameterValue.Value);
+        }
+
+        [Fact]
+        public void PopulateJobConfigurationQuery()
+        {
+            var jobConfig = new JobConfigurationQuery();
+            var command = new BigqueryCommand("sql here")
+            {
+                Parameters = { { BigqueryParameterType.Int64, 10 } },
+                ParameterMode = BigqueryParameterMode.Positional
+            };
+            command.PopulateJobConfigurationQuery(jobConfig);
+            Assert.Equal("sql here", jobConfig.Query);
+            Assert.Equal("positional", jobConfig.ParameterMode);
+            Assert.Equal(1, jobConfig.QueryParameters.Count);
+            Assert.Equal("10", jobConfig.QueryParameters[0].ParameterValue.Value);
+        }
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryParameterCollectionTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryParameterCollectionTest.cs
@@ -1,0 +1,92 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
+using Xunit;
+
+namespace Google.Bigquery.V2.Tests
+{
+    public class BigqueryParameterCollectionTest
+    {
+        [Fact]
+        public void Add_Parameterless()
+        {
+            var collection = new BigqueryParameterCollection();
+            var parameter = collection.Add();
+            Assert.Same(parameter, collection[0]);
+            Assert.Null(parameter.Name);
+            Assert.Null(parameter.Type);
+            Assert.Null(parameter.Value);
+        }
+
+        [Fact]
+        public void Add_NameAndType()
+        {
+            var collection = new BigqueryParameterCollection();
+            var parameter = collection.Add("name", BigqueryParameterType.Date);
+            Assert.Same(parameter, collection[0]);
+            Assert.Equal("name", parameter.Name);
+            Assert.Equal(BigqueryParameterType.Date, parameter.Type);
+            Assert.Null(parameter.Value);
+        }
+
+        [Fact]
+        public void Add_NameTypeValue()
+        {
+            var collection = new BigqueryParameterCollection();
+            var value = DateTime.UtcNow;
+            var parameter = collection.Add("name", BigqueryParameterType.Date, value);
+            Assert.Same(parameter, collection[0]);
+            Assert.Equal("name", parameter.Name);
+            Assert.Equal(BigqueryParameterType.Date, parameter.Type);
+            Assert.Equal(value, parameter.Value);
+        }
+
+        [Fact]
+        public void Add_TypeValue()
+        {
+            var collection = new BigqueryParameterCollection();
+            var value = DateTime.UtcNow;
+            var parameter = collection.Add(BigqueryParameterType.Date, value);
+            Assert.Same(parameter, collection[0]);
+            Assert.Null(parameter.Name);
+            Assert.Equal(BigqueryParameterType.Date, parameter.Type);
+            Assert.Equal(value, parameter.Value);
+        }
+
+        [Fact]
+        public void Add_Parameter()
+        {
+            var collection = new BigqueryParameterCollection();
+            var parameter = new BigqueryParameter();
+            var added = collection.Add(parameter);
+            Assert.Same(parameter, added);
+            Assert.Same(parameter, collection[0]);
+        }
+
+        [Fact]
+        public void ListMemberDelegation()
+        {
+            var p1 = new BigqueryParameter();
+            var p2 = new BigqueryParameter();
+            var collection = new BigqueryParameterCollection { p1, p2 };
+            Assert.Equal(new[] { p1, p2 }, collection);
+            Assert.Same(p1, collection[0]);
+            Assert.Same(p2, collection[1]);
+            Assert.Equal(2, collection.Count);
+
+            collection.Clear();
+            Assert.Equal(0, collection.Count);
+        }
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryParameterTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryParameterTest.cs
@@ -1,0 +1,308 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2.Data;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Xunit;
+
+namespace Google.Bigquery.V2.Tests
+{
+    public class BigqueryParameterTest
+    {
+        // Please excuse the very long lines... it's more readable than 
+        public static IEnumerable<object[]> ToQueryParameterData() => new[]
+        {
+            // Bool
+            ScalarTest("Bool parameter, true", BigqueryParameterType.Bool, true, "TRUE"),
+            ScalarTest("Bool parameter, false", BigqueryParameterType.Bool, false, "FALSE"),
+            ScalarTest("Bool parameter, string value", BigqueryParameterType.Bool, "maybe", "maybe"),
+            ScalarTest("Bool parameter, null value", BigqueryParameterType.Bool, null, null),
+
+            // Float64
+            ScalarTest("Float64 parameter, Int16 value", BigqueryParameterType.Float64, (short)10, "10"),
+            ScalarTest("Float64 parameter, Int16 value", BigqueryParameterType.Float64, (short)10, "10"),
+            ScalarTest("Float64 parameter, Int32 value", BigqueryParameterType.Float64, (int)10, "10"),
+            ScalarTest("Float64 parameter, Int64 value", BigqueryParameterType.Float64, (long)10, "10"),
+            ScalarTest("Float64 parameter, UInt16 value", BigqueryParameterType.Float64, (ushort)10, "10"),
+            ScalarTest("Float64 parameter, UInt32 value", BigqueryParameterType.Float64, (uint)10, "10"),
+            ScalarTest("Float64 parameter, UInt64 value", BigqueryParameterType.Float64, (ulong)10, "10"),
+            ScalarTest("Float64 parameter, Single value", BigqueryParameterType.Float64, 10.5f, "10.5"),
+            ScalarTest("Float64 parameter, Double value", BigqueryParameterType.Float64, 10.5, "10.5"),
+            ScalarTest("Float64 parameter, Single value (+inf)", BigqueryParameterType.Float64, float.PositiveInfinity, "+inf"),
+            ScalarTest("Float64 parameter, Double value (+inf)", BigqueryParameterType.Float64, double.PositiveInfinity, "+inf"),
+            ScalarTest("Float64 parameter, Single value (-inf)", BigqueryParameterType.Float64, float.NegativeInfinity, "-inf"),
+            ScalarTest("Float64 parameter, Double value (-inf)", BigqueryParameterType.Float64, double.NegativeInfinity, "-inf"),
+            ScalarTest("Float64 parameter, Single value (NaN)", BigqueryParameterType.Float64, float.NaN, "NaN"),
+            ScalarTest("Float64 parameter, Double value (NaN)", BigqueryParameterType.Float64, double.NaN, "NaN"),
+            ScalarTest("Float64 parameter, string value", BigqueryParameterType.Float64, "string value", "string value"),
+            ScalarTest("Float64 parameter, null value", BigqueryParameterType.Float64, null, null),
+
+            // Int64...
+            ScalarTest("Int64 parameter, Int16 value", BigqueryParameterType.Int64, (short)10, "10"),
+            ScalarTest("Int64 parameter, Int32 value", BigqueryParameterType.Int64, (int)10, "10"),
+            ScalarTest("Int64 parameter, Int64 value", BigqueryParameterType.Int64, (long)10, "10"),
+            ScalarTest("Int64 parameter, UInt16 value", BigqueryParameterType.Int64, (ushort)10, "10"),
+            ScalarTest("Int64 parameter, UInt32 value", BigqueryParameterType.Int64, (uint)10, "10"),
+            ScalarTest("Int64 parameter, UInt64 value", BigqueryParameterType.Int64, (ulong)10, "10"),
+            ScalarTest("Int64 parameter, string value", BigqueryParameterType.Int64, "string value", "string value"),
+            ScalarTest("Int64 parameter, null value", BigqueryParameterType.Int64, null, null),
+
+            // String...
+            ScalarTest("String parameter, string value", BigqueryParameterType.String, "some value", "some value"),
+            ScalarTest("String parameter, null value", BigqueryParameterType.String, null, null),
+
+            // Bytes...
+            ScalarTest("Bytes parameter, byte[] value", BigqueryParameterType.Bytes, new byte[] { 1, 2 }, "AQI="),
+            ScalarTest("Bytes parameter, string value", BigqueryParameterType.Bytes, "some value", "some value"),
+            ScalarTest("Bytes parameter, null value", BigqueryParameterType.Bytes, null, null),
+
+            // Date
+            ScalarTest("Date parameter, DateTime value", BigqueryParameterType.Date, new DateTime(2016, 10, 31), "2016-10-31"),
+            // This is midnight local time on the 31st, which means its UTC value is actually 2016-10-30T22:00:00
+            // - but we only care about the local value for Date parameters
+            ScalarTest("Date parameter, DateTimeOffset value", BigqueryParameterType.Date, new DateTimeOffset(2016, 10, 31, 0, 0, 0, TimeSpan.FromHours(2)), "2016-10-31"),
+            ScalarTest("Date parameter, string value", BigqueryParameterType.Date, "some value", "some value"),
+            ScalarTest("Date parameter, null value", BigqueryParameterType.Date, null, null),
+
+            // DateTime
+            // Value with ticks is truncated (not rounded). The Kind is irrelevant
+            ScalarTest("DateTime parameter, DateTime value (local)", BigqueryParameterType.DateTime,
+                new DateTime(2016, 10, 31, 1, 2, 3, 123,DateTimeKind.Local).AddTicks(4567),
+                "2016-10-31 01:02:03.123456"),
+            ScalarTest("DateTime parameter, DateTime value (unspecified)", BigqueryParameterType.DateTime,
+                new DateTime(2016, 10, 31, 1, 2, 3, 123, DateTimeKind.Unspecified).AddTicks(4567),
+                "2016-10-31 01:02:03.123456"),
+            ScalarTest("DateTime parameter, DateTime value (UTC)", BigqueryParameterType.DateTime,
+                new DateTime(2016, 10, 31, 1, 2, 3, 123, DateTimeKind.Utc).AddTicks(4567),
+                "2016-10-31 01:02:03.123456"),
+            // This is midnight local time on the 31st, which means its UTC value is actually 2016-10-30T22:00:00
+            // - but we only care about the local value for DateTime parameters
+            ScalarTest("DateTime parameter, DateTimeOffset value", BigqueryParameterType.DateTime,
+                new DateTimeOffset(2016, 10, 31, 0, 0, 0, TimeSpan.FromHours(2)), "2016-10-31 00:00:00"),
+            ScalarTest("DateTime parameter, string value", BigqueryParameterType.Date, "some value", "some value"),
+            ScalarTest("DateTime parameter, null value", BigqueryParameterType.Date, null, null),
+
+            // Time
+            // Truncated to microseconds
+            ScalarTest("Time parameter, TimeSpan value", BigqueryParameterType.Time,
+                TimeSpan.ParseExact("01:23:45.1234567", "hh':'mm':'ss'.'FFFFFFF", CultureInfo.InvariantCulture),
+                "01:23:45.123456"),
+            // Truncated to a single day
+            ScalarTest("Time parameter, TimeSpan value bigger than 24h", BigqueryParameterType.Time,
+                TimeSpan.FromHours(25), "01:00:00.000000"),
+            ScalarTest("Time parameter, TimeSpan value negative", BigqueryParameterType.Time,
+                TimeSpan.FromHours(-1), "23:00:00.000000"),
+            ScalarTest("Time parameter, TimeSpan value large negative", BigqueryParameterType.Time,
+                TimeSpan.FromHours(-25), "23:00:00.000000"),
+            ScalarTest("Time parameter, DateTime value", BigqueryParameterType.Time,
+                new DateTime(2016, 10, 31, 1, 2, 3, 123).AddTicks(4567),
+                "01:02:03.123456"),
+            ScalarTest("Time parameter, DateTimeOffset value", BigqueryParameterType.Time,
+                new DateTimeOffset(2016, 10, 31, 1, 2, 3, 123, TimeSpan.FromHours(2)).AddTicks(4567),
+                "01:02:03.123456"),
+            ScalarTest("Time parameter, string value", BigqueryParameterType.Time, "some value", "some value"),
+            ScalarTest("Time parameter, null value", BigqueryParameterType.Time, null, null),
+
+            // Timestamp
+            ScalarTest("Timestamp parameter, DateTime value (UTC)", BigqueryParameterType.Timestamp,
+                new DateTime(2016, 10, 31, 1, 2, 3, 123, DateTimeKind.Utc).AddTicks(4567),
+                "2016-10-31 01:02:03.123456"), // UTC is implicit
+            ScalarTest("Timestamp parameter, DateTimeOffset value positive offset", BigqueryParameterType.Timestamp,
+                new DateTimeOffset(2016, 10, 31, 0, 0, 0, TimeSpan.FromHours(2)), "2016-10-31 00:00:00+02:00"),
+            ScalarTest("Timestamp parameter, DateTimeOffset value negative offset", BigqueryParameterType.Timestamp,
+                new DateTimeOffset(2016, 10, 31, 0, 0, 0, TimeSpan.FromHours(-2)), "2016-10-31 00:00:00-02:00"),
+            ScalarTest("Timestamp parameter, string value", BigqueryParameterType.Timestamp, "some value", "some value"),
+            ScalarTest("Timestamp parameter, null value", BigqueryParameterType.Timestamp, null, null),
+        };
+
+        public static IEnumerable<object[]> InvalidParameterData => new[]
+        {
+            new object[] { "Local DateTime for Timestamp", BigqueryParameterType.Timestamp, new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Local) },
+            new object[] { "Unspecified DateTime for Timestamp", BigqueryParameterType.Timestamp, new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Unspecified) },
+            new object[] { "Array with null element value", BigqueryParameterType.Array, new[] { "foo", null, "bar" } },
+            new object[] { "Array with null value", BigqueryParameterType.Array, null },
+            new object[] { "Array with non-array value", BigqueryParameterType.Array, 10 },
+            new object[] { "Null value and null type", null, null },
+            new object[] { "DateTime value for Int64 type", BigqueryParameterType.Int64, default(DateTime) },
+        };
+
+        public static IEnumerable<object[]> TypeInferenceData => new[]
+        {
+            new object[] { "Int16", (short) 10, BigqueryParameterType.Int64 },
+            new object[] { "Int32", 10, BigqueryParameterType.Int64 },
+            new object[] { "Int64", (long) 10, BigqueryParameterType.Int64 },
+            new object[] { "UInt16", (ushort) 10, BigqueryParameterType.Int64 },
+            new object[] { "UInt32", (uint) 10, BigqueryParameterType.Int64 },
+            new object[] { "UInt64", (ulong) 10, BigqueryParameterType.Int64 },
+            new object[] { "Single", 1.0f, BigqueryParameterType.Float64 },
+            new object[] { "Double", 1.0d, BigqueryParameterType.Float64 },
+            new object[] { "TimeSpan", TimeSpan.FromHours(1), BigqueryParameterType.Time },
+            new object[] { "DateTime (local)", new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Local), BigqueryParameterType.DateTime },
+            new object[] { "DateTime (unspecified)", new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Unspecified), BigqueryParameterType.DateTime },
+            new object[] { "DateTime (UTC)", new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Utc), BigqueryParameterType.Timestamp },
+            new object[] { "DateTimeOffset", new DateTimeOffset(2016, 10, 31, 0, 0, 0, TimeSpan.FromHours(2)), BigqueryParameterType.Timestamp },
+            new object[] { "Byte[]", new byte[] { 1, 2 }, BigqueryParameterType.Bytes },
+        };
+
+        public static IEnumerable<object[]> ArrayTypeInferenceData => new[]
+        {
+            new object[] { "Int16[]", new short[0], BigqueryParameterType.Int64 },
+            new object[] { "Int32[]", new int[0], BigqueryParameterType.Int64 },
+            new object[] { "Int64[]", new long[0], BigqueryParameterType.Int64 },
+            new object[] { "UInt16[]", new ushort[0], BigqueryParameterType.Int64 },
+            new object[] { "UInt32[]", new uint[0], BigqueryParameterType.Int64 },
+            new object[] { "UInt64[]", new ulong[0], BigqueryParameterType.Int64 },
+            new object[] { "Single[]", new float[0], BigqueryParameterType.Float64 },
+            new object[] { "Double[]", new double[0], BigqueryParameterType.Float64 },
+            new object[] { "TimeSpan[]", new TimeSpan[0], BigqueryParameterType.Time },
+            new object[] { "DateTime[] (local first)", new[] { new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Local), default(DateTime) }, BigqueryParameterType.DateTime },
+            new object[] { "DateTime[] (unspecified first)", new[] { new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Unspecified), default(DateTime) }, BigqueryParameterType.DateTime },
+            // Both values have to be UTC, as everything in the array must be valid for the inferred type.
+            new object[] { "DateTime[] (UTC first)", new[] { new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Utc), new DateTime(2017, 10, 31, 0, 0, 0, DateTimeKind.Utc)}, BigqueryParameterType.Timestamp },
+            new object[] { "DateTime[] (empty)", new DateTime[0], BigqueryParameterType.DateTime },
+            new object[] { "DateTimeOffset[]", new DateTimeOffset[0], BigqueryParameterType.Timestamp },
+            new object[] { "Byte[][]", new byte[0][], BigqueryParameterType.Bytes },
+        };
+
+        [Theory]
+        [MemberData(nameof(ToQueryParameterData))]
+        public void ToQueryParameter_Valid(string name, BigqueryParameter parameter, QueryParameter expectedResult)
+        {
+            // Positional vs named mode difference is only in validation, tested elsewhere.
+            string actualJson = JsonConvert.SerializeObject(parameter.ToQueryParameter(BigqueryParameterMode.Positional));
+            string expectedJson = JsonConvert.SerializeObject(expectedResult);
+            Assert.Equal(actualJson, expectedJson);
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidParameterData))]
+        public void ToQueryParameter_Invalid(string name, BigqueryParameterType? type, object value)
+        {
+            var parameter = new BigqueryParameter(type, value);
+            Assert.Throws<InvalidOperationException>(() => parameter.ToQueryParameter(BigqueryParameterMode.Positional));
+        }
+
+        [Theory]
+        [MemberData(nameof(TypeInferenceData))]
+        public void TypeInference(string name, object value, BigqueryParameterType expectedType)
+        {
+            var parameter = new BigqueryParameter();
+            parameter.Value = value;
+            var queryParameter = parameter.ToQueryParameter(BigqueryParameterMode.Positional);
+            var actualType = EnumMap<BigqueryParameterType>.ToValue(queryParameter.ParameterType.Type);
+            Assert.Equal(expectedType, actualType);
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayTypeInferenceData))]
+        public void ArrayTypeInference(string name, object value, BigqueryParameterType expectedArrayType)
+        {
+            var parameter = new BigqueryParameter();
+            parameter.Value = value;
+            var queryParameter = parameter.ToQueryParameter(BigqueryParameterMode.Positional);
+            Assert.Equal(EnumMap.ToApiValue(BigqueryParameterType.Array), queryParameter.ParameterType.Type);
+            var actualArrayType = EnumMap<BigqueryParameterType>.ToValue(queryParameter.ParameterType.ArrayType.Type);
+            Assert.Equal(expectedArrayType, actualArrayType);
+        }
+
+        [Fact]
+        public void InvalidTypeIsRejected()
+        {
+            var parameter = new BigqueryParameter();
+            Assert.Throws<ArgumentException>(() => parameter.Type = (BigqueryParameterType)(-1));
+        }
+
+        [Fact]
+        public void NeverValidValueIsRejected()
+        {
+            var parameter = new BigqueryParameter();
+            Assert.Throws<ArgumentException>(() => parameter.Value = Guid.NewGuid());
+        }
+
+        [Fact]
+        public void UnnamedParameterCannotBeConvertedWithNamedMode()
+        {
+            var parameter = new BigqueryParameter(BigqueryParameterType.String, "foo");
+            // Prove that it's fine for a positional parameter
+            parameter.ToQueryParameter(BigqueryParameterMode.Positional);
+            Assert.Throws<InvalidOperationException>(() => parameter.ToQueryParameter(BigqueryParameterMode.Named));
+        }
+
+        [Fact]
+        public void StructParametersNotImplemented()
+        {
+            var parameter = new BigqueryParameter(BigqueryParameterType.Struct, null);
+            Assert.Throws<NotImplementedException>(() => parameter.ToQueryParameter(BigqueryParameterMode.Positional));
+        }
+
+        [Fact]
+        public void ExplicitlyTypedArrayType()
+        {
+            var parameter = new BigqueryParameter(BigqueryParameterType.Array, new[] { new DateTimeOffset(new DateTime(2016, 10, 31), new TimeSpan(8, 30, 0)) });
+            parameter.ArrayType = BigqueryParameterType.DateTime;
+            string actualJson = JsonConvert.SerializeObject(parameter.ToQueryParameter(BigqueryParameterMode.Positional));
+
+            var expectedResult = new QueryParameter
+            {
+                ParameterType = new QueryParameterType
+                {
+                    Type = EnumMap.ToApiValue(BigqueryParameterType.Array),
+                    ArrayType = new QueryParameterType { Type = EnumMap.ToApiValue(BigqueryParameterType.DateTime) }
+                },
+                ParameterValue = new QueryParameterValue
+                {
+                    ArrayValues = new[] { new QueryParameterValue { Value = "2016-10-31 00:00:00" } }
+                }
+            };
+            string expectedJson = JsonConvert.SerializeObject(expectedResult);
+            Assert.Equal(actualJson, expectedJson);
+        }
+
+        [Fact]
+        public void Constructor_NameOnly()
+        {
+            var parameter = new BigqueryParameter("name");
+            Assert.Equal("name", parameter.Name);
+            Assert.Null(parameter.Type);
+            Assert.Null(parameter.Value);
+        }
+
+        [Fact]
+        public void Constructor_TypeOnly()
+        {
+            var parameter = new BigqueryParameter(BigqueryParameterType.String);
+            Assert.Null(parameter.Name);
+            Assert.Equal(BigqueryParameterType.String, parameter.Type);
+            Assert.Null(parameter.Value);
+        }
+
+        private static object[] ScalarTest(string name, BigqueryParameterType type, object parameterValue, string expectedValue) =>
+            new object[]
+            {
+                name,
+                new BigqueryParameter(type, parameterValue),
+                ScalarParameter(type, expectedValue)
+            };
+
+        private static QueryParameter ScalarParameter(BigqueryParameterType type, string value) =>
+            new QueryParameter
+            {
+                ParameterType = new QueryParameterType { Type = EnumMap.ToApiValue(type) },
+                ParameterValue = new QueryParameterValue { Value = value }
+            };
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryParameterTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryParameterTest.cs
@@ -153,7 +153,7 @@ namespace Google.Bigquery.V2.Tests
             new object[] { "TimeSpan", TimeSpan.FromHours(1), BigqueryParameterType.Time },
             new object[] { "DateTime (local)", new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Local), BigqueryParameterType.DateTime },
             new object[] { "DateTime (unspecified)", new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Unspecified), BigqueryParameterType.DateTime },
-            new object[] { "DateTime (UTC)", new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Utc), BigqueryParameterType.Timestamp },
+            new object[] { "DateTime (UTC)", new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Utc), BigqueryParameterType.DateTime },
             new object[] { "DateTimeOffset", new DateTimeOffset(2016, 10, 31, 0, 0, 0, TimeSpan.FromHours(2)), BigqueryParameterType.Timestamp },
             new object[] { "Byte[]", new byte[] { 1, 2 }, BigqueryParameterType.Bytes },
         };
@@ -169,11 +169,7 @@ namespace Google.Bigquery.V2.Tests
             new object[] { "Single[]", new float[0], BigqueryParameterType.Float64 },
             new object[] { "Double[]", new double[0], BigqueryParameterType.Float64 },
             new object[] { "TimeSpan[]", new TimeSpan[0], BigqueryParameterType.Time },
-            new object[] { "DateTime[] (local first)", new[] { new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Local), default(DateTime) }, BigqueryParameterType.DateTime },
-            new object[] { "DateTime[] (unspecified first)", new[] { new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Unspecified), default(DateTime) }, BigqueryParameterType.DateTime },
-            // Both values have to be UTC, as everything in the array must be valid for the inferred type.
-            new object[] { "DateTime[] (UTC first)", new[] { new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Utc), new DateTime(2017, 10, 31, 0, 0, 0, DateTimeKind.Utc)}, BigqueryParameterType.Timestamp },
-            new object[] { "DateTime[] (empty)", new DateTime[0], BigqueryParameterType.DateTime },
+            new object[] { "DateTime[]", new DateTime[0], BigqueryParameterType.DateTime },
             new object[] { "DateTimeOffset[]", new DateTimeOffset[0], BigqueryParameterType.Timestamp },
             new object[] { "Byte[][]", new byte[0][], BigqueryParameterType.Bytes },
         };

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryClient.Queries.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryClient.Queries.cs
@@ -21,9 +21,9 @@ namespace Google.Bigquery.V2
     public abstract partial class BigqueryClient
     {
         /// <summary>
-        /// Executes a query synchronously.
+        /// Executes a query.
         /// </summary>
-        /// <param name="sql">The query in BigQuery's SQL dialect. Must not be null.</param>
+        /// <param name="sql">The SQL query. Must not be null.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <returns>The result of the query.</returns>
         public virtual BigqueryQueryJob ExecuteQuery(string sql, ExecuteQueryOptions options = null)
@@ -32,14 +32,40 @@ namespace Google.Bigquery.V2
         }
 
         /// <summary>
-        /// Creates a query job, with more facilities than <see cref="ExecuteQuery"/>, including the option
+        /// Executes a command. This overload allows query parameterization, and is preferred over
+        /// <see cref="ExecuteQuery(string, ExecuteQueryOptions)"/> when values need to be passed in.
+        /// </summary>
+        /// <param name="command">The command to execute. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The result of the query.</returns>
+        public virtual BigqueryQueryJob ExecuteQuery(BigqueryCommand command, ExecuteQueryOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Creates a job for a SQL query, with more facilities than <see cref="ExecuteQuery(string, ExecuteQueryOptions)"/>, including the option
         /// to store the results in a persistent table.
         /// </summary>
-        /// <param name="sql">The query in BigQuery's SQL dialect. Must not be null.</param>
+        /// <param name="sql">The SQL query. Must not be null.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <returns>The query job created. Use <see cref="GetQueryJob(JobReference,GetQueryResultsOptions)"/> to retrieve
         /// the results of the query.</returns>
         public virtual BigqueryJob CreateQueryJob(string sql, CreateQueryJobOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Creates a job for a query/command, with more facilities than <see cref="ExecuteQuery(BigqueryCommand, ExecuteQueryOptions)"/>,
+        /// including the option to store the results in a persistent table. This overload allows query parameterization, and is preferred over
+        /// <see cref="CreateQueryJob(string, CreateQueryJobOptions)"/> when values need to be passed in.
+        /// </summary>
+        /// <param name="command">The command to execute. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The query job created. Use <see cref="GetQueryJob(JobReference,GetQueryResultsOptions)"/> to retrieve
+        /// the results of the query.</returns>
+        public virtual BigqueryJob CreateQueryJob(BigqueryCommand command, CreateQueryJobOptions options = null)
         {
             throw new NotImplementedException();
         }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryCommand.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryCommand.cs
@@ -1,0 +1,81 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Apis.Bigquery.v2.Data;
+using System.Linq;
+
+namespace Google.Bigquery.V2
+{
+    /// <summary>
+    /// A SQL query (or DML command) to be sent to BigQuery, optionally
+    /// including parameters.
+    /// </summary>
+    public sealed class BigqueryCommand
+    {
+        /// <summary>
+        /// The SQL of the command. This must not be null by the time
+        /// the command is executed.
+        /// </summary>
+        public string Sql { get; set; }
+
+        private BigqueryParameterMode _parameterMode = BigqueryParameterMode.Named;
+        /// <summary>
+        /// The mode of the parameter, either named (for parameters such of the form <c>@myparam</c>)
+        /// or positional (for parameters specified as <c>?</c> in the query).
+        /// </summary>
+        public BigqueryParameterMode ParameterMode
+        {
+            get { return _parameterMode; }
+            set { _parameterMode = GaxPreconditions.CheckEnumValue(value, nameof(value)); }
+        }
+
+        /// <summary>
+        /// The parameters used within this command.
+        /// </summary>
+        public BigqueryParameterCollection Parameters { get; } = new BigqueryParameterCollection();
+
+        /// <summary>
+        /// Constructs an instance with no SQL set yet.
+        /// </summary>
+        public BigqueryCommand()
+        {
+        }
+
+        /// <summary>
+        /// Constructs an instance for the given SQL.
+        /// </summary>
+        /// <param name="sql">The SQL to execute.</param>
+        public BigqueryCommand(string sql)
+        {
+            Sql = sql;
+        }
+
+        internal void PopulateQueryRequest(QueryRequest queryRequest)
+        {
+            queryRequest.Query = Sql;
+            // Safe for now; we only have "named" or "positional". This is unlikely to change.
+            queryRequest.ParameterMode = ParameterMode.ToString().ToLowerInvariant();
+            queryRequest.QueryParameters = Parameters.Select(p => p.ToQueryParameter(ParameterMode)).ToList();
+        }
+
+        internal void PopulateJobConfigurationQuery(JobConfigurationQuery query)
+        {
+            query.Query = Sql;
+            // Safe for now; we only have "named" or "positional". This is unlikely to change.
+            query.ParameterMode = ParameterMode.ToString().ToLowerInvariant();
+            query.QueryParameters = Parameters.Select(p => p.ToQueryParameter(ParameterMode)).ToList();
+        }
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryParameter.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryParameter.cs
@@ -1,0 +1,465 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Apis.Bigquery.v2.Data;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using static System.Globalization.CultureInfo;
+
+namespace Google.Bigquery.V2
+{
+    // TODO: Support struct parameters.
+
+    /// <summary>
+    /// A parameter within the <see cref="BigqueryParameterCollection"/> of a <see cref="BigqueryCommand"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each parameter has a name, type and value. Names are irrelevant for queries using
+    /// positional parameters. All scalar types are converted into strings
+    /// before being passed to the server, but the nature of the conversion depends on the specified type.
+    /// </para>
+    /// <para>
+    /// The following list shows the correspondence between the parameter type and valid value types.
+    /// All scalar types may be specified as a string value, which will not be validated or converted on the client,
+    /// but passed to the API as-is.
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description><c>Bool</c>: <c>System.Boolean</c></description></item>
+    ///   <item><description><c>Int64</c>: <c>System.Int16</c>, <c>System.Int32</c>, <c>System.Int64</c>, <c>System.UInt16</c>, <c>System.UInt32</c>,
+    ///   <c>System.UInt64</c></description></item>
+    ///   <item><description><c>Float64</c>: Any type valid for <c>Int64</c>, as well as <c>System.Single</c> and <c>System.Double</c></description></item>
+    ///   <item><description><c>String</c>: <c>System.String</c></description></item>
+    ///   <item><description><c>Bytes</c>: <c>System.Byte[]</c></description></item>
+    ///   <item><description><c>Date</c>: <c>System.DateTime</c>, <c>System.DateTimeOffset</c></description></item>
+    ///   <item><description><c>DateTime</c>: <c>System.DateTime</c>, <c>System.DateTimeOffset</c></description></item>
+    ///   <item><description><c>Time</c>: <c>System.DateTime</c>, <c>System.DateTimeOffset</c>, <c>System.TimeSpan</c></description></item>
+    ///   <item><description><c>Timestamp</c>: <c>System.DateTime</c>, <c>System.DateTimeOffset</c></description></item>
+    ///   <item><description><c>Array</c>: An <c>IReadOnlyList&lt;T&gt;</c> of any of the above types corresponding to the <see cref="ArrayType"/>,
+    ///   which will be inferred from the value's element type if not otherwise specified.</description></item>
+    /// </list>
+    /// <para>
+    /// If the parameter type is null, it is inferred from the value. In most cases that is obvious from the above
+    /// table, but for date and time values the process is more complicated. A <see cref="TimeSpan"/> value is
+    /// always assumed to be a <see cref="BigqueryParameterType.Time"/>, and a <see cref="DateTimeOffset"/> value is
+    /// always assumed to be a <see cref="BigqueryParameterType.Timestamp"/>. A <see cref="DateTime"/> value is assumed
+    /// to be <see cref="BigqueryParameterType.DateTime"/> if its <see cref="DateTime.Kind"/> is <see cref="DateTimeKind.Unspecified"/>
+    /// or <see cref="DateTimeKind.Local"/>, but <see cref="BigqueryParameterType.Timestamp"/> if its <c>Kind</c> is
+    /// <see cref="DateTimeKind.Utc"/>.
+    /// </para>
+    /// <para>
+    /// If an array parameter doesn't specify the array type, the type is inferred from the type of the value. If the value
+    /// is a list of <see cref="DateTime"/> values, then the first value is used to infer the type,
+    /// defaulting to <see cref="BigqueryParameterType.DateTime"/>
+    /// if the value is empty. If the value implements <see cref="IReadOnlyList{T}"/> for multiple type parameters,
+    /// the type inferred is undefined.
+    /// </para>
+    /// <para>
+    /// Array parameters must not have a value of null, and all the elements must be non-null as well.
+    /// </para>
+    /// <para>
+    /// If a <see cref="DateTime"/> value is provided for a <see cref="BigqueryParameterType.Timestamp"/> parameter, the
+    /// value must have a <see cref="DateTime.Kind"/> of <see cref="DateTimeKind.Utc"/>.
+    /// </para>
+    /// </remarks>
+    public sealed class BigqueryParameter
+    {
+        private static HashSet<Type> s_validSingleTypes = new HashSet<Type>
+        {
+            typeof(short), typeof(ushort),
+            typeof(int), typeof(uint),
+            typeof(long), typeof(ulong),
+            typeof(float), typeof(double),
+            typeof(bool),
+            typeof(string), typeof(byte[]),
+            typeof(DateTime), typeof(DateTimeOffset), typeof(TimeSpan)
+        };
+
+        private static List<TypeInfo> s_validRepeatedTypes = s_validSingleTypes
+            .Select(t => typeof(IReadOnlyList<>).MakeGenericType(t).GetTypeInfo())
+            .ToList();
+
+        /// <summary>
+        /// Mapping of CLR type to Bigquery parameter type for simple cases.
+        /// </summary>
+        private static Dictionary<Type, BigqueryParameterType> s_typeMapping = new Dictionary<Type, BigqueryParameterType>
+        {
+            { typeof(short), BigqueryParameterType.Int64 },
+            { typeof(int), BigqueryParameterType.Int64 },
+            { typeof(long), BigqueryParameterType.Int64 },
+            { typeof(ushort), BigqueryParameterType.Int64 },
+            { typeof(uint), BigqueryParameterType.Int64 },
+            { typeof(ulong), BigqueryParameterType.Int64 },
+            { typeof(float), BigqueryParameterType.Float64 },
+            { typeof(double), BigqueryParameterType.Float64 },
+            { typeof(bool), BigqueryParameterType.Bool },
+            { typeof(string), BigqueryParameterType.String },
+            { typeof(byte[]), BigqueryParameterType.Bytes },
+            { typeof(DateTimeOffset), BigqueryParameterType.Timestamp },
+            { typeof(TimeSpan), BigqueryParameterType.Time },
+        };
+
+        /// <summary>
+        /// The name of the parameter. This is irrelevant for positional parameters.
+        /// </summary>
+        public string Name { get; set; }
+
+        private BigqueryParameterType? _type;
+        /// <summary>
+        /// The type of the parameter. If this is null, the type of the parameter is inferred from the value.
+        /// Otherwise, the value must be of one of the supported types for the parameter type. See the <see cref="BigqueryParameter">class documentation</see>
+        /// for details.
+        /// </summary>
+        public BigqueryParameterType? Type
+        {
+            get { return _type; }
+            set { _type = value == null ? default(BigqueryParameterType?) : GaxPreconditions.CheckEnumValue(value.Value, nameof(value)); }
+        }
+
+        private BigqueryParameterType? _arrayType;
+        /// <summary>
+        /// The type of the nested elements, for array parameters. If this is null, the type is inferred from the value.
+        /// </summary>
+        public BigqueryParameterType? ArrayType
+        {
+            get { return _arrayType; }
+            set { _arrayType = value == null ? default(BigqueryParameterType?) : GaxPreconditions.CheckEnumValue(value.Value, nameof(value)); }
+        }
+
+        private object _value;
+        /// <summary>
+        /// The value of the parameter. If this is null, the type of the parameter must be specified
+        /// explicitly.
+        /// </summary>
+        public object Value
+        {
+            get { return _value; }
+            set
+            {
+                ValidateValue(value, nameof(value));
+                _value = value;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a parameter with no name, initial value or type.
+        /// </summary>
+        public BigqueryParameter() : this(null, null, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a parameter with no name, initial value or type.
+        /// </summary>
+        /// <param name="type">The initial type of the parameter.</param>
+        public BigqueryParameter(BigqueryParameterType type) : this(null, type, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a parameter with no name, and the specified type and value.
+        /// </summary>
+        /// <param name="type">The initial type of the parameter.</param>
+        /// <param name="value">The initial value of the parameter.</param>
+        public BigqueryParameter(BigqueryParameterType? type, object value) : this(null, type, value)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a parameter with the given name but no initial value or type.
+        /// </summary>
+        /// <param name="name">The initial name of the parameter.</param>
+        public BigqueryParameter(string name) : this(name, null, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a parameter with the given name and type, but no initial value.
+        /// </summary>
+        /// <param name="name">The initial name of the parameter.</param>
+        /// <param name="type">The initial type of the parameter.</param>
+        public BigqueryParameter(string name, BigqueryParameterType? type) : this(name, type, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a parameter with the given name, type and value.
+        /// </summary>
+        /// <param name="name">The initial name of the parameter.</param>
+        /// <param name="type">The initial type of the parameter.</param>
+        /// <param name="value">The initial value of the parameter.</param>
+        public BigqueryParameter(string name, BigqueryParameterType? type, object value)
+        {
+            Name = name;
+            if (type != null)
+            {
+                Type = GaxPreconditions.CheckEnumValue(type.Value, nameof(type));
+            }
+            ValidateValue(value, nameof(value)); // Proof against refactoring of parameter name...
+            Value = value;
+        }
+
+        internal QueryParameter ToQueryParameter(BigqueryParameterMode parameterMode)
+        {
+            if (parameterMode == BigqueryParameterMode.Named && string.IsNullOrEmpty(Name))
+            {
+                throw new InvalidOperationException("Unnamed parameters cannot be used in command using BigqueryParameterMode.Named");
+            }
+            var value = Value;
+            if (Type == null && value == null)
+            {
+                throw new InvalidOperationException("A null-valued parameter must have an explicitly specified type");
+            }
+            var type = Type ?? InferParameterType(value);
+            var parameter = new QueryParameter
+            {
+                Name = Name,
+                ParameterType = new QueryParameterType { Type = EnumMap.ToApiValue(type) },
+            };
+            switch (type)
+            {
+                case BigqueryParameterType.Array:
+                    return PopulateArrayParameter(parameter, value, ArrayType);
+                case BigqueryParameterType.Bool:
+                    return parameter.PopulateScalar<bool>(value, x => x ? "TRUE" : "FALSE")
+                        ?? parameter.PopulateScalar<string>(value, x => x)
+                        ?? parameter.UseNullScalarOrThrow(value);
+                case BigqueryParameterType.Bytes:
+                    return parameter.PopulateScalar<byte[]>(value, x => Convert.ToBase64String(x))
+                        ?? parameter.PopulateScalar<string>(value, x => x)
+                        ?? parameter.UseNullScalarOrThrow(value);
+                case BigqueryParameterType.Date:
+                    return parameter.PopulateScalar<DateTime>(value, x => x.ToString("yyyy-MM-dd", InvariantCulture))
+                        ?? parameter.PopulateScalar<DateTimeOffset>(value, x => x.ToString("yyyy-MM-dd", InvariantCulture))
+                        ?? parameter.PopulateScalar<string>(value, x => x)
+                        ?? parameter.UseNullScalarOrThrow(value);
+                case BigqueryParameterType.DateTime:
+                    return parameter.PopulateScalar<DateTime>(value, x => x.ToString("yyyy-MM-dd HH:mm:ss.FFFFFF", InvariantCulture))
+                        ?? parameter.PopulateScalar<DateTimeOffset>(value, x => x.ToString("yyyy-MM-dd HH:mm:ss.FFFFFF", InvariantCulture))
+                        ?? parameter.PopulateScalar<string>(value, x => x)
+                        ?? parameter.UseNullScalarOrThrow(value);
+                case BigqueryParameterType.Float64:
+                    return parameter.PopulateInteger(value)
+                        ?? parameter.PopulateFloatingPoint(value)
+                        ?? parameter.PopulateScalar<string>(value, x => x)
+                        ?? parameter.UseNullScalarOrThrow(value);
+                case BigqueryParameterType.Int64:
+                    return parameter.PopulateInteger(value)
+                        ?? parameter.PopulateScalar<string>(value, x => x)
+                        ?? parameter.UseNullScalarOrThrow(value);
+                case BigqueryParameterType.String:
+                    return parameter.PopulateScalar<string>(value, x => x)
+                        ?? parameter.UseNullScalarOrThrow(value);
+                case BigqueryParameterType.Struct: throw new NotImplementedException("Struct parameters are not yet implemented");
+                case BigqueryParameterType.Time:
+                    return parameter.PopulateScalar<TimeSpan>(value, FormatTimeSpan)
+                        ?? parameter.PopulateScalar<DateTimeOffset>(value, x => x.ToString("HH:mm:ss.FFFFFF", InvariantCulture))
+                        ?? parameter.PopulateScalar<DateTime>(value, x => x.ToString("HH:mm:ss.FFFFFF", InvariantCulture))
+                        ?? parameter.PopulateScalar<string>(value, x => x)
+                        ?? parameter.UseNullScalarOrThrow(value);
+                case BigqueryParameterType.Timestamp:
+                    return parameter.PopulateScalar<DateTime>(value, x =>
+                        {
+                            if (x.Kind != DateTimeKind.Utc)
+                            {
+                                throw new InvalidOperationException($"A DateTime with a Kind of {x.Kind} cannot be used for a Timestamp parameter");
+                            }
+                            return x.ToString("yyyy-MM-dd HH:mm:ss.FFFFFF");
+                        })
+                        ?? parameter.PopulateScalar<DateTimeOffset>(value, x => x.ToString("yyyy-MM-dd HH:mm:ss.FFFFFFzzz", InvariantCulture))
+                        ?? parameter.PopulateScalar<string>(value, x => x)
+                        ?? parameter.UseNullScalarOrThrow(value);
+                default: throw new InvalidOperationException($"No conversion available for parameter type {type}");
+            }
+        }
+
+        private static string FormatTimeSpan(TimeSpan ts)
+        {
+            // Normalize to a positive value by adding days if necessary, so -2 hours => 22:00:00 etc.
+            if (ts.Hours < 0)
+            {
+                ts = ts.Add(TimeSpan.FromDays(1 - ts.Days));
+            }
+            return ts.ToString("hh':'mm':'ss'.'ffffff", InvariantCulture);
+        }
+
+        private static BigqueryParameterType InferParameterType(object value)
+        {
+            BigqueryParameterType type;
+            if (s_typeMapping.TryGetValue(value.GetType(), out type))
+            {
+                return type;
+            }
+            if (IsArrayValue(value))
+            {
+                return BigqueryParameterType.Array;
+            }
+            if (value is DateTime)
+            {
+                DateTime dt = (DateTime)value;
+                return dt.Kind == DateTimeKind.Utc ? BigqueryParameterType.Timestamp : BigqueryParameterType.DateTime;
+            }
+            // We should never get here, as we should have validated that the value is vaguely sensible on the Value setter.
+            throw new InvalidOperationException($"Unsupported value type: {value.GetType()}");
+        }
+
+        private static QueryParameter PopulateArrayParameter(QueryParameter parameter, object value, BigqueryParameterType? arrayType)
+        {
+            if (value == null)
+            {
+                throw new InvalidOperationException("The value of an array parameter cannot be null");
+            }
+            if (!IsArrayValue(value))
+            {
+                throw new InvalidOperationException($"Invalid value for array parameter: {value.GetType()}");
+            }
+            List<object> values = ((IEnumerable)value).Cast<object>().ToList();
+            if (values.Any(v => v == null))
+            {
+                throw new InvalidOperationException("Array parameter values cannot contain null elements");
+            }
+            BigqueryParameterType actualArrayType;
+            if (arrayType == null)
+            {
+                Type clrArrayType = GetArrayElementType(value);
+                if (!s_typeMapping.TryGetValue(clrArrayType, out actualArrayType))
+                {
+                    // This would indicate a bug in this class
+                    if (clrArrayType != typeof(DateTime))
+                    {
+                        throw new InvalidOperationException($"Invalid value for array parameter: {value.GetType()}");
+                    }
+                    // The default DateTime value has a type of Unspecified, leading to an array type of DateTime.
+                    DateTime sampleValue = values.Cast<DateTime>().FirstOrDefault();
+                    actualArrayType = sampleValue.Kind == DateTimeKind.Utc ? BigqueryParameterType.Timestamp : BigqueryParameterType.DateTime;
+                }
+            }
+            else
+            {
+                actualArrayType = arrayType.Value;
+            }
+            parameter.ParameterType = new QueryParameterType
+            {
+                Type = EnumMap.ToApiValue(BigqueryParameterType.Array),
+                ArrayType = new QueryParameterType { Type = EnumMap.ToApiValue(actualArrayType) }
+            };
+            var parameterValues = values
+                .Select(p => new BigqueryParameter(actualArrayType, p).ToQueryParameter(BigqueryParameterMode.Positional).ParameterValue)
+                .ToList();
+
+            parameter.ParameterValue = new QueryParameterValue { ArrayValues = parameterValues };
+            return parameter;
+        }
+                
+        private static void ValidateValue(object value, string paramName)
+        {
+            if (value == null ||
+                s_validSingleTypes.Contains(value.GetType()) ||
+                IsArrayValue(value))
+            {
+                return;
+            }
+            throw new ArgumentException(
+                $"Unable to use value of type { value.GetType() } in { nameof(BigqueryParameter)}",
+                paramName);
+        }
+
+        private static bool IsArrayValue(object value) => GetArrayElementType(value) != null;
+
+        private static Type GetArrayElementType(object value)
+        {
+            var typeInfo = value.GetType().GetTypeInfo();
+            return s_validRepeatedTypes.FirstOrDefault(ti => ti.IsAssignableFrom(typeInfo))?.GenericTypeArguments[0];
+        }
+    }
+
+    /// <summary>
+    /// Extension methods on QueryParameter, just to make the above code simpler
+    /// </summary>
+    internal static class QueryParameterExtensions
+    {
+        private static readonly NumberFormatInfo s_floatingPointFormat;
+
+        static QueryParameterExtensions()
+        {
+            s_floatingPointFormat = (NumberFormatInfo)InvariantCulture.NumberFormat.Clone();
+            s_floatingPointFormat.PositiveInfinitySymbol = "+inf";
+            s_floatingPointFormat.NegativeInfinitySymbol = "-inf";
+            s_floatingPointFormat.NaNSymbol = "NaN";
+        }
+
+        /// <summary>
+        /// If the value is of type T, the converter is applied and the paramter value populated,
+        /// and the parameter is returned. Otherwise, null is returned.
+        /// </summary>
+        internal static QueryParameter PopulateScalar<T>(this QueryParameter parameter, object value, Func<T, string> converter)
+        {
+            if (value is T)
+            {
+                parameter.ParameterValue = new QueryParameterValue { Value = converter((T)value) };
+                return parameter;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// If the value is an integer type, the parameter value is populated and the parameter is returned.
+        /// Otherwise, null is returned.
+        /// </summary>
+        internal static QueryParameter PopulateInteger(this QueryParameter parameter, object value)
+        {
+            // Note: we can end up with ulong values that the server will reject here, but it's simpler than trying
+            // to handle everything precisely, and it only defers the error a bit.
+            if (value is ushort || value is short || value is int || value is uint || value is long || value is ulong)
+            {
+                IFormattable formattable = (IFormattable)value;
+                parameter.ParameterValue = new QueryParameterValue { Value = formattable.ToString("d", InvariantCulture) };
+                return parameter;
+            }
+            return null;
+        }
+
+        internal static QueryParameter PopulateFloatingPoint(this QueryParameter parameter, object value)
+        {
+            if (value is float || value is double)
+            {                
+                IFormattable formattable = (IFormattable) value;
+                parameter.ParameterValue = new QueryParameterValue { Value = formattable.ToString("r", s_floatingPointFormat) };
+                return parameter;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// If the value is null, populate the parameter with an QueryParameterValue. Otherwise,
+        /// throw an exception - this is expected to be the last call in a chain, so at this point we know
+        /// we can't handle a value of this type.
+        /// </summary>
+        internal static QueryParameter UseNullScalarOrThrow(this QueryParameter parameter, object value)
+        {            
+            if (value == null)
+            {
+                parameter.ParameterValue = new QueryParameterValue();
+                return parameter;
+            }
+            var clrEnum = EnumMap<BigqueryParameterType>.ToValue(parameter.ParameterType.Type);
+            throw new InvalidOperationException($"Value of type {value.GetType()} cannot be used for a parameter of type {clrEnum}");
+        }
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryParameterCollection.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryParameterCollection.cs
@@ -1,0 +1,92 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Google.Bigquery.V2
+{
+    /// <summary>
+    /// A collection of <see cref="BigqueryParameter"/> elements, as part of a <see cref="BigqueryCommand"/>.
+    /// </summary>
+    public sealed class BigqueryParameterCollection : IReadOnlyList<BigqueryParameter>
+    {
+        private readonly List<BigqueryParameter> _parameters = new List<BigqueryParameter>();
+
+        // Note: no Add(string) or Add(BigqueryParameterType) overloads,
+        // as that makes it too easy to accidentally add two or three parameters
+        // with a collection initializer when we only want one.
+
+        /// <summary>
+        /// Adds a new parameter to the collection, with no name, type or value.
+        /// </summary>
+        /// <returns>The parameter added.</returns>
+        public BigqueryParameter Add() => Add(new BigqueryParameter());
+
+        /// <summary>
+        /// Adds a new parameter to the collection with the given name and type, but no initial value.
+        /// </summary>
+        /// <param name="name">The initial name of the parameter.</param>
+        /// <param name="type">The initial type of the parameter.</param>
+        /// <returns>The parameter added.</returns>
+        public BigqueryParameter Add(string name, BigqueryParameterType? type)
+            => Add(new BigqueryParameter(name, type));
+
+        /// <summary>
+        /// Adds a new parameter to the collection with the given name, type and value.
+        /// </summary>
+        /// <param name="name">The initial name of the parameter.</param>
+        /// <param name="type">The initial type of the parameter.</param>
+        /// <param name="value">The initial value of the parameter.</param>
+        /// <returns>The parameter added.</returns>
+        public BigqueryParameter Add(string name, BigqueryParameterType? type, object value)
+            => Add(new BigqueryParameter(name, type, value));
+
+        /// <summary>
+        /// Adds a new parameter to the collection with the given type and value, but no name.
+        /// </summary>
+        /// <param name="type">The initial type of the parameter.</param>
+        /// <param name="value">The initial value of the parameter.</param>
+        public BigqueryParameter Add(BigqueryParameterType? type, object value)
+            => Add(new BigqueryParameter(type, value));
+
+        /// <summary>
+        /// Adds the specified parameter to the collection.
+        /// </summary>
+        /// <param name="parameter">The parameter to add. Must not be null.</param>
+        /// <returns>The parameter added, i.e. <paramref name="parameter"/>.</returns>
+        public BigqueryParameter Add(BigqueryParameter parameter)
+        {
+            GaxPreconditions.CheckNotNull(parameter, nameof(parameter));
+            _parameters.Add(parameter);
+            return parameter;
+        }
+
+        /// <inheritdoc />
+        public void Clear() => _parameters.Clear();
+
+        /// <inheritdoc />
+        public int Count => _parameters.Count;
+
+        /// <inheritdoc />
+        public BigqueryParameter this[int index] => _parameters[index];
+
+        /// <inheritdoc />
+        public IEnumerator<BigqueryParameter> GetEnumerator() => _parameters.GetEnumerator();
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryParameterMode.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryParameterMode.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Google.Bigquery.V2
+{
+    /// <summary>
+    /// The mode for all the parameters in a <see cref="BigqueryCommand"/>.
+    /// Parameters can be named within the query (<c>@parameterName</c>), or positional (<c>?</c>).
+    /// </summary>
+    public enum BigqueryParameterMode
+    {
+        /// <summary>
+        /// Named parameters are used. All parameters in the command must be named.
+        /// </summary>
+        Named,
+        /// <summary>
+        /// Positional parameters are used. Parameter names are ignored.
+        /// </summary>
+        Positional
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryParameterType.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryParameterType.cs
@@ -1,0 +1,72 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace Google.Bigquery.V2
+{
+    /// <summary>
+    /// The type of a query parameter.
+    /// </summary>
+    /// <remarks>
+    /// This is separate from <see cref="BigqueryDbType"/>
+    /// </remarks>
+    public enum BigqueryParameterType
+    {
+        /// <summary>
+        /// An 64-bit signed integer value.
+        /// </summary>
+        Int64,
+        /// <summary>
+        /// Variable-length binary data.
+        /// </summary>
+        Bytes,
+        /// <summary>
+        /// Variable-length character (Unicode) data.
+        /// </summary>
+        String,
+        /// <summary>
+        /// Represents a logical calendar date. Values range between the years 1 and 9999, inclusive.
+        /// </summary>
+        Date,
+        /// <summary>
+        /// Represents a year, month, day, hour, minute, second, and subsecond (microsecond precision).
+        /// </summary>
+        DateTime,
+        /// <summary>
+        /// Represents a time, independent of a specific date, to microsecond precision.
+        /// </summary>
+        Time,
+        /// <summary>
+        /// Represents an absolute point in time, with microsecond precision. Values range between the years 1 and 9999, inclusive.
+        /// </summary>
+        Timestamp,
+        /// <summary>
+        /// A 64-bit IEEE binary floating-point value.
+        /// </summary>
+        Float64,
+        /// <summary>
+        /// A Boolean value (true or false).
+        /// </summary>
+        Bool,
+        /// <summary>
+        /// Ordered list of zero or more elements of any non-array type.
+        /// </summary>
+        Array,
+        /// <summary>
+        /// Container of ordered fields each with a type (required) and field name (optional).
+        /// </summary>
+        Struct
+    }
+}

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryQueryJob.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryQueryJob.cs
@@ -14,6 +14,7 @@
 
 using Google.Api.Gax;
 using Google.Apis.Bigquery.v2.Data;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -135,7 +136,7 @@ namespace Google.Bigquery.V2
             }
             GetQueryResultsOptions clonedOptions = _options?.Clone() ?? new GetQueryResultsOptions();
             List<BigqueryRow> rows = new List<BigqueryRow>(maxRows);
-            if ((_options.PageSize == null || _options.PageSize > maxRows) && _response.Rows?.Count > maxRows)
+            if ((clonedOptions.PageSize == null || clonedOptions.PageSize > maxRows) && _response.Rows?.Count > maxRows)
             {
                 // Oops. Do it again from scratch, with a useful page size.
                 clonedOptions.PageSize = maxRows;

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/CreateQueryJobOptions.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/CreateQueryJobOptions.cs
@@ -103,7 +103,7 @@ namespace Google.Bigquery.V2
             }
             if (CreateDisposition != null)
             {
-                query.CreateDisposition = EnumMap<CreateDisposition>.ToApiValue(CreateDisposition.Value);
+                query.CreateDisposition = EnumMap.ToApiValue(CreateDisposition.Value);
             }
             if (DefaultDataset != null)
             {
@@ -127,7 +127,7 @@ namespace Google.Bigquery.V2
             }
             if (Priority != null)
             {
-                query.Priority = EnumMap<QueryPriority>.ToApiValue(Priority.Value);
+                query.Priority = EnumMap.ToApiValue(Priority.Value);
             }
             if (UseQueryCache != null)
             {
@@ -135,7 +135,7 @@ namespace Google.Bigquery.V2
             }
             if (WriteDisposition != null)
             {
-                query.WriteDisposition = EnumMap<WriteDisposition>.ToApiValue(WriteDisposition.Value);
+                query.WriteDisposition = EnumMap.ToApiValue(WriteDisposition.Value);
             }
             if (UseLegacySql != null)
             {

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/EnumMap.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/EnumMap.cs
@@ -32,6 +32,15 @@ namespace Google.Bigquery.V2
     }
 
     /// <summary>
+    /// Helpers for EnumMap{T} to take advantage of type inference.
+    /// </summary>
+    internal static class EnumMap
+    {
+        internal static string ToApiValue<T>(T value, string paramName = "value") where T : struct =>
+            EnumMap<T>.ToApiValue(value, paramName);
+    }
+
+    /// <summary>
     /// Conversion between enum values and their API representations.
     /// (Could make this a regular class, but we basically need an instance per type...)
     /// </summary>

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/InsertRow.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/InsertRow.cs
@@ -188,16 +188,16 @@ namespace Google.Bigquery.V2
                 // TODO: Maybe enforce universal only?
                 return dt.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.FFFFFF'Z'", CultureInfo.InvariantCulture);
             }
-            if (value is DateTimeOffset)
+            else if (value is DateTimeOffset)
             {
                 DateTimeOffset dto = (DateTimeOffset)value;
                 return dto.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.FFFFFF'Z'", CultureInfo.InvariantCulture);
             }
-            if (value is InsertRow)
+            else if (value is InsertRow)
             {
                 return ((InsertRow)value).GetJsonValues();
             }
-            if (ValidSingleTypes.Contains(value.GetType()))
+            else if (ValidSingleTypes.Contains(value.GetType()))
             {
                 // Anything single value should be fine as it is. We've already validated that it's a known type.
                 return value;

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/TableSchemaBuilder.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/TableSchemaBuilder.cs
@@ -64,8 +64,8 @@ namespace Google.Bigquery.V2
             Add(new TableFieldSchema
             {
                 Name = name,
-                Type = EnumMap<BigqueryDbType>.ToApiValue(type, nameof(type)),
-                Mode = EnumMap<FieldMode>.ToApiValue(mode, nameof(mode)),
+                Type = EnumMap.ToApiValue(type, nameof(type)),
+                Mode = EnumMap.ToApiValue(mode, nameof(mode)),
                 Description = description,
             });
         }
@@ -92,8 +92,8 @@ namespace Google.Bigquery.V2
             {
                 Name = name,
                 Fields = nestedSchema.Fields,
-                Type = EnumMap<BigqueryDbType>.ToApiValue(BigqueryDbType.Record),
-                Mode = EnumMap<FieldMode>.ToApiValue(mode, nameof(mode)),
+                Type = EnumMap.ToApiValue(BigqueryDbType.Record),
+                Mode = EnumMap.ToApiValue(mode, nameof(mode)),
                 Description = description,
             });
         }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/UploadCsvOptions.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/UploadCsvOptions.cs
@@ -107,11 +107,11 @@ namespace Google.Bigquery.V2
             }
             if (CreateDisposition != null)
             {
-                loadRequest.CreateDisposition = EnumMap<CreateDisposition>.ToApiValue(CreateDisposition.Value);
+                loadRequest.CreateDisposition = EnumMap.ToApiValue(CreateDisposition.Value);
             }
             if (WriteDisposition != null)
             {
-                loadRequest.WriteDisposition = EnumMap<WriteDisposition>.ToApiValue(WriteDisposition.Value);
+                loadRequest.WriteDisposition = EnumMap.ToApiValue(WriteDisposition.Value);
             }
             // TODO: Encoding? Only UTF-8 and ISO-8859-1 are supported... unsure what to do with this.
         }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/UploadJsonOptions.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/UploadJsonOptions.cs
@@ -58,11 +58,11 @@ namespace Google.Bigquery.V2
             }
             if (CreateDisposition != null)
             {
-                loadRequest.CreateDisposition = EnumMap<CreateDisposition>.ToApiValue(CreateDisposition.Value);
+                loadRequest.CreateDisposition = EnumMap.ToApiValue(CreateDisposition.Value);
             }
             if (WriteDisposition != null)
             {
-                loadRequest.WriteDisposition = EnumMap<WriteDisposition>.ToApiValue(WriteDisposition.Value);
+                loadRequest.WriteDisposition = EnumMap.ToApiValue(WriteDisposition.Value);
             }
         }
     }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/project.json
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/project.json
@@ -20,10 +20,10 @@
 
   "dependencies": {
     "Google.Api.Gax.Rest": "1.0.0-beta03",
-    "Google.Apis": "1.16.0",
-    "Google.Apis.Auth": "1.16.0",
-    "Google.Apis.Bigquery.v2": "1.16.0.591",
-    "Google.Apis.Core": "1.16.0"
+    "Google.Apis": "1.18.0",
+    "Google.Apis.Auth": "1.18.0",
+    "Google.Apis.Bigquery.v2": "1.18.0.659",
+    "Google.Apis.Core": "1.18.0"
   },
   "frameworks": {
     "net45": { },

--- a/apis/Google.Bigquery.V2/docs/index.md
+++ b/apis/Google.Bigquery.V2/docs/index.md
@@ -37,6 +37,17 @@ with datasets, tables and query results simpler.
 
 [!code-cs[](obj/snippets/Google.Bigquery.V2.BigqueryClient.txt#QueryOverview)]
 
+## Parameterized queries
+
+Queries can be provided with parameters, either using names (the
+default):
+
+[!code-cs[](obj/snippets/Google.Bigquery.V2.BigqueryClient.txt#ParameterizedQueryNamedParameters)]
+
+Or using positional parameters:
+
+[!code-cs[](obj/snippets/Google.Bigquery.V2.BigqueryClient.txt#ParameterizedQueryPositionalParameters)]
+
 ## Using legacy SQL
 
 By default, [BigqueryClient](obj/api/Google.Bigquery.V2.BigqueryClient.yml)


### PR DESCRIPTION
We don't support Strct parameters yet, but I think we can probably
live without that for v1.0 - and even if we decide later that we
need to add them, this is still worth merging before that.