### PR TITLE
Documentation fixes and build on AppVeyor

### DIFF
--- a/apis/Google.Monitoring.V3/Google.Monitoring.V3.Snippets/GroupServiceClientSnippets.cs
+++ b/apis/Google.Monitoring.V3/Google.Monitoring.V3.Snippets/GroupServiceClientSnippets.cs
@@ -43,7 +43,7 @@ namespace Google.Monitoring.V3
             {
                 Console.WriteLine($"{group.Name}: {group.DisplayName}");
             }
-            // End snippet
+            // FIXME:End snippet
         }
         */
     }

--- a/apis/Google.Monitoring.V3/docs/index.md
+++ b/apis/Google.Monitoring.V3/docs/index.md
@@ -46,7 +46,3 @@ optionally specifying a service endpoint and settings.
 ## List metric descriptors
 
 [!code-cs[](obj/snippets/Google.Monitoring.V3.MetricServiceClient.txt#ListMetricDescriptors)]
-
-## List groups
-
-[!code-cs[](obj/snippets/Google.Monitoring.V3.GroupServiceClient.txt#ListGroups)]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,14 +21,22 @@ install:
   - curl -SL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1 -o .\scripts\dotnet-install.ps1
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
   - ps: '& .\scripts\dotnet-install.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -Version 1.0.0-preview2-003121 -NoPath'
-  # add dotnet to PATH
-  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
+  # Download and unpack docfx
+  - mkdir docfx
+  - cd docfx
+  - curl -SL https://github.com/dotnet/docfx/releases/download/v2.7.2/docfx.zip -o docfx.zip
+  - unzip docfx.zip
+  - cd ..
+  # add dotnet and docfx to PATH
+  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$pwd\docfx;$env:Path"
 
 # Perform the build.
 build_script:
   - dotnet --info
   - bash build.sh
   - bash coveralls.sh
+  - cd docs
+  - bash builddocs.sh
 
 # The tests are run as part of the build.
 test: off

--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -55,22 +55,22 @@ mkdir output/assembled
 
 # For Google.Api.Gax and Google.Api.Gax.Rest
 fetch gax-dotnet googleapis
-dotnet restore external/gax-dotnet
+dotnet restore -v Warning external/gax-dotnet
 
 # For Google.Protobuf
 fetch protobuf google
-dotnet restore external/protobuf
+dotnet restore -v Warning external/protobuf
 # Remove // comments in project.json; dotnet cli is fine with it, but docfx isn't.
 sed -i -r 's/\s+\/\/.*//g' external/protobuf/csharp/src/Google.Protobuf/project.json
 
 # For Grpc.Core etc
 fetch grpc grpc
-dotnet restore external/grpc/src/csharp
+dotnet restore -v Warning external/grpc/src/csharp
 
 # For all REST-based APIs
 fetch google-api-dotnet-client google
 mkdir -p external/google-api-dotnet-client/NuPkgs/Support
-dotnet restore external/google-api-dotnet-client
+dotnet restore -v Warning external/google-api-dotnet-client
 
 # TODO: google/google-api-dotnet-client, but those projects
 # don't work with docfx right now
@@ -80,7 +80,7 @@ if [ -z "$apis" ]
 then
   # Build all APIs, which means every ../apis subdirectory with a "docs" subdirectory,
   # and "root" which is the special top-level docs.
-  apis="`find ../apis -mindepth 2 -maxdepth 2 -name docs -type d | cut -d/ -f3` root"
+  apis="`/usr/bin/find ../apis -mindepth 2 -maxdepth 2 -name docs -type d | cut -d/ -f3` root"
 fi
 
 for api in $apis

--- a/docs/root/call-settings.md
+++ b/docs/root/call-settings.md
@@ -4,9 +4,9 @@
 
 All client libraries wrapping gRPC-based APIs (see the [API layers](api-layers.md) article)
 allow customization of RPC calls by using
-[CallSettings](obj/api/Google.Api.Gax.CallSettings.yml). If `CallSettings` are
+[CallSettings](obj/api/Google.Api.Gax.Grpc.CallSettings.yml). If `CallSettings` are
 not specified sensible defaults are automatically provided.
-See the [CallSettings documentation](obj/api/Google.Api.Gax.CallSettings.yml)
+See the [CallSettings documentation](obj/api/Google.Api.Gax.Grpc.CallSettings.yml)
 for descriptions of the available properties.
 
 The underlying gRPC API uses
@@ -30,9 +30,9 @@ property is used.
 The client-wide `CallSettings` is higher-priority than per-RPC-method `CallSettings`
 because it is often useful to be able to easily specify common properties to use
 for all RPC invocations. For example, a common set of
-[headers](obj/api/Google.Api.Gax.CallSettings.yml#Google_Api_Gax_CallSettings_Headers);
+[headers](obj/api/Google.Api.Gax.Grpc.CallSettings.yml#Google_Api_Gax_Grpc_CallSettings_Headers);
 or a common
-[deadline](obj/api/Google.Api.Gax.CallSettings.yml#Google_Api_Gax_CallSettings_Timing)
+[deadline](obj/api/Google.Api.Gax.Grpc.CallSettings.yml#Google_Api_Gax_Grpc_CallSettings_Timing)
 for multiple RPC invocations.
 
 ## Examples


### PR DESCRIPTION
If we can build all the documentation as part of CI, we shouldn't
end up having to fix it like this again...

(I have suspicions that some docfx errors won't actually count as errors, but at least our own tools dying will.)