### PR TITLE
Update all dependency versions

### DIFF
--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/project.json
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/project.json
@@ -19,12 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Rest": "1.0.0-beta03",
-    "Google.Apis": "1.18.0",
-    "Google.Apis.Auth": "1.18.0",
-    "Google.Apis.Bigquery.v2": "1.18.0.659",
-    "Google.Apis.Core": "1.18.0",
-    "System.Interactive.Async": "3.1.0-rc2"
+    "Google.Api.Gax.Rest": "1.0.0-beta04",
+    "Google.Apis.Bigquery.v2": "1.18.0.659"
   },
   "frameworks": {
     "net45": { },

--- a/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1/project.json
+++ b/apis/Google.Cloud.Language.V1Beta1/Google.Cloud.Language.V1Beta1/project.json
@@ -19,13 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta02",
-    "Google.Api.Gax.Grpc": "1.0.0-beta03",
-    "Google.Apis.Auth": "1.16.0",
-    "Google.Protobuf": "3.0.0",
-    "Grpc.Auth": "1.0.1-pre1",
-    "Grpc.Core": "1.0.1-pre1",
-    "System.Interactive.Async": "3.0.0"
+    "Google.Api.CommonProtos": "1.0.0-beta04",
+    "Google.Api.Gax.Grpc": "1.0.0-beta04"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/project.json
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/project.json
@@ -19,8 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Apis": "1.16.0",
-    "Google.Apis.Compute.v1": "1.16.0.589"
+    "Google.Apis": "1.18.0",
+    "Google.Apis.Compute.v1": "1.18.0.650"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
@@ -19,14 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax.Grpc": "1.0.0-beta03",
-    "Google.Apis.Auth": "1.16.0",
-    "Google.Longrunning": { "target": "project" },
-    "Google.Protobuf": "3.0.0",
-    "Grpc.Auth": "1.0.1-pre1",
-    "Grpc.Core": "1.0.1-pre1",
-    "System.Interactive.Async": "3.0.0"
+    "Google.Api.Gax.Grpc": "1.0.0-beta04",
+    "Google.Longrunning": { "target": "project" }
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
@@ -19,13 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta02",
-    "Google.Api.Gax.Grpc": "1.0.0-beta03",
-    "Google.Apis.Auth": "1.16.0",
-    "Google.Protobuf": "3.0.0",
-    "Grpc.Auth": "1.0.1-pre1",
-    "Grpc.Core": "1.0.1-pre1",
-    "System.Interactive.Async": "3.0.0"
+    "Google.Api.CommonProtos": "1.0.0-beta04",
+    "Google.Api.Gax.Grpc": "1.0.0-beta04"
   },
 
   "frameworks": {

--- a/apis/Google.Datastore.V1/Google.Datastore.V1.Tests/project.json
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1.Tests/project.json
@@ -6,10 +6,9 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Grpc.Testing": "1.0.0-beta03",
+    "Google.Api.Gax.Grpc.Testing": "1.0.0-beta04",
     "Google.Cloud.ClientTesting": { "target": "project" },
     "Google.Datastore.V1": { "target": "project" },
-    "System.Interactive.Async": "3.0.0",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },

--- a/apis/Google.Datastore.V1/Google.Datastore.V1/project.json
+++ b/apis/Google.Datastore.V1/Google.Datastore.V1/project.json
@@ -19,13 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta02",
-    "Google.Api.Gax.Grpc": "1.0.0-beta03",
-    "Google.Apis.Auth": "1.16.0",
-    "Google.Protobuf": "3.0.0",
-    "Grpc.Auth": "1.0.1-pre1",
-    "Grpc.Core": "1.0.1-pre1",
-    "System.Interactive.Async": "3.0.0"
+    "Google.Api.CommonProtos": "1.0.0-beta04",
+    "Google.Api.Gax.Grpc": "1.0.0-beta04"
   },
 
   "frameworks": {

--- a/apis/Google.Devtools.AspNet/Google.Devtools.AspNet/project.json
+++ b/apis/Google.Devtools.AspNet/Google.Devtools.AspNet/project.json
@@ -19,7 +19,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax": "1.0.0-beta03",
+    "Google.Api.Gax": "1.0.0-beta04",
     "Google.Devtools.Clouderrorreporting.V1Beta1": { "target": "project" },
     "Microsoft.AspNet.WebApi.Core": "5.2.3"
   },

--- a/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/project.json
+++ b/apis/Google.Devtools.Clouderrorreporting.V1Beta1/Google.Devtools.Clouderrorreporting.V1Beta1/project.json
@@ -19,13 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta02",
-    "Google.Api.Gax.Grpc": "1.0.0-beta03",
-    "Google.Apis.Auth": "1.16.0",
-    "Google.Protobuf": "3.0.0",
-    "Grpc.Auth": "1.0.1-pre1",
-    "Grpc.Core": "1.0.1-pre1",
-    "System.Interactive.Async": "3.0.0"
+    "Google.Api.CommonProtos": "1.0.0-beta04",
+    "Google.Api.Gax.Grpc": "1.0.0-beta04"
   },
 
   "frameworks": {

--- a/apis/Google.Devtools.Cloudtrace.V1/Google.Devtools.Cloudtrace.V1/project.json
+++ b/apis/Google.Devtools.Cloudtrace.V1/Google.Devtools.Cloudtrace.V1/project.json
@@ -19,13 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta02",
-    "Google.Api.Gax.Grpc": "1.0.0-beta03",
-    "Google.Apis.Auth": "1.16.0",
-    "Google.Protobuf": "3.0.0",
-    "Grpc.Auth": "1.0.1-pre1",
-    "Grpc.Core": "1.0.1-pre1",
-    "System.Interactive.Async": "3.0.0"
+    "Google.Api.CommonProtos": "1.0.0-beta04",
+    "Google.Api.Gax.Grpc": "1.0.0-beta04"
   },
 
   "frameworks": {

--- a/apis/Google.Iam.V1/Google.Iam.V1/project.json
+++ b/apis/Google.Iam.V1/Google.Iam.V1/project.json
@@ -19,11 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta02",
-    "Google.Api.Gax.Grpc": "1.0.0-beta03",
-    "Google.Protobuf": "3.0.0",
-    "Grpc.Core": "1.0.1-pre1",
-    "System.Interactive.Async": "3.0.0"
+    "Google.Api.CommonProtos": "1.0.0-beta04",
+    "Google.Api.Gax.Grpc": "1.0.0-beta04"
   },
 
   "frameworks": {

--- a/apis/Google.Logging.V2/Google.Logging.Log4Net.Tests/project.json
+++ b/apis/Google.Logging.V2/Google.Logging.Log4Net.Tests/project.json
@@ -7,7 +7,7 @@
 
   "dependencies": {
     "Google.Logging.Log4Net": { "target": "project" },
-    "Google.Api.Gax.Testing": "1.0.0-beta03",
+    "Google.Api.Gax.Testing": "1.0.0-beta04",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Moq": "4.6.36-alpha"

--- a/apis/Google.Logging.V2/Google.Logging.Log4Net/project.json
+++ b/apis/Google.Logging.V2/Google.Logging.Log4Net/project.json
@@ -19,8 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta02",
-    "Google.Api.Gax.Grpc": "1.0.0-beta03",
     "Google.Logging.V2": { "target": "project" },
     "log4net": "2.0.5"
   },

--- a/apis/Google.Logging.V2/Google.Logging.Type/project.json
+++ b/apis/Google.Logging.V2/Google.Logging.Type/project.json
@@ -19,8 +19,7 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta02",
-    "Google.Protobuf": "3.0.0"
+    "Google.Api.CommonProtos": "1.0.0-beta04"
   },
 
   "frameworks": {

--- a/apis/Google.Logging.V2/Google.Logging.V2/project.json
+++ b/apis/Google.Logging.V2/Google.Logging.V2/project.json
@@ -19,14 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta02",
-    "Google.Api.Gax.Grpc": "1.0.0-beta03",
-    "Google.Apis.Auth": "1.16.0",
-    "Google.Logging.Type": { "target": "project" },
-    "Google.Protobuf": "3.0.0",
-    "Grpc.Auth": "1.0.1-pre1",
-    "Grpc.Core": "1.0.1-pre1",
-    "System.Interactive.Async": "3.0.0"
+    "Google.Api.Gax.Grpc": "1.0.0-beta04",
+    "Google.Logging.Type": { "target": "project" }
   },
 
   "frameworks": {

--- a/apis/Google.Longrunning/Google.Longrunning.Tests/project.json
+++ b/apis/Google.Longrunning/Google.Longrunning.Tests/project.json
@@ -6,10 +6,9 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Testing": "1.0.0-beta03",
+    "Google.Api.Gax.Testing": "1.0.0-beta04",
     "Google.Cloud.ClientTesting": { "target": "project" },
     "Google.Longrunning": { "target": "project" },
-    "System.Interactive.Async": "3.0.0",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },

--- a/apis/Google.Longrunning/Google.Longrunning/project.json
+++ b/apis/Google.Longrunning/Google.Longrunning/project.json
@@ -20,10 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax.Grpc": "1.0.0-beta03",
-    "Google.Protobuf": "3.0.0",
-    "Grpc.Core": "1.0.1-pre1",
-    "System.Interactive.Async": "3.0.0"
+    "Google.Api.Gax.Grpc": "1.0.0-beta04"
   },
 
   "frameworks": {

--- a/apis/Google.Monitoring.V3/Google.Monitoring.V3/project.json
+++ b/apis/Google.Monitoring.V3/Google.Monitoring.V3/project.json
@@ -20,12 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax.Grpc": "1.0.0-beta03",
-    "Google.Apis.Auth": "1.16.0",
-    "Google.Protobuf": "3.0.0",
-    "Grpc.Auth": "1.0.1-pre1",
-    "Grpc.Core": "1.0.1-pre1",
-    "System.Interactive.Async": "3.0.0"
+    "Google.Api.Gax.Grpc": "1.0.0-beta04"
   },
 
   "frameworks": {

--- a/apis/Google.Pubsub.V1/Google.Pubsub.V1/project.json
+++ b/apis/Google.Pubsub.V1/Google.Pubsub.V1/project.json
@@ -19,14 +19,9 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta02",
-    "Google.Api.Gax.Grpc": "1.0.0-beta03",
-    "Google.Apis.Auth": "1.16.0",
-    "Google.Iam.V1": { "target": "project" },
-    "Google.Protobuf": "3.0.0",
-    "Grpc.Auth": "1.0.1-pre1",
-    "Grpc.Core": "1.0.1-pre1",
-    "System.Interactive.Async": "3.0.0"
+    "Google.Api.CommonProtos": "1.0.0-beta04",
+    "Google.Api.Gax.Grpc": "1.0.0-beta04",
+    "Google.Iam.V1": { "target": "project" }
   },
 
   "frameworks": {

--- a/apis/Google.Storage.V1/Google.Storage.V1/project.json
+++ b/apis/Google.Storage.V1/Google.Storage.V1/project.json
@@ -19,11 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Rest": "1.0.0-beta03",
-    "Google.Apis": "1.16.0",
-    "Google.Apis.Auth": "1.16.0",
-    "Google.Apis.Core": "1.16.0",
-    "Google.Apis.Storage.v1": "1.16.0.579"
+    "Google.Api.Gax.Rest": "1.0.0-beta04",
+    "Google.Apis.Storage.v1": "1.18.0.658"
   },
   "frameworks": {
     "net45": { },

--- a/generateapis.sh
+++ b/generateapis.sh
@@ -7,7 +7,7 @@ set -e
 OS=linux
 [[ ${OS} = "windows" ]] && EXE_SUFFIX=.exe || EXE_SUFFIX=
 
-GRPC_VERSION=1.0.1-pre1
+GRPC_VERSION=1.0.1
 PROTOBUF_VERSION=3.1.0
 PROTOC=packages/Grpc.Tools.$GRPC_VERSION/tools/${OS}_x64/protoc${EXE_SUFFIX}
 GRPC_PLUGIN=packages/Grpc.Tools.$GRPC_VERSION/tools/${OS}_x64/grpc_csharp_plugin${EXE_SUFFIX}


### PR DESCRIPTION
- Remove unnecessary dependencies (which are already present via transient dependencies)
- Update CommonProtos to beta04 everywhere
- Update all GAX packages to beta04
- Update Storage dependency to 1.18.0.658
- Update generateapis.sh to take gRPC 1.0.1