### PR TITLE
Signed URLs for Storage

### DIFF
--- a/apis/Google.Storage.V1/Google.Storage.V1.IntegrationTests/SignedUrlUtilsTest.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1.IntegrationTests/SignedUrlUtilsTest.cs
@@ -1,0 +1,499 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Json;
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Google.Storage.V1.IntegrationTests
+{
+    using static TestHelpers;
+
+    [Collection(nameof(StorageFixture))]
+    public class SignedUrlUtilsTest
+    {
+        private readonly string _credentialsFilePath = GetCredentialsFilePath();
+        private readonly TimeSpan _duration = TimeSpan.FromSeconds(5);
+        private readonly StorageFixture _fixture;
+        private readonly HttpClient _httpClient = new HttpClient();
+
+        public SignedUrlUtilsTest(StorageFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async void DeleteTest()
+        {
+            var bucket = _fixture.SingleVersionBucket;
+            var name = GenerateName();
+
+            var url = SignedUrlUtils.Create(
+                bucket,
+                name,
+                _credentialsFilePath,
+                _duration,
+                HttpMethod.Delete);
+
+            // Upload an object which can be deleted with the URL.
+            await _fixture.Client.UploadObjectAsync(bucket, name, "", new MemoryStream(_fixture.SmallContent));
+
+            // Verify that the URL works initially.
+            var response = await _httpClient.DeleteAsync(url);
+            Assert.True(response.IsSuccessStatusCode);
+            var obj = await _fixture.Client.ListObjectsAsync(bucket, name).FirstOrDefault(o => o.Name == name);
+            Assert.Null(obj);
+
+            // Restore the object and wait until the URL expires. 
+            await _fixture.Client.UploadObjectAsync(bucket, name, "", new MemoryStream(_fixture.SmallContent));
+            await Task.Delay(_duration);
+
+            // Verify that the URL no longer works.
+            response = await _httpClient.DeleteAsync(url);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            obj = await _fixture.Client.ListObjectsAsync(bucket, name).FirstOrDefault(o => o.Name == name);
+            Assert.NotNull(obj);
+
+            // Cleanup
+            await _fixture.Client.DeleteObjectAsync(bucket, name);
+        }
+
+        [Fact]
+        public async void GetTest()
+        {
+            var url = SignedUrlUtils.Create(
+                _fixture.ReadBucket,
+                _fixture.SmallObject,
+                _credentialsFilePath,
+                _duration);
+
+            // Verify that the URL works initially.
+            var response = await _httpClient.GetAsync(url);
+            var result = await response.Content.ReadAsByteArrayAsync();
+            Assert.Equal(_fixture.SmallContent, result);
+
+            // Wait until the URL expires.
+            await Task.Delay(_duration);
+
+            // Verify that the URL no longer works.
+            response = await _httpClient.GetAsync(url);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async void GetBucketTest()
+        {
+            var bucket = _fixture.ReadBucket;
+
+            var url = SignedUrlUtils.Create(
+                bucket,
+                null,
+                _credentialsFilePath,
+                _duration);
+
+            // Verify that the URL works initially.
+            var response = await _httpClient.GetAsync(url);
+            var result = await response.Content.ReadAsStringAsync();
+            var document = XDocument.Parse(result);
+            var ns = document.Root.GetDefaultNamespace();
+            var keys = document.Root.Elements(ns + "Contents").Select(contents => contents.Element(ns + "Key").Value).ToList();
+            var objectNames = await _fixture.Client.ListObjectsAsync(bucket, null).Select(o => o.Name).ToList();
+            Assert.Equal(objectNames, keys);
+
+            // Wait until the URL expires.
+            await Task.Delay(_duration);
+
+            // Verify that the URL no longer works.
+            response = await _httpClient.GetAsync(url);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async void GetWithCustomerSuppliedEncryptionKeysTest()
+        {
+            var bucket = _fixture.SingleVersionBucket;
+            var name = GenerateName();
+            var data = _fixture.SmallContent;
+
+            string key;
+            string hash;
+            using (var rand = RandomNumberGenerator.Create())
+            using (var sha256 = SHA256.Create())
+            {
+                var keyBytes = new byte[32];
+                rand.GetBytes(keyBytes);
+                key = Convert.ToBase64String(keyBytes);
+                hash = Convert.ToBase64String(sha256.ComputeHash(keyBytes));
+            }
+
+            // TODO: Replace this with calls to the StorageClient if/when it supports customer-supplied encryption keys.
+            var putRequest = new HttpRequestMessage()
+            {
+                Content = new ByteArrayContent(data),
+                Method = HttpMethod.Put,
+                Headers = {
+                    { "x-goog-encryption-algorithm", "AES256" },
+                    { "x-goog-encryption-key", key },
+                    { "x-goog-encryption-key-sha256", hash }
+                }
+            };
+            putRequest.RequestUri = new Uri(SignedUrlUtils.Create(
+                bucket,
+                name,
+                _credentialsFilePath,
+                expiration: null,
+                request: putRequest));
+            var response = await _httpClient.SendAsync(putRequest);
+            Assert.True(response.IsSuccessStatusCode);
+
+            // Make sure the encryption succeeded.
+            await Assert.ThrowsAsync<GoogleApiException>(
+                () => _fixture.Client.DownloadObjectAsync(bucket, name, new MemoryStream()));
+            
+            Func<HttpRequestMessage> createGetRequest = () => new HttpRequestMessage()
+            {
+                Method = HttpMethod.Get,
+                Headers = {
+                    { "x-goog-encryption-algorithm", "AES256" },
+                    { "x-goog-encryption-key", key },
+                    { "x-goog-encryption-key-sha256", hash }
+                }
+            };
+            var request = createGetRequest();
+            var url = SignedUrlUtils.Create(
+                bucket,
+                name,
+                _credentialsFilePath,
+                _duration,
+                request);
+            request.RequestUri = new Uri(url);
+
+            // Verify that the URL works initially.
+            response = await _httpClient.SendAsync(request);
+            var result = await response.Content.ReadAsByteArrayAsync();
+            Assert.Equal(data, result);
+
+            // Wait until the URL expires.
+            await Task.Delay(_duration);
+
+            // Verify that the URL no longer works.
+            request = createGetRequest();
+            request.RequestUri = new Uri(url);
+            response = await _httpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+            // Cleanup
+            await _fixture.Client.DeleteObjectAsync(bucket, name);
+        }
+
+        [Fact]
+        public async void GetNoExpirationTest()
+        {
+            var url = SignedUrlUtils.Create(
+                _fixture.ReadBucket,
+                _fixture.SmallObject,
+                _credentialsFilePath,
+                expiration: null);
+
+            // Verify that the URL works.
+            var response = await _httpClient.GetAsync(url);
+            var result = await response.Content.ReadAsByteArrayAsync();
+            Assert.Equal(_fixture.SmallContent, result);
+        }
+
+        [Fact]
+        public async void GetWithCustomHeadersTest()
+        {
+            Func<HttpRequestMessage> createRequest = () => new HttpRequestMessage()
+            {
+                Method = HttpMethod.Get,
+                Headers = {
+                    { "x-goog-foo", "xy\r\n z" },
+                    { "x-goog-bar", "  12345   " },
+                    { "x-goog-foo", new [] { "A B  C", "def" } }
+                }
+            };
+            var request = createRequest();
+            var url = SignedUrlUtils.Create(
+                _fixture.ReadBucket,
+                _fixture.SmallObject,
+                _credentialsFilePath,
+                _duration,
+                request);
+            request.RequestUri = new Uri(url);
+
+            // Verify that the URL works initially.
+            var response = await _httpClient.SendAsync(request);
+            var result = await response.Content.ReadAsByteArrayAsync();
+            Assert.Equal(_fixture.SmallContent, result);
+
+            // Wait until the URL expires.
+            await Task.Delay(_duration);
+
+            // Verify that the URL no longer works.
+            request = createRequest();
+            request.RequestUri = new Uri(url);
+            response = await _httpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async void HeadTest()
+        {
+            var url = SignedUrlUtils.Create(
+                _fixture.ReadBucket,
+                _fixture.SmallObject,
+                _credentialsFilePath,
+                _duration,
+                HttpMethod.Head);
+            Func<HttpRequestMessage> createRequest = () => new HttpRequestMessage(HttpMethod.Head, url);
+
+            // Verify that the URL works initially.
+            var response = await _httpClient.SendAsync(createRequest());
+            Assert.True(response.IsSuccessStatusCode);
+
+            // Wait until the URL expires.
+            await Task.Delay(_duration);
+
+            // Verify that the URL no longer works.
+            response = await _httpClient.SendAsync(createRequest());
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async void HeadWithGetMethodSignedURLTest()
+        {
+            var url = SignedUrlUtils.Create(
+                _fixture.ReadBucket,
+                _fixture.SmallObject,
+                _credentialsFilePath,
+                _duration,
+                HttpMethod.Get);
+            Func<HttpRequestMessage> createRequest = () => new HttpRequestMessage(HttpMethod.Head, url);
+
+            // Verify that the URL works initially.
+            var response = await _httpClient.SendAsync(createRequest());
+            Assert.True(response.IsSuccessStatusCode);
+
+            // Wait until the URL expires.
+            await Task.Delay(_duration);
+
+            // Verify that the URL no longer works.
+            response = await _httpClient.SendAsync(createRequest());
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async void PutTest()
+        {
+            var expireAction1 = await PutTestHelper(useContentMD5: false, useContentType: false);
+            var expireAction2 = await PutTestHelper(useContentMD5: true, useContentType: false);
+            var expireAction3 = await PutTestHelper(useContentMD5: false, useContentType: true);
+            var expireAction4 = await PutTestHelper(useContentMD5: true, useContentType: true);
+
+            // Wait for all URLs to expire.
+            await Task.Delay(_duration);
+
+            await expireAction1();
+            await expireAction2();
+            await expireAction3();
+            await expireAction4();
+        }
+
+        private async Task<Func<Task>> PutTestHelper(bool useContentMD5, bool useContentType)
+        {
+            var bucket = _fixture.SingleVersionBucket;
+            var name = GenerateName();
+            var data = _fixture.SmallContent;
+
+            Func<ByteArrayContent> createPutContent = () =>
+            {
+                var putContent = new ByteArrayContent(data);
+                if (useContentMD5)
+                {
+                    using (var md5 = MD5.Create())
+                    {
+                        putContent.Headers.ContentMD5 = md5.ComputeHash(data);
+                    }
+                }
+                if (useContentType)
+                {
+                    putContent.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+                }
+                return putContent;
+            };
+            var content = createPutContent();
+            var url = SignedUrlUtils.Create(
+                bucket,
+                name,
+                _credentialsFilePath,
+                _duration,
+                HttpMethod.Put,
+                contentHeaders: content.Headers.ToDictionary(h => h.Key, h => h.Value));
+
+            // Verify that the URL works initially.
+            var response = await _httpClient.PutAsync(url, content);
+            Assert.True(response.IsSuccessStatusCode);
+            var result = new MemoryStream();
+            await _fixture.Client.DownloadObjectAsync(bucket, name, result);
+            Assert.Equal(result.ToArray(), _fixture.SmallContent);
+
+            // Reset the state and wait until the URL expires.
+            await _fixture.Client.DeleteObjectAsync(bucket, name);
+
+            return async () =>
+            {
+                // Verify that the URL no longer works.
+                content = createPutContent();
+                response = await _httpClient.PutAsync(url, content);
+                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+                var obj = await _fixture.Client.ListObjectsAsync(bucket, name).FirstOrDefault(o => o.Name == name);
+                Assert.Null(obj);
+            };
+        }
+
+        [Fact]
+        public async void PutWithCustomHeadersTest()
+        {
+            var bucket = _fixture.SingleVersionBucket;
+            var name = GenerateName();
+            var data = _fixture.SmallContent;
+
+            Func<HttpRequestMessage> createRequest = () =>
+            {
+                using (var md5 = MD5.Create())
+                {
+                    return new HttpRequestMessage()
+                    {
+                        Content = new ByteArrayContent(data)
+                        {
+                            Headers = {
+                                { "Content-MD5", Convert.ToBase64String(md5.ComputeHash(data)) },
+                                { "Content-Type", "text/plain" },
+                                { "x-goog-z-content-foo", "val1" },
+                                { "x-goog-a-content-bar", "val2" },
+                                { "x-goog-foo", new [] { "val3", "val4" } }
+                            }
+                        },
+                        Method = HttpMethod.Put,
+                        Headers = {
+                            { "x-goog-foo", "xy\r\n z" },
+                            { "x-goog-bar", "  12345   " },
+                            { "x-goog-foo", new [] { "A B  C", "def" } }
+                        }
+                    };
+                }
+            };
+            var request = createRequest();
+            var url = SignedUrlUtils.Create(
+                bucket,
+                name,
+                _credentialsFilePath,
+                _duration,
+                request);
+            request.RequestUri = new Uri(url);
+
+            // Verify that the URL works initially.
+            var response = await _httpClient.SendAsync(request);
+            Assert.True(response.IsSuccessStatusCode);
+            var result = new MemoryStream();
+            await _fixture.Client.DownloadObjectAsync(bucket, name, result);
+            Assert.Equal(result.ToArray(), _fixture.SmallContent);
+
+            // Reset the state and wait until the URL expires.
+            await _fixture.Client.DeleteObjectAsync(bucket, name);
+            await Task.Delay(_duration);
+
+            // Verify that the URL no longer works.
+            request = createRequest();
+            request.RequestUri = new Uri(url);
+            response = await _httpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var obj = await _fixture.Client.ListObjectsAsync(bucket, name).FirstOrDefault(o => o.Name == name);
+            Assert.Null(obj);
+        }
+
+        private static string GetCredentialsFilePath()
+        {
+            // TODO: This is taken and changed slightly from DefaultCredentialProvider. Expose the pieces necessary so we don't need to duplicate logic.
+            var credentialFilePath = Environment.GetEnvironmentVariable(CredentialEnvironmentVariable) ?? GetWellKnownCredentialFilePath();
+            if (!string.IsNullOrEmpty(credentialFilePath) && File.Exists(credentialFilePath))
+            {
+                try
+                {
+                    using (var credentialStream = File.OpenRead(credentialFilePath))
+                    {
+                        var credentialParameters = NewtonsoftJsonSerializer.Instance.Deserialize<JsonCredentialParameters>(credentialStream);
+                        if (credentialParameters.Type == JsonCredentialParameters.ServiceAccountCredentialType)
+                        {
+                            return credentialFilePath;
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException("Error deserializing JSON credential data.", e);
+                }
+            }
+
+            throw new InvalidOperationException($"Set the {CredentialEnvironmentVariable} environment variable to a service account credentials JSON file");
+        }
+
+        // TODO: Everything below is taking from DefaultCredentialProvider. Try to expose it somehow to we don't need to duplicate logic.
+
+        /// <summary>
+        /// Environment variable override which stores the default application credentials file path.
+        /// </summary>
+        private const string CredentialEnvironmentVariable = "GOOGLE_APPLICATION_CREDENTIALS";
+
+        /// <summary>Well known file which stores the default application credentials.</summary>
+        private const string WellKnownCredentialsFile = "application_default_credentials.json";
+
+        /// <summary>Environment variable which contains the Application Data settings.</summary>
+        private const string AppdataEnvironmentVariable = "APPDATA";
+
+        /// <summary>Environment variable which contains the location of home directory on UNIX systems.</summary>
+        private const string HomeEnvironmentVariable = "HOME";
+
+        /// <summary>GCloud configuration directory in Windows, relative to %APPDATA%.</summary>
+        private const string CloudSDKConfigDirectoryWindows = "gcloud";
+
+        /// <summary>GCloud configuration directory on Linux/Mac, relative to $HOME.</summary>
+        private static readonly string CloudSDKConfigDirectoryUnix = Path.Combine(".config", "gcloud");
+
+        private static string GetWellKnownCredentialFilePath()
+        {
+            var appData = Environment.GetEnvironmentVariable(AppdataEnvironmentVariable);
+            if (appData != null)
+            {
+                return Path.Combine(appData, CloudSDKConfigDirectoryWindows, WellKnownCredentialsFile);
+            }
+            var unixHome = Environment.GetEnvironmentVariable(HomeEnvironmentVariable);
+            if (unixHome != null)
+            {
+                return Path.Combine(unixHome, CloudSDKConfigDirectoryUnix, WellKnownCredentialsFile);
+            }
+            return Path.Combine(CloudSDKConfigDirectoryWindows, WellKnownCredentialsFile);
+        }
+    }
+}

--- a/apis/Google.Storage.V1/Google.Storage.V1.Snippets/SignedUrlUtilsSnippets.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1.Snippets/SignedUrlUtilsSnippets.cs
@@ -1,0 +1,178 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Storage.V1.Snippets
+{
+    [Collection(nameof(StorageSnippetFixture))]
+    public class SignedUrlUtilsSnippets
+    {
+        private readonly string credentialsFilePath = GetCredentialsFilePath();
+        private readonly StorageSnippetFixture _fixture;
+        private readonly HttpClient httpClient = new HttpClient();
+
+        public SignedUrlUtilsSnippets(StorageSnippetFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async void SignedURLGet()
+        {
+            var bucketName = _fixture.BucketName;
+            var objectName = _fixture.HelloStorageObjectName;
+
+            // Sample: SignedURLGet
+            // Create a signed URL which can be used to get a specific object for one hour.
+            string url = SignedUrlUtils.Create(
+                bucketName,
+                objectName,
+                credentialsFilePath,
+                TimeSpan.FromHours(1),
+                HttpMethod.Get);
+
+            // Get the content at the created URL.
+            HttpResponseMessage response = await httpClient.GetAsync(url);
+            string content = await response.Content.ReadAsStringAsync();
+            // End sample
+
+            Assert.Equal(_fixture.HelloWorldContent, content);
+        }
+
+        [Fact]
+        public async void SignedURLPut()
+        {
+            var bucketName = _fixture.BucketName;
+
+            // Sample: SignedURLPut
+            // Create a signed URL which allows the requester to PUT data with the text/plain content-type.
+            var destination = "places/world.txt";
+            string url = SignedUrlUtils.Create(
+                bucketName,
+                destination,
+                credentialsFilePath,
+                TimeSpan.FromHours(1),
+                HttpMethod.Put,
+                contentHeaders: new Dictionary<string, IEnumerable<string>> {
+                    { "Content-Type", new[] { "text/plain" } }
+                });
+
+            // Upload the content into the bucket using the signed URL.
+            string source = "world.txt";
+
+            ByteArrayContent content;
+            using (FileStream stream = File.OpenRead(source))
+            {
+                byte[] data = new byte[stream.Length];
+                stream.Read(data, 0, data.Length);
+                content = new ByteArrayContent(data)
+                {
+                    Headers = { ContentType = new MediaTypeHeaderValue("text/plain") }
+                };
+            }
+
+            HttpResponseMessage response = await httpClient.PutAsync(url, content);
+            // End sample
+
+            Assert.True(response.IsSuccessStatusCode);
+
+            var client = StorageClient.Create();
+            var result = new MemoryStream();
+            await client.DownloadObjectAsync(bucketName, destination, result);
+            using (var stream = File.OpenRead(source))
+            {
+                var data = new byte[stream.Length];
+                stream.Read(data, 0, data.Length);
+                Assert.Equal(result.ToArray(), data);
+            }
+
+            await client.DeleteObjectAsync(bucketName, destination);
+        }
+
+        private static string GetCredentialsFilePath()
+        {
+            // TODO: This is taken and changed slightly from DefaultCredentialProvider. Expose the pieces necessary so we don't need to duplicate logic.
+            var credentialFilePath = Environment.GetEnvironmentVariable(CredentialEnvironmentVariable) ?? GetWellKnownCredentialFilePath();
+            if (!string.IsNullOrEmpty(credentialFilePath) && File.Exists(credentialFilePath))
+            {
+                try
+                {
+                    using (var credentialStream = File.OpenRead(credentialFilePath))
+                    {
+                        var credentialParameters = NewtonsoftJsonSerializer.Instance.Deserialize<JsonCredentialParameters>(credentialStream);
+                        if (credentialParameters.Type == JsonCredentialParameters.ServiceAccountCredentialType)
+                        {
+                            return credentialFilePath;
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException("Error deserializing JSON credential data.", e);
+                }
+            }
+
+            throw new InvalidOperationException($"Set the {CredentialEnvironmentVariable} environment variable to a service account credentials JSON file");
+        }
+
+        // TODO: Everything below is taking from DefaultCredentialProvider. Try to expose it somehow to we don't need to duplicate logic.
+
+        /// <summary>
+        /// Environment variable override which stores the default application credentials file path.
+        /// </summary>
+        private const string CredentialEnvironmentVariable = "GOOGLE_APPLICATION_CREDENTIALS";
+
+        /// <summary>Well known file which stores the default application credentials.</summary>
+        private const string WellKnownCredentialsFile = "application_default_credentials.json";
+
+        /// <summary>Environment variable which contains the Application Data settings.</summary>
+        private const string AppdataEnvironmentVariable = "APPDATA";
+
+        /// <summary>Environment variable which contains the location of home directory on UNIX systems.</summary>
+        private const string HomeEnvironmentVariable = "HOME";
+
+        /// <summary>GCloud configuration directory in Windows, relative to %APPDATA%.</summary>
+        private const string CloudSDKConfigDirectoryWindows = "gcloud";
+
+        /// <summary>GCloud configuration directory on Linux/Mac, relative to $HOME.</summary>
+        private static readonly string CloudSDKConfigDirectoryUnix = Path.Combine(".config", "gcloud");
+
+        private static string GetWellKnownCredentialFilePath()
+        {
+            var appData = Environment.GetEnvironmentVariable(AppdataEnvironmentVariable);
+            if (appData != null)
+            {
+                return Path.Combine(appData, CloudSDKConfigDirectoryWindows, WellKnownCredentialsFile);
+            }
+            var unixHome = Environment.GetEnvironmentVariable(HomeEnvironmentVariable);
+            if (unixHome != null)
+            {
+                return Path.Combine(unixHome, CloudSDKConfigDirectoryUnix, WellKnownCredentialsFile);
+            }
+            return Path.Combine(CloudSDKConfigDirectoryWindows, WellKnownCredentialsFile);
+        }
+    }
+}

--- a/apis/Google.Storage.V1/Google.Storage.V1/SignedUrlUtils.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/SignedUrlUtils.cs
@@ -1,0 +1,434 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Json;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Google.Storage.V1
+{
+    /// <summary>
+    /// Class which helps create signed URLs which can be used to provide limited access to specific buckets and objects
+    /// to anyone in possession of the URL, regardless of whether they have a Google account.
+    /// </summary>
+    /// <remarks>
+    /// See https://cloud.google.com/storage/docs/access-control/signed-urls for more information on signed URLs.
+    /// </remarks>
+    public static class SignedUrlUtils
+    {
+        private const string GoogHeaderPrefix = "x-goog-";
+        private const string GoogEncryptionKeyHeader = "x-goog-encryption-key";
+        private const string GoogEncryptionKeySHA256Header = "x-goog-encryption-key-sha256";
+        private const string StorageHost = "https://storage.googleapis.com";
+        private static readonly DateTimeOffset UnixEpoch = new DateTimeOffset(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc), TimeSpan.Zero);
+
+        /// <summary>
+        /// Creates a signed URL which can be used to provide limited access to specific buckets and objects to anyone
+        /// in possession of the URL, regardless of whether they have a Google account.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// When the <paramref name="request"/> is specified, some of its headers will be included in the signed URL's
+        /// signature, and therefore must be included in requests made with the created URL. These are the Content-MD5 and
+        /// Content-Type content headers as well as any content or request header with a name starting with "x-goog-".
+        /// </para>
+        /// <para>
+        /// If <paramref name="request"/> is null, no headers are included in the signed URL's signature, so any requests
+        /// made with the created URL must not contain Content-MD5, Content-Type, or any header starting with "x-goog-".
+        /// </para>
+        /// <para>
+        /// Note that if the entity is encrypted with customer-supplied encryption keys (see
+        /// https://cloud.google.com/storage/docs/encryption for more information), the <b>x-goog-encryption-algorithm</b>,
+        /// <b>x-goog-encryption-key</b>, and <b>x-goog-encryption-key-sha256</b> headers will be required when making the
+        /// request. However, only the x-goog-encryption-algorithm header is included in the signature for the signed URL.
+        /// So the sample <paramref name="request"/> specified only needs to have the x-goog-encryption-algorithm request
+        /// header. The other headers can be included, but will be ignored.
+        /// </para>
+        /// <para>
+        /// Note that when GET is specified as the <paramref name="request"/>, both GET and HEAD requests can be made with
+        /// the created signed URL.
+        /// </para>
+        /// <para>
+        /// See https://cloud.google.com/storage/docs/access-control/signed-urls for more information on signed URLs.
+        /// </para>
+        /// </remarks>
+        /// <param name="bucket">The name of the bucket. Must not be null.</param>
+        /// <param name="objectName">The name of the object within the bucket. May be null, in which case the signed URL
+        /// will refer to the bucket instead of an object.</param>
+        /// <param name="credentialFilePath">The path to the JSON key file for a service account. Must not be null.</param>
+        /// <param name="duration">The length of time for which the signed URL should remain usable.</param>
+        /// <param name="request">A sample request for which the signed URL might be used. May be null.</param>
+        /// <exception cref="InvalidOperationException">
+        /// The <paramref name="credentialFilePath"/> does not refer to a valid JSON service account key file.
+        /// </exception>
+        /// <returns>
+        /// The signed URL which can be used to provide access to a bucket or object for a limited amount of time.
+        /// </returns>
+        public static string Create(
+            string bucket,
+            string objectName,
+            string credentialFilePath,
+            TimeSpan duration,
+            HttpRequestMessage request) =>
+                Create(bucket, objectName, credentialFilePath, DateTimeOffset.UtcNow + duration, request);
+
+        /// <summary>
+        /// Creates a signed URL which can be used to provide limited access to specific buckets and objects to anyone
+        /// in possession of the URL, regardless of whether they have a Google account.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// When the <paramref name="request"/> is specified, some of its headers will be included in the signed URL's
+        /// signature, and therefore must be included in requests made with the created URL. These are the Content-MD5 and
+        /// Content-Type content headers as well as any content or request header with a name starting with "x-goog-".
+        /// </para>
+        /// <para>
+        /// If <paramref name="request"/> is null, no headers are included in the signed URL's signature, so any requests
+        /// made with the created URL must not contain Content-MD5, Content-Type, or any header starting with "x-goog-".
+        /// </para>
+        /// <para>
+        /// Note that if the entity is encrypted with customer-supplied encryption keys (see
+        /// https://cloud.google.com/storage/docs/encryption for more information), the <b>x-goog-encryption-algorithm</b>,
+        /// <b>x-goog-encryption-key</b>, and <b>x-goog-encryption-key-sha256</b> headers will be required when making the
+        /// request. However, only the x-goog-encryption-algorithm header is included in the signature for the signed URL.
+        /// So the sample <paramref name="request"/> specified only needs to have the x-goog-encryption-algorithm request
+        /// header. The other headers can be included, but will be ignored.
+        /// </para>
+        /// <para>
+        /// Note that when GET is specified as the <paramref name="request"/>, both GET and HEAD requests can be made with
+        /// the created signed URL.
+        /// </para>
+        /// <para>
+        /// See https://cloud.google.com/storage/docs/access-control/signed-urls for more information on signed URLs.
+        /// </para>
+        /// </remarks>
+        /// <param name="bucket">The name of the bucket. Must not be null.</param>
+        /// <param name="objectName">The name of the object within the bucket. May be null, in which case the signed URL
+        /// will refer to the bucket instead of an object.</param>
+        /// <param name="credentialFilePath">The path to the JSON key file for a service account. Must not be null.</param>
+        /// <param name="expiration">The point in time after which the signed URL will be invalid. May be null, in which
+        /// case the signed URL never expires.</param>
+        /// <param name="request">A sample request for which the signed URL might be used. May be null.</param>
+        /// <exception cref="InvalidOperationException">
+        /// The <paramref name="credentialFilePath"/> does not refer to a valid JSON service account key file.
+        /// </exception>
+        /// <returns>
+        /// The signed URL which can be used to provide access to a bucket or object for a limited amount of time.
+        /// </returns>
+        public static string Create(
+            string bucket,
+            string objectName,
+            string credentialFilePath,
+            DateTimeOffset? expiration,
+            HttpRequestMessage request) =>
+                Create(
+                    bucket,
+                    objectName,
+                    credentialFilePath,
+                    expiration,
+                    request?.Method,
+                    request?.Headers?.ToDictionary(h => h.Key, h => h.Value),
+                    request?.Content?.Headers?.ToDictionary(h => h.Key, h => h.Value));
+
+        /// <summary>
+        /// Creates a signed URL which can be used to provide limited access to specific buckets and objects to anyone
+        /// in possession of the URL, regardless of whether they have a Google account.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// When either of the headers collections are specified, there are certain headers which will be included in the
+        /// signed URL's signature, and therefore must be included in requests made with the created URL. These are the
+        /// Content-MD5 and Content-Type content headers as well as any content or request header with a name starting
+        /// with "x-goog-".
+        /// </para>
+        /// <para>
+        /// If the headers collections are null or empty, no headers are included in the signed URL's signature, so any
+        /// requests made with the created URL must not contain Content-MD5, Content-Type, or any header starting with "x-goog-".
+        /// </para>
+        /// <para>
+        /// Note that if the entity is encrypted with customer-supplied encryption keys (see
+        /// https://cloud.google.com/storage/docs/encryption for more information), the <b>x-goog-encryption-algorithm</b>,
+        /// <b>x-goog-encryption-key</b>, and <b>x-goog-encryption-key-sha256</b> headers will be required when making the
+        /// request. However, only the x-goog-encryption-algorithm header is included in the signature for the signed URL.
+        /// So the <paramref name="requestHeaders"/> specified only need to have the x-goog-encryption-algorithm header.
+        /// The other headers can be included, but will be ignored.
+        /// </para>
+        /// <para>
+        /// Note that when GET is specified as the <paramref name="requestMethod"/> (or it is null, in which case GET is
+        /// used), both GET and HEAD requests can be made with the created signed URL.
+        /// </para>
+        /// <para>
+        /// See https://cloud.google.com/storage/docs/access-control/signed-urls for more information on signed URLs.
+        /// </para>
+        /// </remarks>
+        /// <param name="bucket">The name of the bucket. Must not be null.</param>
+        /// <param name="objectName">The name of the object within the bucket. May be null, in which case the signed URL
+        /// will refer to the bucket instead of an object.</param>
+        /// <param name="credentialFilePath">The path to the JSON key file for a service account. Must not be null.</param>
+        /// <param name="duration">The length of time for which the signed URL should remain usable.</param>
+        /// <param name="requestMethod">The HTTP request method for which the signed URL is allowed to be used. May be null,
+        /// in which case GET will be used.</param>
+        /// <param name="requestHeaders">The headers which will be included with the request. May be null.</param>
+        /// <param name="contentHeaders">The headers for the content which will be included with the request.
+        /// May be null.</param>
+        /// <exception cref="InvalidOperationException">
+        /// The <paramref name="credentialFilePath"/> does not refer to a valid JSON service account key file.
+        /// </exception>
+        /// <returns>
+        /// The signed URL which can be used to provide access to a bucket or object for a limited amount of time.
+        /// </returns>
+        public static string Create(
+            string bucket,
+            string objectName,
+            string credentialFilePath,
+            TimeSpan duration,
+            HttpMethod requestMethod = null,
+            Dictionary<string, IEnumerable<string>> requestHeaders = null,
+            Dictionary<string, IEnumerable<string>> contentHeaders = null) =>
+                Create(
+                    bucket,
+                    objectName,
+                    credentialFilePath,
+                    DateTimeOffset.UtcNow + duration,
+                    requestMethod,
+                    requestHeaders,
+                    contentHeaders);
+
+        /// <summary>
+        /// Creates a signed URL which can be used to provide limited access to specific buckets and objects to anyone
+        /// in possession of the URL, regardless of whether they have a Google account.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// When either of the headers collections are specified, there are certain headers which will be included in the
+        /// signed URL's signature, and therefore must be included in requests made with the created URL. These are the
+        /// Content-MD5 and Content-Type content headers as well as any content or request header with a name starting
+        /// with "x-goog-".
+        /// </para>
+        /// <para>
+        /// If the headers collections are null or empty, no headers are included in the signed URL's signature, so any
+        /// requests made with the created URL must not contain Content-MD5, Content-Type, or any header starting with "x-goog-".
+        /// </para>
+        /// <para>
+        /// Note that if the entity is encrypted with customer-supplied encryption keys (see
+        /// https://cloud.google.com/storage/docs/encryption for more information), the <b>x-goog-encryption-algorithm</b>,
+        /// <b>x-goog-encryption-key</b>, and <b>x-goog-encryption-key-sha256</b> headers will be required when making the
+        /// request. However, only the x-goog-encryption-algorithm header is included in the signature for the signed URL.
+        /// So the <paramref name="requestHeaders"/> specified only need to have the x-goog-encryption-algorithm header.
+        /// The other headers can be included, but will be ignored.
+        /// </para>
+        /// <para>
+        /// Note that when GET is specified as the <paramref name="requestMethod"/> (or it is null, in which case GET is
+        /// used), both GET and HEAD requests can be made with the created signed URL.
+        /// </para>
+        /// <para>
+        /// See https://cloud.google.com/storage/docs/access-control/signed-urls for more information on signed URLs.
+        /// </para>
+        /// </remarks>
+        /// <param name="bucket">The name of the bucket. Must not be null.</param>
+        /// <param name="objectName">The name of the object within the bucket. May be null, in which case the signed URL
+        /// will refer to the bucket instead of an object.</param>
+        /// <param name="credentialFilePath">The path to the JSON key file for a service account. Must not be null.</param>
+        /// <param name="expiration">The point in time after which the signed URL will be invalid. May be null, in which
+        /// case the signed URL never expires.</param>
+        /// <param name="requestMethod">The HTTP request method for which the signed URL is allowed to be used. May be null,
+        /// in which case GET will be used.</param>
+        /// <param name="requestHeaders">The headers which will be included with the request. May be null.</param>
+        /// <param name="contentHeaders">The headers for the content which will be included with the request.
+        /// May be null.</param>
+        /// <exception cref="InvalidOperationException">
+        /// The <paramref name="credentialFilePath"/> does not refer to a valid JSON service account key file.
+        /// </exception>
+        /// <returns>
+        /// The signed URL which can be used to provide access to a bucket or object for a limited amount of time.
+        /// </returns>
+        public static string Create(
+            string bucket,
+            string objectName,
+            string credentialFilePath,
+            DateTimeOffset? expiration,
+            HttpMethod requestMethod = null,
+            Dictionary<string, IEnumerable<string>> requestHeaders = null,
+            Dictionary<string, IEnumerable<string>> contentHeaders = null)
+        {
+            StorageClientImpl.ValidateBucketName(bucket);
+            GaxPreconditions.CheckNotNull(credentialFilePath, nameof(credentialFilePath));
+
+            var credentials = ParseCredentials(credentialFilePath);
+            var expiryUnixSeconds = ((int?)((expiration - UnixEpoch)?.TotalSeconds))?.ToString(CultureInfo.InvariantCulture);
+            var resourcePath = $"/{bucket}";
+            if (objectName != null)
+            {
+                resourcePath += $"/{objectName}";
+            }
+            var extensionHeaders = GetExtensionHeaders(requestHeaders, contentHeaders);
+
+            var contentMD5 = GetFirstHeaderValue(contentHeaders, "Content-MD5");
+            var contentType = GetFirstHeaderValue(contentHeaders, "Content-Type");
+
+            var signatureLines = new List<string>
+            {
+                (requestMethod ?? HttpMethod.Get).ToString(),
+                contentMD5,
+                contentType,
+                expiryUnixSeconds
+            };
+            signatureLines.AddRange(extensionHeaders.Select(
+                header => $"{header.Key}:{string.Join(", ", header.Value)}"));
+            signatureLines.Add(resourcePath);
+
+            var signature = CreateSignature(string.Join("\n", signatureLines), credentials);
+
+            var queryParameters = new List<string> { $"GoogleAccessId={credentials.Id}" };
+            if (expiryUnixSeconds != null)
+            {
+                queryParameters.Add($"Expires={expiryUnixSeconds}");
+            }
+            queryParameters.Add($"Signature={signature}");
+            return $"{StorageHost}{resourcePath}?{string.Join("&", queryParameters)}";
+        }
+
+        private static string CreateSignature(string data, ServiceAccountCredential.Initializer initializer)
+        {
+            // TODO: This is taken from ServiceAccountCredential. Expose this somehow so we don't need to duplicate logic.
+            using (var hashAlg = SHA256.Create())
+            {
+                byte[] assertionHash = hashAlg.ComputeHash(Encoding.UTF8.GetBytes(data));
+#if NETSTANDARD1_3
+            var sigBytes = initializer.Key.SignHash(assertionHash, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+#else
+                const string Sha256Oig = "2.16.840.1.101.3.4.2.1";
+                var sigBytes = initializer.Key.SignHash(assertionHash, Sha256Oig);
+#endif
+                return WebUtility.UrlEncode(Convert.ToBase64String(sigBytes));
+            }
+        }
+
+        private static SortedDictionary<string, StringBuilder> GetExtensionHeaders(
+            Dictionary<string, IEnumerable<string>> requestHeaders,
+            Dictionary<string, IEnumerable<string>> contentHeaders)
+        {
+            // These docs indicate how to include extension headers in the signature, but they're not exactly
+            // correct (values must be trimmed, newlines are replaced with empty strings, not whitespace, and
+            // values are concatenated with ", " instead of ",", but not when joining request and content headers).
+            // https://cloud.google.com/storage/docs/access-control/signed-urls#about-canonical-extension-headers
+            var extensionHeaders = new SortedDictionary<string, StringBuilder>();
+
+            if (requestHeaders != null)
+            {
+                PopulateExtensionHeaders(requestHeaders, extensionHeaders);
+            }
+
+            if (contentHeaders != null)
+            {
+                PopulateExtensionHeaders(
+                    contentHeaders,
+                    extensionHeaders,
+                    keysToExcludeSpaceInNextValueSeparator: new HashSet<string>(extensionHeaders.Keys));
+            }
+
+            return extensionHeaders;
+        }
+
+        private static void PopulateExtensionHeaders(
+            Dictionary<string, IEnumerable<string>> headers,
+            SortedDictionary<string, StringBuilder> extensionHeaders,
+            HashSet<string> keysToExcludeSpaceInNextValueSeparator = null)
+        {
+            foreach (var header in headers)
+            {
+                var key = header.Key.ToLowerInvariant();
+                if (!key.StartsWith(GoogHeaderPrefix) ||
+                    key == GoogEncryptionKeyHeader ||
+                    key == GoogEncryptionKeySHA256Header)
+                {
+                    continue;
+                }
+
+                StringBuilder values;
+                if (!extensionHeaders.TryGetValue(key, out values))
+                {
+                    values = new StringBuilder();
+                    extensionHeaders.Add(key, values);
+                }
+                else
+                {
+                    if (keysToExcludeSpaceInNextValueSeparator == null ||
+                        !keysToExcludeSpaceInNextValueSeparator.Remove(key))
+                    {
+                        values.Append(' ');
+                    }
+                    values.Append(',');
+                }
+
+                values.Append(string.Join(", ",
+                    header.Value.Select(s => s.Trim().Replace("\r\n", "").Replace("\n", ""))));
+            }
+        }
+
+        private static string GetFirstHeaderValue(Dictionary<string, IEnumerable<string>> contentHeaders, string name)
+        {
+            IEnumerable<string> values;
+            if (contentHeaders != null && contentHeaders.TryGetValue(name, out values))
+            {
+                return values.FirstOrDefault();
+            }
+            return null;
+        }
+
+        private static ServiceAccountCredential.Initializer ParseCredentials(string credentialFilePath)
+        {
+            var credentialParameters = ParseCredentialParameters(credentialFilePath);
+            return new ServiceAccountCredential.Initializer(credentialParameters.ClientEmail)
+                .FromPrivateKey(credentialParameters.PrivateKey);
+        }
+
+        private static JsonCredentialParameters ParseCredentialParameters(string credentialFilePath)
+        {
+            // TODO: This is taken from two places in DefaultCredentialProvider. Expose those pieces so we don't need to duplicate logic.
+            JsonCredentialParameters credentialParameters;
+            try
+            {
+                using (var credentialStream = File.OpenRead(credentialFilePath))
+                {
+                    credentialParameters = NewtonsoftJsonSerializer.Instance.Deserialize<JsonCredentialParameters>(credentialStream);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException("Error deserializing JSON credential data.", e);
+            }
+
+            if (credentialParameters.Type != JsonCredentialParameters.ServiceAccountCredentialType ||
+                string.IsNullOrEmpty(credentialParameters.ClientEmail) ||
+                string.IsNullOrEmpty(credentialParameters.PrivateKey))
+            {
+                throw new InvalidOperationException("JSON data does not represent a valid service account credential.");
+            }
+
+            return credentialParameters;
+        }
+    }
+}

--- a/apis/Google.Storage.V1/docs/index.md
+++ b/apis/Google.Storage.V1/docs/index.md
@@ -32,3 +32,18 @@ Common operations are exposed via the
 # Sample code
 
 [!code-cs[](obj/snippets/Google.Storage.V1.StorageClient.txt#Overview)]
+
+## Signed URLs
+
+Signed URLs can be created to provide limited access to specific buckets and
+objects to anyone in possession of the URL, regardless of whether they have
+a Google account.
+
+For example, Signed URLs can be created to provide read-only access to
+existing objects:
+
+[!code-cs[](obj/snippets/Google.Storage.V1.SignedUrlUtils.txt#SignedURLGet)]
+
+Or write-only access to put specific object content into a bucket:
+
+[!code-cs[](obj/snippets/Google.Storage.V1.SignedUrlUtils.txt#SignedURLPut)]


### PR DESCRIPTION
Note: I wasn't quite sure how best to let someone specify the request and content headers. I originally had the parameters as HttpRequestHeaders and HttpContentHeaders, respectively, but since those types don't have public constructors, it made things a little weird for the normal case where you want to construct a URL to be used later. You needed to create a fake HttpRequestMessage and/or HttpContent value, populate them with the headers you want to be required in the Signed URL, and then pass those header collections. So I settled on having them be `Dictionary<string, IEnumerable<string>>`, but it still feels a little clumsy. Maybe someone can think of a better way.