### PR TITLE
Fix and speed up BigQuery snippet tests

### DIFF
--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Snippets/BigqueryClientSnippets.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Snippets/BigqueryClientSnippets.cs
@@ -419,7 +419,7 @@ namespace Google.Bigquery.V2.Snippets
             Assert.NotEmpty(jobs);
         }
 
-        [Fact]
+        [Fact(Skip = "The streaming buffer never empties quickly enough")]
         public void ExportCsv()
         {
             // TODO: Make this simpler in the wrapper
@@ -481,7 +481,7 @@ namespace Google.Bigquery.V2.Snippets
         // TODO: ImportCsv
         // TODO: ImportJson
 
-        [Fact]
+        [Fact(Skip = "The streaming buffer never empties quickly enough")]
         public void CopyTable()
         {
             // TODO: Make this simpler in the wrapper
@@ -862,14 +862,14 @@ namespace Google.Bigquery.V2.Snippets
             BigqueryClient client = await BigqueryClient.CreateAsync(projectId);
             // The insert ID is optional, but can avoid duplicate data
             // when retrying inserts.
-            InsertRow row1 = new InsertRow("row1")
+            InsertRow row1 = new InsertRow("row1-async")
             {
                 { "player", "Jane" },
                 { "level", 3 },
                 { "score", 3600 },
                 { "game_started", DateTime.UtcNow }
             };
-            InsertRow row2 = new InsertRow("row2")
+            InsertRow row2 = new InsertRow("row2-async")
             {
                 { "player", "Jeff" },
                 { "level", 2 },
@@ -1034,7 +1034,7 @@ namespace Google.Bigquery.V2.Snippets
             Assert.NotEmpty(jobs);
         }
 
-        [Fact]
+        [Fact(Skip = "The streaming buffer never empties quickly enough")]
         public async Task ExportCsvAsync()
         {
             // TODO: Make this simpler in the wrapper
@@ -1096,7 +1096,7 @@ namespace Google.Bigquery.V2.Snippets
         // TODO: ImportCsv
         // TODO: ImportJson
 
-        [Fact]
+        [Fact(Skip = "The streaming buffer never empties quickly enough")]
         public async Task CopyTableAsync()
         {
             // TODO: Make this simpler in the wrapper


### PR DESCRIPTION
- The insert IDs are meant to be unique - Insert wasn't inserting anything because InsertAsync
  has already used the same IDs.
- There's no point in waiting for 30 seconds for the CopyTable and ExportCsv methods.
  We should consider killing them, or demonstrate the functionality with pre-existing tables.
  For the moment, let's just skip them.