### PR TITLE
Seal various classes and turn public fields (!) into properties

### DIFF
--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/CodeHealthTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/CodeHealthTest.cs
@@ -12,27 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Apis.Bigquery.v2;
+using Google.Cloud.ClientTesting;
+using Xunit;
 
-namespace Google.Bigquery.V2
+namespace Google.Bigquery.V2.Tests
 {
-    /// <summary>
-    /// Options used when listing datasets. Details TBD.
-    /// </summary>
-    public sealed class ListDatasetsOptions
+    public class CodeHealthTest
     {
-        /// <summary>
-        /// The number of results to return per page. (This modifies the per-request page size;
-        /// it does not affect the total number of results returned.)
-        /// </summary>
-        public int? PageSize { get; set; }
-
-        internal void ModifyRequest(DatasetsResource.ListRequest request)
+        [Fact]
+        public void PrivateFields()
         {
-            if (PageSize != null)
-            {
-                request.MaxResults = PageSize;
-            }
+            CodeHealthTester.AssertAllFieldsPrivate(typeof(BigqueryClient));
+        }
+
+        [Fact]
+        public void SealedClasses()
+        {
+            CodeHealthTester.AssertClassesAreSealedOrAbstract(typeof(BigqueryClient));
         }
     }
 }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryQueryJob.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryQueryJob.cs
@@ -27,7 +27,7 @@ namespace Google.Bigquery.V2
     /// <summary>
     /// A job known to be running a query. The job may not have completed yet.
     /// </summary>
-    public class BigqueryQueryJob
+    public sealed class BigqueryQueryJob
     {
         private readonly GetQueryResultsResponse _response;
         private readonly BigqueryClient _client;
@@ -254,7 +254,7 @@ namespace Google.Bigquery.V2
                 TotalRows = response.TotalRows
             };
 
-        private class AsyncRowEnumerable : IAsyncEnumerable<BigqueryRow>
+        private sealed class AsyncRowEnumerable : IAsyncEnumerable<BigqueryRow>
         {
             private readonly BigqueryQueryJob _job;
 
@@ -269,7 +269,7 @@ namespace Google.Bigquery.V2
             }
         }
 
-        private class AsyncRowEnumerator : IAsyncEnumerator<BigqueryRow>
+        private sealed class AsyncRowEnumerator : IAsyncEnumerator<BigqueryRow>
         {
             private readonly BigqueryQueryJob _job;
             private readonly GetQueryResultsOptions _options;

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/EnumMap.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/EnumMap.cs
@@ -21,7 +21,7 @@ using System.Reflection;
 namespace Google.Bigquery.V2
 {
     [AttributeUsage(AttributeTargets.Field)]
-    internal class ApiValueAttribute : Attribute
+    internal sealed class ApiValueAttribute : Attribute
     {
         public string Value { get; set; }
 

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/ListJobsOptions.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/ListJobsOptions.cs
@@ -20,7 +20,7 @@ namespace Google.Bigquery.V2
     /// <summary>
     /// Options for <c>ListJobs</c> operations.
     /// </summary>
-    public class ListJobsOptions
+    public sealed class ListJobsOptions
     {
         /// <summary>
         /// If set, only return jobs in the specified state.

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/ListRowsOptions.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/ListRowsOptions.cs
@@ -19,7 +19,7 @@ namespace Google.Bigquery.V2
     /// <summary>
     /// Options for <c>ListRows</c> operations.
     /// </summary>
-    public class ListRowsOptions
+    public sealed class ListRowsOptions
     {
         /// <summary>
         /// The number of results to return per page. (This modifies the per-request page size;

--- a/apis/Google.Storage.V1/Google.Storage.V1.Tests/CodeHealthTest.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1.Tests/CodeHealthTest.cs
@@ -12,27 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Apis.Bigquery.v2;
+using Google.Cloud.ClientTesting;
+using Xunit;
 
-namespace Google.Bigquery.V2
+namespace Google.Storage.V1.Tests
 {
-    /// <summary>
-    /// Options used when listing datasets. Details TBD.
-    /// </summary>
-    public sealed class ListDatasetsOptions
+    public class CodeHealthTest
     {
-        /// <summary>
-        /// The number of results to return per page. (This modifies the per-request page size;
-        /// it does not affect the total number of results returned.)
-        /// </summary>
-        public int? PageSize { get; set; }
-
-        internal void ModifyRequest(DatasetsResource.ListRequest request)
+        [Fact]
+        public void PrivateFields()
         {
-            if (PageSize != null)
-            {
-                request.MaxResults = PageSize;
-            }
+            CodeHealthTester.AssertAllFieldsPrivate(typeof(StorageClient));
+        }
+
+        [Fact]
+        public void SealedClasses()
+        {
+            CodeHealthTester.AssertClassesAreSealedOrAbstract(typeof(StorageClient));
         }
     }
 }

--- a/apis/Google.Storage.V1/Google.Storage.V1/CopyObjectOptions.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/CopyObjectOptions.cs
@@ -22,7 +22,7 @@ namespace Google.Storage.V1
     /// <summary>
     /// Options for <c>CopyObject</c> operations.
     /// </summary>
-    public class CopyObjectOptions
+    public sealed class CopyObjectOptions
     {
         // TODO: maxBytesRewrittenPerCall? Specific to rewrite...
 

--- a/apis/Google.Storage.V1/Google.Storage.V1/DeleteBucketOptions.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/DeleteBucketOptions.cs
@@ -20,7 +20,7 @@ namespace Google.Storage.V1
     /// <summary>
     /// Options for <c>DeleteBucket</c> operations.
     /// </summary>
-    public class DeleteBucketOptions
+    public sealed class DeleteBucketOptions
     {
         /// <summary>
         /// Precondition for deletion: the bucket is only deleted if its

--- a/apis/Google.Storage.V1/Google.Storage.V1/DeleteObjectOptions.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/DeleteObjectOptions.cs
@@ -20,7 +20,7 @@ namespace Google.Storage.V1
     /// <summary>
     /// Options for <c>DeleteObject</c> operations.
     /// </summary>
-    public class DeleteObjectOptions
+    public sealed class DeleteObjectOptions
     {
         /// <summary>
         /// The generation to delete. If this is not specified, the latest

--- a/apis/Google.Storage.V1/Google.Storage.V1/DownloadObjectOptions.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/DownloadObjectOptions.cs
@@ -22,38 +22,38 @@ namespace Google.Storage.V1
     /// <summary>
     /// Options for <c>DownloadObject</c> operations.
     /// </summary>
-    public class DownloadObjectOptions
+    public sealed class DownloadObjectOptions
     {
         /// <summary>
         /// The chunk size to use for each request.
         /// </summary>
-        public int? ChunkSize;
+        public int? ChunkSize { get; set; }
 
         /// <summary>
         /// The generation to download. When not specified, the latest version
         /// is always downloaded.
         /// </summary>
-        public long? Generation;
+        public long? Generation { get; set; }
 
         /// <summary>
         /// Precondition for download: the object is only downloaded if its generation matches the given value.
         /// </summary>
-        public long? IfGenerationMatch;
+        public long? IfGenerationMatch { get; set; }
 
         /// <summary>
         /// Precondition for download: the object is only downloaded if its generation does not match the given value.
         /// </summary>
-        public long? IfGenerationNotMatch;
+        public long? IfGenerationNotMatch { get; set; }
 
         /// <summary>
         /// Precondition for download: the object is only downloaded if its meta-generation matches the given value.
         /// </summary>
-        public long? IfMetagenerationMatch;
+        public long? IfMetagenerationMatch { get; set; }
 
         /// <summary>
         /// Precondition for download: the object is only downloaded if its meta-generation does not match the given value.
         /// </summary>
-        public long? IfMetagenerationNotMatch;
+        public long? IfMetagenerationNotMatch { get; set; }
 
         internal void ModifyDownloader(MediaDownloader downloader)
         {

--- a/apis/Google.Storage.V1/Google.Storage.V1/GetBucketOptions.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/GetBucketOptions.cs
@@ -22,7 +22,7 @@ namespace Google.Storage.V1
     /// <summary>
     /// Options for <c>GetBucket</c> operations.
     /// </summary>
-    public class GetBucketOptions
+    public sealed class GetBucketOptions
     {
         /// <summary>
         /// Precondition for retrieval: the bucket is only fetched if its

--- a/apis/Google.Storage.V1/Google.Storage.V1/GetObjectOptions.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/GetObjectOptions.cs
@@ -22,7 +22,7 @@ namespace Google.Storage.V1
     /// <summary>
     /// Options for <c>GetObject</c> operations.
     /// </summary>
-    public class GetObjectOptions
+    public sealed class GetObjectOptions
     {
         /// <summary>
         /// The generation of the object resource to fetch. When not

--- a/apis/Google.Storage.V1/Google.Storage.V1/ListBucketsOptions.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/ListBucketsOptions.cs
@@ -21,7 +21,7 @@ namespace Google.Storage.V1
     /// <summary>
     /// Options for <c>ListBuckets</c> operations.
     /// </summary>
-    public class ListBucketsOptions
+    public sealed class ListBucketsOptions
     {
         /// <summary>
         /// The prefix to match. Only buckets with names that start with this string will be returned.

--- a/apis/Google.Storage.V1/Google.Storage.V1/ListObjectsOptions.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/ListObjectsOptions.cs
@@ -21,7 +21,7 @@ namespace Google.Storage.V1
     /// <summary>
     /// Options for <c>ListObjects</c> operations.
     /// </summary>
-    public class ListObjectsOptions
+    public sealed class ListObjectsOptions
     {
         // TODO: We can't currently return both objects *and* prefixes. Should we have a separate ListPrefixes method?
         // Something more complex? It's unclear how common this is.

--- a/apis/Google.Storage.V1/Google.Storage.V1/PatchBucketOptions.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/PatchBucketOptions.cs
@@ -22,24 +22,24 @@ namespace Google.Storage.V1
     /// <summary>
     /// Options for <c>PatchBucket</c> operations.
     /// </summary>
-    public class PatchBucketOptions
+    public sealed class PatchBucketOptions
     {        
         /// <summary>
         /// Precondition for patch: the bucket is only patched if its current
         /// meta-generation matches the given value.
         /// </summary>
-        public long? IfMetagenerationMatch;
+        public long? IfMetagenerationMatch { get; set; }
 
         /// <summary>
         /// Precondition for patch: the bucket is only patched if its current
         /// meta-generation does not match the given value.
         /// </summary>
-        public long? IfMetagenerationNotMatch;
+        public long? IfMetagenerationNotMatch { get; set; }
 
         /// <summary>
         /// The projection of the updated object to return.
         /// </summary>
-        public Projection? Projection;
+        public Projection? Projection { get; set; }
 
         /// <summary>
         /// A pre-defined ACL of the bucket for simple access control scenarios.

--- a/apis/Google.Storage.V1/Google.Storage.V1/PatchObjectOptions.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/PatchObjectOptions.cs
@@ -22,7 +22,7 @@ namespace Google.Storage.V1
     /// <summary>
     /// Options for <c>PatchObject</c> operations.
     /// </summary>
-    public class PatchObjectOptions
+    public sealed class PatchObjectOptions
     {
         /// <summary>
         /// If present, selects a specific revision of this object (as opposed to the latest version, the default).
@@ -33,35 +33,35 @@ namespace Google.Storage.V1
         /// Precondition for patch: the object is only patched if the existing object's
         /// generation matches the given value.
         /// </summary>
-        public long? IfGenerationMatch;
+        public long? IfGenerationMatch { get; set; }
 
         /// <summary>
         /// Precondition for patch: the object is only patched if the existing object's
         /// generation does not match the given value.
         /// </summary>
-        public long? IfGenerationNotMatch;
+        public long? IfGenerationNotMatch { get; set; }
 
         /// <summary>
         /// Precondition for patch: the object is only patched if the existing object's
         /// meta-generation matches the given value.
         /// </summary>
-        public long? IfMetagenerationMatch;
+        public long? IfMetagenerationMatch { get; set; }
 
         /// <summary>
         /// Precondition for patch: the object is only patched if the existing object's
         /// meta-generation does not match the given value.
         /// </summary>
-        public long? IfMetagenerationNotMatch;
+        public long? IfMetagenerationNotMatch { get; set; }
 
         /// <summary>
         /// The projection of the updated object to return.
         /// </summary>
-        public Projection? Projection;
+        public Projection? Projection { get; set; }
 
         /// <summary>
         /// A pre-defined ACL for simple access control scenarios.
         /// </summary>
-        public PredefinedObjectAcl? PredefinedAcl;
+        public PredefinedObjectAcl? PredefinedAcl { get; set; }
 
         internal void ModifyRequest(PatchRequest request)
         {

--- a/apis/Google.Storage.V1/Google.Storage.V1/UpdateBucketOptions.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/UpdateBucketOptions.cs
@@ -22,24 +22,24 @@ namespace Google.Storage.V1
     /// <summary>
     /// Options for <c>UpdateBucket</c> operations.
     /// </summary>
-    public class UpdateBucketOptions
+    public sealed class UpdateBucketOptions
     {
         /// <summary>
         /// Precondition for update: the bucket is only updated if its current
         /// meta-generation matches the given value.
         /// </summary>
-        public long? IfMetagenerationMatch;
+        public long? IfMetagenerationMatch { get; set; }
 
         /// <summary>
         /// Precondition for update: the bucket is only updated if its current
         /// meta-generation does not match the given value.
         /// </summary>
-        public long? IfMetagenerationNotMatch;
+        public long? IfMetagenerationNotMatch { get; set; }
 
         /// <summary>
         /// The projection of the updated object to return.
         /// </summary>
-        public Projection? Projection;
+        public Projection? Projection { get; set; }
 
         /// <summary>
         /// A pre-defined ACL of the bucket for simple access control scenarios.

--- a/apis/Google.Storage.V1/Google.Storage.V1/UpdateObjectOptions.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/UpdateObjectOptions.cs
@@ -22,7 +22,7 @@ namespace Google.Storage.V1
     /// <summary>
     /// Options for <c>UpdateObject</c> operations.
     /// </summary>
-    public class UpdateObjectOptions
+    public sealed class UpdateObjectOptions
     {
         /// <summary>
         /// If present, selects a specific revision of this object (as opposed to the latest version, the default).

--- a/apis/Google.Storage.V1/Google.Storage.V1/UploadObjectOptions.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/UploadObjectOptions.cs
@@ -25,7 +25,7 @@ namespace Google.Storage.V1
     /// <summary>
     /// Options for <c>UploadObject</c> operations.
     /// </summary>
-    public class UploadObjectOptions
+    public sealed class UploadObjectOptions
     {
         /// <summary>
         /// The minimum chunk size for uploading.

--- a/tools/Google.Cloud.ClientTesting/CodeHealthTester.cs
+++ b/tools/Google.Cloud.ClientTesting/CodeHealthTester.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Google.Cloud.ClientTesting
+{
+    public static class CodeHealthTester
+    {
+        /// <summary>
+        /// Asserts that all the fields in the assembly containing the given type are private,
+        /// other than for constants.
+        /// </summary>
+        public static void AssertAllFieldsPrivate(Type sampleType)
+        {
+            var badFields = from type in sampleType.GetTypeInfo().Assembly.DefinedTypes
+                            // Exempt enums and compiler-generated types
+                            where !type.IsEnum && !type.IsDefined(typeof(CompilerGeneratedAttribute))
+                            from field in type.DeclaredFields
+                            where !field.IsPrivate && !field.IsLiteral
+                            // Allow internal static readonly fields, e.g. for singletons
+                            where !(field.IsAssembly && field.IsStatic && field.IsInitOnly)
+                            select $"{type.Name}.{field.Name}";
+            // Force output to show the bad fields
+            Assert.Equal(new string[0], badFields.ToList());
+        }
+
+        /// <summary>
+        /// Asserts that all the classes in the assembly containing the given type are either abstract
+        /// or sealed.
+        /// </summary>
+        public static void AssertClassesAreSealedOrAbstract(Type sampleType)
+        {
+            var badTypes = from type in sampleType.GetTypeInfo().Assembly.DefinedTypes
+                           where type.IsClass && !type.IsAbstract && !type.IsSealed
+                           select type.Name;
+            // Force output to show the bad types
+            Assert.Equal(new string[0], badTypes.ToList());
+        }
+    }
+}


### PR DESCRIPTION
Added rudimentary code health tests - just for the REST
libraries at the moment. These could of course be implemented
in any number of other ways, but this felt like the simplest
way to get started, and it spotted various issues...

Fixes #160 along the way. (Not for the gRPC clients, but they
don't have all the options classes anyway, which was my main concern.)