### PR TITLE
Temporary fix for dotnet cli installer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,8 @@ install:
   - mkdir .\scripts
   - curl -SL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1 -o .\scripts\dotnet-install.ps1
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
+  # Workaround for https://github.com/dotnet/cli/issues/4712
+  - mkdir .dotnetcli
   - ps: '& .\scripts\dotnet-install.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -Version 1.0.0-preview2-003121 -NoPath'
   # Download and unpack docfx
   - mkdir docfx


### PR DESCRIPTION
See https://github.com/dotnet/cli/issues/4712 for
cause - the script is generally designed not to need the
installation directory to exist beforehand, but a recent change
broke that.