### PR TITLE
Implement default preconditions for object/bucket updates

### DIFF
--- a/apis/Google.Storage.V1/Google.Storage.V1/StorageClient.UpdateBucket.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/StorageClient.UpdateBucket.cs
@@ -25,9 +25,16 @@ namespace Google.Storage.V1
         /// Updates the metadata for a storage bucket synchronously.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// As this is a full update, <paramref name="bucket"/> must be fully populated. This is typically
         /// obtained by performing another operation (such as <see cref="GetBucket(string, GetBucketOptions)"/>
         /// with a "full" projection, and then modifying the returned object.
+        /// </para>
+        /// <para>
+        /// If no preconditions are explicitly set in <paramref name="options"/>, the metageneration of <paramref name="bucket"/>
+        /// is used as a precondition for the update, unless <see cref="UpdateBucketOptions.ForceNoPreconditions"/> is
+        /// set to <c>true</c>.
+        /// </para>
         /// </remarks>
         /// <param name="bucket">Bucket to update. Must not be null, and must have populated <c>Name</c>,
         /// <c>Bucket</c> and <c>Acl</c> properties.</param>
@@ -45,9 +52,16 @@ namespace Google.Storage.V1
         /// Updates the metadata for storage bucket asynchronously.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// As this is a full update, <paramref name="bucket"/> must be fully populated. This is typically
         /// obtained by performing another operation (such as <see cref="GetBucketAsync(string, GetBucketOptions, CancellationToken)"/>
         /// with a "full" projection, and then modifying the returned object.
+        /// </para>
+        /// <para>
+        /// If no preconditions are explicitly set in <paramref name="options"/>, the metageneration of <paramref name="bucket"/>
+        /// is used as a precondition for the update, unless <see cref="UpdateBucketOptions.ForceNoPreconditions"/> is
+        /// set to <c>true</c>.
+        /// </para>
         /// </remarks>
         /// <param name="bucket">Bucket to update. Must not be null, and must have populated <c>Name</c>
         /// and <c>Acl</c> properties.</param>

--- a/apis/Google.Storage.V1/Google.Storage.V1/StorageClient.UpdateObject.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/StorageClient.UpdateObject.cs
@@ -27,9 +27,17 @@ namespace Google.Storage.V1
         /// Updates the metadata for an object in storage synchronously.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// As this is a full update, <paramref name="obj"/> must be fully populated. This is typically
         /// obtained by performing another operation (such as <see cref="GetObject(string, string, GetObjectOptions)"/>
         /// with a "full" projection, and then modifying the returned object.
+        /// </para>
+        /// <para>
+        /// If no preconditions are explicitly set in <paramref name="options"/>, the generation and
+        /// metageneration of <paramref name="obj"/> are used as a precondition for the update,
+        /// unless <see cref="UpdateObjectOptions.ForceNoPreconditions"/> is
+        /// set to <c>true</c>.
+        /// </para>
         /// </remarks>
         /// <param name="obj">Object to update. Must not be null, and must have populated <c>Name</c>,
         /// <c>Bucket</c> and <c>Acl</c> properties.</param>
@@ -47,9 +55,17 @@ namespace Google.Storage.V1
         /// Updates the metadata for an object in storage asynchronously.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// As this is a full update, <paramref name="obj"/> must be fully populated. This is typically
         /// obtained by performing another operation (such as <see cref="GetObjectAsync(string, string, GetObjectOptions, CancellationToken)"/>
         /// with a "full" projection, and then modifying the returned object.
+        /// </para>
+        /// <para>
+        /// If no preconditions are explicitly set in <paramref name="options"/>, the generation and
+        /// metageneration of <paramref name="obj"/> are used as a precondition for the update,
+        /// unless <see cref="UpdateObjectOptions.ForceNoPreconditions"/> is
+        /// set to <c>true</c>.
+        /// </para>
         /// </remarks>
         /// <param name="obj">Object to update. Must not be null, and must have populated <c>Name</c>,
         /// <c>Bucket</c> and <c>Acl</c> properties.</param>

--- a/apis/Google.Storage.V1/Google.Storage.V1/StorageClientImpl.UpdateBucket.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/StorageClientImpl.UpdateBucket.cs
@@ -40,7 +40,7 @@ namespace Google.Storage.V1
             ValidateBucket(bucket, nameof(bucket));
             GaxPreconditions.CheckArgument(bucket.Acl != null, nameof(bucket), "The Acl property of the bucket to update is null");
             var request = Service.Buckets.Update(bucket, bucket.Name);
-            options?.ModifyRequest(request);
+            options?.ModifyRequest(request, bucket);
             return request;
         }
     }

--- a/apis/Google.Storage.V1/Google.Storage.V1/StorageClientImpl.UpdateObject.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/StorageClientImpl.UpdateObject.cs
@@ -42,7 +42,7 @@ namespace Google.Storage.V1
             GaxPreconditions.CheckArgument(obj.Name != null, nameof(obj), "The Name property of the object to update is null");
             GaxPreconditions.CheckArgument(obj.Acl != null, nameof(obj), "The Acl property of the object to update is null");
             var request = Service.Objects.Update(obj, obj.Bucket, obj.Name);
-            options?.ModifyRequest(request);
+            options?.ModifyRequest(request, obj);
             return request;
         }
     }


### PR DESCRIPTION
For an object, both the generation and metageneration are used as
preconditions. For a bucket, there's only the metageneration.

This doesn't apply a precondition when uploading new data; it
only affects metadata (UpdateObject/UpdateBucket). We may wish to
change this decision later, based on feedback.

This will fix #397 when it's all done.

// cc @Capstan, @SurferJeffAtGoogle for comments.