### PR TITLE
Remove restriction on update object/bucket

### DIFF
--- a/apis/Google.Storage.V1/Google.Storage.V1.IntegrationTests/UpdateBucketTest.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1.IntegrationTests/UpdateBucketTest.cs
@@ -35,7 +35,7 @@ namespace Google.Storage.V1.IntegrationTests
             var bucketName = _fixture.BucketPrefix + "bucket-to-update";
             _fixture.CreateBucket(bucketName, false);
 
-            var bucket = client.GetBucket(bucketName, new GetBucketOptions { Projection = Projection.Full });
+            var bucket = client.GetBucket(bucketName);
             bucket.Website = new WebsiteData { MainPageSuffix = "http://example.com" };
 
             client.UpdateBucket(bucket);

--- a/apis/Google.Storage.V1/Google.Storage.V1.IntegrationTests/UpdateObjectTest.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1.IntegrationTests/UpdateObjectTest.cs
@@ -36,21 +36,10 @@ namespace Google.Storage.V1.IntegrationTests
         {
             var client = _fixture.Client;
             var obj = client.UploadObject(_fixture.SingleVersionBucket, GenerateName(), null,
-                new MemoryStream(_fixture.SmallContent), new UploadObjectOptions { Projection = Projection.Full });
+                new MemoryStream(_fixture.SmallContent));
             obj.Metadata = new Dictionary<string, string> { { "key", "value" } };
             var updated = client.UpdateObject(obj);
             Assert.Equal("value", updated.Metadata["key"]);
-        }
-
-        [Fact]
-        public void NoAcl()
-        {
-            // Common way this would happen... we're not getting the full projection, so we have no ACLs.
-            var client = _fixture.Client;
-            var obj = client.UploadObject(_fixture.SingleVersionBucket, GenerateName(), null,
-                new MemoryStream(_fixture.SmallContent));
-            obj.Metadata = new Dictionary<string, string> { { "key", "value" } };
-            Assert.Throws<ArgumentException>(() => client.UpdateObject(obj));
         }
     }
 }

--- a/apis/Google.Storage.V1/Google.Storage.V1.Snippets/StorageClientSnippets.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1.Snippets/StorageClientSnippets.cs
@@ -123,7 +123,7 @@ namespace Google.Storage.V1.Snippets
 
             // Snippet: UpdateBucket
             var client = StorageClient.Create();
-            var bucket = client.GetBucket(bucketName, new GetBucketOptions { Projection = Projection.Full });
+            var bucket = client.GetBucket(bucketName);
             bucket.Website = new Bucket.WebsiteData
             {
                 MainPageSuffix = "index.html",
@@ -285,10 +285,7 @@ namespace Google.Storage.V1.Snippets
                     { "key2", "value2" }
                 }
             };
-            // The update call requires full object information, so we set the projection to "full" here.
-            // An alternative would be to upload the object and then separately fetch it, again with
-            // a full projection.
-            obj = client.UploadObject(obj, new MemoryStream(content), new UploadObjectOptions { Projection = Projection.Full });
+            obj = client.UploadObject(obj, new MemoryStream(content));
             obj.Metadata.Remove("key1");
             obj.Metadata["key2"] = "updated-value2";
             obj.Metadata["key3"] = "value3";

--- a/apis/Google.Storage.V1/Google.Storage.V1/StorageClient.UpdateBucket.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/StorageClient.UpdateBucket.cs
@@ -26,18 +26,12 @@ namespace Google.Storage.V1
         /// </summary>
         /// <remarks>
         /// <para>
-        /// As this is a full update, <paramref name="bucket"/> must be fully populated. This is typically
-        /// obtained by performing another operation (such as <see cref="GetBucket(string, GetBucketOptions)"/>
-        /// with a "full" projection, and then modifying the returned object.
-        /// </para>
-        /// <para>
         /// If no preconditions are explicitly set in <paramref name="options"/>, the metageneration of <paramref name="bucket"/>
         /// is used as a precondition for the update, unless <see cref="UpdateBucketOptions.ForceNoPreconditions"/> is
         /// set to <c>true</c>.
         /// </para>
         /// </remarks>
-        /// <param name="bucket">Bucket to update. Must not be null, and must have populated <c>Name</c>,
-        /// <c>Bucket</c> and <c>Acl</c> properties.</param>
+        /// <param name="bucket">Bucket to update. Must not be null, and must have a populated <c>Name</c>.</param>
         /// <param name="options">Additional options for the update. May be null, in which case appropriate
         /// defaults will be used.</param>
         /// <returns>The <see cref="Bucket"/> representation of the updated storage bucket.</returns>
@@ -53,18 +47,12 @@ namespace Google.Storage.V1
         /// </summary>
         /// <remarks>
         /// <para>
-        /// As this is a full update, <paramref name="bucket"/> must be fully populated. This is typically
-        /// obtained by performing another operation (such as <see cref="GetBucketAsync(string, GetBucketOptions, CancellationToken)"/>
-        /// with a "full" projection, and then modifying the returned object.
-        /// </para>
-        /// <para>
         /// If no preconditions are explicitly set in <paramref name="options"/>, the metageneration of <paramref name="bucket"/>
         /// is used as a precondition for the update, unless <see cref="UpdateBucketOptions.ForceNoPreconditions"/> is
         /// set to <c>true</c>.
         /// </para>
         /// </remarks>
-        /// <param name="bucket">Bucket to update. Must not be null, and must have populated <c>Name</c>
-        /// and <c>Acl</c> properties.</param>
+        /// <param name="bucket">Bucket to update. Must not be null, and must have a populated <c>Name</c>.</param>
         /// <param name="options">Additional options for the update. May be null, in which case appropriate
         /// defaults will be used.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>

--- a/apis/Google.Storage.V1/Google.Storage.V1/StorageClient.UpdateObject.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/StorageClient.UpdateObject.cs
@@ -28,19 +28,14 @@ namespace Google.Storage.V1
         /// </summary>
         /// <remarks>
         /// <para>
-        /// As this is a full update, <paramref name="obj"/> must be fully populated. This is typically
-        /// obtained by performing another operation (such as <see cref="GetObject(string, string, GetObjectOptions)"/>
-        /// with a "full" projection, and then modifying the returned object.
-        /// </para>
-        /// <para>
         /// If no preconditions are explicitly set in <paramref name="options"/>, the generation and
         /// metageneration of <paramref name="obj"/> are used as a precondition for the update,
         /// unless <see cref="UpdateObjectOptions.ForceNoPreconditions"/> is
         /// set to <c>true</c>.
         /// </para>
         /// </remarks>
-        /// <param name="obj">Object to update. Must not be null, and must have populated <c>Name</c>,
-        /// <c>Bucket</c> and <c>Acl</c> properties.</param>
+        /// <param name="obj">Object to update. Must not be null, and must have populated <c>Name</c> and
+        /// <c>Bucket</c> properties.</param>
         /// <param name="options">Additional options for the update. May be null, in which case appropriate
         /// defaults will be used.</param>
         /// <returns>The <see cref="Object"/> representation of the updated storage object.</returns>
@@ -56,19 +51,14 @@ namespace Google.Storage.V1
         /// </summary>
         /// <remarks>
         /// <para>
-        /// As this is a full update, <paramref name="obj"/> must be fully populated. This is typically
-        /// obtained by performing another operation (such as <see cref="GetObjectAsync(string, string, GetObjectOptions, CancellationToken)"/>
-        /// with a "full" projection, and then modifying the returned object.
-        /// </para>
-        /// <para>
         /// If no preconditions are explicitly set in <paramref name="options"/>, the generation and
         /// metageneration of <paramref name="obj"/> are used as a precondition for the update,
         /// unless <see cref="UpdateObjectOptions.ForceNoPreconditions"/> is
         /// set to <c>true</c>.
         /// </para>
         /// </remarks>
-        /// <param name="obj">Object to update. Must not be null, and must have populated <c>Name</c>,
-        /// <c>Bucket</c> and <c>Acl</c> properties.</param>
+        /// <param name="obj">Object to update. Must not be null, and must have populated <c>Name</c> and
+        /// <c>Bucket</c> properties.</param>
         /// <param name="options">Additional options for the update. May be null, in which case appropriate
         /// defaults will be used.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>

--- a/apis/Google.Storage.V1/Google.Storage.V1/StorageClientImpl.UpdateBucket.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/StorageClientImpl.UpdateBucket.cs
@@ -38,7 +38,6 @@ namespace Google.Storage.V1
         private BucketsResource.UpdateRequest CreateUpdateBucketRequest(Bucket bucket, UpdateBucketOptions options)
         {
             ValidateBucket(bucket, nameof(bucket));
-            GaxPreconditions.CheckArgument(bucket.Acl != null, nameof(bucket), "The Acl property of the bucket to update is null");
             var request = Service.Buckets.Update(bucket, bucket.Name);
             options?.ModifyRequest(request, bucket);
             return request;

--- a/apis/Google.Storage.V1/Google.Storage.V1/StorageClientImpl.UpdateObject.cs
+++ b/apis/Google.Storage.V1/Google.Storage.V1/StorageClientImpl.UpdateObject.cs
@@ -40,7 +40,6 @@ namespace Google.Storage.V1
             GaxPreconditions.CheckNotNull(obj, nameof(obj));
             GaxPreconditions.CheckArgument(obj.Bucket != null, nameof(obj), "The Bucket property of the object to update is null");
             GaxPreconditions.CheckArgument(obj.Name != null, nameof(obj), "The Name property of the object to update is null");
-            GaxPreconditions.CheckArgument(obj.Acl != null, nameof(obj), "The Acl property of the object to update is null");
             var request = Service.Objects.Update(obj, obj.Bucket, obj.Name);
             options?.ModifyRequest(request, obj);
             return request;


### PR DESCRIPTION
The restriction has been removed on the server side (as proved by
snippet and integration tests) so we don't need to guard against
it in the client code. Docs amended too.

This means we can close #159 as obsolete.