### PR TITLE
NOT FOR SUBMISSION Sketch of the hash validating code.

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Crc32cTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Crc32cTest.cs
@@ -56,7 +56,8 @@ namespace Google.Cloud.Storage.V1.Tests
         public void Hash(IEnumerable<byte> source, byte[] expectedHash)
         {
             var hasher = new Crc32c();
-            byte[] actualHash = hasher.ComputeHash(source.ToArray());
+            hasher.UpdateHash(source.ToArray(), 0, source.Count());
+            byte[] actualHash = hasher.GetHash();
             Assert.Equal(expectedHash, actualHash);
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/DownloadObjectOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/DownloadObjectOptionsTest.cs
@@ -23,7 +23,7 @@ namespace Google.Cloud.Storage.V1.Tests
         [Fact]
         public void ModifyDownloader_DefaultOptions()
         {
-            var downloader = new MediaDownloader(null);
+            var downloader = new TmpMediaDownloader(null);
             var options = new DownloadObjectOptions();
             options.ModifyDownloader(downloader);
             Assert.Equal(MediaDownloader.MaximumChunkSize, downloader.ChunkSize);
@@ -32,7 +32,7 @@ namespace Google.Cloud.Storage.V1.Tests
         [Fact]
         public void ModifyDownloader_WithChunkSize()
         {
-            var downloader = new MediaDownloader(null);
+            var downloader = new TmpMediaDownloader(null);
             var options = new DownloadObjectOptions { ChunkSize = 2048 };
             options.ModifyDownloader(downloader);
             Assert.Equal(2048, downloader.ChunkSize);

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UploadObjectOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UploadObjectOptionsTest.cs
@@ -53,7 +53,7 @@ namespace Google.Cloud.Storage.V1.Tests
         [Fact]
         public void ModifyMediaUpload_DefaultOptions()
         {
-            var upload = new InsertMediaUpload(new DummyService(), null, "bucket", new MemoryStream(), null);
+            var upload = new TmpInsertMediaUpload(new DummyService(), null, "bucket", new MemoryStream(), null);
             var options = new UploadObjectOptions();
             options.ModifyMediaUpload(upload);
             Assert.Equal(ResumableUpload<InsertMediaUpload>.DefaultChunkSize, upload.ChunkSize);
@@ -68,7 +68,7 @@ namespace Google.Cloud.Storage.V1.Tests
         [Fact]
         public void ModifyMediaUpload_AllOptions_PositiveMatch()
         {
-            var upload = new InsertMediaUpload(new DummyService(), null, "bucket", new MemoryStream(), null);
+            var upload = new TmpInsertMediaUpload(new DummyService(), null, "bucket", new MemoryStream(), null);
             var options = new UploadObjectOptions
             {
                 ChunkSize = UploadObjectOptions.MinimumChunkSize * 3,
@@ -89,7 +89,7 @@ namespace Google.Cloud.Storage.V1.Tests
         [Fact]
         public void ModifyMediaUpload_AllOptions_NegativeMatch()
         {
-            var upload = new InsertMediaUpload(new DummyService(), null, "bucket", new MemoryStream(), null);
+            var upload = new TmpInsertMediaUpload(new DummyService(), null, "bucket", new MemoryStream(), null);
             var options = new UploadObjectOptions
             {
                 ChunkSize = UploadObjectOptions.MinimumChunkSize * 3,
@@ -110,7 +110,7 @@ namespace Google.Cloud.Storage.V1.Tests
         [Fact]
         public void ModifyMediaUpload_MatchNotMatchConflicts()
         {
-            var upload = new InsertMediaUpload(new DummyService(), null, "bucket", new MemoryStream(), null);
+            var upload = new TmpInsertMediaUpload(new DummyService(), null, "bucket", new MemoryStream(), null);
             Assert.Throws<ArgumentException>(() =>
             {
                 var options = new UploadObjectOptions { IfGenerationMatch = 1L, IfGenerationNotMatch = 2L };

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DownloadObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DownloadObjectOptions.cs
@@ -55,7 +55,7 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public long? IfMetagenerationNotMatch { get; set; }
 
-        internal void ModifyDownloader(MediaDownloader downloader)
+        internal void ModifyDownloader(TmpMediaDownloader downloader)
         {
             if (ChunkSize != null)
             {

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/HashProvidingUpload.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/HashProvidingUpload.cs
@@ -1,0 +1,152 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Services;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using static Google.Apis.Storage.v1.ObjectsResource;
+using Object = Google.Apis.Storage.v1.Data.Object;
+using System.Net.Http;
+
+namespace Google.Cloud.Storage.V1
+{
+    internal class TmpInsertMediaUpload : Google.Apis.Upload.TmpResumableUpload<Google.Apis.Storage.v1.Data.Object, Google.Apis.Storage.v1.Data.Object>
+    {
+
+        /// <summary>Data format for the response.</summary>
+        /// [default: json]
+        [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual System.Nullable<InsertMediaUpload.AltEnum> Alt { get; set; }
+
+        /// <summary>Selector specifying which fields to include in a partial response.</summary>
+        [Google.Apis.Util.RequestParameterAttribute("fields", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual string Fields { get; set; }
+
+        /// <summary>API key. Your API key identifies your project and provides you with API access, quota, and
+        /// reports. Required unless you provide an OAuth 2.0 token.</summary>
+        [Google.Apis.Util.RequestParameterAttribute("key", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual string Key { get; set; }
+
+        /// <summary>OAuth 2.0 token for the current user.</summary>
+        [Google.Apis.Util.RequestParameterAttribute("oauth_token", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual string OauthToken { get; set; }
+
+        /// <summary>Returns response with indentations and line breaks.</summary>
+        /// [default: true]
+        [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual System.Nullable<bool> PrettyPrint { get; set; }
+
+        /// <summary>Available to use for quota purposes for server-side applications. Can be any arbitrary string
+        /// assigned to a user, but should not exceed 40 characters. Overrides userIp if both are
+        /// provided.</summary>
+        [Google.Apis.Util.RequestParameterAttribute("quotaUser", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual string QuotaUser { get; set; }
+
+        /// <summary>IP address of the site where the request originates. Use this if you want to enforce per-user
+        /// limits.</summary>
+        [Google.Apis.Util.RequestParameterAttribute("userIp", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual string UserIp { get; set; }
+
+
+        /// <summary>Name of the bucket in which to store the new object. Overrides the provided object metadata's
+        /// bucket value, if any.</summary>
+        [Google.Apis.Util.RequestParameterAttribute("bucket", Google.Apis.Util.RequestParameterType.Path)]
+        public virtual string Bucket { get; private set; }
+
+        /// <summary>If set, sets the contentEncoding property of the final object to this value. Setting this
+        /// parameter is equivalent to setting the contentEncoding metadata property. This can be useful when
+        /// uploading an object with uploadType=media to indicate the encoding of the content being
+        /// uploaded.</summary>
+        [Google.Apis.Util.RequestParameterAttribute("contentEncoding", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual string ContentEncoding { get; set; }
+
+        /// <summary>Makes the operation conditional on whether the object's current generation matches the given
+        /// value.</summary>
+        [Google.Apis.Util.RequestParameterAttribute("ifGenerationMatch", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual System.Nullable<long> IfGenerationMatch { get; set; }
+
+        /// <summary>Makes the operation conditional on whether the object's current generation does not match the
+        /// given value.</summary>
+        [Google.Apis.Util.RequestParameterAttribute("ifGenerationNotMatch", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual System.Nullable<long> IfGenerationNotMatch { get; set; }
+
+        /// <summary>Makes the operation conditional on whether the object's current metageneration matches the
+        /// given value.</summary>
+        [Google.Apis.Util.RequestParameterAttribute("ifMetagenerationMatch", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual System.Nullable<long> IfMetagenerationMatch { get; set; }
+
+        /// <summary>Makes the operation conditional on whether the object's current metageneration does not match
+        /// the given value.</summary>
+        [Google.Apis.Util.RequestParameterAttribute("ifMetagenerationNotMatch", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual System.Nullable<long> IfMetagenerationNotMatch { get; set; }
+
+        /// <summary>Name of the object. Required when the object metadata is not otherwise provided. Overrides the
+        /// object metadata's name value, if any. For information about how to URL encode object names to be path
+        /// safe, see Encoding URI Path Parts.</summary>
+        [Google.Apis.Util.RequestParameterAttribute("name", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual string Name { get; set; }
+
+        /// <summary>Apply a predefined set of access controls to this object.</summary>
+        [Google.Apis.Util.RequestParameterAttribute("predefinedAcl", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual System.Nullable<InsertMediaUpload.PredefinedAclEnum> PredefinedAcl { get; set; }        
+
+        /// <summary>Set of properties to return. Defaults to noAcl, unless the object resource specifies the acl
+        /// property, when it defaults to full.</summary>
+        [Google.Apis.Util.RequestParameterAttribute("projection", Google.Apis.Util.RequestParameterType.Query)]
+        public virtual System.Nullable<InsertMediaUpload.ProjectionEnum> Projection { get; set; }
+
+        /// <summary>Constructs a new Insert media upload instance.</summary>
+        public TmpInsertMediaUpload(Google.Apis.Services.IClientService service, Google.Apis.Storage.v1.Data.Object body, string
+         bucket, System.IO.Stream stream, string contentType)
+            : base(service, string.Format("/{0}/{1}{2}", "upload", service.BasePath, "b/{bucket}/o"), "POST", stream, contentType)
+        {
+            Bucket = bucket;
+            Body = body;
+        }
+    }
+
+    /// <summary>
+    /// Subclass of <see cref="InsertMediaUpload"/> which provides the expected crc32c hash
+    /// of the chunk in a header for each request.
+    /// </summary>
+    internal sealed class HashProvidingUpload : TmpInsertMediaUpload
+    {
+        internal HashProvidingUpload(IClientService service, Object body, string bucket, Stream stream, string contentType)
+            : base(service, body, bucket, stream, contentType)
+        {
+        }
+
+        protected override void ModifyRequest(HttpRequestMessage httpRequest)
+        {
+            base.ModifyRequest(httpRequest);
+
+            var hash = new Crc32c();
+            // We know the request contains data in memory, either as a ByteArrayContent or a StreamContent
+            // wrapping a MemoryStream.
+            var stream = httpRequest.Content.ReadAsStreamAsync().Result;
+            // Nice and small...
+            byte[] hashBuffer = new byte[1024];
+            int bytesRead;
+            while ((bytesRead = stream.Read(hashBuffer, 0, hashBuffer.Length)) > 0)
+            {
+                hash.UpdateHash(hashBuffer, 0, bytesRead);
+            }
+            stream.Position = 0;
+            httpRequest.Headers.Add(Crc32c.HashHeaderName, $"{Crc32c.HashName}={Convert.ToBase64String(hash.GetHash())}");
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/HashValidatingDownloader.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/HashValidatingDownloader.cs
@@ -1,0 +1,81 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Download;
+using Google.Apis.Services;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+
+namespace Google.Cloud.Storage.V1
+{
+    /// <summary>
+    /// Subclass of <see cref="MediaDownloader"/> which validates the data it receives
+    /// against a CRC32c hash set in the header.
+    /// </summary>
+    internal sealed class HashValidatingDownloader : TmpMediaDownloader
+    {
+        private string crc32cHashBase64;
+        private Crc32c hasher;
+
+        /// <summary>Constructs a new downloader with the given client service.</summary>
+        internal HashValidatingDownloader(IClientService service) : base(service)
+        {
+        }
+
+        protected override void OnResponseReceived(HttpResponseMessage response)
+        {
+            base.OnResponseReceived(response);
+
+            crc32cHashBase64 = null;
+            hasher = new Crc32c();
+
+            IEnumerable<string> values;
+            if (response.Headers.TryGetValues(Crc32c.HashHeaderName, out values))
+            {
+                string prefix = Crc32c.HashName + "=";
+                foreach (var value in values.SelectMany(v => v.Split(',')))
+                {
+                    if (value.StartsWith(prefix))
+                    {
+                        crc32cHashBase64 = value.Substring(prefix.Length);
+                        break;
+                    }
+                }
+            }
+        }
+
+        protected override void OnDataReceived(byte[] data, int length)
+        {
+            base.OnDataReceived(data, length);
+            hasher.UpdateHash(data, 0, length);
+        }
+
+        protected override void OnDownloadCompleted()
+        {
+            base.OnDownloadCompleted();
+
+            if (crc32cHashBase64 != null)
+            {
+                string actualHash = Convert.ToBase64String(hasher.GetHash());
+                if (actualHash != crc32cHashBase64)
+                {
+                    throw new IOException($"Incorrect hash: expected '{crc32cHashBase64}' (base64), was '{actualHash}' (base64)");
+                }
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/RemoveMe/MediaApiErrorHandling.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/RemoveMe/MediaApiErrorHandling.cs
@@ -1,0 +1,69 @@
+﻿/*
+Copyright 2015 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+
+using Google.Apis.Requests;
+using Google.Apis.Services;
+using Google.Apis.Util;
+
+namespace Google.Apis.Media
+{
+    /// <summary>
+    /// Common error handling code for the Media API.
+    /// </summary>
+    internal static class MediaApiErrorHandling
+    {
+        /// <summary>
+        /// Creates a suitable exception for an HTTP response, attempting to parse the body as
+        /// JSON but falling back to just using the text as the message.
+        /// </summary>
+        internal static async Task<GoogleApiException> ExceptionForResponseAsync(
+            IClientService service,
+            HttpResponseMessage response)
+        {
+            // If we can't even read the response, let that exception bubble up, just as it would have done
+            // if the error had been occurred when sending the request.
+            string responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            RequestError parsedError = null;
+            string message = responseText;
+            try
+            {
+                var parsedResponse = service.Serializer.Deserialize<StandardResponse<object>>(responseText);
+                if (parsedResponse != null && parsedResponse.Error != null)
+                {
+                    parsedError = parsedResponse.Error;
+                    message = parsedError.ToString();
+                }
+            }
+            catch (JsonException)
+            {
+                // Just make do with a null RequestError, and the message set to the body of the response.
+                // The contents of the caught exception aren't particularly useful - we don't need to include it
+                // as a cause, for example. The expectation is that the exception returned by this method (below)
+                // will be thrown by the caller.
+            }
+            return new GoogleApiException(service.Name, message)
+            {
+                Error = parsedError,
+                HttpStatusCode = response.StatusCode
+            };
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/RemoveMe/MediaDownloader.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/RemoveMe/MediaDownloader.cs
@@ -1,0 +1,355 @@
+﻿#pragma warning disable CS1591
+/*
+Copyright 2013 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Google.Apis.Logging;
+using Google.Apis.Media;
+using Google.Apis.Services;
+using Google.Apis.Util;
+using System.Net.Http.Headers;
+
+namespace Google.Apis.Download
+{
+    /// <summary>
+    /// A media downloader implementation which handles media downloads.
+    /// </summary>
+    public class TmpMediaDownloader : IMediaDownloader
+    {
+        static TmpMediaDownloader()
+        {
+            UriPatcher.PatchUriQuirks();
+        }
+
+        private static readonly ILogger Logger = ApplicationContext.Logger.ForType<TmpMediaDownloader>();
+
+        /// <summary>The service which this downloader belongs to.</summary>
+        private readonly IClientService service;
+
+        private const int MB = 0x100000;
+
+        /// <summary>Maximum chunk size. Default value is 10*MB.</summary>
+        public const int MaximumChunkSize = 10 * MB;
+
+        private int chunkSize = MaximumChunkSize;
+        /// <summary>
+        /// Gets or sets the amount of data that will be downloaded before notifying the caller of
+        /// the download's progress.
+        /// Must not exceed <see cref="MaximumChunkSize"/>.
+        /// Default value is <see cref="MaximumChunkSize"/>.
+        /// </summary>
+        public int ChunkSize
+        {
+            get { return chunkSize; }
+            set
+            {
+                if (value > MaximumChunkSize)
+                {
+                    throw new ArgumentOutOfRangeException("ChunkSize");
+                }
+                chunkSize = value;
+            }
+        }
+
+        /// <summary>
+        /// The range header for the request, if any. This can be used to download specific parts
+        /// of the requested media.
+        /// </summary>
+        public RangeHeaderValue Range { get; set; }
+
+        #region Progress
+
+        /// <summary>
+        /// Download progress model, which contains the status of the download, the amount of bytes whose where 
+        /// downloaded so far, and an exception in case an error had occurred.
+        /// </summary>
+        private class DownloadProgress : IDownloadProgress
+        {
+            /// <summary>Constructs a new progress instance.</summary>
+            /// <param name="status">The status of the download.</param>
+            /// <param name="bytes">The number of bytes received so far.</param>
+            public DownloadProgress(DownloadStatus status, long bytes)
+            {
+                Status = status;
+                BytesDownloaded = bytes;
+            }
+
+            /// <summary>Constructs a new progress instance.</summary>
+            /// <param name="exception">An exception which occurred during the download.</param>
+            /// <param name="bytes">The number of bytes received before the exception occurred.</param>
+            public DownloadProgress(Exception exception, long bytes)
+            {
+                Status = DownloadStatus.Failed;
+                BytesDownloaded = bytes;
+                Exception = exception;
+            }
+
+            /// <summary>Gets or sets the status of the download.</summary>
+            public DownloadStatus Status { get; private set; }
+
+            /// <summary>Gets or sets the amount of bytes that have been downloaded so far.</summary>
+            public long BytesDownloaded { get; private set; }
+
+            /// <summary>Gets or sets the exception which occurred during the download or <c>null</c>.</summary>
+            public Exception Exception { get; private set; }
+        }
+
+        /// <summary>
+        /// Updates the current progress and call the <see cref="ProgressChanged"/> event to notify listeners.
+        /// </summary>
+        private void UpdateProgress(IDownloadProgress progress)
+        {
+            ProgressChanged?.Invoke(progress);
+        }
+
+        #endregion
+
+        /// <summary>Constructs a new downloader with the given client service.</summary>
+        public TmpMediaDownloader(IClientService service)
+        {
+            this.service = service;
+        }
+
+        #region IMediaDownloader Overrides
+
+        public event Action<IDownloadProgress> ProgressChanged;
+
+        #region Download (sync and async)
+
+        public IDownloadProgress Download(string url, Stream stream)
+        {
+            return DownloadCoreAsync(url, stream, CancellationToken.None).Result;
+        }
+
+        public async Task<IDownloadProgress> DownloadAsync(string url, Stream stream)
+        {
+            return await DownloadAsync(url, stream, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public async Task<IDownloadProgress> DownloadAsync(string url, Stream stream,
+            CancellationToken cancellationToken)
+        {
+            return await DownloadCoreAsync(url, stream, cancellationToken).ConfigureAwait(false);
+        }
+
+        #endregion
+
+        #endregion
+
+        /// <summary>
+        /// CountedBuffer bundles together a byte buffer and a count of valid bytes.
+        /// </summary>
+        private class CountedBuffer
+        {
+            public byte[] Data { get; set; }
+
+            /// <summary>
+            /// How many bytes at the beginning of Data are valid.
+            /// </summary>
+            public int Count { get; private set; }
+
+            public CountedBuffer(int size)
+            {
+                Data = new byte[size];
+                Count = 0;
+            }
+
+            /// <summary>
+            /// Returns true if the buffer contains no data.
+            /// </summary>
+            public bool IsEmpty { get { return Count == 0; } }
+
+            /// <summary>
+            /// Read data from stream until the stream is empty or the buffer is full.
+            /// </summary>
+            /// <param name="stream">Stream from which to read.</param>
+            /// <param name="cancellationToken">Cancellation token for the operation.</param>
+            public async Task Fill(Stream stream, CancellationToken cancellationToken)
+            {
+                // ReadAsync may return if it has *any* data available, so we loop.
+                while (Count < Data.Length)
+                {
+                    int read = await stream.ReadAsync(Data, Count, Data.Length - Count, cancellationToken).ConfigureAwait(false);
+                    if (read == 0) { break; }
+                    Count += read;
+                }
+            }
+
+            /// <summary>
+            /// Remove the first n bytes of the buffer. Move any remaining valid bytes to the beginning.
+            /// Trying to remove more bytes than the buffer contains just clears the buffer.
+            /// </summary>
+            /// <param name="n">The number of bytes to remove.</param>
+            public void RemoveFromFront(int n)
+            {
+                if (n >= Count)
+                {
+                    Count = 0;
+                }
+                else
+                {
+                    // Some valid data remains.
+                    Array.Copy(Data, n, Data, 0, Count - n);
+                    Count -= n;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The core download logic. We download the media and write it to an output stream
+        /// ChunkSize bytes at a time, raising the ProgressChanged event after each chunk.
+        /// 
+        /// The chunking behavior is largely a historical artifact: a previous implementation
+        /// issued multiple web requests, each for ChunkSize bytes. Now we do everything in
+        /// one request, but the API and client-visible behavior are retained for compatibility.
+        /// </summary>
+        /// <param name="url">The URL of the resource to download.</param>
+        /// <param name="stream">The download will download the resource into this stream.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel this download in the middle.</param>
+        /// <returns>A task with the download progress object. If an exception occurred during the download, its 
+        /// <see cref="IDownloadProgress.Exception "/> property will contain the exception.</returns>
+        private async Task<IDownloadProgress> DownloadCoreAsync(string url, Stream stream,
+            CancellationToken cancellationToken)
+        {
+            url.ThrowIfNull("url");
+            stream.ThrowIfNull("stream");
+            if (!stream.CanWrite)
+            {
+                throw new ArgumentException("stream doesn't support write operations");
+            }
+
+            // Add alt=media to the query parameters.
+            var uri = new UriBuilder(url);
+            if (uri.Query == null || uri.Query.Length <= 1)
+            {
+                uri.Query = "alt=media";
+            }
+            else
+            {
+                // Remove the leading '?'. UriBuilder.Query doesn't round-trip.
+                uri.Query = uri.Query.Substring(1) + "&alt=media";
+            }
+
+            var request = new HttpRequestMessage(HttpMethod.Get, uri.ToString());
+            request.Headers.Range = Range;
+
+            // Number of bytes sent to the caller's stream.
+            long bytesReturned = 0;
+
+            try
+            {
+                // Signal SendAsync to return as soon as the response headers are read.
+                // We'll stream the content ourselves as it becomes available.
+                var completionOption = HttpCompletionOption.ResponseHeadersRead;
+
+                using (var response = await service.HttpClient.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false))
+                {
+                    OnResponseReceived(response);
+
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        throw await MediaApiErrorHandling.ExceptionForResponseAsync(service, response).ConfigureAwait(false);
+                    }
+
+                    using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                    {
+                        // We send ChunkSize bytes at a time to the caller, but we keep ChunkSize + 1 bytes
+                        // buffered. That way we can tell when we've reached the end of the response, even if the
+                        // response length is evenly divisible by ChunkSize, and we can avoid sending a Downloading
+                        // event followed by a Completed event with no bytes downloaded in between.
+                        //
+                        // This maintains the client-visible behavior of a previous implementation.
+                        var buffer = new CountedBuffer(ChunkSize + 1);
+
+                        while (true)
+                        {
+                            await buffer.Fill(responseStream, cancellationToken).ConfigureAwait(false);
+
+                            // Send one chunk to the caller's stream.
+                            int bytesToReturn = Math.Min(ChunkSize, buffer.Count);
+                            OnDataReceived(buffer.Data, bytesToReturn);
+                            await stream.WriteAsync(buffer.Data, 0, bytesToReturn, cancellationToken).ConfigureAwait(false);
+                            bytesReturned += bytesToReturn;
+
+                            buffer.RemoveFromFront(ChunkSize);
+                            if (buffer.IsEmpty)
+                            {
+                                // We had <= ChunkSize bytes buffered, so we've read and returned the entire response.
+                                // Skip sending a Downloading event. We'll send Completed instead.
+                                break;
+                            }
+
+                            UpdateProgress(new DownloadProgress(DownloadStatus.Downloading, bytesReturned));
+                        }
+                    }
+                    OnDownloadCompleted();
+
+                    var finalProgress = new DownloadProgress(DownloadStatus.Completed, bytesReturned);
+                    UpdateProgress(finalProgress);
+                    return finalProgress;
+                }
+            }
+            catch (TaskCanceledException ex)
+            {
+                Logger.Error(ex, "Download media was canceled");
+                UpdateProgress(new DownloadProgress(ex, bytesReturned));
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Exception occurred while downloading media");
+                var progress = new DownloadProgress(ex, bytesReturned);
+                UpdateProgress(progress);
+                return progress;
+            }
+        }
+
+        /// <summary>
+        /// Called when an HTTP response is received, allowing subclasses to examine headers.
+        /// </summary>
+        /// <param name="response">HTTP response received.</param>
+        protected virtual void OnResponseReceived(HttpResponseMessage response)
+        {
+            // No-op
+        }
+
+        /// <summary>
+        /// Called when an HTTP response is received, allowing subclasses to examine data before it's
+        /// written to the client stream.
+        /// </summary>
+        /// <param name="data">Byte array containing the data downloaded.</param>
+        /// <param name="length">Length of data downloaded in this chunk, in bytes.</param>
+        protected virtual void OnDataReceived(byte[] data, int length)
+        {
+            // No-op
+        }
+
+        /// <summary>
+        /// Called when a download has completed, allowing subclasses to perform any final validation
+        /// or transformation.
+        /// </summary>
+        protected virtual void OnDownloadCompleted()
+        {
+            // No-op
+        }
+    }
+}
+#pragma warning restore CS1591

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/RemoveMe/ResumableUpload.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/RemoveMe/ResumableUpload.cs
@@ -1,0 +1,964 @@
+﻿#pragma warning disable CS1591
+/*
+Copyright 2012 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System;
+using System.Collections;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Reflection;
+
+using Google.Apis.Http;
+using Google.Apis.Logging;
+using Google.Apis.Media;
+using Google.Apis.Requests;
+using Google.Apis.Services;
+using Google.Apis.Testing;
+using Google.Apis.Util;
+
+namespace Google.Apis.Upload
+{
+    /// <summary>
+    /// Media upload which uses Google's resumable media upload protocol to upload data.
+    /// </summary>
+    /// <remarks>
+    /// See: https://developers.google.com/drive/manage-uploads#resumable for more information on the protocol.
+    /// </remarks>
+    /// <typeparam name="TRequest">
+    /// The type of the body of this request. Generally this should be the metadata related to the content to be 
+    /// uploaded. Must be serializable to/from JSON.
+    /// </typeparam>
+    public class TmpResumableUpload<TRequest>
+    {
+        #region Constants
+
+        /// <summary>The class logger.</summary>
+        private static readonly ILogger Logger = ApplicationContext.Logger.ForType<TmpResumableUpload<TRequest>>();
+
+        private const int KB = 0x400;
+        private const int MB = 0x100000;
+
+        /// <summary>Minimum chunk size (except the last one). Default value is 256*KB.</summary>
+        public const int MinimumChunkSize = 256 * KB;
+
+        /// <summary>Default chunk size. Default value is 10*MB.</summary>
+        public const int DefaultChunkSize = 10 * MB;
+
+        /// <summary>
+        /// Defines how many bytes are read from the input stream in each stream read action. 
+        /// The read will continue until we read <see cref="MinimumChunkSize"/> or we reached the end of the stream.
+        /// </summary>
+        internal int BufferSize = 4 * KB;
+
+        /// <summary>Indicates the stream's size is unknown.</summary>
+        private const int UnknownSize = -1;
+
+        /// <summary>The mime type for the encoded JSON body.</summary>
+        private const string JsonMimeType = "application/json; charset=UTF-8";
+
+        /// <summary>Payload description headers, describing the content itself.</summary>
+        private const string PayloadContentTypeHeader = "X-Upload-Content-Type";
+
+        /// <summary>Payload description headers, describing the content itself.</summary>
+        private const string PayloadContentLengthHeader = "X-Upload-Content-Length";
+
+        /// <summary>Specify the type of this upload (this class supports resumable only).</summary>
+        private const string UploadType = "uploadType";
+
+        /// <summary>The uploadType parameter value for resumable uploads.</summary>
+        private const string Resumable = "resumable";
+
+        /// <summary>Content-Range header value for the body upload of zero length files.</summary>
+        private const string ZeroByteContentRangeHeader = "bytes */0";
+
+        #endregion // Constants
+
+        #region Construction
+
+        /// <summary>
+        /// Create a resumable upload instance with the required parameters.
+        /// </summary>
+        /// <param name="service">The client service.</param>
+        /// <param name="path">The path for this media upload method.</param>
+        /// <param name="httpMethod">The HTTP method to start this upload.</param>
+        /// <param name="contentStream">The stream containing the content to upload.</param>
+        /// <param name="contentType">Content type of the content to be uploaded. Some services
+        /// may allow this to be null; others require a content type to be specified and will
+        /// fail when the upload is started if the value is null.</param>
+        /// <remarks>
+        /// Caller is responsible for maintaining the <paramref name="contentStream"/> open until the upload is 
+        /// completed.
+        /// Caller is responsible for closing the <paramref name="contentStream"/>.
+        /// </remarks>
+        protected TmpResumableUpload(IClientService service, string path, string httpMethod, Stream contentStream,
+            string contentType)
+        {
+            service.ThrowIfNull(nameof(service));
+            path.ThrowIfNull(nameof(path));
+            httpMethod.ThrowIfNullOrEmpty(nameof(httpMethod));
+            contentStream.ThrowIfNull(nameof(contentStream));
+
+            this.Service = service;
+            this.Path = path;
+            this.HttpMethod = httpMethod;
+            this.ContentStream = contentStream;
+            this.ContentType = contentType;
+        }
+
+        #endregion // Construction
+
+        #region Properties
+
+        /// <summary>Gets or sets the service.</summary>
+        public IClientService Service { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the path of the method (combined with
+        /// <see cref="Google.Apis.Services.IClientService.BaseUri"/>) to produce 
+        /// absolute Uri. 
+        /// </summary>
+        public string Path { get; private set; }
+
+        /// <summary>Gets or sets the HTTP method of this upload (used to initialize the upload).</summary>
+        public string HttpMethod { get; private set; }
+
+        /// <summary>Gets or sets the stream to upload.</summary>
+        public Stream ContentStream { get; private set; }
+
+        /// <summary>Gets or sets the stream's Content-Type.</summary>
+        public string ContentType { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the length of the steam. Will be <see cref="UnknownSize" /> if the media content length is 
+        /// unknown. 
+        /// </summary>
+        private long StreamLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content of the last buffer request to the server or <c>null</c>. It is used when the media
+        /// content length is unknown, for resending it in case of server error.
+        /// Only used with a non-seekable stream.
+        /// </summary>
+        private byte[] LastMediaRequest { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last request length.
+        /// Only used with a non-seekable stream.
+        /// </summary>
+        private int LastMediaLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets the resumable session Uri. 
+        /// See https://developers.google.com/drive/manage-uploads#save-session-uri" for more details.
+        /// </summary>
+        private Uri UploadUri { get; set; }
+
+        /// <summary>Gets or sets the amount of bytes the server had received so far.</summary>
+        private long BytesServerReceived { get; set; }
+
+        /// <summary>Gets or sets the amount of bytes the client had sent so far.</summary>
+        private long BytesClientSent { get; set; }
+
+        /// <summary>Gets or sets the body of this request.</summary>
+        public TRequest Body { get; set; }
+
+        /// <summary>Change this value ONLY for testing purposes!</summary>
+        [VisibleForTestOnly]
+        protected int chunkSize = DefaultChunkSize;
+
+        /// <summary>
+        /// Gets or sets the size of each chunk sent to the server.
+        /// Chunks (except the last chunk) must be a multiple of <see cref="MinimumChunkSize"/> to be compatible with 
+        /// Google upload servers.
+        /// </summary>
+        public int ChunkSize
+        {
+            get { return chunkSize; }
+            set
+            {
+                if (value < MinimumChunkSize)
+                {
+                    throw new ArgumentOutOfRangeException("ChunkSize");
+                }
+                chunkSize = value;
+            }
+        }
+
+        #endregion // Properties
+
+        #region Events
+
+        /// <summary>Event called whenever the progress of the upload changes.</summary>
+        public event Action<IUploadProgress> ProgressChanged;
+
+        #endregion //Events
+
+        #region Error handling (Exception and 5xx)
+
+        /// <summary>
+        /// Callback class that is invoked on abnormal response or an exception.
+        /// This class changes the request to query the current status of the upload in order to find how many bytes  
+        /// were successfully uploaded before the error occurred.
+        /// See https://developers.google.com/drive/manage-uploads#resume-upload for more details.
+        /// </summary>
+        class ServerErrorCallback : IHttpUnsuccessfulResponseHandler, IHttpExceptionHandler, IDisposable
+        {
+            private TmpResumableUpload<TRequest> Owner { get; set; }
+
+            /// <summary>
+            /// Constructs a new callback and register it as unsuccessful response handler and exception handler on the 
+            /// configurable message handler.
+            /// </summary>
+            public ServerErrorCallback(TmpResumableUpload<TRequest> resumable)
+            {
+                this.Owner = resumable;
+                Owner.Service.HttpClient.MessageHandler.AddUnsuccessfulResponseHandler(this);
+                Owner.Service.HttpClient.MessageHandler.AddExceptionHandler(this);
+            }
+
+            public Task<bool> HandleResponseAsync(HandleUnsuccessfulResponseArgs args)
+            {
+                var result = false;
+                var statusCode = (int)args.Response.StatusCode;
+                // Handle the error if and only if all the following conditions occur:
+                // - there is going to be an actual retry
+                // - the message request is for media upload with the current Uri (remember that the message handler
+                //   can be invoked from other threads \ messages, so we should call server error callback only if the
+                //   request is in the current context).
+                // - we got a 5xx server error.
+                if (args.SupportsRetry && args.Request.RequestUri.Equals(Owner.UploadUri) && statusCode / 100 == 5)
+                {
+                    result = OnServerError(args.Request);
+                }
+
+                TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
+                tcs.SetResult(result);
+                return tcs.Task;
+            }
+
+            public Task<bool> HandleExceptionAsync(HandleExceptionArgs args)
+            {
+                var result = args.SupportsRetry && !args.CancellationToken.IsCancellationRequested &&
+                    args.Request.RequestUri.Equals(Owner.UploadUri) ? OnServerError(args.Request) : false;
+
+                TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
+                tcs.SetResult(result);
+                return tcs.Task;
+            }
+
+            /// <summary>Changes the request in order to resume the interrupted upload.</summary>
+            private bool OnServerError(HttpRequestMessage request)
+            {
+                // Clear all headers and set Content-Range and Content-Length headers.
+                var range = String.Format("bytes */{0}", Owner.StreamLength < 0 ? "*" : Owner.StreamLength.ToString());
+                request.Headers.Clear();
+                request.Method = System.Net.Http.HttpMethod.Put;
+                request.SetEmptyContent().Headers.Add("Content-Range", range);
+                return true;
+            }
+
+            public void Dispose()
+            {
+                Owner.Service.HttpClient.MessageHandler.RemoveUnsuccessfulResponseHandler(this);
+                Owner.Service.HttpClient.MessageHandler.RemoveExceptionHandler(this);
+            }
+        }
+
+        #endregion
+
+        #region Progress Monitoring
+
+        /// <summary>Class that communicates the progress of resumable uploads to a container.</summary>
+        private class ResumableUploadProgress : IUploadProgress
+        {
+            /// <summary>
+            /// Create a ResumableUploadProgress instance.
+            /// </summary>
+            /// <param name="status">The status of the upload.</param>
+            /// <param name="bytesSent">The number of bytes sent so far.</param>
+            public ResumableUploadProgress(UploadStatus status, long bytesSent)
+            {
+                Status = status;
+                BytesSent = bytesSent;
+            }
+
+            /// <summary>
+            /// Create a ResumableUploadProgress instance.
+            /// </summary>
+            /// <param name="exception">An exception that occurred during the upload.</param>
+            /// <param name="bytesSent">The number of bytes sent before this exception occurred.</param>
+            public ResumableUploadProgress(Exception exception, long bytesSent)
+            {
+                Status = UploadStatus.Failed;
+                BytesSent = bytesSent;
+                Exception = exception;
+            }
+
+            public UploadStatus Status { get; private set; }
+            public long BytesSent { get; private set; }
+            public Exception Exception { get; private set; }
+        }
+
+        /// <summary>
+        /// Current state of progress of the upload.
+        /// </summary>
+        /// <seealso cref="ProgressChanged"/>
+        private ResumableUploadProgress Progress { get; set; }
+
+        /// <summary>
+        /// Updates the current progress and call the <see cref="ProgressChanged"/> event to notify listeners.
+        /// </summary>
+        private void UpdateProgress(ResumableUploadProgress progress)
+        {
+            Progress = progress;
+            ProgressChanged?.Invoke(progress);
+        }
+
+        /// <summary>
+        /// Get the current progress state.
+        /// </summary>
+        /// <returns>An IUploadProgress describing the current progress of the upload.</returns>
+        /// <seealso cref="ProgressChanged"/>
+        public IUploadProgress GetProgress()
+        {
+            return Progress;
+        }
+
+        #endregion
+
+        #region UploadSessionData
+        /// <summary>
+        /// Event called when an UploadUri is created. 
+        /// Not needed if the application program will not support resuming after a program restart.
+        /// </summary>
+        /// <remarks>
+        /// Within the event, persist the UploadUri to storage.
+        /// It is strongly recommended that the full path filename (or other media identifier) is also stored so that it can be compared to the current open filename (media) upon restart.
+        /// </remarks>
+        public event Action<IUploadSessionData> UploadSessionData;
+        /// <summary>
+        /// Data to be passed to the application program to allow resuming an upload after a program restart.
+        /// </summary>
+        private class ResumeableUploadSessionData : IUploadSessionData
+        {
+            /// <summary>
+            /// Create a ResumeableUploadSessionData instance to pass the UploadUri to the client.
+            /// </summary>
+            /// <param name="uploadUri">The resumable session URI.</param>
+            public ResumeableUploadSessionData(Uri uploadUri)
+            {
+                UploadUri = uploadUri;
+            }
+            public Uri UploadUri { get; private set; }
+        }
+        /// <summary>
+        /// Send data (UploadUri) to application so it can store it to persistent storage.
+        /// </summary>
+        private void SendUploadSessionData(ResumeableUploadSessionData sessionData)
+        {
+            UploadSessionData?.Invoke(sessionData);
+        }
+        #endregion
+
+        #region Upload Implementation
+
+        /// <summary>
+        /// Uploads the content to the server. This method is synchronous and will block until the upload is completed.
+        /// </summary>
+        /// <remarks>
+        /// In case the upload fails the <see cref="IUploadProgress.Exception"/> will contain the exception that
+        /// cause the failure.
+        /// </remarks>
+        public IUploadProgress Upload()
+        {
+            return UploadAsync(CancellationToken.None).Result;
+        }
+
+        /// <summary>Uploads the content asynchronously to the server.</summary>
+        public Task<IUploadProgress> UploadAsync()
+        {
+            return UploadAsync(CancellationToken.None);
+        }
+
+        /// <summary>Uploads the content to the server using the given cancellation token.</summary>
+        /// <remarks>
+        /// In case the upload fails <see cref="IUploadProgress.Exception"/> will contain the exception that
+        /// cause the failure. The only exception which will be thrown is 
+        /// <see cref="System.Threading.Tasks.TaskCanceledException"/> which indicates that the task was canceled.
+        /// </remarks>
+        /// <param name="cancellationToken">A cancellation token to cancel operation.</param>
+        public async Task<IUploadProgress> UploadAsync(CancellationToken cancellationToken)
+        {
+            BytesServerReceived = 0;
+            UpdateProgress(new ResumableUploadProgress(UploadStatus.Starting, 0));
+            // Check if the stream length is known.
+            StreamLength = ContentStream.CanSeek ? ContentStream.Length : UnknownSize;
+
+            try
+            {
+                UploadUri = await InitializeUpload(cancellationToken).ConfigureAwait(false);
+                if (ContentStream.CanSeek)
+                {
+                    SendUploadSessionData(new ResumeableUploadSessionData(UploadUri));
+                }
+                Logger.Debug("MediaUpload[{0}] - Start uploading...", UploadUri);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "MediaUpload - Exception occurred while initializing the upload");
+                UpdateProgress(new ResumableUploadProgress(ex, BytesServerReceived));
+                return Progress;
+            }
+
+            return await UploadCoreAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Resumes the upload from the last point it was interrupted. 
+        /// Use when resuming and the program was not restarted.
+        /// </summary>
+        public IUploadProgress Resume()
+        {
+            return ResumeAsync(null, CancellationToken.None).Result;
+        }
+        /// <summary>
+        /// Resumes the upload from the last point it was interrupted. 
+        /// Use when the program was restarted and you wish to resume the upload that was in progress when the program was halted. 
+        /// Implemented only for ContentStreams where .CanSeek is True.
+        /// </summary>
+        /// <remarks>
+        /// In your application's UploadSessionData Event Handler, store UploadUri.AbsoluteUri property value (resumable session URI string value)
+        /// to persistent storage for use with Resume() or ResumeAsync() upon a program restart.
+        /// It is strongly recommended that the FullPathFilename of the media file that is being uploaded is saved also so that a subsequent execution of the
+        /// program can compare the saved FullPathFilename value to the FullPathFilename of the media file that it has opened for uploading.
+        /// You do not need to seek to restart point in the ContentStream file.
+        /// </remarks>
+        /// <param name="uploadUri">VideosResource.InsertMediaUpload UploadUri property value that was saved to persistent storage during a prior execution.</param>
+        public IUploadProgress Resume(Uri uploadUri)
+        {
+            return ResumeAsync(uploadUri, CancellationToken.None).Result;
+        }
+        /// <summary>
+        /// Asynchronously resumes the upload from the last point it was interrupted.
+        /// </summary>
+        /// <remarks>
+        /// You do not need to seek to restart point in the ContentStream file.
+        /// </remarks>
+        public Task<IUploadProgress> ResumeAsync()
+        {
+            return ResumeAsync(null, CancellationToken.None);
+        }
+        /// <summary>
+        /// Asynchronously resumes the upload from the last point it was interrupted. 
+        /// Use when resuming and the program was not restarted.
+        /// </summary>
+        /// <remarks>
+        /// You do not need to seek to restart point in the ContentStream file.
+        /// </remarks>
+        /// <param name="cancellationToken">A cancellation token to cancel the asynchronous operation.</param>
+        public Task<IUploadProgress> ResumeAsync(CancellationToken cancellationToken)
+        {
+            return ResumeAsync(null, cancellationToken);
+        }
+        /// <summary>
+        /// Asynchronously resumes the upload from the last point it was interrupted. 
+        /// Use when resuming and the program was restarted.
+        /// Implemented only for ContentStreams where .CanSeek is True.
+        /// </summary>
+        /// <remarks>
+        /// In your application's UploadSessionData Event Handler, store UploadUri.AbsoluteUri property value (resumable session URI string value)
+        /// to persistent storage for use with Resume() or ResumeAsync() upon a program restart.
+        /// It is strongly recommended that the FullPathFilename of the media file that is being uploaded is saved also so that a subsequent execution of the
+        /// program can compare the saved FullPathFilename value to the FullPathFilename of the media file that it has opened for uploading.
+        /// You do not need to seek to restart point in the ContentStream file.
+        /// </remarks>
+        /// <param name="uploadUri">VideosResource.InsertMediaUpload UploadUri property value that was saved to persistent storage during a prior execution.</param>
+        public Task<IUploadProgress> ResumeAsync(Uri uploadUri)
+        {
+            return ResumeAsync(uploadUri, CancellationToken.None);
+        }
+        /// <summary>
+        /// Asynchronously resumes the upload from the last point it was interrupted. 
+        /// Use when the program was restarted and you wish to resume the upload that was in progress when the program was halted.
+        /// Implemented only for ContentStreams where .CanSeek is True.
+        /// </summary>
+        /// <remarks>
+        /// In your application's UploadSessionData Event Handler, store UploadUri.AbsoluteUri property value (resumable session URI string value)
+        /// to persistent storage for use with Resume() or ResumeAsync() upon a program restart.
+        /// It is strongly recommended that the FullPathFilename of the media file that is being uploaded is saved also so that a subsequent execution of the
+        /// program can compare the saved FullPathFilename value to the FullPathFilename of the media file that it has opened for uploading.
+        /// You do not need to seek to restart point in the ContentStream file.
+        /// </remarks>
+        /// <param name="uploadUri">VideosResource.InsertMediaUpload UploadUri property value that was saved to persistent storage during a prior execution.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel the asynchronous operation.</param>
+        public async Task<IUploadProgress> ResumeAsync(Uri uploadUri, CancellationToken cancellationToken)
+        {
+            // When called with uploadUri parameter of non-null value, the UploadUri is being
+            // provided upon a program restart to resume a previously interrupted upload.
+            if (uploadUri != null)
+            {
+                if (ContentStream.CanSeek)
+                {
+                    Logger.Info("Resuming after program restart: UploadUri={0}", uploadUri);
+                    UploadUri = uploadUri;
+                    StreamLength =  ContentStream.Length;
+                }
+                else
+                {
+                    throw new NotImplementedException("Resume after program restart not allowed when ContentStream.CanSeek is false");
+                }
+            }
+            if (UploadUri == null)
+            {
+                Logger.Info("There isn't any upload in progress, so starting to upload again");
+                return await UploadAsync(cancellationToken).ConfigureAwait(false);
+            }
+            // The first "resuming" request is to query the server in which point the upload was interrupted.
+            var range = String.Format("bytes */{0}", StreamLength < 0 ? "*" : StreamLength.ToString());
+            HttpRequestMessage request = new RequestBuilder()
+            {
+                BaseUri = UploadUri,
+                Method = HttpConsts.Put
+            }.CreateRequest();
+            request.SetEmptyContent().Headers.Add("Content-Range", range);
+
+            try
+            {
+                HttpResponseMessage response;
+                using (var callback = new ServerErrorCallback(this))
+                {
+                    response = await Service.HttpClient.SendAsync(request, cancellationToken)
+                      .ConfigureAwait(false);
+                }
+
+                if (await HandleResponse(response).ConfigureAwait(false))
+                {
+                    // All the media was successfully upload.
+                    UpdateProgress(new ResumableUploadProgress(UploadStatus.Completed, BytesServerReceived));
+                    return Progress;
+                }
+            }
+            catch (TaskCanceledException ex)
+            {
+                Logger.Error(ex, "MediaUpload[{0}] - Task was canceled", UploadUri);
+                UpdateProgress(new ResumableUploadProgress(ex, BytesServerReceived));
+                throw ex;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "MediaUpload[{0}] - Exception occurred while resuming uploading media", UploadUri);
+                UpdateProgress(new ResumableUploadProgress(ex, BytesServerReceived));
+                return Progress;
+            }
+
+            // Continue to upload the media stream.
+            return await UploadCoreAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>The core logic for uploading a stream. It is used by the upload and resume methods.</summary>
+        private async Task<IUploadProgress> UploadCoreAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                using (var callback = new ServerErrorCallback(this))
+                {
+                    while (!await SendNextChunkAsync(ContentStream, cancellationToken).ConfigureAwait(false))
+                    {
+                        UpdateProgress(new ResumableUploadProgress(UploadStatus.Uploading, BytesServerReceived));
+                    }
+                    UpdateProgress(new ResumableUploadProgress(UploadStatus.Completed, BytesServerReceived));
+                }
+            }
+            catch (TaskCanceledException ex)
+            {
+                Logger.Error(ex, "MediaUpload[{0}] - Task was canceled", UploadUri);
+                UpdateProgress(new ResumableUploadProgress(ex, BytesServerReceived));
+                throw ex;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "MediaUpload[{0}] - Exception occurred while uploading media", UploadUri);
+                UpdateProgress(new ResumableUploadProgress(ex, BytesServerReceived));
+            }
+
+            return Progress;
+        }
+
+        /// <summary>
+        /// Initializes the resumable upload by calling the resumable rest interface to get a unique upload location.
+        /// See https://developers.google.com/drive/manage-uploads#start-resumable for more details.
+        /// </summary>
+        /// <returns>
+        /// The unique upload location for this upload, returned in the Location header
+        /// </returns>
+        private async Task<Uri> InitializeUpload(CancellationToken cancellationToken)
+        {
+            HttpRequestMessage request = CreateInitializeRequest();
+            var response = await Service.HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            
+            if (!response.IsSuccessStatusCode)
+            {
+                throw await MediaApiErrorHandling.ExceptionForResponseAsync(Service, response).ConfigureAwait(false);
+            }
+            return response.Headers.Location;
+        }
+
+        /// <summary>
+        /// Allows a subclass to modify a request before it's sent.
+        /// </summary>
+        /// <param name="httpRequest">The request about to be sent.</param>
+        protected virtual void ModifyRequest(HttpRequestMessage httpRequest)
+        {
+        }
+
+        /// <summary>
+        /// Process a response from the final upload chunk call.
+        /// </summary>
+        /// <param name="httpResponse">The response body from the final uploaded chunk.</param>
+        protected virtual void ProcessResponse(HttpResponseMessage httpResponse)
+        {
+        }
+
+        /// <summary>Uploads the next chunk of data to the server.</summary>
+        /// <returns><c>True</c> if the entire media has been completely uploaded.</returns>
+        protected async Task<bool> SendNextChunkAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            HttpRequestMessage request = new RequestBuilder()
+                {
+                    BaseUri = UploadUri,
+                    Method = HttpConsts.Put
+                }.CreateRequest();
+
+            // Prepare next chunk to send.
+            int contentLength = ContentStream.CanSeek
+                ? PrepareNextChunkKnownSize(request, stream, cancellationToken)
+                : PrepareNextChunkUnknownSize(request, stream, cancellationToken);
+
+            BytesClientSent = BytesServerReceived + contentLength;
+
+            Logger.Debug("MediaUpload[{0}] - Sending bytes={1}-{2}", UploadUri, BytesServerReceived,
+                BytesClientSent - 1);
+
+            ModifyRequest(request);
+
+            HttpResponseMessage response = await Service.HttpClient.SendAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            return await HandleResponse(response).ConfigureAwait(false);
+        }
+
+        /// <summary>Handles a media upload HTTP response.</summary>
+        /// <returns><c>True</c> if the entire media has been completely uploaded.</returns>
+        private async Task<bool> HandleResponse(HttpResponseMessage response)
+        {
+            if (response.IsSuccessStatusCode)
+            {
+                MediaCompleted(response);
+                return true;
+            }
+            else if (response.StatusCode == (HttpStatusCode)308)
+            {
+                // The upload protocol uses 308 to indicate that there is more data expected from the server.
+                // If the server has received no bytes, it indicates this by not including
+                // a Range header in the response..
+                var range = response.Headers.FirstOrDefault(x => x.Key == "Range").Value?.First();
+                BytesServerReceived = GetNextByte(range);
+                Logger.Debug("MediaUpload[{0}] - {1} Bytes were sent successfully", UploadUri, BytesServerReceived);
+                return false;
+            }
+            throw await MediaApiErrorHandling.ExceptionForResponseAsync(Service, response).ConfigureAwait(false);
+        }
+
+        /// <summary>A callback when the media was uploaded successfully.</summary>
+        private void MediaCompleted(HttpResponseMessage response)
+        {
+            Logger.Debug("MediaUpload[{0}] - media was uploaded successfully", UploadUri);
+            ProcessResponse(response);
+            BytesServerReceived = StreamLength;
+
+            // Clear the last request byte array.
+            LastMediaRequest = null;
+        }
+
+        /// <summary>Prepares the given request with the next chunk in case the steam length is unknown.</summary>
+        private int PrepareNextChunkUnknownSize(HttpRequestMessage request, Stream stream,
+            CancellationToken cancellationToken)
+        {
+            if (LastMediaRequest == null)
+            {
+                // Initialise state
+                // ChunkSize + 1 to give room for one extra byte for end-of-stream checking
+                LastMediaRequest = new byte[ChunkSize + 1];
+                LastMediaLength = 0;
+            }
+            // Re-use any bytes the server hasn't received
+            int copyCount = (int)(BytesClientSent - BytesServerReceived)
+                + Math.Max(0, LastMediaLength - ChunkSize);
+            if (LastMediaLength != copyCount)
+            {
+                Buffer.BlockCopy(LastMediaRequest, LastMediaLength - copyCount, LastMediaRequest, 0, copyCount);
+                LastMediaLength = copyCount;
+            }
+            // Read any more required bytes from stream, to form the next chunk
+            while (LastMediaLength < ChunkSize + 1 && StreamLength == UnknownSize)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                int readSize = Math.Min(BufferSize, ChunkSize + 1 - LastMediaLength);
+                int len = stream.Read(LastMediaRequest, LastMediaLength, readSize);
+                LastMediaLength += len;
+                if (len == 0)
+                {
+                    // Stream ended, so we know the length
+                    StreamLength = BytesServerReceived + LastMediaLength;
+                }
+            }
+            // Set Content-Length and Content-Range.
+            int contentLength = Math.Min(ChunkSize, LastMediaLength);
+            var byteArrayContent = new ByteArrayContent(LastMediaRequest, 0, contentLength);
+            byteArrayContent.Headers.Add("Content-Range", GetContentRangeHeader(BytesServerReceived, contentLength));
+            request.Content = byteArrayContent;
+            return contentLength;
+        }
+
+        /// <summary>Prepares the given request with the next chunk in case the steam length is known.</summary>
+        private int PrepareNextChunkKnownSize(HttpRequestMessage request, Stream stream,
+            CancellationToken cancellationToken)
+        {
+            int chunkSize = (int)Math.Min(StreamLength - BytesServerReceived, (long)ChunkSize);
+
+            // Stream length is known and it supports seek and position operations.
+            // We can change the stream position and read bytes from the last point.
+            byte[] buffer = new byte[Math.Min(chunkSize, BufferSize)];
+
+            // If the number of bytes received by the server isn't equal to the amount of bytes the client sent, we 
+            // need to change the position of the input stream, otherwise we can continue from the current position.
+            if (stream.Position != BytesServerReceived)
+            {
+                stream.Position = BytesServerReceived;
+            }
+
+            MemoryStream ms = new MemoryStream(chunkSize);
+            int bytesRead = 0;
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Read from input stream and write to output stream.
+                // TODO(peleyal): write a utility similar to (.NET 4 Stream.CopyTo method).
+                int len = stream.Read(buffer, 0, (int)Math.Min(buffer.Length, chunkSize - bytesRead));
+                if (len == 0) break;
+                ms.Write(buffer, 0, len);
+                bytesRead += len;
+            }
+
+            // Set the stream position to beginning and wrap it with stream content.
+            ms.Position = 0;
+            request.Content = new StreamContent(ms);
+            request.Content.Headers.Add("Content-Range", GetContentRangeHeader(BytesServerReceived, chunkSize));
+
+            return chunkSize;
+        }
+
+        /// <summary>Returns the next byte index need to be sent.</summary>
+        private long GetNextByte(string range)
+        {
+            return range == null ? 0 : long.Parse(range.Substring(range.IndexOf('-') + 1)) + 1;
+        }
+
+        /// <summary>
+        /// Build a content range header of the form: "bytes X-Y/T" where:
+        /// <list type="">
+        /// <item>X is the first byte being sent.</item>
+        /// <item>Y is the last byte in the range being sent (inclusive).</item>
+        /// <item>T is the total number of bytes in the range or * for unknown size.</item>
+        /// </list>
+        /// </summary>
+        /// <remarks>
+        /// See: RFC2616 HTTP/1.1, Section 14.16 Header Field Definitions, Content-Range
+        /// http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.16
+        /// </remarks>
+        /// <param name="chunkStart">Start of the chunk.</param>
+        /// <param name="chunkSize">Size of the chunk being sent.</param>
+        /// <returns>The content range header value.</returns>
+        private string GetContentRangeHeader(long chunkStart, long chunkSize)
+        {
+            string strLength = StreamLength < 0 ? "*" : StreamLength.ToString();
+
+            // If a file of length 0 is sent, one chunk needs to be sent with 0 size.
+            // This chunk cannot be specified with the standard (inclusive) range header.
+            // In this case, use * to indicate no bytes sent in the Content-Range header.
+            if (chunkStart == 0 && chunkSize == 0 && StreamLength == 0)
+            {
+                return ZeroByteContentRangeHeader;
+            }
+            else
+            {
+                long chunkEnd = chunkStart + chunkSize - 1;
+                return String.Format("bytes {0}-{1}/{2}", chunkStart, chunkEnd, strLength);
+            }
+        }
+
+        /// <summary>Creates a request to initialize a request.</summary>
+        private HttpRequestMessage CreateInitializeRequest()
+        {
+            var builder = new RequestBuilder()
+            {
+                BaseUri = new Uri(Service.BaseUri),
+                Path = Path,
+                Method = HttpMethod,
+            };
+
+            // init parameters
+            builder.AddParameter(RequestParameterType.Query, "key", Service.ApiKey);
+            builder.AddParameter(RequestParameterType.Query, "uploadType", "resumable");
+            SetAllPropertyValues(builder);
+
+            HttpRequestMessage request = builder.CreateRequest();
+            if (ContentType != null)
+            {
+                request.Headers.Add(PayloadContentTypeHeader, ContentType);
+            }
+
+            // if the length is unknown at the time of this request, omit "X-Upload-Content-Length" header
+            if (ContentStream.CanSeek)
+            {
+                request.Headers.Add(PayloadContentLengthHeader, StreamLength.ToString());
+            }
+
+            Service.SetRequestSerailizedContent(request, Body);
+            return request;
+        }
+
+        /// <summary>
+        /// Reflectively enumerate the properties of this object looking for all properties containing the 
+        /// RequestParameterAttribute and copy their values into the request builder.
+        /// </summary>
+        private void SetAllPropertyValues(RequestBuilder requestBuilder)
+        {
+            Type myType = this.GetType();
+            var properties = myType.GetProperties();
+
+            foreach (var property in properties)
+            {
+                var attribute = Utilities.GetCustomAttribute<RequestParameterAttribute>(property);
+
+                if (attribute != null)
+                {
+                    string name = attribute.Name ?? property.Name.ToLower();
+                    object value = property.GetValue(this, null);
+                    if (value != null)
+                    {
+                        var valueAsEnumerable = value as IEnumerable;
+                        if (!(value is string) && valueAsEnumerable != null)
+                        {
+                            foreach (var elem in valueAsEnumerable)
+                            {
+                                requestBuilder.AddParameter(attribute.Type, name, Utilities.ConvertToString(elem));
+                            }
+                        }
+                        else
+                        {
+                            // Otherwise just convert it to a string.
+                            requestBuilder.AddParameter(attribute.Type, name, Utilities.ConvertToString(value));
+                        }
+                    }
+                }
+            }
+        }
+
+        #endregion Upload Implementation
+    }
+
+    /// <summary>
+    /// Media upload which uses Google's resumable media upload protocol to upload data.
+    /// The version with two types contains both a request object and a response object.
+    /// </summary>
+    /// <remarks>
+    /// See: https://developers.google.com/gdata/docs/resumable_upload for
+    /// information on the protocol.
+    /// </remarks>
+    /// <typeparam name="TRequest">
+    /// The type of the body of this request. Generally this should be the metadata related 
+    /// to the content to be uploaded. Must be serializable to/from JSON.
+    /// </typeparam>
+    /// <typeparam name="TResponse">
+    /// The type of the response body.
+    /// </typeparam>
+    public class TmpResumableUpload<TRequest, TResponse> : TmpResumableUpload<TRequest>
+    {
+        #region Construction
+
+        /// <summary>
+        /// Create a resumable upload instance with the required parameters.
+        /// </summary>
+        /// <param name="service">The client service.</param>
+        /// <param name="path">The path for this media upload method.</param>
+        /// <param name="httpMethod">The HTTP method to start this upload.</param>
+        /// <param name="contentStream">The stream containing the content to upload.</param>
+        /// <param name="contentType">Content type of the content to be uploaded.</param>
+        /// <remarks>
+        /// The stream <paramref name="contentStream"/> must support the "Length" property.
+        /// Caller is responsible for maintaining the <paramref name="contentStream"/> open until the 
+        /// upload is completed.
+        /// Caller is responsible for closing the <paramref name="contentStream"/>.
+        /// </remarks>
+        protected TmpResumableUpload(IClientService service, string path, string httpMethod,
+            Stream contentStream, string contentType)
+            : base(service, path, httpMethod, contentStream, contentType) { }
+
+        #endregion // Construction
+
+        #region Properties
+
+        /// <summary>
+        /// The response body.
+        /// </summary>
+        /// <remarks>
+        /// This property will be set during upload. The <see cref="ResponseReceived"/> event
+        /// is triggered when this has been set.
+        /// </remarks>
+        public TResponse ResponseBody { get; private set; }
+
+        #endregion // Properties
+
+        #region Events
+
+        /// <summary>Event which is called when the response metadata is processed.</summary>
+        public event Action<TResponse> ResponseReceived;
+
+        #endregion // Events
+
+        #region Overrides
+
+        /// <summary>Process the response body </summary>
+        protected override void ProcessResponse(HttpResponseMessage response)
+        {
+            base.ProcessResponse(response);
+            ResponseBody = Service.DeserializeResponse<TResponse>(response).Result;
+
+            ResponseReceived?.Invoke(ResponseBody);
+        }
+
+        #endregion // Overrides
+    }
+}
+
+#pragma warning restore CS1591

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.DownloadObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.DownloadObject.cs
@@ -103,7 +103,7 @@ namespace Google.Cloud.Storage.V1
         {
             // URI will definitely not be null; that's constructed internally.
             GaxPreconditions.CheckNotNull(destination, nameof(destination));
-            var downloader = new MediaDownloader(Service);
+            var downloader = new HashValidatingDownloader(Service);
             options?.ModifyDownloader(downloader);
             string uri = options == null ? baseUri : options.GetUri(baseUri);
             if (progress != null)
@@ -126,7 +126,7 @@ namespace Google.Cloud.Storage.V1
             IProgress<IDownloadProgress> progress)
         {
             GaxPreconditions.CheckNotNull(destination, nameof(destination));
-            var downloader = new MediaDownloader(Service);
+            var downloader = new HashValidatingDownloader(Service);
             options?.ModifyDownloader(downloader);
             string uri = options == null ? baseUri : options.GetUri(baseUri);
             if (progress != null)

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.UploadObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.UploadObject.cs
@@ -65,7 +65,7 @@ namespace Google.Cloud.Storage.V1
         {
             ValidateObject(destination, nameof(destination));
             GaxPreconditions.CheckNotNull(source, nameof(source));
-            var mediaUpload = Service.Objects.Insert(destination, destination.Bucket, source, destination.ContentType);
+            var mediaUpload = new HashProvidingUpload(Service, destination, destination.Bucket, source, destination.ContentType);
             options?.ModifyMediaUpload(mediaUpload);
             if (progress != null)
             {
@@ -89,7 +89,7 @@ namespace Google.Cloud.Storage.V1
         {
             ValidateObject(destination, nameof(destination));
             GaxPreconditions.CheckNotNull(source, nameof(source));
-            var mediaUpload = Service.Objects.Insert(destination, destination.Bucket, source, destination.ContentType);
+            var mediaUpload = new HashProvidingUpload(Service, destination, destination.Bucket, source, destination.ContentType);
             options?.ModifyMediaUpload(mediaUpload);
             if (progress != null)
             {

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UploadObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UploadObjectOptions.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Storage.V1
         /// <summary>
         /// The minimum chunk size for uploading.
         /// </summary>
-        public const int MinimumChunkSize = ResumableUpload<Object>.MinimumChunkSize;
+        public const int MinimumChunkSize = TmpResumableUpload<Object>.MinimumChunkSize;
 
         /// <summary>
         /// Precondition for upload: the object is only uploaded if the existing object's
@@ -85,7 +85,7 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public Projection? Projection { get; set; }
 
-        internal void ModifyMediaUpload(InsertMediaUpload upload)
+        internal void ModifyMediaUpload(TmpInsertMediaUpload upload)
         {
             // Note the use of ArgumentException here, as this will basically be the result of invalid
             // options being passed to a public method.


### PR DESCRIPTION
This has a copy of the relevant REST support library code (and one
generated class) for ease of testing - we'd need to make changes to
the REST support library, then use those from this package. (So only
the Hash* code would actually be new.)

I've moved away from Crc32c extending HashAlgorithm as the
netstandard version doesn't expose enough members to be useful.

This code appears to work for download validation, but doesn't help
for upload - nothing appears to check it. I'm tempted to make the
changes to the upload REST code anyway so that it's easy to
implement later on.