### PR TITLE
Add overload of UploadJson to take a sequence of strings

### DIFF
--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.IntegrationTests/BigqueryFixture.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.IntegrationTests/BigqueryFixture.cs
@@ -126,10 +126,8 @@ namespace Google.Bigquery.V2.IntegrationTests
                     FieldMode.Repeated
                 }
             }.Build());
-            // TODO: We need to make this easier to use.
             List<string> jsonRows = LoadTextResource("personsData.json");
-            var bytes = Encoding.UTF8.GetBytes(string.Join("\n", jsonRows));
-            var job = table.UploadJson(new MemoryStream(bytes));
+            var job = table.UploadJson(jsonRows);
 
             var result = job.PollUntilCompleted();
             var errors = result.Status.ErrorResult;

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Snippets/BigqueryClientSnippets.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Snippets/BigqueryClientSnippets.cs
@@ -318,7 +318,7 @@ namespace Google.Bigquery.V2.Snippets
         }
 
         [Fact]
-        public void UploadJson()
+        public void UploadJson_Stream()
         {
             string projectId = _fixture.ProjectId;
             string datasetId = _fixture.GameDatasetId;
@@ -327,7 +327,7 @@ namespace Google.Bigquery.V2.Snippets
             BigqueryTable table = BigqueryClient.Create(projectId).GetTable(datasetId, tableId);
             int rowsBefore = table.ListRows().Count();
 
-            // Snippet: UploadJson(*,*,*,*,*)
+            // Snippet: UploadJson(*,*,*,Stream,*)
             BigqueryClient client = BigqueryClient.Create(projectId);
             // Note that there's a single line per JSON object. This is not a JSON array.
             IEnumerable<string> jsonRows = new string[]
@@ -344,6 +344,49 @@ namespace Google.Bigquery.V2.Snippets
             // create a schema to pass into the call.
             TableSchema schema = null;
             BigqueryJob job = client.UploadJson(datasetId, tableId, schema, stream);
+            // Use the job to find out when the data has finished being inserted into the table,
+            // report errors etc.
+            // End snippet
+
+            BigqueryJob result = job.PollUntilCompleted();
+            // If there are any errors, display them *then* fail.
+            if (result.Status.ErrorResult != null)
+            {
+                foreach (ErrorProto error in result.Status.Errors)
+                {
+                    Console.WriteLine(error.Message);
+                }
+            }
+            Assert.Null(result.Status.ErrorResult);
+
+            int rowsAfter = table.ListRows().Count();
+            Assert.Equal(rowsBefore + 2, rowsAfter);
+        }
+
+        [Fact]
+        public void UploadJson_Strings()
+        {
+            string projectId = _fixture.ProjectId;
+            string datasetId = _fixture.GameDatasetId;
+            string tableId = _fixture.HistoryTableId;
+
+            BigqueryTable table = BigqueryClient.Create(projectId).GetTable(datasetId, tableId);
+            int rowsBefore = table.ListRows().Count();
+
+            // Snippet: UploadJson(*,*,*,IEnumerable<string>,*)
+            BigqueryClient client = BigqueryClient.Create(projectId);
+            // Note that there's a single line per JSON object. This is not a JSON array.
+            IEnumerable<string> jsonRows = new string[]
+            {
+                "{ 'player': 'Jean', 'score': 500, 'level': 1, 'game_started': '2012-08-19 12:41:35.220' }",
+                "{ 'player': 'Joe', 'score': 705, 'level': 1, 'game_started': '2014-01-01 08:30:35.000' }",
+            }.Select(row => row.Replace('\'', '"')); // Simple way of representing C# in JSON to avoid escaping " everywhere.
+
+            // This example uploads data to an existing table. If the upload will create a new table
+            // or if the schema in the JSON isn't identical to the schema in the table,
+            // create a schema to pass into the call.
+            TableSchema schema = null;
+            BigqueryJob job = client.UploadJson(datasetId, tableId, schema, jsonRows);
             // Use the job to find out when the data has finished being inserted into the table,
             // report errors etc.
             // End snippet
@@ -933,7 +976,7 @@ namespace Google.Bigquery.V2.Snippets
         }
 
         [Fact]
-        public async Task UploadJsonAsync()
+        public async Task UploadJsonAsync_Stream()
         {
             string projectId = _fixture.ProjectId;
             string datasetId = _fixture.GameDatasetId;
@@ -942,7 +985,7 @@ namespace Google.Bigquery.V2.Snippets
             BigqueryTable table = BigqueryClient.Create(projectId).GetTable(datasetId, tableId);
             int rowsBefore = table.ListRows().Count();
 
-            // Snippet: UploadJsonAsync(*,*,*,*,*,*)
+            // Snippet: UploadJsonAsync(*,*,*,*,Stream,*,*)
             BigqueryClient client = await BigqueryClient.CreateAsync(projectId);
             // Note that there's a single line per JSON object. This is not a JSON array.
             IEnumerable<string> jsonRows = new string[]
@@ -959,6 +1002,49 @@ namespace Google.Bigquery.V2.Snippets
             // create a schema to pass into the call.
             TableSchema schema = null;
             BigqueryJob job = await client.UploadJsonAsync(datasetId, tableId, schema, stream);
+            // Use the job to find out when the data has finished being inserted into the table,
+            // report errors etc.
+            // End snippet
+
+            BigqueryJob result = job.PollUntilCompleted();
+            // If there are any errors, display them *then* fail.
+            if (result.Status.ErrorResult != null)
+            {
+                foreach (ErrorProto error in result.Status.Errors)
+                {
+                    Console.WriteLine(error.Message);
+                }
+            }
+            Assert.Null(result.Status.ErrorResult);
+
+            int rowsAfter = table.ListRows().Count();
+            Assert.Equal(rowsBefore + 2, rowsAfter);
+        }
+
+        [Fact]
+        public async Task UploadJsonAsync_Strings()
+        {
+            string projectId = _fixture.ProjectId;
+            string datasetId = _fixture.GameDatasetId;
+            string tableId = _fixture.HistoryTableId;
+
+            BigqueryTable table = BigqueryClient.Create(projectId).GetTable(datasetId, tableId);
+            int rowsBefore = table.ListRows().Count();
+
+            // Snippet: UploadJsonAsync(*,*,*,*,IEnumerable<string>,*,*)
+            BigqueryClient client = await BigqueryClient.CreateAsync(projectId);
+            // Note that there's a single line per JSON object. This is not a JSON array.
+            IEnumerable<string> jsonRows = new string[]
+            {
+                "{ 'player': 'Jean', 'score': 500, 'level': 1, 'game_started': '2012-08-19 12:41:35.220' }",
+                "{ 'player': 'Joe', 'score': 705, 'level': 1, 'game_started': '2014-01-01 08:30:35.000' }",
+            }.Select(row => row.Replace('\'', '"')); // Simple way of representing C# in JSON to avoid escaping " everywhere.
+
+            // This example uploads data to an existing table. If the upload will create a new table
+            // or if the schema in the JSON isn't identical to the schema in the table,
+            // create a schema to pass into the call.
+            TableSchema schema = null;
+            BigqueryJob job = await client.UploadJsonAsync(datasetId, tableId, schema, jsonRows);
             // Use the job to find out when the data has finished being inserted into the table,
             // report errors etc.
             // End snippet

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryClientTest.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2.Tests/BigqueryClientTest.cs
@@ -363,7 +363,7 @@ namespace Google.Bigquery.V2.Tests
         }
 
         [Fact]
-        public void UploadJsonEquivalents()
+        public void UploadJson_Stream_Equivalents()
         {
             var datasetId = "dataset";
             var tableId = "table";
@@ -377,6 +377,23 @@ namespace Google.Bigquery.V2.Tests
                 client => client.UploadJson(datasetId, tableId, schema, stream, options),
                 client => client.UploadJson(ProjectId, datasetId, tableId, schema, stream, options),
                 client => new BigqueryTable(client, GetTable(tableReference, schema)).UploadJson(stream, options));
+        }
+
+        [Fact]
+        public void UploadJson_Strings_Equivalents()
+        {
+            var datasetId = "dataset";
+            var tableId = "table";
+            var jobReference = GetJobReference("job");
+            var tableReference = GetTableReference(datasetId, tableId);
+            var schema = new TableSchemaBuilder().Build();
+            var options = new UploadJsonOptions();
+            var rows = new[] { "a", "b" };
+            VerifyEquivalent(new BigqueryJob(new DerivedBigqueryClient(), new Job { JobReference = jobReference }),
+                client => client.UploadJson(MatchesWhenSerialized(tableReference), schema, rows, options),
+                client => client.UploadJson(datasetId, tableId, schema, rows, options),
+                client => client.UploadJson(ProjectId, datasetId, tableId, schema, rows, options),
+                client => new BigqueryTable(client, GetTable(tableReference, schema)).UploadJson(rows, options));
         }
 
         [Fact]
@@ -676,7 +693,7 @@ namespace Google.Bigquery.V2.Tests
         }
 
         [Fact]
-        public void UploadJsonAsyncEquivalents()
+        public void UploadJson_Stream_AsyncEquivalents()
         {
             var datasetId = "dataset";
             var tableId = "table";
@@ -691,6 +708,24 @@ namespace Google.Bigquery.V2.Tests
                 client => client.UploadJsonAsync(datasetId, tableId, schema, stream, options, token),
                 client => client.UploadJsonAsync(ProjectId, datasetId, tableId, schema, stream, options, token),
                 client => new BigqueryTable(client, GetTable(tableReference, schema)).UploadJsonAsync(stream, options, token));
+        }
+
+        [Fact]
+        public void UploadJson_Strings_AsyncEquivalents()
+        {
+            var datasetId = "dataset";
+            var tableId = "table";
+            var jobReference = GetJobReference("job");
+            var tableReference = GetTableReference(datasetId, tableId);
+            var schema = new TableSchemaBuilder().Build();
+            var options = new UploadJsonOptions();
+            var token = new CancellationTokenSource().Token;
+            var rows = new[] { "a", "b" };
+            VerifyEquivalentAsync(new BigqueryJob(new DerivedBigqueryClient(), new Job { JobReference = jobReference }),
+                client => client.UploadJsonAsync(MatchesWhenSerialized(tableReference), schema, rows, options, token),
+                client => client.UploadJsonAsync(datasetId, tableId, schema, rows, options, token),
+                client => client.UploadJsonAsync(ProjectId, datasetId, tableId, schema, rows, options, token),
+                client => new BigqueryTable(client, GetTable(tableReference, schema)).UploadJsonAsync(rows, options, token));
         }
 
         [Fact]

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryClient.InsertData.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryClient.InsertData.cs
@@ -110,6 +110,64 @@ namespace Google.Bigquery.V2
         }
 
         /// <summary>
+        /// Uploads a sequence of JSON rows to a table specified by project ID, dataset ID and table ID.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="UploadJson(TableReference, TableSchema, IEnumerable{String}, UploadJsonOptions)"/>.
+        /// </summary>
+        /// <remarks>
+        /// Each element of <paramref name="rows"/> is converted into a single line of text by replacing carriage returns and line
+        /// feeds with spaces. This is safe as they cannot exist within well-formed JSON keys or values, and simply means that the
+        /// original JSON can be formatted however you choose.
+        /// </remarks>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="schema">The schema of the data. May be null if the table already exists, in which case the table schema will be fetched and used.</param>
+        /// <param name="rows">The sequence of JSON strings to upload. Must not be null, and must not contain null elements.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>A data upload job.</returns>
+        public virtual BigqueryJob UploadJson(string projectId, string datasetId, string tableId,
+            TableSchema schema, IEnumerable<string> rows, UploadJsonOptions options = null) =>
+            UploadJson(GetTableReference(projectId, datasetId, tableId), schema, rows, options);
+
+        /// <summary>
+        /// Uploads a sequence of JSON rows to a table in this client's project specified by dataset ID and table ID.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="UploadJson(TableReference, TableSchema, IEnumerable{String}, UploadJsonOptions)"/>.
+        /// </summary>
+        /// <remarks>
+        /// Each element of <paramref name="rows"/> is converted into a single line of text by replacing carriage returns and line
+        /// feeds with spaces. This is safe as they cannot exist within well-formed JSON keys or values, and simply means that the
+        /// original JSON can be formatted however you choose.
+        /// </remarks>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="schema">The schema of the data. May be null if the table already exists, in which case the table schema will be fetched and used.</param>
+        /// <param name="rows">The sequence of JSON strings to upload. Must not be null, and must not contain null elements.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>A data upload job.</returns>
+        public virtual BigqueryJob UploadJson(string datasetId, string tableId,
+            TableSchema schema, IEnumerable<string> rows, UploadJsonOptions options = null) =>
+            UploadJson(GetTableReference(datasetId, tableId), schema, rows, options);
+
+        /// <summary>
+        /// Uploads a sequence of JSON rows to a table.
+        /// </summary>
+        /// <remarks>
+        /// Each element of <paramref name="rows"/> is converted into a single line of text by replacing carriage returns and line
+        /// feeds with spaces. This is safe as they cannot exist within well-formed JSON keys or values, and simply means that the
+        /// original JSON can be formatted however you choose.
+        /// </remarks>
+        /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
+        /// <param name="schema">The schema of the data. May be null if the table already exists, in which case the table schema will be fetched and used.</param>
+        /// <param name="rows">The sequence of JSON strings to upload. Must not be null, and must not contain null elements.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>A data upload job.</returns>
+        public virtual BigqueryJob UploadJson(TableReference tableReference,
+            TableSchema schema, IEnumerable<string> rows, UploadJsonOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Inserts a single row of data into a table specified by project ID, dataset ID and table ID.
         /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="Insert(TableReference, InsertRow, InsertOptions)"/>.
         /// </summary>
@@ -311,6 +369,70 @@ namespace Google.Bigquery.V2
         /// a data upload job.</returns>
         public virtual Task<BigqueryJob> UploadJsonAsync(TableReference tableReference,
             TableSchema schema, Stream input, UploadJsonOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Asynchronously uploads a sequence of JSON rows to a table specified by project ID, dataset ID and table ID.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="UploadJsonAsync(TableReference, TableSchema, IEnumerable{String}, UploadJsonOptions, CancellationToken)"/>.
+        /// </summary>
+        /// <remarks>
+        /// Each element of <paramref name="rows"/> is converted into a single line of text by replacing carriage returns and line
+        /// feeds with spaces. This is safe as they cannot exist within well-formed JSON keys or values, and simply means that the
+        /// original JSON can be formatted however you choose.
+        /// </remarks>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="schema">The schema of the data. May be null if the table already exists, in which case the table schema will be fetched and used.</param>
+        /// <param name="rows">The sequence of JSON strings to upload. Must not be null, and must not contain null elements.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// A data upload job.</returns>
+        public virtual Task<BigqueryJob> UploadJsonAsync(string projectId, string datasetId, string tableId,
+            TableSchema schema, IEnumerable<string> rows, UploadJsonOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            UploadJsonAsync(GetTableReference(projectId, datasetId, tableId), schema, rows, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously uploads a sequence of JSON rows to a table in this client's project specified by dataset ID and table ID.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="UploadJsonAsync(TableReference, TableSchema, IEnumerable{String}, UploadJsonOptions, CancellationToken)"/>.
+        /// </summary>
+        /// <remarks>
+        /// Each element of <paramref name="rows"/> is converted into a single line of text by replacing carriage returns and line
+        /// feeds with spaces. This is safe as they cannot exist within well-formed JSON keys or values, and simply means that the
+        /// original JSON can be formatted however you choose.
+        /// </remarks>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="schema">The schema of the data. May be null if the table already exists, in which case the table schema will be fetched and used.</param>
+        /// <param name="rows">The sequence of JSON strings to upload. Must not be null, and must not contain null elements.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// A data upload job.</returns>
+        public virtual Task<BigqueryJob> UploadJsonAsync(string datasetId, string tableId,
+            TableSchema schema, IEnumerable<string> rows, UploadJsonOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            UploadJsonAsync(GetTableReference(datasetId, tableId), schema, rows, options, cancellationToken);
+
+        /// <summary>
+        /// Uploads a sequence of JSON rows to a table.
+        /// </summary>
+        /// <remarks>
+        /// Each element of <paramref name="rows"/> is converted into a single line of text by replacing carriage returns and line
+        /// feeds with spaces. This is safe as they cannot exist within well-formed JSON keys or values, and simply means that the
+        /// original JSON can be formatted however you choose.
+        /// </remarks>
+        /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
+        /// <param name="schema">The schema of the data. May be null if the table already exists, in which case the table schema will be fetched and used.</param>
+        /// <param name="rows">The sequence of JSON strings to upload. Must not be null, and must not contain null elements.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// A data upload job.</returns>
+        public virtual Task<BigqueryJob> UploadJsonAsync(TableReference tableReference,
+            TableSchema schema, IEnumerable<string> rows, UploadJsonOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             throw new NotImplementedException();
         }

--- a/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryTable.cs
+++ b/apis/Google.Bigquery.V2/Google.Bigquery.V2/BigqueryTable.cs
@@ -97,6 +97,20 @@ namespace Google.Bigquery.V2
         public BigqueryJob UploadJson(Stream input, UploadJsonOptions options = null) => _client.UploadJson(Reference, Schema, input, options);
 
         /// <summary>
+        /// Uploads a sequence of JSON rows to this table.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigqueryClient.UploadJson(TableReference, TableSchema, IEnumerable{String}, UploadJsonOptions)"/>.
+        /// </summary>
+        /// <remarks>
+        /// Each element of <paramref name="rows"/> is converted into a single line of text by replacing carriage returns and line
+        /// feeds with spaces. This is safe as they cannot exist within well-formed JSON keys or values, and simply means that the
+        /// original JSON can be formatted however you choose.
+        /// </remarks>
+        /// <param name="rows">The sequence of JSON strings to upload. Must not be null, and must not contain null elements.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>A data upload job.</returns>
+        public BigqueryJob UploadJson(IEnumerable<string> rows, UploadJsonOptions options = null) => _client.UploadJson(Reference, Schema, rows, options);
+
+        /// <summary>
         /// Lists the rows within this table, similar to a <c>SELECT * FROM ...</c> query.
         /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigqueryClient.ListRows(TableReference, TableSchema, ListRowsOptions)"/>.
         /// </summary>
@@ -151,6 +165,23 @@ namespace Google.Bigquery.V2
 
         /// <summary>
         /// Asynchronously uploads a stream of JSON data to this table.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigqueryClient.UploadJsonAsync(TableReference, TableSchema, IEnumerable{String}, UploadJsonOptions, CancellationToken)"/>.
+        /// </summary>
+        /// <remarks>
+        /// Each element of <paramref name="rows"/> is converted into a single line of text by replacing carriage returns and line
+        /// feeds with spaces. This is safe as they cannot exist within well-formed JSON keys or values, and simply means that the
+        /// original JSON can be formatted however you choose.
+        /// </remarks>
+        /// <param name="rows">The sequence of JSON strings to upload. Must not be null, and must not contain null elements.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// a data upload job.</returns>
+        public Task<BigqueryJob> UploadJsonAsync(IEnumerable<string> rows, UploadJsonOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            _client.UploadJsonAsync(Reference, Schema, rows, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously uploads a sequence of JSON rows to this table.
         /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigqueryClient.UploadJsonAsync(TableReference, TableSchema, Stream, UploadJsonOptions, CancellationToken)"/>.
         /// </summary>
         /// <param name="input">The stream of input data. Must not be null.</param>


### PR DESCRIPTION
This is a reasonably small API surface change, but should make it much simpler to use.
I don't think there's any need to add overloads taking a single string, a params string[] etc.
Given that we have 3 overloads already, adding another 6 would be overkill - it's easy enough
to create a string array where necessary.

This fixes #330.