### PR TITLE
log4net FileName may be null

### DIFF
--- a/apis/Google.Logging.V2/Google.Logging.Log4Net/GoogleStackdriverAppender.cs
+++ b/apis/Google.Logging.V2/Google.Logging.Log4Net/GoogleStackdriverAppender.cs
@@ -182,7 +182,8 @@ namespace Google.Logging.Log4Net
             var labels = new Dictionary<string, string>();
             if (_withMetaData.Contains(MetaDataType.Location))
             {
-                labels.Add(nameof(MetaDataType.Location) + ".FileName", loggingEvent.LocationInformation.FileName);
+                if(loggingEvent.LocationInformation.FileName != null)
+                    labels.Add(nameof(MetaDataType.Location) + ".FileName", loggingEvent.LocationInformation.FileName);
                 labels.Add(nameof(MetaDataType.Location) + ".ClassName", loggingEvent.LocationInformation.ClassName);
                 labels.Add(nameof(MetaDataType.Location) + ".LineNumber", loggingEvent.LocationInformation.LineNumber);
             }


### PR DESCRIPTION
This fixes the root cause `null` of this exception. You may wish to revisit exception handling for this to produce better errors. If label values can't be null, perhaps this is a better way to safeguard this.

![image](https://cloud.githubusercontent.com/assets/80104/20531776/a617a28e-b08c-11e6-9a12-3c1070e9e29e.png)

![image](https://cloud.githubusercontent.com/assets/80104/20531888/02440e76-b08d-11e6-87fe-feff50d94b76.png)