### PR TITLE
Add ThrowOnAny() methods for jobs

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/BigQueryJobSnippets.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/BigQueryJobSnippets.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Xunit;
+
+namespace Google.Cloud.BigQuery.V2.Snippets
+{
+    [Collection(nameof(BigQuerySnippetFixture))]
+    public class BigQueryJobSnippets
+    {
+        private readonly BigQuerySnippetFixture _fixture;
+
+        public BigQueryJobSnippets(BigQuerySnippetFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public void ThrowOnAnyError()
+        {
+            string projectId = _fixture.ProjectId;
+
+            // Snippet: ThrowOnAnyError
+            BigQueryClient client = BigQueryClient.Create(projectId);
+
+            string sql = $"This is a broken query";
+            BigQueryJob query = client.CreateQueryJob(sql).PollUntilCompleted();
+            try
+            {
+                // Usually this method is called in a chain. It returns the same job
+                // if there are no errors.
+                query = query.ThrowOnAnyError();
+            }
+            catch (GoogleApiException exception)
+            {
+                foreach (var error in exception.Error.Errors)
+                {
+                    Console.WriteLine($"Location: {error.Location}; Reason: {error.Reason}; Message: {error.Message}");
+                }
+            }
+            // End sample
+
+            Assert.Throws<GoogleApiException>(() => query.ThrowOnAnyError());
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.InsertData.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.InsertData.cs
@@ -108,18 +108,19 @@ namespace Google.Cloud.BigQuery.V2
 
         private void HandleInsertAllResponse(TableDataInsertAllResponse response)
         {
-            if (response.InsertErrors != null)
+            var errors = response.InsertErrors;
+            if (errors?.Count > 0)
             {
                 var exception = new GoogleApiException(Service.Name, "Error inserting data")
                 {
                     Error = new RequestError
                     {
                         Errors = response.InsertErrors
-                            .SelectMany(errors => (errors.Errors ?? Enumerable.Empty<ErrorProto>()).Select(error => new SingleError
+                            .SelectMany(rowErrors => (rowErrors.Errors ?? Enumerable.Empty<ErrorProto>()).Select(error => new SingleError
                             {
                                 Location = error.Location,
                                 Reason = error.Reason,
-                                Message = $"Row {errors.Index}: {error.Message}"
+                                Message = $"Row {rowErrors.Index}: {error.Message}"
                             }))
                             .ToList()
                     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryQueryJob.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryQueryJob.cs
@@ -14,6 +14,7 @@
 
 using Google.Api.Gax;
 using Google.Apis.Bigquery.v2.Data;
+using Google.Apis.Requests;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -157,6 +158,35 @@ namespace Google.Cloud.BigQuery.V2
 
             }
             return new BigQueryResultSet(rows, Schema, JobReference, pageToken);
+        }
+
+        /// <summary>
+        /// Returns <c>this</c> if the job has no errors, or throws an exception containing the
+        /// errors. A job may have errors but still contain useful information, and may also contain
+        /// errors before completing.
+        /// </summary>
+        /// <exception cref="GoogleApiException">The job has errors.</exception>
+        /// <returns><c>this</c> if the job has no errors.</returns>
+        public BigQueryQueryJob ThrowOnAnyError()
+        {
+            var errors = _response.Errors;
+            if (errors?.Count > 0)
+            {
+                throw new GoogleApiException(_client.Service.Name, $"Job {JobReference.ProjectId}/{JobReference.JobId} contained errors")
+                {
+                    Error = new RequestError
+                    {
+                        Errors = errors.Select(error => new SingleError
+                        {
+                            Location = error.Location,
+                            Reason = error.Reason,
+                            Message = error.Message
+                        })
+                        .ToList()
+                    }
+                };
+            }
+            return this;
         }
 
         /// <summary>


### PR DESCRIPTION
Only BigQueryJob has a snippet for this, because it's hard to get
a BigQueryQueryJob with errors - for invalid SQL, the request fails.
We'd need some way of creating a valid query that failed partially.

Fixes #329.