### PR TITLE
add assembly to complete example

### DIFF
--- a/apis/Google.Logging.V2/Google.Logging.Log4Net/readme.md
+++ b/apis/Google.Logging.V2/Google.Logging.Log4Net/readme.md
@@ -83,7 +83,7 @@ So, for example, a complete configuration might look like this:
 ``` xml
 <?xml version="1.0" encoding="utf-8" ?>
 <log4net>
-  <appender name="CloudLogger" type="Google.Logging.Log4Net.GoogleStackdriverAppender">
+  <appender name="CloudLogger" type="Google.Logging.Log4Net.GoogleStackdriverAppender,Google.Logging.Log4Net">
     <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value="%-4timestamp [%thread] %-5level %logger %ndc - %message" />
     </layout>


### PR DESCRIPTION
This was one of the other items I stumbled on when getting started. The complete example was missing the assembly name. The other example is not missing it.