### PR TITLE
Make BigQueryRow.GetFieldIndex public

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/TableSchemaExtensionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/TableSchemaExtensionsTest.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Google.Apis.Bigquery.v2.Data;
+using Xunit;
+
+namespace Google.Cloud.BigQuery.V2.Tests
+{
+    public class TableSchemaExtensionsTest
+    {
+        [Fact]
+        public void GetFieldIndex()
+        {
+            var schema = new TableSchema
+            {
+                Fields = new List<TableFieldSchema>
+                {
+                    new TableFieldSchema { Name = "foo" },
+                    new TableFieldSchema { Name = "bar" }
+                }
+            };
+            Assert.Equal(1, schema.GetFieldIndex("bar"));
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
@@ -52,7 +52,7 @@ namespace Google.Cloud.BigQuery.V2
         /// <summary>
         /// Retrieves a cell value by field name.
         /// </summary>
-        public object this[string name] => this[GetFieldIndex(name)];
+        public object this[string name] => this[Schema.GetFieldIndex(name)];
 
         /// <summary>
         /// Retrieves a cell value by index.
@@ -160,18 +160,6 @@ namespace Google.Cloud.BigQuery.V2
                 ret[field.Name] = ConvertSingleValue(token.Type == JTokenType.String ? (string)token : (object)token, field);
             }
             return ret;
-        }
-
-        private int GetFieldIndex(string fieldName)
-        {
-            for (int i = 0; i < Schema.Fields.Count; i++)
-            {
-                if (Schema.Fields[i].Name == fieldName)
-                {
-                    return i;
-                }
-            }
-            throw new KeyNotFoundException($"No such field: '{fieldName}'");
         }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/TableSchemaExtensions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/TableSchemaExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Google.Api.Gax;
+using Google.Apis.Bigquery.v2.Data;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// Extension methods over table schemas.
+    /// </summary>
+    public static class TableSchemaExtensions
+    {
+        /// <summary>
+        /// Retrieves the index of a field given its name.
+        /// </summary>
+        public static int GetFieldIndex(this TableSchema schema, string fieldName)
+        {
+            GaxPreconditions.CheckNotNull(schema, nameof(schema));
+            GaxPreconditions.CheckNotNull(fieldName, nameof(fieldName));
+
+            for (int i = 0; i < schema.Fields.Count; i++)
+            {
+                if (schema.Fields[i].Name == fieldName)
+                {
+                    return i;
+                }
+            }
+            throw new KeyNotFoundException($"No such field: '{fieldName}'");
+        }
+    }
+}


### PR DESCRIPTION
This API can be useful in general, and can be relied upon by the ADO.NET provider.