### PR TITLE
Update all projects to use the newly-released GAX (and common protos) beta05

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.JobCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.JobCrud.cs
@@ -67,7 +67,7 @@ namespace Google.Cloud.BigQuery.V2
             GaxPreconditions.CheckNotNull(jobReference, nameof(jobReference));
             return Polling.PollRepeatedly(ignoredDeadline => GetJob(jobReference, options),
                 job => job.State == JobState.Done,
-                Clock, Scheduler, pollSettings ?? s_defaultPollSettings);
+                Clock, Scheduler, pollSettings ?? s_defaultPollSettings, CancellationToken.None);
         }
 
         /// <inheritdoc />
@@ -109,7 +109,7 @@ namespace Google.Cloud.BigQuery.V2
             GaxPreconditions.CheckNotNull(jobReference, nameof(jobReference));
             return Polling.PollRepeatedlyAsync(ignoredDeadline => GetJobAsync(jobReference, options, cancellationToken),
                 job => job.State == JobState.Done,
-                Clock, Scheduler, pollSettings ?? s_defaultPollSettings);
+                Clock, Scheduler, pollSettings ?? s_defaultPollSettings, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
@@ -104,7 +104,7 @@ namespace Google.Cloud.BigQuery.V2
         {
             GaxPreconditions.CheckNotNull(jobReference, nameof(jobReference));
             return Polling.PollRepeatedly(ignoredDeadline => GetQueryResults(jobReference, options),
-                job => job.Completed, Clock, Scheduler, pollSettings ?? s_defaultPollSettings);
+                job => job.Completed, Clock, Scheduler, pollSettings ?? s_defaultPollSettings, CancellationToken.None);
         }
 
         /// <inheritdoc />
@@ -198,7 +198,7 @@ namespace Google.Cloud.BigQuery.V2
         {
             GaxPreconditions.CheckNotNull(jobReference, nameof(jobReference));
             return Polling.PollRepeatedlyAsync(ignoredDeadline => GetQueryResultsAsync(jobReference, options, cancellationToken),
-                job => job.Completed, Clock, Scheduler, pollSettings ?? s_defaultPollSettings);
+                job => job.Completed, Clock, Scheduler, pollSettings ?? s_defaultPollSettings, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/project.json
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/project.json
@@ -19,7 +19,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Rest": "1.0.0-beta04-CI00109",
+    "Google.Api.Gax.Rest": "1.0.0-beta05",
     "Google.Apis.Bigquery.v2": "1.18.0.659"
   },
   "frameworks": {

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/project.json
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/project.json
@@ -6,7 +6,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Grpc.Testing": "1.0.0-beta04",
+    "Google.Api.Gax.Grpc.Testing": "1.0.0-beta05",
     "Google.Cloud.ClientTesting": { "target": "project" },
     "Google.Cloud.Datastore.V1": { "target": "project" },
     "xunit": "2.2.0-beta2-build3300",

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/project.json
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/project.json
@@ -19,8 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax.Grpc": "1.0.0-beta04-CI00109"
+    "Google.Api.CommonProtos": "1.0.0-beta05",
+    "Google.Api.Gax.Grpc": "1.0.0-beta05"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/project.json
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/project.json
@@ -19,8 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax.Grpc": "1.0.0-beta04-CI00109"
+    "Google.Api.CommonProtos": "1.0.0-beta05",
+    "Google.Api.Gax.Grpc": "1.0.0-beta05"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/project.json
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/project.json
@@ -19,8 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax.Grpc": "1.0.0-beta04"
+    "Google.Api.CommonProtos": "1.0.0-beta05",
+    "Google.Api.Gax.Grpc": "1.0.0-beta05"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/project.json
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/project.json
@@ -19,8 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax.Grpc": "1.0.0-beta04-CI00109"
+    "Google.Api.CommonProtos": "1.0.0-beta05",
+    "Google.Api.Gax.Grpc": "1.0.0-beta05"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/Log4NetTest.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/Log4NetTest.cs
@@ -24,6 +24,7 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -68,18 +69,7 @@ namespace Google.Cloud.Logging.Log4Net.Tests
         /// </summary>
         private class NoDelayScheduler : IScheduler
         {
-            public Task Delay(TimeSpan delay) => Task.FromResult(0);
-
-            public async Task Schedule(Action action, TimeSpan delay)
-            {
-                await Delay(delay);
-                action();
-            }
-
-            public void Sleep(TimeSpan delay)
-            {
-                // Do nothing
-            }
+            public Task Delay(TimeSpan delay, CancellationToken cancellationToken) => Task.FromResult(0);
         }
 
         private Task RunTest(

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/project.json
@@ -7,7 +7,7 @@
 
   "dependencies": {
     "Google.Cloud.Logging.Log4Net": { "target": "project" },
-    "Google.Api.Gax.Testing": "1.0.0-beta04",
+    "Google.Api.Gax.Testing": "1.0.0-beta05",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Moq": "4.6.36-alpha"

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/LogUploader.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/LogUploader.cs
@@ -19,6 +19,7 @@ using Grpc.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Google.Cloud.Logging.Log4Net
@@ -132,7 +133,7 @@ namespace Google.Cloud.Logging.Log4Net
                 catch (Exception)
                 {
                     // Always retry, regardless of error, as there's nothing much else to be done.
-                    await _scheduler.Delay(errorDelay);
+                    await _scheduler.Delay(errorDelay, CancellationToken.None);
                     errorDelay = new TimeSpan((long)(errorDelay.Ticks * _serverErrorBackoffSettings.DelayMultiplier));
                     if (errorDelay > _serverErrorBackoffSettings.MaxDelay)
                     {

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Type/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Type/project.json
@@ -19,7 +19,7 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta04"
+    "Google.Api.CommonProtos": "1.0.0-beta05"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/project.json
@@ -19,7 +19,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Grpc": "1.0.0-beta04-CI00109",
+    "Google.Api.Gax.Grpc": "1.0.0-beta05",
     "Google.Cloud.Logging.Type": { "target": "project" }
   },
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/project.json
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/project.json
@@ -19,8 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax.Grpc": "1.0.0-beta04-CI00109"
+    "Google.Api.CommonProtos": "1.0.0-beta05",
+    "Google.Api.Gax.Grpc": "1.0.0-beta05"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/project.json
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/project.json
@@ -19,8 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax.Grpc": "1.0.0-beta04-CI00109",
+    "Google.Api.CommonProtos": "1.0.0-beta05",
+    "Google.Api.Gax.Grpc": "1.0.0-beta05",
     "Google.Cloud.Iam.V1": { "target": "project" }
   },
 

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
@@ -19,7 +19,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Grpc": "1.0.0-beta04-CI00109",
+    "Google.Api.Gax.Grpc": "1.0.0-beta05",
     "Google.LongRunning": { "target": "project" }
   },
 

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/project.json
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/project.json
@@ -19,7 +19,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Rest": "1.0.0-beta04-CI00109",
+    "Google.Api.Gax.Rest": "1.0.0-beta05",
     "Google.Apis.Storage.v1": "1.18.0.658"
   },
   "frameworks": {

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/project.json
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/project.json
@@ -19,8 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax.Grpc": "1.0.0-beta04-CI00109"
+    "Google.Api.CommonProtos": "1.0.0-beta05",
+    "Google.Api.Gax.Grpc": "1.0.0-beta05"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
@@ -19,8 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax.Grpc": "1.0.0-beta04-CI00109"
+    "Google.Api.CommonProtos": "1.0.0-beta05",
+    "Google.Api.Gax.Grpc": "1.0.0-beta05"
   },
 
   "frameworks": {

--- a/apis/Google.Devtools.AspNet/Google.Devtools.AspNet.Tests/project.json
+++ b/apis/Google.Devtools.AspNet/Google.Devtools.AspNet.Tests/project.json
@@ -6,7 +6,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Testing": "1.0.0-beta04",
+    "Google.Api.Gax.Testing": "1.0.0-beta05",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Google.Devtools.AspNet": { "target": "project" },
     "xunit": "2.2.0-beta3-build3402",

--- a/apis/Google.Devtools.AspNet/Google.Devtools.AspNet/project.json
+++ b/apis/Google.Devtools.AspNet/Google.Devtools.AspNet/project.json
@@ -18,8 +18,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax": "1.0.0-beta04-CI00109",
+    "Google.Api.CommonProtos": "1.0.0-beta05",
+    "Google.Api.Gax": "1.0.0-beta05",
     "Google.Cloud.ErrorReporting.V1Beta1": { "target": "project" },
     "Google.Cloud.Trace.V1": { "target": "project" },
     "Microsoft.AspNet.WebApi.Core": "5.2.3"

--- a/apis/Google.LongRunning/Google.LongRunning.Tests/project.json
+++ b/apis/Google.LongRunning/Google.LongRunning.Tests/project.json
@@ -6,7 +6,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Testing": "1.0.0-beta04",
+    "Google.Api.Gax.Testing": "1.0.0-beta05",
     "Google.Cloud.ClientTesting": { "target": "project" },
     "Google.LongRunning": { "target": "project" },
     "xunit": "2.2.0-beta2-build3300",

--- a/apis/Google.LongRunning/Google.LongRunning/Operation.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/Operation.cs
@@ -137,9 +137,12 @@ namespace Google.LongRunning
             {
                 return this;
             }
-            // TODO: Use the deadline.
+            // TODO: Use the deadline and get a cancellation token from the effective call settings.
             Func<DateTime?, Operation<T>> pollAction = deadline => PollOnce(callSettings);
-            return Polling.PollRepeatedly(pollAction, o => o.IsCompleted, Client.Clock, Client.Scheduler, pollSettings ?? s_defaultPollSettings);
+            return Polling.PollRepeatedly(
+                pollAction, o => o.IsCompleted,
+                Client.Clock, Client.Scheduler, pollSettings ?? s_defaultPollSettings,
+                CancellationToken.None);
         }
 
         /// <summary>
@@ -159,9 +162,12 @@ namespace Google.LongRunning
             {
                 return Task.FromResult(this);
             }
-            // TODO: Use the deadline.
+            // TODO: Use the deadline and get a cancellation token from the effective call settings.
             Func<DateTime?, Task<Operation<T>>> pollAction = deadline => PollOnceAsync(callSettings);
-            return Polling.PollRepeatedlyAsync(pollAction, o => o.IsCompleted, Client.Clock, Client.Scheduler, pollSettings ?? s_defaultPollSettings);
+            return Polling.PollRepeatedlyAsync(
+                pollAction, o => o.IsCompleted,
+                Client.Clock, Client.Scheduler, pollSettings ?? s_defaultPollSettings,
+                CancellationToken.None);
         }
 
         /// <summary>

--- a/apis/Google.LongRunning/Google.LongRunning/project.json
+++ b/apis/Google.LongRunning/Google.LongRunning/project.json
@@ -19,8 +19,8 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta04",
-    "Google.Api.Gax.Grpc": "1.0.0-beta04-CI00109"
+    "Google.Api.CommonProtos": "1.0.0-beta05",
+    "Google.Api.Gax.Grpc": "1.0.0-beta05"
   },
 
   "frameworks": {


### PR DESCRIPTION
This additionally requires Operation to be updated to pass in a cancellation token.
It's not the *right* cancellation token, but we can fix that later.

Finally, Logging needs to pass in a cancellation token too, although
we don't have one at all there.