### PR TITLE
Use the number of seconds the tasks were running to get the number of allowed traces

### DIFF
--- a/apis/Google.Devtools.AspNet/Google.Devtools.AspNet.Tests/CloudTrace/RateLimiterTest.cs
+++ b/apis/Google.Devtools.AspNet/Google.Devtools.AspNet.Tests/CloudTrace/RateLimiterTest.cs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 using Moq;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -69,6 +71,10 @@ namespace Google.Devtools.AspNet.Tests
                 int canTraceCounter = 0;
                 int threads = 10;
 
+                // Start a timer to get the total time from tasks starting to ending.
+                Stopwatch timer = new Stopwatch();
+                timer.Start();
+
                 // Start 10 threads to hit the rate limiter
                 Task[] tasks = new Task[threads];
                 for (int i = 0; i < threads; i++)
@@ -86,9 +92,12 @@ namespace Google.Devtools.AspNet.Tests
                     });
                 }
 
-                // Set a timeout of 2.1 seconds which should allow 2 traces.
+                // Set a timeout to 2.1 seconds which should allow 2 traces unless control
+                // of the tasks does not return right away.  To ensure a proper trace count
+                // use the number of seconds to check the trace count.
                 await Task.Delay(2100);
-                Assert.Equal(2, canTraceCounter);
+                var elapsedSeconds = Math.Floor(timer.ElapsedMilliseconds / 1000.0);
+                Assert.Equal(elapsedSeconds, canTraceCounter);
             }
             finally
             {

--- a/apis/Google.Devtools.AspNet/Google.Devtools.AspNet.Tests/CloudTrace/RateLimiterTest.cs
+++ b/apis/Google.Devtools.AspNet/Google.Devtools.AspNet.Tests/CloudTrace/RateLimiterTest.cs
@@ -72,8 +72,7 @@ namespace Google.Devtools.AspNet.Tests
                 int threads = 10;
 
                 // Start a timer to get the total time from tasks starting to ending.
-                Stopwatch timer = new Stopwatch();
-                timer.Start();
+                Stopwatch timer = Stopwatch.StartNew();
 
                 // Start 10 threads to hit the rate limiter
                 Task[] tasks = new Task[threads];
@@ -96,7 +95,7 @@ namespace Google.Devtools.AspNet.Tests
                 // of the tasks does not return right away.  To ensure a proper trace count
                 // use the number of seconds to check the trace count.
                 await Task.Delay(2100);
-                var elapsedSeconds = Math.Floor(timer.ElapsedMilliseconds / 1000.0);
+                var elapsedSeconds = Math.Floor(timer.Elapsed.TotalSeconds);
 
                 // Allow for the trace count to be one lower than expected to account
                 // for the elapsed time being on the second mark or close and the

--- a/apis/Google.Devtools.AspNet/Google.Devtools.AspNet.Tests/CloudTrace/RateLimiterTest.cs
+++ b/apis/Google.Devtools.AspNet/Google.Devtools.AspNet.Tests/CloudTrace/RateLimiterTest.cs
@@ -97,7 +97,11 @@ namespace Google.Devtools.AspNet.Tests
                 // use the number of seconds to check the trace count.
                 await Task.Delay(2100);
                 var elapsedSeconds = Math.Floor(timer.ElapsedMilliseconds / 1000.0);
-                Assert.Equal(elapsedSeconds, canTraceCounter);
+
+                // Allow for the trace count to be one lower than expected to account
+                // for the elapsed time being on the second mark or close and the
+                // limiter not getting a final request.
+                Assert.InRange(canTraceCounter, elapsedSeconds - 1, elapsedSeconds);
             }
             finally
             {


### PR DESCRIPTION
Using a predetermined count was causing intermittent failures if the tasks ran longer than expected.

Fixes #610 