### PR TITLE
Update all version numbers ready for release

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/project.json
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta04-*",
+  "version": "1.0.0-beta05-*",
   "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/project.json
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0-beta04-*",
+  "version": "1.0.0-beta05-*",
   "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/project.json
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-*",
+  "version": "0.4.0-*",
   "description": "Recommended Google client library to access the Stackdriver Error Reporting API, which groups and counts similar errors from cloud services. The Stackdriver Error Reporting API provides a way to report new errors and read access to error groups and their associated errors.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/project.json
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0-beta04-*",
+  "version": "1.0.0-beta05-*",
   "description": "gRPC services for the Google Identity and Access Management API. This library is typically used as a dependency for other API client libraries.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/project.json
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0-beta01-*",
+  "version": "1.0.0-beta02-*",
   "description": "Recommended Google client library to access the Google Cloud Natural Language API, which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0-beta04-*",
+  "version": "1.0.0-beta05-*",
   "description": "Log4Net client library for the Google Stackdriver Logging API.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Type/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Type/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta04-*",
+  "version": "1.0.0-beta05-*",
   "description": "Version-agnostic types for the Google Stackdriver Logging API.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta04-*",
+  "version": "1.0.0-beta05-*",
   "description": "Recommended Google client library to access the Google Stackdriver Logging API, which writes log entries and manages your logs, log sinks, and logs-based metrics.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/project.json
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.3.0-*",
+  "version": "0.4.0-*",
   "description": "Google Compute Engine Metadata v1 client library",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/project.json
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-*",
+  "version": "0.4.0-*",
   "description": "Recommended Google client library to access the Stackdriver Monitoring API, which manages your Stackdriver Monitoring data and configurations. Most projects must be associated with a Stackdriver account, with a few exceptions as noted on the individual method pages.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/project.json
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0-beta04-*",
+  "version": "1.0.0-beta05-*",
   "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.4.0-*",
+  "version": "0.5.0-*",
   "description": "Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/project.json
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta04-*",
+  "version": "1.0.0-beta05-*",
   "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/project.json
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-*",
+  "version": "0.4.0-*",
   "description": "Recommended Google client library to access the Google Cloud Trace API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0-alpha03-*",
+  "version": "1.0.0-alpha04-*",
   "description": "Recommended Google client library to access the Google Cloud Vision API, which integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Devtools.AspNet/Google.Devtools.AspNet/project.json
+++ b/apis/Google.Devtools.AspNet/Google.Devtools.AspNet/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0-*",
+  "version": "0.3.0-*",
   "description": "Google Stackdriver Instrumentation Libraries for ASP.NET.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.LongRunning/Google.LongRunning/project.json
+++ b/apis/Google.LongRunning/Google.LongRunning/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0-beta03-*",
+  "version": "1.0.0-beta04-*",
   "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",
   "authors": [ "Google Inc." ],
 


### PR DESCRIPTION
- All 1.0.0-{alpha/beta}-x versions are now 1.0.0-{alpha/beta}-x+1
- All 0.x.0 versions are now 0.x+1.0.

(Even though we're changing name, we're keeping the same linear versions for all libraries. It's easier than having two 1.0.0-beta01 versions differing only in name, for example.)