### PR TITLE
Regenerate all APIs

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Query.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Query.cs
@@ -2399,6 +2399,7 @@ namespace Google.Cloud.Datastore.V1 {
     ///  In a single transaction, subsequent query result batches for the same query
     ///  can have a greater snapshot version number. Each batch's snapshot version
     ///  is valid for all preceding batches.
+    ///  The value will be zero for eventually consistent queries.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public long SnapshotVersion {

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Common.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Common.cs
@@ -24,37 +24,39 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
           string.Concat(
             "Cjhnb29nbGUvZGV2dG9vbHMvY2xvdWRlcnJvcnJlcG9ydGluZy92MWJldGEx",
             "L2NvbW1vbi5wcm90bxIrZ29vZ2xlLmRldnRvb2xzLmNsb3VkZXJyb3JyZXBv",
-            "cnRpbmcudjFiZXRhMRocZ29vZ2xlL2FwaS9hbm5vdGF0aW9ucy5wcm90bxof",
-            "Z29vZ2xlL3Byb3RvYnVmL3RpbWVzdGFtcC5wcm90byKBAQoKRXJyb3JHcm91",
-            "cBIMCgRuYW1lGAEgASgJEhAKCGdyb3VwX2lkGAIgASgJElMKD3RyYWNraW5n",
-            "X2lzc3VlcxgDIAMoCzI6Lmdvb2dsZS5kZXZ0b29scy5jbG91ZGVycm9ycmVw",
-            "b3J0aW5nLnYxYmV0YTEuVHJhY2tpbmdJc3N1ZSIcCg1UcmFja2luZ0lzc3Vl",
-            "EgsKA3VybBgBIAEoCSLvAQoKRXJyb3JFdmVudBIuCgpldmVudF90aW1lGAEg",
-            "ASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBJUCg9zZXJ2aWNlX2Nv",
-            "bnRleHQYAiABKAsyOy5nb29nbGUuZGV2dG9vbHMuY2xvdWRlcnJvcnJlcG9y",
-            "dGluZy52MWJldGExLlNlcnZpY2VDb250ZXh0Eg8KB21lc3NhZ2UYAyABKAkS",
-            "SgoHY29udGV4dBgFIAEoCzI5Lmdvb2dsZS5kZXZ0b29scy5jbG91ZGVycm9y",
-            "cmVwb3J0aW5nLnYxYmV0YTEuRXJyb3JDb250ZXh0IjIKDlNlcnZpY2VDb250",
-            "ZXh0Eg8KB3NlcnZpY2UYAiABKAkSDwoHdmVyc2lvbhgDIAEoCSLJAQoMRXJy",
-            "b3JDb250ZXh0ElUKDGh0dHBfcmVxdWVzdBgBIAEoCzI/Lmdvb2dsZS5kZXZ0",
-            "b29scy5jbG91ZGVycm9ycmVwb3J0aW5nLnYxYmV0YTEuSHR0cFJlcXVlc3RD",
-            "b250ZXh0EgwKBHVzZXIYAiABKAkSVAoPcmVwb3J0X2xvY2F0aW9uGAMgASgL",
-            "MjsuZ29vZ2xlLmRldnRvb2xzLmNsb3VkZXJyb3JyZXBvcnRpbmcudjFiZXRh",
-            "MS5Tb3VyY2VMb2NhdGlvbiKIAQoSSHR0cFJlcXVlc3RDb250ZXh0Eg4KBm1l",
-            "dGhvZBgBIAEoCRILCgN1cmwYAiABKAkSEgoKdXNlcl9hZ2VudBgDIAEoCRIQ",
-            "CghyZWZlcnJlchgEIAEoCRIcChRyZXNwb25zZV9zdGF0dXNfY29kZRgFIAEo",
-            "BRIRCglyZW1vdGVfaXAYBiABKAkiTwoOU291cmNlTG9jYXRpb24SEQoJZmls",
-            "ZV9wYXRoGAEgASgJEhMKC2xpbmVfbnVtYmVyGAIgASgFEhUKDWZ1bmN0aW9u",
-            "X25hbWUYBCABKAlCZgovY29tLmdvb2dsZS5kZXZ0b29scy5jbG91ZGVycm9y",
-            "cmVwb3J0aW5nLnYxYmV0YTFCC0NvbW1vblByb3RvUAGqAiNHb29nbGUuQ2xv",
-            "dWQuRXJyb3JSZXBvcnRpbmcuVjFCZXRhMWIGcHJvdG8z"));
+            "cnRpbmcudjFiZXRhMRocZ29vZ2xlL2FwaS9hbm5vdGF0aW9ucy5wcm90bxoj",
+            "Z29vZ2xlL2FwaS9tb25pdG9yZWRfcmVzb3VyY2UucHJvdG8aH2dvb2dsZS9w",
+            "cm90b2J1Zi90aW1lc3RhbXAucHJvdG8igQEKCkVycm9yR3JvdXASDAoEbmFt",
+            "ZRgBIAEoCRIQCghncm91cF9pZBgCIAEoCRJTCg90cmFja2luZ19pc3N1ZXMY",
+            "AyADKAsyOi5nb29nbGUuZGV2dG9vbHMuY2xvdWRlcnJvcnJlcG9ydGluZy52",
+            "MWJldGExLlRyYWNraW5nSXNzdWUiHAoNVHJhY2tpbmdJc3N1ZRILCgN1cmwY",
+            "ASABKAki7wEKCkVycm9yRXZlbnQSLgoKZXZlbnRfdGltZRgBIAEoCzIaLmdv",
+            "b2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASVAoPc2VydmljZV9jb250ZXh0GAIg",
+            "ASgLMjsuZ29vZ2xlLmRldnRvb2xzLmNsb3VkZXJyb3JyZXBvcnRpbmcudjFi",
+            "ZXRhMS5TZXJ2aWNlQ29udGV4dBIPCgdtZXNzYWdlGAMgASgJEkoKB2NvbnRl",
+            "eHQYBSABKAsyOS5nb29nbGUuZGV2dG9vbHMuY2xvdWRlcnJvcnJlcG9ydGlu",
+            "Zy52MWJldGExLkVycm9yQ29udGV4dCJJCg5TZXJ2aWNlQ29udGV4dBIPCgdz",
+            "ZXJ2aWNlGAIgASgJEg8KB3ZlcnNpb24YAyABKAkSFQoNcmVzb3VyY2VfdHlw",
+            "ZRgEIAEoCSLJAQoMRXJyb3JDb250ZXh0ElUKDGh0dHBfcmVxdWVzdBgBIAEo",
+            "CzI/Lmdvb2dsZS5kZXZ0b29scy5jbG91ZGVycm9ycmVwb3J0aW5nLnYxYmV0",
+            "YTEuSHR0cFJlcXVlc3RDb250ZXh0EgwKBHVzZXIYAiABKAkSVAoPcmVwb3J0",
+            "X2xvY2F0aW9uGAMgASgLMjsuZ29vZ2xlLmRldnRvb2xzLmNsb3VkZXJyb3Jy",
+            "ZXBvcnRpbmcudjFiZXRhMS5Tb3VyY2VMb2NhdGlvbiKIAQoSSHR0cFJlcXVl",
+            "c3RDb250ZXh0Eg4KBm1ldGhvZBgBIAEoCRILCgN1cmwYAiABKAkSEgoKdXNl",
+            "cl9hZ2VudBgDIAEoCRIQCghyZWZlcnJlchgEIAEoCRIcChRyZXNwb25zZV9z",
+            "dGF0dXNfY29kZRgFIAEoBRIRCglyZW1vdGVfaXAYBiABKAkiTwoOU291cmNl",
+            "TG9jYXRpb24SEQoJZmlsZV9wYXRoGAEgASgJEhMKC2xpbmVfbnVtYmVyGAIg",
+            "ASgFEhUKDWZ1bmN0aW9uX25hbWUYBCABKAlCZgovY29tLmdvb2dsZS5kZXZ0",
+            "b29scy5jbG91ZGVycm9ycmVwb3J0aW5nLnYxYmV0YTFCC0NvbW1vblByb3Rv",
+            "UAGqAiNHb29nbGUuQ2xvdWQuRXJyb3JSZXBvcnRpbmcuVjFCZXRhMWIGcHJv",
+            "dG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::Google.Api.AnnotationsReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Google.Api.AnnotationsReflection.Descriptor, global::Google.Api.MonitoredResourceReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ErrorGroup), global::Google.Cloud.ErrorReporting.V1Beta1.ErrorGroup.Parser, new[]{ "Name", "GroupId", "TrackingIssues" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.TrackingIssue), global::Google.Cloud.ErrorReporting.V1Beta1.TrackingIssue.Parser, new[]{ "Url" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ErrorEvent), global::Google.Cloud.ErrorReporting.V1Beta1.ErrorEvent.Parser, new[]{ "EventTime", "ServiceContext", "Message", "Context" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ServiceContext), global::Google.Cloud.ErrorReporting.V1Beta1.ServiceContext.Parser, new[]{ "Service", "Version" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ServiceContext), global::Google.Cloud.ErrorReporting.V1Beta1.ServiceContext.Parser, new[]{ "Service", "Version", "ResourceType" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ErrorContext), global::Google.Cloud.ErrorReporting.V1Beta1.ErrorContext.Parser, new[]{ "HttpRequest", "User", "ReportLocation" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.HttpRequestContext), global::Google.Cloud.ErrorReporting.V1Beta1.HttpRequestContext.Parser, new[]{ "Method", "Url", "UserAgent", "Referrer", "ResponseStatusCode", "RemoteIp" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.SourceLocation), global::Google.Cloud.ErrorReporting.V1Beta1.SourceLocation.Parser, new[]{ "FilePath", "LineNumber", "FunctionName" }, null, null, null)
@@ -633,6 +635,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
     public ServiceContext(ServiceContext other) : this() {
       service_ = other.service_;
       version_ = other.version_;
+      resourceType_ = other.resourceType_;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -675,6 +678,24 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       }
     }
 
+    /// <summary>Field number for the "resource_type" field.</summary>
+    public const int ResourceTypeFieldNumber = 4;
+    private string resourceType_ = "";
+    /// <summary>
+    ///  Type of the MonitoredResource. List of possible values:
+    ///  https://cloud.google.com/monitoring/api/resources
+    ///
+    ///  Value is set automatically for incoming errors and must not be set when
+    ///  reporting errors.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string ResourceType {
+      get { return resourceType_; }
+      set {
+        resourceType_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ServiceContext);
@@ -690,6 +711,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       }
       if (Service != other.Service) return false;
       if (Version != other.Version) return false;
+      if (ResourceType != other.ResourceType) return false;
       return true;
     }
 
@@ -698,6 +720,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       int hash = 1;
       if (Service.Length != 0) hash ^= Service.GetHashCode();
       if (Version.Length != 0) hash ^= Version.GetHashCode();
+      if (ResourceType.Length != 0) hash ^= ResourceType.GetHashCode();
       return hash;
     }
 
@@ -716,6 +739,10 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
         output.WriteRawTag(26);
         output.WriteString(Version);
       }
+      if (ResourceType.Length != 0) {
+        output.WriteRawTag(34);
+        output.WriteString(ResourceType);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -726,6 +753,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       }
       if (Version.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Version);
+      }
+      if (ResourceType.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(ResourceType);
       }
       return size;
     }
@@ -740,6 +770,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       }
       if (other.Version.Length != 0) {
         Version = other.Version;
+      }
+      if (other.ResourceType.Length != 0) {
+        ResourceType = other.ResourceType;
       }
     }
 
@@ -757,6 +790,10 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
           }
           case 26: {
             Version = input.ReadString();
+            break;
+          }
+          case 34: {
+            ResourceType = input.ReadString();
             break;
           }
         }

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsService.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsService.cs
@@ -40,74 +40,77 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
             "Lmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASSwoFb3JkZXIYCSABKA4yPC5n",
             "b29nbGUuZGV2dG9vbHMuY2xvdWRlcnJvcnJlcG9ydGluZy52MWJldGExLkVy",
             "cm9yR3JvdXBPcmRlchIRCglwYWdlX3NpemUYCyABKAUSEgoKcGFnZV90b2tl",
-            "bhgMIAEoCSKKAQoWTGlzdEdyb3VwU3RhdHNSZXNwb25zZRJXChFlcnJvcl9n",
+            "bhgMIAEoCSLAAQoWTGlzdEdyb3VwU3RhdHNSZXNwb25zZRJXChFlcnJvcl9n",
             "cm91cF9zdGF0cxgBIAMoCzI8Lmdvb2dsZS5kZXZ0b29scy5jbG91ZGVycm9y",
             "cmVwb3J0aW5nLnYxYmV0YTEuRXJyb3JHcm91cFN0YXRzEhcKD25leHRfcGFn",
-            "ZV90b2tlbhgCIAEoCSKGBAoPRXJyb3JHcm91cFN0YXRzEkYKBWdyb3VwGAEg",
-            "ASgLMjcuZ29vZ2xlLmRldnRvb2xzLmNsb3VkZXJyb3JyZXBvcnRpbmcudjFi",
-            "ZXRhMS5FcnJvckdyb3VwEg0KBWNvdW50GAIgASgDEhwKFGFmZmVjdGVkX3Vz",
-            "ZXJzX2NvdW50GAMgASgDEk0KDHRpbWVkX2NvdW50cxgEIAMoCzI3Lmdvb2ds",
-            "ZS5kZXZ0b29scy5jbG91ZGVycm9ycmVwb3J0aW5nLnYxYmV0YTEuVGltZWRD",
-            "b3VudBIzCg9maXJzdF9zZWVuX3RpbWUYBSABKAsyGi5nb29nbGUucHJvdG9i",
-            "dWYuVGltZXN0YW1wEjIKDmxhc3Rfc2Vlbl90aW1lGAYgASgLMhouZ29vZ2xl",
-            "LnByb3RvYnVmLlRpbWVzdGFtcBJWChFhZmZlY3RlZF9zZXJ2aWNlcxgHIAMo",
-            "CzI7Lmdvb2dsZS5kZXZ0b29scy5jbG91ZGVycm9ycmVwb3J0aW5nLnYxYmV0",
-            "YTEuU2VydmljZUNvbnRleHQSHQoVbnVtX2FmZmVjdGVkX3NlcnZpY2VzGAgg",
-            "ASgFEk8KDnJlcHJlc2VudGF0aXZlGAkgASgLMjcuZ29vZ2xlLmRldnRvb2xz",
-            "LmNsb3VkZXJyb3JyZXBvcnRpbmcudjFiZXRhMS5FcnJvckV2ZW50InkKClRp",
-            "bWVkQ291bnQSDQoFY291bnQYASABKAMSLgoKc3RhcnRfdGltZRgCIAEoCzIa",
-            "Lmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLAoIZW5kX3RpbWUYAyABKAsy",
-            "Gi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wIo4CChFMaXN0RXZlbnRzUmVx",
-            "dWVzdBIUCgxwcm9qZWN0X25hbWUYASABKAkSEAoIZ3JvdXBfaWQYAiABKAkS",
-            "WQoOc2VydmljZV9maWx0ZXIYAyABKAsyQS5nb29nbGUuZGV2dG9vbHMuY2xv",
-            "dWRlcnJvcnJlcG9ydGluZy52MWJldGExLlNlcnZpY2VDb250ZXh0RmlsdGVy",
-            "Ek8KCnRpbWVfcmFuZ2UYBCABKAsyOy5nb29nbGUuZGV2dG9vbHMuY2xvdWRl",
-            "cnJvcnJlcG9ydGluZy52MWJldGExLlF1ZXJ5VGltZVJhbmdlEhEKCXBhZ2Vf",
-            "c2l6ZRgGIAEoBRISCgpwYWdlX3Rva2VuGAcgASgJInwKEkxpc3RFdmVudHNS",
-            "ZXNwb25zZRJNCgxlcnJvcl9ldmVudHMYASADKAsyNy5nb29nbGUuZGV2dG9v",
-            "bHMuY2xvdWRlcnJvcnJlcG9ydGluZy52MWJldGExLkVycm9yRXZlbnQSFwoP",
-            "bmV4dF9wYWdlX3Rva2VuGAIgASgJIucBCg5RdWVyeVRpbWVSYW5nZRJSCgZw",
-            "ZXJpb2QYASABKA4yQi5nb29nbGUuZGV2dG9vbHMuY2xvdWRlcnJvcnJlcG9y",
-            "dGluZy52MWJldGExLlF1ZXJ5VGltZVJhbmdlLlBlcmlvZCKAAQoGUGVyaW9k",
-            "EhYKElBFUklPRF9VTlNQRUNJRklFRBAAEhEKDVBFUklPRF8xX0hPVVIQARIS",
-            "Cg5QRVJJT0RfNl9IT1VSUxACEhAKDFBFUklPRF8xX0RBWRADEhEKDVBFUklP",
-            "RF8xX1dFRUsQBBISCg5QRVJJT0RfMzBfREFZUxAFIjgKFFNlcnZpY2VDb250",
-            "ZXh0RmlsdGVyEg8KB3NlcnZpY2UYAiABKAkSDwoHdmVyc2lvbhgDIAEoCSIr",
-            "ChNEZWxldGVFdmVudHNSZXF1ZXN0EhQKDHByb2plY3RfbmFtZRgBIAEoCSIW",
-            "ChREZWxldGVFdmVudHNSZXNwb25zZSp1ChNUaW1lZENvdW50QWxpZ25tZW50",
-            "EiUKIUVSUk9SX0NPVU5UX0FMSUdOTUVOVF9VTlNQRUNJRklFRBAAEhsKF0FM",
-            "SUdOTUVOVF9FUVVBTF9ST1VOREVEEAESGgoWQUxJR05NRU5UX0VRVUFMX0FU",
-            "X0VORBACKn0KD0Vycm9yR3JvdXBPcmRlchIbChdHUk9VUF9PUkRFUl9VTlNQ",
-            "RUNJRklFRBAAEg4KCkNPVU5UX0RFU0MQARISCg5MQVNUX1NFRU5fREVTQxAC",
-            "EhAKDENSRUFURURfREVTQxADEhcKE0FGRkVDVEVEX1VTRVJTX0RFU0MQBDLy",
-            "BAoRRXJyb3JTdGF0c1NlcnZpY2US0AEKDkxpc3RHcm91cFN0YXRzEkIuZ29v",
-            "Z2xlLmRldnRvb2xzLmNsb3VkZXJyb3JyZXBvcnRpbmcudjFiZXRhMS5MaXN0",
-            "R3JvdXBTdGF0c1JlcXVlc3QaQy5nb29nbGUuZGV2dG9vbHMuY2xvdWRlcnJv",
-            "cnJlcG9ydGluZy52MWJldGExLkxpc3RHcm91cFN0YXRzUmVzcG9uc2UiNYLT",
-            "5JMCLxItL3YxYmV0YTEve3Byb2plY3RfbmFtZT1wcm9qZWN0cy8qfS9ncm91",
-            "cFN0YXRzEsABCgpMaXN0RXZlbnRzEj4uZ29vZ2xlLmRldnRvb2xzLmNsb3Vk",
-            "ZXJyb3JyZXBvcnRpbmcudjFiZXRhMS5MaXN0RXZlbnRzUmVxdWVzdBo/Lmdv",
-            "b2dsZS5kZXZ0b29scy5jbG91ZGVycm9ycmVwb3J0aW5nLnYxYmV0YTEuTGlz",
-            "dEV2ZW50c1Jlc3BvbnNlIjGC0+STAisSKS92MWJldGExL3twcm9qZWN0X25h",
-            "bWU9cHJvamVjdHMvKn0vZXZlbnRzEsYBCgxEZWxldGVFdmVudHMSQC5nb29n",
-            "bGUuZGV2dG9vbHMuY2xvdWRlcnJvcnJlcG9ydGluZy52MWJldGExLkRlbGV0",
-            "ZUV2ZW50c1JlcXVlc3QaQS5nb29nbGUuZGV2dG9vbHMuY2xvdWRlcnJvcnJl",
-            "cG9ydGluZy52MWJldGExLkRlbGV0ZUV2ZW50c1Jlc3BvbnNlIjGC0+STAisq",
-            "KS92MWJldGExL3twcm9qZWN0X25hbWU9cHJvamVjdHMvKn0vZXZlbnRzQnEK",
-            "L2NvbS5nb29nbGUuZGV2dG9vbHMuY2xvdWRlcnJvcnJlcG9ydGluZy52MWJl",
-            "dGExQhZFcnJvclN0YXRzU2VydmljZVByb3RvUAGqAiNHb29nbGUuQ2xvdWQu",
-            "RXJyb3JSZXBvcnRpbmcuVjFCZXRhMWIGcHJvdG8z"));
+            "ZV90b2tlbhgCIAEoCRI0ChB0aW1lX3JhbmdlX2JlZ2luGAQgASgLMhouZ29v",
+            "Z2xlLnByb3RvYnVmLlRpbWVzdGFtcCKGBAoPRXJyb3JHcm91cFN0YXRzEkYK",
+            "BWdyb3VwGAEgASgLMjcuZ29vZ2xlLmRldnRvb2xzLmNsb3VkZXJyb3JyZXBv",
+            "cnRpbmcudjFiZXRhMS5FcnJvckdyb3VwEg0KBWNvdW50GAIgASgDEhwKFGFm",
+            "ZmVjdGVkX3VzZXJzX2NvdW50GAMgASgDEk0KDHRpbWVkX2NvdW50cxgEIAMo",
+            "CzI3Lmdvb2dsZS5kZXZ0b29scy5jbG91ZGVycm9ycmVwb3J0aW5nLnYxYmV0",
+            "YTEuVGltZWRDb3VudBIzCg9maXJzdF9zZWVuX3RpbWUYBSABKAsyGi5nb29n",
+            "bGUucHJvdG9idWYuVGltZXN0YW1wEjIKDmxhc3Rfc2Vlbl90aW1lGAYgASgL",
+            "MhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBJWChFhZmZlY3RlZF9zZXJ2",
+            "aWNlcxgHIAMoCzI7Lmdvb2dsZS5kZXZ0b29scy5jbG91ZGVycm9ycmVwb3J0",
+            "aW5nLnYxYmV0YTEuU2VydmljZUNvbnRleHQSHQoVbnVtX2FmZmVjdGVkX3Nl",
+            "cnZpY2VzGAggASgFEk8KDnJlcHJlc2VudGF0aXZlGAkgASgLMjcuZ29vZ2xl",
+            "LmRldnRvb2xzLmNsb3VkZXJyb3JyZXBvcnRpbmcudjFiZXRhMS5FcnJvckV2",
+            "ZW50InkKClRpbWVkQ291bnQSDQoFY291bnQYASABKAMSLgoKc3RhcnRfdGlt",
+            "ZRgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLAoIZW5kX3Rp",
+            "bWUYAyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wIo4CChFMaXN0",
+            "RXZlbnRzUmVxdWVzdBIUCgxwcm9qZWN0X25hbWUYASABKAkSEAoIZ3JvdXBf",
+            "aWQYAiABKAkSWQoOc2VydmljZV9maWx0ZXIYAyABKAsyQS5nb29nbGUuZGV2",
+            "dG9vbHMuY2xvdWRlcnJvcnJlcG9ydGluZy52MWJldGExLlNlcnZpY2VDb250",
+            "ZXh0RmlsdGVyEk8KCnRpbWVfcmFuZ2UYBCABKAsyOy5nb29nbGUuZGV2dG9v",
+            "bHMuY2xvdWRlcnJvcnJlcG9ydGluZy52MWJldGExLlF1ZXJ5VGltZVJhbmdl",
+            "EhEKCXBhZ2Vfc2l6ZRgGIAEoBRISCgpwYWdlX3Rva2VuGAcgASgJIrIBChJM",
+            "aXN0RXZlbnRzUmVzcG9uc2USTQoMZXJyb3JfZXZlbnRzGAEgAygLMjcuZ29v",
+            "Z2xlLmRldnRvb2xzLmNsb3VkZXJyb3JyZXBvcnRpbmcudjFiZXRhMS5FcnJv",
+            "ckV2ZW50EhcKD25leHRfcGFnZV90b2tlbhgCIAEoCRI0ChB0aW1lX3Jhbmdl",
+            "X2JlZ2luGAQgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCLnAQoO",
+            "UXVlcnlUaW1lUmFuZ2USUgoGcGVyaW9kGAEgASgOMkIuZ29vZ2xlLmRldnRv",
+            "b2xzLmNsb3VkZXJyb3JyZXBvcnRpbmcudjFiZXRhMS5RdWVyeVRpbWVSYW5n",
+            "ZS5QZXJpb2QigAEKBlBlcmlvZBIWChJQRVJJT0RfVU5TUEVDSUZJRUQQABIR",
+            "Cg1QRVJJT0RfMV9IT1VSEAESEgoOUEVSSU9EXzZfSE9VUlMQAhIQCgxQRVJJ",
+            "T0RfMV9EQVkQAxIRCg1QRVJJT0RfMV9XRUVLEAQSEgoOUEVSSU9EXzMwX0RB",
+            "WVMQBSJPChRTZXJ2aWNlQ29udGV4dEZpbHRlchIPCgdzZXJ2aWNlGAIgASgJ",
+            "Eg8KB3ZlcnNpb24YAyABKAkSFQoNcmVzb3VyY2VfdHlwZRgEIAEoCSIrChNE",
+            "ZWxldGVFdmVudHNSZXF1ZXN0EhQKDHByb2plY3RfbmFtZRgBIAEoCSIWChRE",
+            "ZWxldGVFdmVudHNSZXNwb25zZSp1ChNUaW1lZENvdW50QWxpZ25tZW50EiUK",
+            "IUVSUk9SX0NPVU5UX0FMSUdOTUVOVF9VTlNQRUNJRklFRBAAEhsKF0FMSUdO",
+            "TUVOVF9FUVVBTF9ST1VOREVEEAESGgoWQUxJR05NRU5UX0VRVUFMX0FUX0VO",
+            "RBACKn0KD0Vycm9yR3JvdXBPcmRlchIbChdHUk9VUF9PUkRFUl9VTlNQRUNJ",
+            "RklFRBAAEg4KCkNPVU5UX0RFU0MQARISCg5MQVNUX1NFRU5fREVTQxACEhAK",
+            "DENSRUFURURfREVTQxADEhcKE0FGRkVDVEVEX1VTRVJTX0RFU0MQBDLyBAoR",
+            "RXJyb3JTdGF0c1NlcnZpY2US0AEKDkxpc3RHcm91cFN0YXRzEkIuZ29vZ2xl",
+            "LmRldnRvb2xzLmNsb3VkZXJyb3JyZXBvcnRpbmcudjFiZXRhMS5MaXN0R3Jv",
+            "dXBTdGF0c1JlcXVlc3QaQy5nb29nbGUuZGV2dG9vbHMuY2xvdWRlcnJvcnJl",
+            "cG9ydGluZy52MWJldGExLkxpc3RHcm91cFN0YXRzUmVzcG9uc2UiNYLT5JMC",
+            "LxItL3YxYmV0YTEve3Byb2plY3RfbmFtZT1wcm9qZWN0cy8qfS9ncm91cFN0",
+            "YXRzEsABCgpMaXN0RXZlbnRzEj4uZ29vZ2xlLmRldnRvb2xzLmNsb3VkZXJy",
+            "b3JyZXBvcnRpbmcudjFiZXRhMS5MaXN0RXZlbnRzUmVxdWVzdBo/Lmdvb2ds",
+            "ZS5kZXZ0b29scy5jbG91ZGVycm9ycmVwb3J0aW5nLnYxYmV0YTEuTGlzdEV2",
+            "ZW50c1Jlc3BvbnNlIjGC0+STAisSKS92MWJldGExL3twcm9qZWN0X25hbWU9",
+            "cHJvamVjdHMvKn0vZXZlbnRzEsYBCgxEZWxldGVFdmVudHMSQC5nb29nbGUu",
+            "ZGV2dG9vbHMuY2xvdWRlcnJvcnJlcG9ydGluZy52MWJldGExLkRlbGV0ZUV2",
+            "ZW50c1JlcXVlc3QaQS5nb29nbGUuZGV2dG9vbHMuY2xvdWRlcnJvcnJlcG9y",
+            "dGluZy52MWJldGExLkRlbGV0ZUV2ZW50c1Jlc3BvbnNlIjGC0+STAisqKS92",
+            "MWJldGExL3twcm9qZWN0X25hbWU9cHJvamVjdHMvKn0vZXZlbnRzQnEKL2Nv",
+            "bS5nb29nbGUuZGV2dG9vbHMuY2xvdWRlcnJvcnJlcG9ydGluZy52MWJldGEx",
+            "QhZFcnJvclN0YXRzU2VydmljZVByb3RvUAGqAiNHb29nbGUuQ2xvdWQuRXJy",
+            "b3JSZXBvcnRpbmcuVjFCZXRhMWIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Api.AnnotationsReflection.Descriptor, global::Google.Cloud.ErrorReporting.V1Beta1.CommonReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.DurationReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Google.Cloud.ErrorReporting.V1Beta1.TimedCountAlignment), typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ErrorGroupOrder), }, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ListGroupStatsRequest), global::Google.Cloud.ErrorReporting.V1Beta1.ListGroupStatsRequest.Parser, new[]{ "ProjectName", "GroupId", "ServiceFilter", "TimeRange", "TimedCountDuration", "Alignment", "AlignmentTime", "Order", "PageSize", "PageToken" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ListGroupStatsResponse), global::Google.Cloud.ErrorReporting.V1Beta1.ListGroupStatsResponse.Parser, new[]{ "ErrorGroupStats", "NextPageToken" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ListGroupStatsResponse), global::Google.Cloud.ErrorReporting.V1Beta1.ListGroupStatsResponse.Parser, new[]{ "ErrorGroupStats", "NextPageToken", "TimeRangeBegin" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ErrorGroupStats), global::Google.Cloud.ErrorReporting.V1Beta1.ErrorGroupStats.Parser, new[]{ "Group", "Count", "AffectedUsersCount", "TimedCounts", "FirstSeenTime", "LastSeenTime", "AffectedServices", "NumAffectedServices", "Representative" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.TimedCount), global::Google.Cloud.ErrorReporting.V1Beta1.TimedCount.Parser, new[]{ "Count", "StartTime", "EndTime" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ListEventsRequest), global::Google.Cloud.ErrorReporting.V1Beta1.ListEventsRequest.Parser, new[]{ "ProjectName", "GroupId", "ServiceFilter", "TimeRange", "PageSize", "PageToken" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ListEventsResponse), global::Google.Cloud.ErrorReporting.V1Beta1.ListEventsResponse.Parser, new[]{ "ErrorEvents", "NextPageToken" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ListEventsResponse), global::Google.Cloud.ErrorReporting.V1Beta1.ListEventsResponse.Parser, new[]{ "ErrorEvents", "NextPageToken", "TimeRangeBegin" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.QueryTimeRange), global::Google.Cloud.ErrorReporting.V1Beta1.QueryTimeRange.Parser, new[]{ "Period" }, null, new[]{ typeof(global::Google.Cloud.ErrorReporting.V1Beta1.QueryTimeRange.Types.Period) }, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ServiceContextFilter), global::Google.Cloud.ErrorReporting.V1Beta1.ServiceContextFilter.Parser, new[]{ "Service", "Version" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.ServiceContextFilter), global::Google.Cloud.ErrorReporting.V1Beta1.ServiceContextFilter.Parser, new[]{ "Service", "Version", "ResourceType" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.DeleteEventsRequest), global::Google.Cloud.ErrorReporting.V1Beta1.DeleteEventsRequest.Parser, new[]{ "ProjectName" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.ErrorReporting.V1Beta1.DeleteEventsResponse), global::Google.Cloud.ErrorReporting.V1Beta1.DeleteEventsResponse.Parser, null, null, null, null)
           }));
@@ -270,7 +273,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
     public const int TimeRangeFieldNumber = 5;
     private global::Google.Cloud.ErrorReporting.V1Beta1.QueryTimeRange timeRange_;
     /// <summary>
-    ///  [Required] List data for the given time range.
+    ///  [Optional] List data for the given time range.
+    ///  If not set a default time range is used. The field time_range_begin
+    ///  in the response will specify the beginning of this time range.
     ///  Only &lt;code>ErrorGroupStats&lt;/code> with a non-zero count in the given time
     ///  range are returned, unless the request contains an explicit group_id list.
     ///  If a group_id list is given, also &lt;code>ErrorGroupStats&lt;/code> with zero
@@ -639,6 +644,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
     public ListGroupStatsResponse(ListGroupStatsResponse other) : this() {
       errorGroupStats_ = other.errorGroupStats_.Clone();
       nextPageToken_ = other.nextPageToken_;
+      TimeRangeBegin = other.timeRangeBegin_ != null ? other.TimeRangeBegin.Clone() : null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -675,6 +681,23 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       }
     }
 
+    /// <summary>Field number for the "time_range_begin" field.</summary>
+    public const int TimeRangeBeginFieldNumber = 4;
+    private global::Google.Protobuf.WellKnownTypes.Timestamp timeRangeBegin_;
+    /// <summary>
+    ///  The timestamp specifies the start time to which the request was restricted.
+    ///  The start time is set based on the requested time range. It may be adjusted
+    ///  to a later time if a project has exceeded the storage quota and older data
+    ///  has been deleted.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::Google.Protobuf.WellKnownTypes.Timestamp TimeRangeBegin {
+      get { return timeRangeBegin_; }
+      set {
+        timeRangeBegin_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ListGroupStatsResponse);
@@ -690,6 +713,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       }
       if(!errorGroupStats_.Equals(other.errorGroupStats_)) return false;
       if (NextPageToken != other.NextPageToken) return false;
+      if (!object.Equals(TimeRangeBegin, other.TimeRangeBegin)) return false;
       return true;
     }
 
@@ -698,6 +722,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       int hash = 1;
       hash ^= errorGroupStats_.GetHashCode();
       if (NextPageToken.Length != 0) hash ^= NextPageToken.GetHashCode();
+      if (timeRangeBegin_ != null) hash ^= TimeRangeBegin.GetHashCode();
       return hash;
     }
 
@@ -713,6 +738,10 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
         output.WriteRawTag(18);
         output.WriteString(NextPageToken);
       }
+      if (timeRangeBegin_ != null) {
+        output.WriteRawTag(34);
+        output.WriteMessage(TimeRangeBegin);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -721,6 +750,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       size += errorGroupStats_.CalculateSize(_repeated_errorGroupStats_codec);
       if (NextPageToken.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(NextPageToken);
+      }
+      if (timeRangeBegin_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(TimeRangeBegin);
       }
       return size;
     }
@@ -733,6 +765,12 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       errorGroupStats_.Add(other.errorGroupStats_);
       if (other.NextPageToken.Length != 0) {
         NextPageToken = other.NextPageToken;
+      }
+      if (other.timeRangeBegin_ != null) {
+        if (timeRangeBegin_ == null) {
+          timeRangeBegin_ = new global::Google.Protobuf.WellKnownTypes.Timestamp();
+        }
+        TimeRangeBegin.MergeFrom(other.TimeRangeBegin);
       }
     }
 
@@ -750,6 +788,13 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
           }
           case 18: {
             NextPageToken = input.ReadString();
+            break;
+          }
+          case 34: {
+            if (timeRangeBegin_ == null) {
+              timeRangeBegin_ = new global::Google.Protobuf.WellKnownTypes.Timestamp();
+            }
+            input.ReadMessage(timeRangeBegin_);
             break;
           }
         }
@@ -1411,7 +1456,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
     /// <summary>
     ///  [Required] The resource name of the Google Cloud Platform project. Written
     ///  as `projects/` plus the
-    ///  [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+    ///  [Google Cloud Platform project
+    ///  ID](https://support.google.com/cloud/answer/6158840).
     ///  Example: `projects/my-project-123`.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1457,6 +1503,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
     private global::Google.Cloud.ErrorReporting.V1Beta1.QueryTimeRange timeRange_;
     /// <summary>
     ///  [Optional] List only data for the given time range.
+    ///  If not set a default time range is used. The field time_range_begin
+    ///  in the response will specify the beginning of this time range.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Google.Cloud.ErrorReporting.V1Beta1.QueryTimeRange TimeRange {
@@ -1689,6 +1737,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
     public ListEventsResponse(ListEventsResponse other) : this() {
       errorEvents_ = other.errorEvents_.Clone();
       nextPageToken_ = other.nextPageToken_;
+      TimeRangeBegin = other.timeRangeBegin_ != null ? other.TimeRangeBegin.Clone() : null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1725,6 +1774,20 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       }
     }
 
+    /// <summary>Field number for the "time_range_begin" field.</summary>
+    public const int TimeRangeBeginFieldNumber = 4;
+    private global::Google.Protobuf.WellKnownTypes.Timestamp timeRangeBegin_;
+    /// <summary>
+    ///  The timestamp specifies the start time to which the request was restricted.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::Google.Protobuf.WellKnownTypes.Timestamp TimeRangeBegin {
+      get { return timeRangeBegin_; }
+      set {
+        timeRangeBegin_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ListEventsResponse);
@@ -1740,6 +1803,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       }
       if(!errorEvents_.Equals(other.errorEvents_)) return false;
       if (NextPageToken != other.NextPageToken) return false;
+      if (!object.Equals(TimeRangeBegin, other.TimeRangeBegin)) return false;
       return true;
     }
 
@@ -1748,6 +1812,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       int hash = 1;
       hash ^= errorEvents_.GetHashCode();
       if (NextPageToken.Length != 0) hash ^= NextPageToken.GetHashCode();
+      if (timeRangeBegin_ != null) hash ^= TimeRangeBegin.GetHashCode();
       return hash;
     }
 
@@ -1763,6 +1828,10 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
         output.WriteRawTag(18);
         output.WriteString(NextPageToken);
       }
+      if (timeRangeBegin_ != null) {
+        output.WriteRawTag(34);
+        output.WriteMessage(TimeRangeBegin);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1771,6 +1840,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       size += errorEvents_.CalculateSize(_repeated_errorEvents_codec);
       if (NextPageToken.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(NextPageToken);
+      }
+      if (timeRangeBegin_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(TimeRangeBegin);
       }
       return size;
     }
@@ -1783,6 +1855,12 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       errorEvents_.Add(other.errorEvents_);
       if (other.NextPageToken.Length != 0) {
         NextPageToken = other.NextPageToken;
+      }
+      if (other.timeRangeBegin_ != null) {
+        if (timeRangeBegin_ == null) {
+          timeRangeBegin_ = new global::Google.Protobuf.WellKnownTypes.Timestamp();
+        }
+        TimeRangeBegin.MergeFrom(other.TimeRangeBegin);
       }
     }
 
@@ -1800,6 +1878,13 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
           }
           case 18: {
             NextPageToken = input.ReadString();
+            break;
+          }
+          case 34: {
+            if (timeRangeBegin_ == null) {
+              timeRangeBegin_ = new global::Google.Protobuf.WellKnownTypes.Timestamp();
+            }
+            input.ReadMessage(timeRangeBegin_);
             break;
           }
         }
@@ -2006,6 +2091,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
     public ServiceContextFilter(ServiceContextFilter other) : this() {
       service_ = other.service_;
       version_ = other.version_;
+      resourceType_ = other.resourceType_;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2043,6 +2129,21 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       }
     }
 
+    /// <summary>Field number for the "resource_type" field.</summary>
+    public const int ResourceTypeFieldNumber = 4;
+    private string resourceType_ = "";
+    /// <summary>
+    ///  [Optional] The exact value to match against
+    ///  [`ServiceContext.resource_type`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.resource_type).
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string ResourceType {
+      get { return resourceType_; }
+      set {
+        resourceType_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ServiceContextFilter);
@@ -2058,6 +2159,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       }
       if (Service != other.Service) return false;
       if (Version != other.Version) return false;
+      if (ResourceType != other.ResourceType) return false;
       return true;
     }
 
@@ -2066,6 +2168,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       int hash = 1;
       if (Service.Length != 0) hash ^= Service.GetHashCode();
       if (Version.Length != 0) hash ^= Version.GetHashCode();
+      if (ResourceType.Length != 0) hash ^= ResourceType.GetHashCode();
       return hash;
     }
 
@@ -2084,6 +2187,10 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
         output.WriteRawTag(26);
         output.WriteString(Version);
       }
+      if (ResourceType.Length != 0) {
+        output.WriteRawTag(34);
+        output.WriteString(ResourceType);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2094,6 +2201,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       }
       if (Version.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Version);
+      }
+      if (ResourceType.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(ResourceType);
       }
       return size;
     }
@@ -2108,6 +2218,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
       }
       if (other.Version.Length != 0) {
         Version = other.Version;
+      }
+      if (other.ResourceType.Length != 0) {
+        ResourceType = other.ResourceType;
       }
     }
 
@@ -2125,6 +2238,10 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
           }
           case 26: {
             Version = input.ReadString();
+            break;
+          }
+          case 34: {
+            ResourceType = input.ReadString();
             break;
           }
         }
@@ -2174,7 +2291,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1 {
     /// <summary>
     ///  [Required] The resource name of the Google Cloud Platform project. Written
     ///  as `projects/` plus the
-    ///  [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+    ///  [Google Cloud Platform project
+    ///  ID](https://support.google.com/cloud/answer/6158840).
     ///  Example: `projects/my-project-123`.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.cs
@@ -318,7 +318,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// Example: <code>projects/my-project-123</code>.
         /// </param>
         /// <param name="timeRange">
-        /// [Required] List data for the given time range.
+        /// [Optional] List data for the given time range.
+        /// If not set a default time range is used. The field time_range_begin
+        /// in the response will specify the beginning of this time range.
         /// Only <code>ErrorGroupStats</code> with a non-zero count in the given time
         /// range are returned, unless the request contains an explicit group_id list.
         /// If a group_id list is given, also <code>ErrorGroupStats</code> with zero
@@ -360,7 +362,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// Example: <code>projects/my-project-123</code>.
         /// </param>
         /// <param name="timeRange">
-        /// [Required] List data for the given time range.
+        /// [Optional] List data for the given time range.
+        /// If not set a default time range is used. The field time_range_begin
+        /// in the response will specify the beginning of this time range.
         /// Only <code>ErrorGroupStats</code> with a non-zero count in the given time
         /// range are returned, unless the request contains an explicit group_id list.
         /// If a group_id list is given, also <code>ErrorGroupStats</code> with zero
@@ -396,7 +400,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <param name="projectName">
         /// [Required] The resource name of the Google Cloud Platform project. Written
         /// as `projects/` plus the
-        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// [Google Cloud Platform project
+        /// ID](https://support.google.com/cloud/answer/6158840).
         /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="groupId">
@@ -432,7 +437,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <param name="projectName">
         /// [Required] The resource name of the Google Cloud Platform project. Written
         /// as `projects/` plus the
-        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// [Google Cloud Platform project
+        /// ID](https://support.google.com/cloud/answer/6158840).
         /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="groupId">
@@ -468,7 +474,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <param name="projectName">
         /// [Required] The resource name of the Google Cloud Platform project. Written
         /// as `projects/` plus the
-        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// [Google Cloud Platform project
+        /// ID](https://support.google.com/cloud/answer/6158840).
         /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="callSettings">
@@ -490,7 +497,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <param name="projectName">
         /// [Required] The resource name of the Google Cloud Platform project. Written
         /// as `projects/` plus the
-        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// [Google Cloud Platform project
+        /// ID](https://support.google.com/cloud/answer/6158840).
         /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="cancellationToken">
@@ -511,7 +519,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <param name="projectName">
         /// [Required] The resource name of the Google Cloud Platform project. Written
         /// as `projects/` plus the
-        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// [Google Cloud Platform project
+        /// ID](https://support.google.com/cloud/answer/6158840).
         /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="callSettings">
@@ -579,7 +588,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// Example: <code>projects/my-project-123</code>.
         /// </param>
         /// <param name="timeRange">
-        /// [Required] List data for the given time range.
+        /// [Optional] List data for the given time range.
+        /// If not set a default time range is used. The field time_range_begin
+        /// in the response will specify the beginning of this time range.
         /// Only <code>ErrorGroupStats</code> with a non-zero count in the given time
         /// range are returned, unless the request contains an explicit group_id list.
         /// If a group_id list is given, also <code>ErrorGroupStats</code> with zero
@@ -629,7 +640,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// Example: <code>projects/my-project-123</code>.
         /// </param>
         /// <param name="timeRange">
-        /// [Required] List data for the given time range.
+        /// [Optional] List data for the given time range.
+        /// If not set a default time range is used. The field time_range_begin
+        /// in the response will specify the beginning of this time range.
         /// Only <code>ErrorGroupStats</code> with a non-zero count in the given time
         /// range are returned, unless the request contains an explicit group_id list.
         /// If a group_id list is given, also <code>ErrorGroupStats</code> with zero
@@ -673,7 +686,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <param name="projectName">
         /// [Required] The resource name of the Google Cloud Platform project. Written
         /// as `projects/` plus the
-        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// [Google Cloud Platform project
+        /// ID](https://support.google.com/cloud/answer/6158840).
         /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="groupId">
@@ -717,7 +731,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <param name="projectName">
         /// [Required] The resource name of the Google Cloud Platform project. Written
         /// as `projects/` plus the
-        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// [Google Cloud Platform project
+        /// ID](https://support.google.com/cloud/answer/6158840).
         /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="groupId">
@@ -761,7 +776,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <param name="projectName">
         /// [Required] The resource name of the Google Cloud Platform project. Written
         /// as `projects/` plus the
-        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// [Google Cloud Platform project
+        /// ID](https://support.google.com/cloud/answer/6158840).
         /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="callSettings">
@@ -788,7 +804,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <param name="projectName">
         /// [Required] The resource name of the Google Cloud Platform project. Written
         /// as `projects/` plus the
-        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        /// [Google Cloud Platform project
+        /// ID](https://support.google.com/cloud/answer/6158840).
         /// Example: `projects/my-project-123`.
         /// </param>
         /// <param name="callSettings">

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/IamPolicyGrpc.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/IamPolicyGrpc.cs
@@ -111,6 +111,8 @@ namespace Google.Cloud.Iam.V1 {
 
       /// <summary>
       ///  Returns permissions that a caller has on the specified resource.
+      ///  If the resource does not exist, this will return an empty set of
+      ///  permissions, not a NOT_FOUND error.
       /// </summary>
       public virtual global::System.Threading.Tasks.Task<global::Google.Cloud.Iam.V1.TestIamPermissionsResponse> TestIamPermissions(global::Google.Cloud.Iam.V1.TestIamPermissionsRequest request, ServerCallContext context)
       {
@@ -212,6 +214,8 @@ namespace Google.Cloud.Iam.V1 {
       }
       /// <summary>
       ///  Returns permissions that a caller has on the specified resource.
+      ///  If the resource does not exist, this will return an empty set of
+      ///  permissions, not a NOT_FOUND error.
       /// </summary>
       public virtual global::Google.Cloud.Iam.V1.TestIamPermissionsResponse TestIamPermissions(global::Google.Cloud.Iam.V1.TestIamPermissionsRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
@@ -219,6 +223,8 @@ namespace Google.Cloud.Iam.V1 {
       }
       /// <summary>
       ///  Returns permissions that a caller has on the specified resource.
+      ///  If the resource does not exist, this will return an empty set of
+      ///  permissions, not a NOT_FOUND error.
       /// </summary>
       public virtual global::Google.Cloud.Iam.V1.TestIamPermissionsResponse TestIamPermissions(global::Google.Cloud.Iam.V1.TestIamPermissionsRequest request, CallOptions options)
       {
@@ -226,6 +232,8 @@ namespace Google.Cloud.Iam.V1 {
       }
       /// <summary>
       ///  Returns permissions that a caller has on the specified resource.
+      ///  If the resource does not exist, this will return an empty set of
+      ///  permissions, not a NOT_FOUND error.
       /// </summary>
       public virtual AsyncUnaryCall<global::Google.Cloud.Iam.V1.TestIamPermissionsResponse> TestIamPermissionsAsync(global::Google.Cloud.Iam.V1.TestIamPermissionsRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
@@ -233,6 +241,8 @@ namespace Google.Cloud.Iam.V1 {
       }
       /// <summary>
       ///  Returns permissions that a caller has on the specified resource.
+      ///  If the resource does not exist, this will return an empty set of
+      ///  permissions, not a NOT_FOUND error.
       /// </summary>
       public virtual AsyncUnaryCall<global::Google.Cloud.Iam.V1.TestIamPermissionsResponse> TestIamPermissionsAsync(global::Google.Cloud.Iam.V1.TestIamPermissionsRequest request, CallOptions options)
       {

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Policy.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Policy.cs
@@ -22,14 +22,14 @@ namespace Google.Cloud.Iam.V1 {
     static PolicyReflection() {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
-            "Chpnb29nbGUvaWFtL3YxL3BvbGljeS5wcm90bxINZ29vZ2xlLmlhbS52MSJR",
-            "CgZQb2xpY3kSDwoHdmVyc2lvbhgBIAEoBRIoCghiaW5kaW5ncxgEIAMoCzIW",
-            "Lmdvb2dsZS5pYW0udjEuQmluZGluZxIMCgRldGFnGAMgASgMIigKB0JpbmRp",
-            "bmcSDAoEcm9sZRgBIAEoCRIPCgdtZW1iZXJzGAIgAygJQjsKEWNvbS5nb29n",
-            "bGUuaWFtLnYxQgtQb2xpY3lQcm90b1AB+AEBqgITR29vZ2xlLkNsb3VkLklh",
-            "bS5WMWIGcHJvdG8z"));
+            "Chpnb29nbGUvaWFtL3YxL3BvbGljeS5wcm90bxINZ29vZ2xlLmlhbS52MRoc",
+            "Z29vZ2xlL2FwaS9hbm5vdGF0aW9ucy5wcm90byJRCgZQb2xpY3kSDwoHdmVy",
+            "c2lvbhgBIAEoBRIoCghiaW5kaW5ncxgEIAMoCzIWLmdvb2dsZS5pYW0udjEu",
+            "QmluZGluZxIMCgRldGFnGAMgASgMIigKB0JpbmRpbmcSDAoEcm9sZRgBIAEo",
+            "CRIPCgdtZW1iZXJzGAIgAygJQjsKEWNvbS5nb29nbGUuaWFtLnYxQgtQb2xp",
+            "Y3lQcm90b1AB+AEBqgITR29vZ2xlLkNsb3VkLklhbS5WMWIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { },
+          new pbr::FileDescriptor[] { global::Google.Api.AnnotationsReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Iam.V1.Policy), global::Google.Cloud.Iam.V1.Policy.Parser, new[]{ "Version", "Bindings", "Etag" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Iam.V1.Binding), global::Google.Cloud.Iam.V1.Binding.Parser, new[]{ "Role", "Members" }, null, null, null)

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Common.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Common.cs
@@ -530,9 +530,11 @@ namespace Google.Cloud.Monitoring.V3 {
   }
 
   /// <summary>
-  ///  Describes how to combine, or aggregate, multiple time series to
-  ///  provide different views of the data.
-  ///  See [Aggregation](/monitoring/api/learn_more#aggregation) for more details.
+  ///  Describes how to combine multiple time series to provide different views of
+  ///  the data.  Aggregation consists of an alignment step on individual time
+  ///  series (`per_series_aligner`) followed by an optional reduction of the data
+  ///  across different time series (`cross_series_reducer`).  For more details, see
+  ///  [Aggregation](/monitoring/api/learn_more#aggregation).
   /// </summary>
   public sealed partial class Aggregation : pb::IMessage<Aggregation> {
     private static readonly pb::MessageParser<Aggregation> _parser = new pb::MessageParser<Aggregation>(() => new Aggregation());
@@ -645,16 +647,19 @@ namespace Google.Cloud.Monitoring.V3 {
     private readonly pbc::RepeatedField<string> groupByFields_ = new pbc::RepeatedField<string>();
     /// <summary>
     ///  The set of fields to preserve when `crossSeriesReducer` is
-    ///  specified. The `groupByFields` determine how the time series
-    ///  are partitioned into subsets prior to applying the aggregation
+    ///  specified. The `groupByFields` determine how the time series are
+    ///  partitioned into subsets prior to applying the aggregation
     ///  function. Each subset contains time series that have the same
     ///  value for each of the grouping fields. Each individual time
     ///  series is a member of exactly one subset. The
     ///  `crossSeriesReducer` is applied to each subset of time series.
-    ///  Fields not specified in `groupByFields` are aggregated away.
-    ///  If `groupByFields` is not specified, the time series are
-    ///  aggregated into a single output time series. If
-    ///  `crossSeriesReducer` is not defined, this field is ignored.
+    ///  It is not possible to reduce across different resource types, so
+    ///  this field implicitly contains `resource.type`.  Fields not
+    ///  specified in `groupByFields` are aggregated away.  If
+    ///  `groupByFields` is not specified and all the time series have
+    ///  the same resource type, then the time series are aggregated into
+    ///  a single output time series. If `crossSeriesReducer` is not
+    ///  defined, this field is ignored.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public pbc::RepeatedField<string> GroupByFields {
@@ -812,7 +817,7 @@ namespace Google.Cloud.Monitoring.V3 {
         [pbr::OriginalName("ALIGN_RATE")] AlignRate = 2,
         /// <summary>
         ///  Align by interpolating between adjacent points around the
-        ///  period boundary. This alignment is valid for gauge and delta
+        ///  period boundary. This alignment is valid for gauge
         ///  metrics with numeric values. The value type of the result is the same
         ///  as the value type of the input.
         /// </summary>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClient.cs
@@ -625,6 +625,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// The messages in the request will be published on this topic.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="messages">
         /// The messages to publish.
@@ -650,6 +651,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// The messages in the request will be published on this topic.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="messages">
         /// The messages to publish.
@@ -675,6 +677,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// The messages in the request will be published on this topic.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="messages">
         /// The messages to publish.
@@ -698,6 +701,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// The name of the topic to get.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -717,6 +721,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// The name of the topic to get.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -735,6 +740,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// The name of the topic to get.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -754,6 +760,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="project">
         /// The name of the cloud project that topics belong to.
+        /// Format is `projects/{project}`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -783,6 +790,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="project">
         /// The name of the cloud project that topics belong to.
+        /// Format is `projects/{project}`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -812,6 +820,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// The name of the topic that subscriptions are attached to.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -841,6 +850,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// The name of the topic that subscriptions are attached to.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -874,6 +884,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// Name of the topic to delete.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -897,6 +908,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// Name of the topic to delete.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -919,6 +931,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// Name of the topic to delete.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1090,6 +1103,8 @@ namespace Google.Cloud.PubSub.V1
 
         /// <summary>
         /// Returns permissions that a caller has on the specified resource.
+        /// If the resource does not exist, this will return an empty set of
+        /// permissions, not a NOT_FOUND error.
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource for which the policy detail is being requested.
@@ -1118,6 +1133,8 @@ namespace Google.Cloud.PubSub.V1
 
         /// <summary>
         /// Returns permissions that a caller has on the specified resource.
+        /// If the resource does not exist, this will return an empty set of
+        /// permissions, not a NOT_FOUND error.
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource for which the policy detail is being requested.
@@ -1146,6 +1163,8 @@ namespace Google.Cloud.PubSub.V1
 
         /// <summary>
         /// Returns permissions that a caller has on the specified resource.
+        /// If the resource does not exist, this will return an empty set of
+        /// permissions, not a NOT_FOUND error.
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource for which the policy detail is being requested.
@@ -1302,6 +1321,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// The messages in the request will be published on this topic.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="messages">
         /// The messages to publish.
@@ -1333,6 +1353,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// The messages in the request will be published on this topic.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="messages">
         /// The messages to publish.
@@ -1362,6 +1383,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// The name of the topic to get.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1386,6 +1408,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// The name of the topic to get.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1410,6 +1433,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="project">
         /// The name of the cloud project that topics belong to.
+        /// Format is `projects/{project}`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1446,6 +1470,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="project">
         /// The name of the cloud project that topics belong to.
+        /// Format is `projects/{project}`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1482,6 +1507,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// The name of the topic that subscriptions are attached to.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1518,6 +1544,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// The name of the topic that subscriptions are attached to.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1558,6 +1585,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// Name of the topic to delete.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1586,6 +1614,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="topic">
         /// Name of the topic to delete.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1733,6 +1762,8 @@ namespace Google.Cloud.PubSub.V1
 
         /// <summary>
         /// Returns permissions that a caller has on the specified resource.
+        /// If the resource does not exist, this will return an empty set of
+        /// permissions, not a NOT_FOUND error.
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource for which the policy detail is being requested.
@@ -1767,6 +1798,8 @@ namespace Google.Cloud.PubSub.V1
 
         /// <summary>
         /// Returns permissions that a caller has on the specified resource.
+        /// If the resource does not exist, this will return an empty set of
+        /// permissions, not a NOT_FOUND error.
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource for which the policy detail is being requested.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Pubsub.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Pubsub.cs
@@ -315,8 +315,7 @@ namespace Google.Cloud.PubSub.V1 {
     public const int DataFieldNumber = 1;
     private pb::ByteString data_ = pb::ByteString.Empty;
     /// <summary>
-    ///  The message payload. For JSON requests, the value of this field must be
-    ///  [base64-encoded](https://tools.ietf.org/html/rfc4648).
+    ///  The message payload.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public pb::ByteString Data {
@@ -533,6 +532,7 @@ namespace Google.Cloud.PubSub.V1 {
     private string topic_ = "";
     /// <summary>
     ///  The name of the topic to get.
+    ///  Format is `projects/{project}/topics/{topic}`.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Topic {
@@ -657,6 +657,7 @@ namespace Google.Cloud.PubSub.V1 {
     private string topic_ = "";
     /// <summary>
     ///  The messages in the request will be published on this topic.
+    ///  Format is `projects/{project}/topics/{topic}`.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Topic {
@@ -921,6 +922,7 @@ namespace Google.Cloud.PubSub.V1 {
     private string project_ = "";
     /// <summary>
     ///  The name of the cloud project that topics belong to.
+    ///  Format is `projects/{project}`.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Project {
@@ -1255,6 +1257,7 @@ namespace Google.Cloud.PubSub.V1 {
     private string topic_ = "";
     /// <summary>
     ///  The name of the topic that subscriptions are attached to.
+    ///  Format is `projects/{project}/topics/{topic}`.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Topic {
@@ -1588,6 +1591,7 @@ namespace Google.Cloud.PubSub.V1 {
     private string topic_ = "";
     /// <summary>
     ///  Name of the topic to delete.
+    ///  Format is `projects/{project}/topics/{topic}`.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Topic {
@@ -1733,6 +1737,7 @@ namespace Google.Cloud.PubSub.V1 {
     private string topic_ = "";
     /// <summary>
     ///  The name of the topic from which this subscription is receiving messages.
+    ///  Format is `projects/{project}/topics/{topic}`.
     ///  The value of this field will be `_deleted-topic_` if the topic has been
     ///  deleted.
     /// </summary>
@@ -1774,15 +1779,15 @@ namespace Google.Cloud.PubSub.V1 {
     ///  deadline. To override this value for a given message, call
     ///  `ModifyAckDeadline` with the corresponding `ack_id` if using
     ///  pull.
+    ///  The minimum custom deadline you can specify is 10 seconds.
     ///  The maximum custom deadline you can specify is 600 seconds (10 minutes).
+    ///  If this parameter is 0, a default value of 10 seconds is used.
     ///
     ///  For push delivery, this value is also used to set the request timeout for
     ///  the call to the push endpoint.
     ///
     ///  If the subscriber never acknowledges the message, the Pub/Sub
     ///  system will eventually redeliver the message.
-    ///
-    ///  If this parameter is 0, a default value of 10 seconds is used.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int AckDeadlineSeconds {
@@ -2288,6 +2293,7 @@ namespace Google.Cloud.PubSub.V1 {
     private string subscription_ = "";
     /// <summary>
     ///  The name of the subscription to get.
+    ///  Format is `projects/{project}/subscriptions/{sub}`.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Subscription {
@@ -2413,6 +2419,7 @@ namespace Google.Cloud.PubSub.V1 {
     private string project_ = "";
     /// <summary>
     ///  The name of the cloud project that subscriptions belong to.
+    ///  Format is `projects/{project}`.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Project {
@@ -2746,6 +2753,7 @@ namespace Google.Cloud.PubSub.V1 {
     private string subscription_ = "";
     /// <summary>
     ///  The subscription to delete.
+    ///  Format is `projects/{project}/subscriptions/{sub}`.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Subscription {
@@ -2870,6 +2878,7 @@ namespace Google.Cloud.PubSub.V1 {
     private string subscription_ = "";
     /// <summary>
     ///  The name of the subscription.
+    ///  Format is `projects/{project}/subscriptions/{sub}`.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Subscription {
@@ -3036,6 +3045,7 @@ namespace Google.Cloud.PubSub.V1 {
     private string subscription_ = "";
     /// <summary>
     ///  The subscription from which messages should be pulled.
+    ///  Format is `projects/{project}/subscriptions/{sub}`.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Subscription {
@@ -3049,11 +3059,12 @@ namespace Google.Cloud.PubSub.V1 {
     public const int ReturnImmediatelyFieldNumber = 2;
     private bool returnImmediately_;
     /// <summary>
-    ///  If this is specified as true the system will respond immediately even if
-    ///  it is not able to return a message in the `Pull` response. Otherwise the
-    ///  system is allowed to wait until at least one message is available rather
-    ///  than returning no messages. The client may cancel the request if it does
-    ///  not wish to wait any longer for the response.
+    ///  If this field set to true, the system will respond immediately even if
+    ///  it there are no messages available to return in the `Pull` response.
+    ///  Otherwise, the system may wait (for a bounded amount of time) until at
+    ///  least one message is available, rather than returning no messages. The
+    ///  client may cancel the request if it does not wish to wait any longer for
+    ///  the response.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public bool ReturnImmediately {
@@ -3344,6 +3355,7 @@ namespace Google.Cloud.PubSub.V1 {
     private string subscription_ = "";
     /// <summary>
     ///  The name of the subscription.
+    ///  Format is `projects/{project}/subscriptions/{sub}`.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Subscription {
@@ -3371,10 +3383,12 @@ namespace Google.Cloud.PubSub.V1 {
     private int ackDeadlineSeconds_;
     /// <summary>
     ///  The new ack deadline with respect to the time this request was sent to
-    ///  the Pub/Sub system. Must be >= 0. For example, if the value is 10, the new
+    ///  the Pub/Sub system. For example, if the value is 10, the new
     ///  ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
     ///  was made. Specifying zero may immediately make the message available for
     ///  another pull request.
+    ///  The minimum deadline you can specify is 0 seconds.
+    ///  The maximum deadline you can specify is 600 seconds (10 minutes).
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int AckDeadlineSeconds {
@@ -3524,6 +3538,7 @@ namespace Google.Cloud.PubSub.V1 {
     private string subscription_ = "";
     /// <summary>
     ///  The subscription whose message is being acknowledged.
+    ///  Format is `projects/{project}/subscriptions/{sub}`.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Subscription {

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PubsubGrpc.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PubsubGrpc.cs
@@ -114,8 +114,11 @@ namespace Google.Cloud.PubSub.V1 {
       ///  If the corresponding topic doesn't exist, returns `NOT_FOUND`.
       ///
       ///  If the name is not provided in the request, the server will assign a random
-      ///  name for this subscription on the same project as the topic. Note that
-      ///  for REST API requests, you must specify a name.
+      ///  name for this subscription on the same project as the topic, conforming
+      ///  to the
+      ///  [resource name format](https://cloud.google.com/pubsub/docs/overview#names).
+      ///  The generated name is populated in the returned Subscription object.
+      ///  Note that for REST API requests, you must specify a name in the request.
       /// </summary>
       public virtual global::System.Threading.Tasks.Task<global::Google.Cloud.PubSub.V1.Subscription> CreateSubscription(global::Google.Cloud.PubSub.V1.Subscription request, ServerCallContext context)
       {
@@ -139,11 +142,11 @@ namespace Google.Cloud.PubSub.V1 {
       }
 
       /// <summary>
-      ///  Deletes an existing subscription. All pending messages in the subscription
+      ///  Deletes an existing subscription. All messages retained in the subscription
       ///  are immediately dropped. Calls to `Pull` after deletion will return
       ///  `NOT_FOUND`. After a subscription is deleted, a new one may be created with
       ///  the same name, but the new one has no association with the old
-      ///  subscription, or its topic unless the same topic is specified.
+      ///  subscription or its topic unless the same topic is specified.
       /// </summary>
       public virtual global::System.Threading.Tasks.Task<global::Google.Protobuf.WellKnownTypes.Empty> DeleteSubscription(global::Google.Cloud.PubSub.V1.DeleteSubscriptionRequest request, ServerCallContext context)
       {
@@ -231,8 +234,11 @@ namespace Google.Cloud.PubSub.V1 {
       ///  If the corresponding topic doesn't exist, returns `NOT_FOUND`.
       ///
       ///  If the name is not provided in the request, the server will assign a random
-      ///  name for this subscription on the same project as the topic. Note that
-      ///  for REST API requests, you must specify a name.
+      ///  name for this subscription on the same project as the topic, conforming
+      ///  to the
+      ///  [resource name format](https://cloud.google.com/pubsub/docs/overview#names).
+      ///  The generated name is populated in the returned Subscription object.
+      ///  Note that for REST API requests, you must specify a name in the request.
       /// </summary>
       public virtual global::Google.Cloud.PubSub.V1.Subscription CreateSubscription(global::Google.Cloud.PubSub.V1.Subscription request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
@@ -244,8 +250,11 @@ namespace Google.Cloud.PubSub.V1 {
       ///  If the corresponding topic doesn't exist, returns `NOT_FOUND`.
       ///
       ///  If the name is not provided in the request, the server will assign a random
-      ///  name for this subscription on the same project as the topic. Note that
-      ///  for REST API requests, you must specify a name.
+      ///  name for this subscription on the same project as the topic, conforming
+      ///  to the
+      ///  [resource name format](https://cloud.google.com/pubsub/docs/overview#names).
+      ///  The generated name is populated in the returned Subscription object.
+      ///  Note that for REST API requests, you must specify a name in the request.
       /// </summary>
       public virtual global::Google.Cloud.PubSub.V1.Subscription CreateSubscription(global::Google.Cloud.PubSub.V1.Subscription request, CallOptions options)
       {
@@ -257,8 +266,11 @@ namespace Google.Cloud.PubSub.V1 {
       ///  If the corresponding topic doesn't exist, returns `NOT_FOUND`.
       ///
       ///  If the name is not provided in the request, the server will assign a random
-      ///  name for this subscription on the same project as the topic. Note that
-      ///  for REST API requests, you must specify a name.
+      ///  name for this subscription on the same project as the topic, conforming
+      ///  to the
+      ///  [resource name format](https://cloud.google.com/pubsub/docs/overview#names).
+      ///  The generated name is populated in the returned Subscription object.
+      ///  Note that for REST API requests, you must specify a name in the request.
       /// </summary>
       public virtual AsyncUnaryCall<global::Google.Cloud.PubSub.V1.Subscription> CreateSubscriptionAsync(global::Google.Cloud.PubSub.V1.Subscription request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
@@ -270,8 +282,11 @@ namespace Google.Cloud.PubSub.V1 {
       ///  If the corresponding topic doesn't exist, returns `NOT_FOUND`.
       ///
       ///  If the name is not provided in the request, the server will assign a random
-      ///  name for this subscription on the same project as the topic. Note that
-      ///  for REST API requests, you must specify a name.
+      ///  name for this subscription on the same project as the topic, conforming
+      ///  to the
+      ///  [resource name format](https://cloud.google.com/pubsub/docs/overview#names).
+      ///  The generated name is populated in the returned Subscription object.
+      ///  Note that for REST API requests, you must specify a name in the request.
       /// </summary>
       public virtual AsyncUnaryCall<global::Google.Cloud.PubSub.V1.Subscription> CreateSubscriptionAsync(global::Google.Cloud.PubSub.V1.Subscription request, CallOptions options)
       {
@@ -334,44 +349,44 @@ namespace Google.Cloud.PubSub.V1 {
         return CallInvoker.AsyncUnaryCall(__Method_ListSubscriptions, null, options, request);
       }
       /// <summary>
-      ///  Deletes an existing subscription. All pending messages in the subscription
+      ///  Deletes an existing subscription. All messages retained in the subscription
       ///  are immediately dropped. Calls to `Pull` after deletion will return
       ///  `NOT_FOUND`. After a subscription is deleted, a new one may be created with
       ///  the same name, but the new one has no association with the old
-      ///  subscription, or its topic unless the same topic is specified.
+      ///  subscription or its topic unless the same topic is specified.
       /// </summary>
       public virtual global::Google.Protobuf.WellKnownTypes.Empty DeleteSubscription(global::Google.Cloud.PubSub.V1.DeleteSubscriptionRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
         return DeleteSubscription(request, new CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      ///  Deletes an existing subscription. All pending messages in the subscription
+      ///  Deletes an existing subscription. All messages retained in the subscription
       ///  are immediately dropped. Calls to `Pull` after deletion will return
       ///  `NOT_FOUND`. After a subscription is deleted, a new one may be created with
       ///  the same name, but the new one has no association with the old
-      ///  subscription, or its topic unless the same topic is specified.
+      ///  subscription or its topic unless the same topic is specified.
       /// </summary>
       public virtual global::Google.Protobuf.WellKnownTypes.Empty DeleteSubscription(global::Google.Cloud.PubSub.V1.DeleteSubscriptionRequest request, CallOptions options)
       {
         return CallInvoker.BlockingUnaryCall(__Method_DeleteSubscription, null, options, request);
       }
       /// <summary>
-      ///  Deletes an existing subscription. All pending messages in the subscription
+      ///  Deletes an existing subscription. All messages retained in the subscription
       ///  are immediately dropped. Calls to `Pull` after deletion will return
       ///  `NOT_FOUND`. After a subscription is deleted, a new one may be created with
       ///  the same name, but the new one has no association with the old
-      ///  subscription, or its topic unless the same topic is specified.
+      ///  subscription or its topic unless the same topic is specified.
       /// </summary>
       public virtual AsyncUnaryCall<global::Google.Protobuf.WellKnownTypes.Empty> DeleteSubscriptionAsync(global::Google.Cloud.PubSub.V1.DeleteSubscriptionRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
         return DeleteSubscriptionAsync(request, new CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      ///  Deletes an existing subscription. All pending messages in the subscription
+      ///  Deletes an existing subscription. All messages retained in the subscription
       ///  are immediately dropped. Calls to `Pull` after deletion will return
       ///  `NOT_FOUND`. After a subscription is deleted, a new one may be created with
       ///  the same name, but the new one has no association with the old
-      ///  subscription, or its topic unless the same topic is specified.
+      ///  subscription or its topic unless the same topic is specified.
       /// </summary>
       public virtual AsyncUnaryCall<global::Google.Protobuf.WellKnownTypes.Empty> DeleteSubscriptionAsync(global::Google.Cloud.PubSub.V1.DeleteSubscriptionRequest request, CallOptions options)
       {

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
@@ -597,8 +597,11 @@ namespace Google.Cloud.PubSub.V1
         /// If the corresponding topic doesn't exist, returns `NOT_FOUND`.
         ///
         /// If the name is not provided in the request, the server will assign a random
-        /// name for this subscription on the same project as the topic. Note that
-        /// for REST API requests, you must specify a name.
+        /// name for this subscription on the same project as the topic, conforming
+        /// to the
+        /// [resource name format](https://cloud.google.com/pubsub/docs/overview#names).
+        /// The generated name is populated in the returned Subscription object.
+        /// Note that for REST API requests, you must specify a name in the request.
         /// </summary>
         /// <param name="name">
         /// The name of the subscription. It must have the format
@@ -610,6 +613,7 @@ namespace Google.Cloud.PubSub.V1
         /// </param>
         /// <param name="topic">
         /// The name of the topic from which this subscription is receiving messages.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// The value of this field will be `_deleted-topic_` if the topic has been
         /// deleted.
         /// </param>
@@ -629,15 +633,15 @@ namespace Google.Cloud.PubSub.V1
         /// deadline. To override this value for a given message, call
         /// `ModifyAckDeadline` with the corresponding `ack_id` if using
         /// pull.
+        /// The minimum custom deadline you can specify is 10 seconds.
         /// The maximum custom deadline you can specify is 600 seconds (10 minutes).
+        /// If this parameter is 0, a default value of 10 seconds is used.
         ///
         /// For push delivery, this value is also used to set the request timeout for
         /// the call to the push endpoint.
         ///
         /// If the subscriber never acknowledges the message, the Pub/Sub
         /// system will eventually redeliver the message.
-        ///
-        /// If this parameter is 0, a default value of 10 seconds is used.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -661,8 +665,11 @@ namespace Google.Cloud.PubSub.V1
         /// If the corresponding topic doesn't exist, returns `NOT_FOUND`.
         ///
         /// If the name is not provided in the request, the server will assign a random
-        /// name for this subscription on the same project as the topic. Note that
-        /// for REST API requests, you must specify a name.
+        /// name for this subscription on the same project as the topic, conforming
+        /// to the
+        /// [resource name format](https://cloud.google.com/pubsub/docs/overview#names).
+        /// The generated name is populated in the returned Subscription object.
+        /// Note that for REST API requests, you must specify a name in the request.
         /// </summary>
         /// <param name="name">
         /// The name of the subscription. It must have the format
@@ -674,6 +681,7 @@ namespace Google.Cloud.PubSub.V1
         /// </param>
         /// <param name="topic">
         /// The name of the topic from which this subscription is receiving messages.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// The value of this field will be `_deleted-topic_` if the topic has been
         /// deleted.
         /// </param>
@@ -693,15 +701,15 @@ namespace Google.Cloud.PubSub.V1
         /// deadline. To override this value for a given message, call
         /// `ModifyAckDeadline` with the corresponding `ack_id` if using
         /// pull.
+        /// The minimum custom deadline you can specify is 10 seconds.
         /// The maximum custom deadline you can specify is 600 seconds (10 minutes).
+        /// If this parameter is 0, a default value of 10 seconds is used.
         ///
         /// For push delivery, this value is also used to set the request timeout for
         /// the call to the push endpoint.
         ///
         /// If the subscriber never acknowledges the message, the Pub/Sub
         /// system will eventually redeliver the message.
-        ///
-        /// If this parameter is 0, a default value of 10 seconds is used.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -727,8 +735,11 @@ namespace Google.Cloud.PubSub.V1
         /// If the corresponding topic doesn't exist, returns `NOT_FOUND`.
         ///
         /// If the name is not provided in the request, the server will assign a random
-        /// name for this subscription on the same project as the topic. Note that
-        /// for REST API requests, you must specify a name.
+        /// name for this subscription on the same project as the topic, conforming
+        /// to the
+        /// [resource name format](https://cloud.google.com/pubsub/docs/overview#names).
+        /// The generated name is populated in the returned Subscription object.
+        /// Note that for REST API requests, you must specify a name in the request.
         /// </summary>
         /// <param name="name">
         /// The name of the subscription. It must have the format
@@ -740,6 +751,7 @@ namespace Google.Cloud.PubSub.V1
         /// </param>
         /// <param name="topic">
         /// The name of the topic from which this subscription is receiving messages.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// The value of this field will be `_deleted-topic_` if the topic has been
         /// deleted.
         /// </param>
@@ -759,15 +771,15 @@ namespace Google.Cloud.PubSub.V1
         /// deadline. To override this value for a given message, call
         /// `ModifyAckDeadline` with the corresponding `ack_id` if using
         /// pull.
+        /// The minimum custom deadline you can specify is 10 seconds.
         /// The maximum custom deadline you can specify is 600 seconds (10 minutes).
+        /// If this parameter is 0, a default value of 10 seconds is used.
         ///
         /// For push delivery, this value is also used to set the request timeout for
         /// the call to the push endpoint.
         ///
         /// If the subscriber never acknowledges the message, the Pub/Sub
         /// system will eventually redeliver the message.
-        ///
-        /// If this parameter is 0, a default value of 10 seconds is used.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -790,6 +802,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription to get.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -809,6 +822,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription to get.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -827,6 +841,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription to get.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -846,6 +861,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="project">
         /// The name of the cloud project that subscriptions belong to.
+        /// Format is `projects/{project}`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -875,6 +891,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="project">
         /// The name of the cloud project that subscriptions belong to.
+        /// Format is `projects/{project}`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -900,14 +917,15 @@ namespace Google.Cloud.PubSub.V1
         }
 
         /// <summary>
-        /// Deletes an existing subscription. All pending messages in the subscription
+        /// Deletes an existing subscription. All messages retained in the subscription
         /// are immediately dropped. Calls to `Pull` after deletion will return
         /// `NOT_FOUND`. After a subscription is deleted, a new one may be created with
         /// the same name, but the new one has no association with the old
-        /// subscription, or its topic unless the same topic is specified.
+        /// subscription or its topic unless the same topic is specified.
         /// </summary>
         /// <param name="subscription">
         /// The subscription to delete.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -923,14 +941,15 @@ namespace Google.Cloud.PubSub.V1
         }
 
         /// <summary>
-        /// Deletes an existing subscription. All pending messages in the subscription
+        /// Deletes an existing subscription. All messages retained in the subscription
         /// are immediately dropped. Calls to `Pull` after deletion will return
         /// `NOT_FOUND`. After a subscription is deleted, a new one may be created with
         /// the same name, but the new one has no association with the old
-        /// subscription, or its topic unless the same topic is specified.
+        /// subscription or its topic unless the same topic is specified.
         /// </summary>
         /// <param name="subscription">
         /// The subscription to delete.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -945,14 +964,15 @@ namespace Google.Cloud.PubSub.V1
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        /// Deletes an existing subscription. All pending messages in the subscription
+        /// Deletes an existing subscription. All messages retained in the subscription
         /// are immediately dropped. Calls to `Pull` after deletion will return
         /// `NOT_FOUND`. After a subscription is deleted, a new one may be created with
         /// the same name, but the new one has no association with the old
-        /// subscription, or its topic unless the same topic is specified.
+        /// subscription or its topic unless the same topic is specified.
         /// </summary>
         /// <param name="subscription">
         /// The subscription to delete.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -976,16 +996,19 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="ackIds">
         /// List of acknowledgment IDs.
         /// </param>
         /// <param name="ackDeadlineSeconds">
         /// The new ack deadline with respect to the time this request was sent to
-        /// the Pub/Sub system. Must be >= 0. For example, if the value is 10, the new
+        /// the Pub/Sub system. For example, if the value is 10, the new
         /// ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
         /// was made. Specifying zero may immediately make the message available for
         /// another pull request.
+        /// The minimum deadline you can specify is 0 seconds.
+        /// The maximum deadline you can specify is 600 seconds (10 minutes).
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1011,16 +1034,19 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="ackIds">
         /// List of acknowledgment IDs.
         /// </param>
         /// <param name="ackDeadlineSeconds">
         /// The new ack deadline with respect to the time this request was sent to
-        /// the Pub/Sub system. Must be >= 0. For example, if the value is 10, the new
+        /// the Pub/Sub system. For example, if the value is 10, the new
         /// ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
         /// was made. Specifying zero may immediately make the message available for
         /// another pull request.
+        /// The minimum deadline you can specify is 0 seconds.
+        /// The maximum deadline you can specify is 600 seconds (10 minutes).
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
@@ -1047,16 +1073,19 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="ackIds">
         /// List of acknowledgment IDs.
         /// </param>
         /// <param name="ackDeadlineSeconds">
         /// The new ack deadline with respect to the time this request was sent to
-        /// the Pub/Sub system. Must be >= 0. For example, if the value is 10, the new
+        /// the Pub/Sub system. For example, if the value is 10, the new
         /// ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
         /// was made. Specifying zero may immediately make the message available for
         /// another pull request.
+        /// The minimum deadline you can specify is 0 seconds.
+        /// The maximum deadline you can specify is 600 seconds (10 minutes).
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1084,6 +1113,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The subscription whose message is being acknowledged.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="ackIds">
         /// The acknowledgment ID for the messages being acknowledged that was returned
@@ -1114,6 +1144,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The subscription whose message is being acknowledged.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="ackIds">
         /// The acknowledgment ID for the messages being acknowledged that was returned
@@ -1144,6 +1175,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The subscription whose message is being acknowledged.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="ackIds">
         /// The acknowledgment ID for the messages being acknowledged that was returned
@@ -1171,13 +1203,15 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The subscription from which messages should be pulled.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="returnImmediately">
-        /// If this is specified as true the system will respond immediately even if
-        /// it is not able to return a message in the `Pull` response. Otherwise the
-        /// system is allowed to wait until at least one message is available rather
-        /// than returning no messages. The client may cancel the request if it does
-        /// not wish to wait any longer for the response.
+        /// If this field set to true, the system will respond immediately even if
+        /// it there are no messages available to return in the `Pull` response.
+        /// Otherwise, the system may wait (for a bounded amount of time) until at
+        /// least one message is available, rather than returning no messages. The
+        /// client may cancel the request if it does not wish to wait any longer for
+        /// the response.
         /// </param>
         /// <param name="maxMessages">
         /// The maximum number of messages returned for this request. The Pub/Sub
@@ -1206,13 +1240,15 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The subscription from which messages should be pulled.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="returnImmediately">
-        /// If this is specified as true the system will respond immediately even if
-        /// it is not able to return a message in the `Pull` response. Otherwise the
-        /// system is allowed to wait until at least one message is available rather
-        /// than returning no messages. The client may cancel the request if it does
-        /// not wish to wait any longer for the response.
+        /// If this field set to true, the system will respond immediately even if
+        /// it there are no messages available to return in the `Pull` response.
+        /// Otherwise, the system may wait (for a bounded amount of time) until at
+        /// least one message is available, rather than returning no messages. The
+        /// client may cancel the request if it does not wish to wait any longer for
+        /// the response.
         /// </param>
         /// <param name="maxMessages">
         /// The maximum number of messages returned for this request. The Pub/Sub
@@ -1242,13 +1278,15 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The subscription from which messages should be pulled.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="returnImmediately">
-        /// If this is specified as true the system will respond immediately even if
-        /// it is not able to return a message in the `Pull` response. Otherwise the
-        /// system is allowed to wait until at least one message is available rather
-        /// than returning no messages. The client may cancel the request if it does
-        /// not wish to wait any longer for the response.
+        /// If this field set to true, the system will respond immediately even if
+        /// it there are no messages available to return in the `Pull` response.
+        /// Otherwise, the system may wait (for a bounded amount of time) until at
+        /// least one message is available, rather than returning no messages. The
+        /// client may cancel the request if it does not wish to wait any longer for
+        /// the response.
         /// </param>
         /// <param name="maxMessages">
         /// The maximum number of messages returned for this request. The Pub/Sub
@@ -1279,6 +1317,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="pushConfig">
         /// The push configuration for future deliveries.
@@ -1312,6 +1351,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="pushConfig">
         /// The push configuration for future deliveries.
@@ -1345,6 +1385,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="pushConfig">
         /// The push configuration for future deliveries.
@@ -1525,6 +1566,8 @@ namespace Google.Cloud.PubSub.V1
 
         /// <summary>
         /// Returns permissions that a caller has on the specified resource.
+        /// If the resource does not exist, this will return an empty set of
+        /// permissions, not a NOT_FOUND error.
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource for which the policy detail is being requested.
@@ -1553,6 +1596,8 @@ namespace Google.Cloud.PubSub.V1
 
         /// <summary>
         /// Returns permissions that a caller has on the specified resource.
+        /// If the resource does not exist, this will return an empty set of
+        /// permissions, not a NOT_FOUND error.
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource for which the policy detail is being requested.
@@ -1581,6 +1626,8 @@ namespace Google.Cloud.PubSub.V1
 
         /// <summary>
         /// Returns permissions that a caller has on the specified resource.
+        /// If the resource does not exist, this will return an empty set of
+        /// permissions, not a NOT_FOUND error.
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource for which the policy detail is being requested.
@@ -1686,8 +1733,11 @@ namespace Google.Cloud.PubSub.V1
         /// If the corresponding topic doesn't exist, returns `NOT_FOUND`.
         ///
         /// If the name is not provided in the request, the server will assign a random
-        /// name for this subscription on the same project as the topic. Note that
-        /// for REST API requests, you must specify a name.
+        /// name for this subscription on the same project as the topic, conforming
+        /// to the
+        /// [resource name format](https://cloud.google.com/pubsub/docs/overview#names).
+        /// The generated name is populated in the returned Subscription object.
+        /// Note that for REST API requests, you must specify a name in the request.
         /// </summary>
         /// <param name="name">
         /// The name of the subscription. It must have the format
@@ -1699,6 +1749,7 @@ namespace Google.Cloud.PubSub.V1
         /// </param>
         /// <param name="topic">
         /// The name of the topic from which this subscription is receiving messages.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// The value of this field will be `_deleted-topic_` if the topic has been
         /// deleted.
         /// </param>
@@ -1718,15 +1769,15 @@ namespace Google.Cloud.PubSub.V1
         /// deadline. To override this value for a given message, call
         /// `ModifyAckDeadline` with the corresponding `ack_id` if using
         /// pull.
+        /// The minimum custom deadline you can specify is 10 seconds.
         /// The maximum custom deadline you can specify is 600 seconds (10 minutes).
+        /// If this parameter is 0, a default value of 10 seconds is used.
         ///
         /// For push delivery, this value is also used to set the request timeout for
         /// the call to the push endpoint.
         ///
         /// If the subscriber never acknowledges the message, the Pub/Sub
         /// system will eventually redeliver the message.
-        ///
-        /// If this parameter is 0, a default value of 10 seconds is used.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1758,8 +1809,11 @@ namespace Google.Cloud.PubSub.V1
         /// If the corresponding topic doesn't exist, returns `NOT_FOUND`.
         ///
         /// If the name is not provided in the request, the server will assign a random
-        /// name for this subscription on the same project as the topic. Note that
-        /// for REST API requests, you must specify a name.
+        /// name for this subscription on the same project as the topic, conforming
+        /// to the
+        /// [resource name format](https://cloud.google.com/pubsub/docs/overview#names).
+        /// The generated name is populated in the returned Subscription object.
+        /// Note that for REST API requests, you must specify a name in the request.
         /// </summary>
         /// <param name="name">
         /// The name of the subscription. It must have the format
@@ -1771,6 +1825,7 @@ namespace Google.Cloud.PubSub.V1
         /// </param>
         /// <param name="topic">
         /// The name of the topic from which this subscription is receiving messages.
+        /// Format is `projects/{project}/topics/{topic}`.
         /// The value of this field will be `_deleted-topic_` if the topic has been
         /// deleted.
         /// </param>
@@ -1790,15 +1845,15 @@ namespace Google.Cloud.PubSub.V1
         /// deadline. To override this value for a given message, call
         /// `ModifyAckDeadline` with the corresponding `ack_id` if using
         /// pull.
+        /// The minimum custom deadline you can specify is 10 seconds.
         /// The maximum custom deadline you can specify is 600 seconds (10 minutes).
+        /// If this parameter is 0, a default value of 10 seconds is used.
         ///
         /// For push delivery, this value is also used to set the request timeout for
         /// the call to the push endpoint.
         ///
         /// If the subscriber never acknowledges the message, the Pub/Sub
         /// system will eventually redeliver the message.
-        ///
-        /// If this parameter is 0, a default value of 10 seconds is used.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1829,6 +1884,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription to get.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1853,6 +1909,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription to get.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1877,6 +1934,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="project">
         /// The name of the cloud project that subscriptions belong to.
+        /// Format is `projects/{project}`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1913,6 +1971,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="project">
         /// The name of the cloud project that subscriptions belong to.
+        /// Format is `projects/{project}`.
         /// </param>
         /// <param name="pageToken">
         /// The token returned from the previous request.
@@ -1945,14 +2004,15 @@ namespace Google.Cloud.PubSub.V1
         }
 
         /// <summary>
-        /// Deletes an existing subscription. All pending messages in the subscription
+        /// Deletes an existing subscription. All messages retained in the subscription
         /// are immediately dropped. Calls to `Pull` after deletion will return
         /// `NOT_FOUND`. After a subscription is deleted, a new one may be created with
         /// the same name, but the new one has no association with the old
-        /// subscription, or its topic unless the same topic is specified.
+        /// subscription or its topic unless the same topic is specified.
         /// </summary>
         /// <param name="subscription">
         /// The subscription to delete.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1973,14 +2033,15 @@ namespace Google.Cloud.PubSub.V1
         }
 
         /// <summary>
-        /// Deletes an existing subscription. All pending messages in the subscription
+        /// Deletes an existing subscription. All messages retained in the subscription
         /// are immediately dropped. Calls to `Pull` after deletion will return
         /// `NOT_FOUND`. After a subscription is deleted, a new one may be created with
         /// the same name, but the new one has no association with the old
-        /// subscription, or its topic unless the same topic is specified.
+        /// subscription or its topic unless the same topic is specified.
         /// </summary>
         /// <param name="subscription">
         /// The subscription to delete.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2009,16 +2070,19 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="ackIds">
         /// List of acknowledgment IDs.
         /// </param>
         /// <param name="ackDeadlineSeconds">
         /// The new ack deadline with respect to the time this request was sent to
-        /// the Pub/Sub system. Must be >= 0. For example, if the value is 10, the new
+        /// the Pub/Sub system. For example, if the value is 10, the new
         /// ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
         /// was made. Specifying zero may immediately make the message available for
         /// another pull request.
+        /// The minimum deadline you can specify is 0 seconds.
+        /// The maximum deadline you can specify is 600 seconds (10 minutes).
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2051,16 +2115,19 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="ackIds">
         /// List of acknowledgment IDs.
         /// </param>
         /// <param name="ackDeadlineSeconds">
         /// The new ack deadline with respect to the time this request was sent to
-        /// the Pub/Sub system. Must be >= 0. For example, if the value is 10, the new
+        /// the Pub/Sub system. For example, if the value is 10, the new
         /// ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
         /// was made. Specifying zero may immediately make the message available for
         /// another pull request.
+        /// The minimum deadline you can specify is 0 seconds.
+        /// The maximum deadline you can specify is 600 seconds (10 minutes).
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2095,6 +2162,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The subscription whose message is being acknowledged.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="ackIds">
         /// The acknowledgment ID for the messages being acknowledged that was returned
@@ -2131,6 +2199,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The subscription whose message is being acknowledged.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="ackIds">
         /// The acknowledgment ID for the messages being acknowledged that was returned
@@ -2164,13 +2233,15 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The subscription from which messages should be pulled.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="returnImmediately">
-        /// If this is specified as true the system will respond immediately even if
-        /// it is not able to return a message in the `Pull` response. Otherwise the
-        /// system is allowed to wait until at least one message is available rather
-        /// than returning no messages. The client may cancel the request if it does
-        /// not wish to wait any longer for the response.
+        /// If this field set to true, the system will respond immediately even if
+        /// it there are no messages available to return in the `Pull` response.
+        /// Otherwise, the system may wait (for a bounded amount of time) until at
+        /// least one message is available, rather than returning no messages. The
+        /// client may cancel the request if it does not wish to wait any longer for
+        /// the response.
         /// </param>
         /// <param name="maxMessages">
         /// The maximum number of messages returned for this request. The Pub/Sub
@@ -2206,13 +2277,15 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The subscription from which messages should be pulled.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="returnImmediately">
-        /// If this is specified as true the system will respond immediately even if
-        /// it is not able to return a message in the `Pull` response. Otherwise the
-        /// system is allowed to wait until at least one message is available rather
-        /// than returning no messages. The client may cancel the request if it does
-        /// not wish to wait any longer for the response.
+        /// If this field set to true, the system will respond immediately even if
+        /// it there are no messages available to return in the `Pull` response.
+        /// Otherwise, the system may wait (for a bounded amount of time) until at
+        /// least one message is available, rather than returning no messages. The
+        /// client may cancel the request if it does not wish to wait any longer for
+        /// the response.
         /// </param>
         /// <param name="maxMessages">
         /// The maximum number of messages returned for this request. The Pub/Sub
@@ -2250,6 +2323,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="pushConfig">
         /// The push configuration for future deliveries.
@@ -2289,6 +2363,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         /// <param name="subscription">
         /// The name of the subscription.
+        /// Format is `projects/{project}/subscriptions/{sub}`.
         /// </param>
         /// <param name="pushConfig">
         /// The push configuration for future deliveries.
@@ -2446,6 +2521,8 @@ namespace Google.Cloud.PubSub.V1
 
         /// <summary>
         /// Returns permissions that a caller has on the specified resource.
+        /// If the resource does not exist, this will return an empty set of
+        /// permissions, not a NOT_FOUND error.
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource for which the policy detail is being requested.
@@ -2480,6 +2557,8 @@ namespace Google.Cloud.PubSub.V1
 
         /// <summary>
         /// Returns permissions that a caller has on the specified resource.
+        /// If the resource does not exist, this will return an empty set of
+        /// permissions, not a NOT_FOUND error.
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource for which the policy detail is being requested.

--- a/apis/Google.LongRunning/Google.LongRunning.Snippets/OperationsClientSnippets.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.Snippets/OperationsClientSnippets.g.cs
@@ -1,30 +1,16 @@
 // Copyright 2016, Google Inc. All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//     * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Generated code. DO NOT EDIT!
 

--- a/apis/Google.LongRunning/Google.LongRunning/OperationsClient.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/OperationsClient.cs
@@ -1,30 +1,16 @@
 // Copyright 2016, Google Inc. All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//     * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Generated code. DO NOT EDIT!
 

--- a/apis/Google.LongRunning/Google.LongRunning/ResourceNames.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/ResourceNames.cs
@@ -1,30 +1,16 @@
 // Copyright 2016, Google Inc. All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//     * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Generated code. DO NOT EDIT!
 

--- a/generateapis.sh
+++ b/generateapis.sh
@@ -127,9 +127,20 @@ generate_api Google.Cloud.Speech.V1Beta1 google/cloud/speech/v1beta1 cloud_speec
 generate_api Google.Cloud.Logging.V2 google/logging/v2 logging.yaml google/logging/type
 generate_api Google.Cloud.Trace.V1 google/devtools/cloudtrace/v1 trace.yaml
 generate_api Google.Cloud.ErrorReporting.V1Beta1 google/devtools/clouderrorreporting/v1beta1 errorreporting.yaml
-generate_api Google.LongRunning google/longrunning longrunning/longrunning.yaml
 generate_api Google.Cloud.PubSub.V1 google/pubsub/v1 pubsub.yaml
 generate_api Google.Cloud.Datastore.V1 google/datastore/v1 datastore.yaml
 generate_api Google.Cloud.Monitoring.V3 google/monitoring/v3 monitoring.yaml
 
-# TODO: Generate just the grpc/protos for IAM.
+# Generate LongRunning, after changing the license text (because we use
+# Apache for LRO where other languages use BSD)
+sed -i s/license-header-bsd-3-clause.txt/license-header-apache-2.0.txt/g googleapis/google/longrunning/longrunning_gapic.yaml
+generate_api Google.LongRunning google/longrunning longrunning/longrunning.yaml
+
+# IAM (just proto and grpc)
+$PROTOC \
+  --csharp_out=apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1 \
+  --grpc_out=apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1 \
+  -I googleapis \
+  -I $CORE_PROTOS_ROOT \
+  --plugin=protoc-gen-grpc=$GRPC_PLUGIN \
+  googleapis/google/iam/v1/*.proto


### PR DESCRIPTION
Suggest reviewing one commit at a time. Only the first commit contains any manual changes.

The namespaces for Google.Cloud.Trace and Google.LongRunning were manually edited in googleapis, and one import was removed from Cloud Error Reporting (awaiting upstream changes flushing through).