### PR TITLE
Update all 0.x versions to 1.0.0-alpha01

### DIFF
--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/project.json
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0-*",
+  "version": "1.0.0-alpha01-*",
   "description": "Recommended Google client library to access the Stackdriver Error Reporting API, which groups and counts similar errors from cloud services. The Stackdriver Error Reporting API provides a way to report new errors and read access to error groups and their associated errors.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/project.json
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.4.0-*",
+  "version": "1.0.0-alpha01-*",
   "description": "Google Compute Engine Metadata v1 client library",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/project.json
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0-*",
+  "version": "1.0.0-alpha01-*",
   "description": "Recommended Google client library to access the Stackdriver Monitoring API, which manages your Stackdriver Monitoring data and configurations. Most projects must be associated with a Stackdriver account, with a few exceptions as noted on the individual method pages.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.5.0-*",
+  "version": "1.0.0-alpha01-*",
   "description": "Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/project.json
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0-*",
+  "version": "1.0.0-alpha01-*",
   "description": "Recommended Google client library to access the Google Cloud Trace API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Devtools.AspNet/Google.Devtools.AspNet/project.json
+++ b/apis/Google.Devtools.AspNet/Google.Devtools.AspNet/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-*",
+  "version": "1.0.0-alpha01-*",
   "description": "Google Stackdriver Instrumentation Libraries for ASP.NET.",
   "authors": [ "Google Inc." ],
 


### PR DESCRIPTION
We're going to stop using 0.x other than for:
- Prior to initial alpha release
- Early access to myget before we're ready for alpha