### PR TITLE
Request-object methods and new logging configuration

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreClientSnippets.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreClientSnippets.cs
@@ -38,7 +38,7 @@ namespace Google.Cloud.Datastore.V1.Snippets
             string projectId = _fixture.ProjectId;
             string namespaceId = _fixture.NamespaceId;
 
-            // Snippet: Lookup
+            // Snippet: Lookup(*,*,*,*)
             KeyFactory keyFactory = new KeyFactory(projectId, namespaceId, "book");
             Key key1 = keyFactory.CreateKey("pride_and_prejudice");
             Key key2 = keyFactory.CreateKey("not_present");
@@ -162,7 +162,7 @@ namespace Google.Cloud.Datastore.V1.Snippets
             string projectId = _fixture.ProjectId;
             string namespaceId = _fixture.NamespaceId;
 
-            // Snippet: AllocateIds
+            // Snippet: AllocateIds(*,*,*)
             DatastoreClient client = DatastoreClient.Create();
             KeyFactory keyFactory = new KeyFactory(projectId, namespaceId, "message");
             AllocateIdsResponse response = client.AllocateIds(projectId,

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreClientSnippets.g.cs
@@ -61,6 +61,40 @@ namespace Google.Cloud.Datastore.V1.Snippets
             // End snippet
         }
 
+        public async Task LookupAsync_RequestObject()
+        {
+            // Snippet: LookupAsync(LookupRequest,CallSettings)
+            // Create client
+            DatastoreClient datastoreClient = DatastoreClient.Create();
+            // Initialize request argument(s)
+            LookupRequest request = new LookupRequest
+            {
+                ProjectId = "",
+                ReadOptions = new ReadOptions(),
+                Keys = { },
+            };
+            // Make the request
+            LookupResponse response = await datastoreClient.LookupAsync(request);
+            // End snippet
+        }
+
+        public void Lookup_RequestObject()
+        {
+            // Snippet: Lookup(LookupRequest,CallSettings)
+            // Create client
+            DatastoreClient datastoreClient = DatastoreClient.Create();
+            // Initialize request argument(s)
+            LookupRequest request = new LookupRequest
+            {
+                ProjectId = "",
+                ReadOptions = new ReadOptions(),
+                Keys = { },
+            };
+            // Make the request
+            LookupResponse response = datastoreClient.Lookup(request);
+            // End snippet
+        }
+
         public async Task RunQueryAsync1()
         {
             // Snippet: RunQueryAsync(string,PartitionId,ReadOptions,Query,CallSettings)
@@ -123,6 +157,40 @@ namespace Google.Cloud.Datastore.V1.Snippets
             // End snippet
         }
 
+        public async Task RunQueryAsync_RequestObject()
+        {
+            // Snippet: RunQueryAsync(RunQueryRequest,CallSettings)
+            // Create client
+            DatastoreClient datastoreClient = DatastoreClient.Create();
+            // Initialize request argument(s)
+            RunQueryRequest request = new RunQueryRequest
+            {
+                ProjectId = "",
+                PartitionId = new PartitionId(),
+                ReadOptions = new ReadOptions(),
+            };
+            // Make the request
+            RunQueryResponse response = await datastoreClient.RunQueryAsync(request);
+            // End snippet
+        }
+
+        public void RunQuery_RequestObject()
+        {
+            // Snippet: RunQuery(RunQueryRequest,CallSettings)
+            // Create client
+            DatastoreClient datastoreClient = DatastoreClient.Create();
+            // Initialize request argument(s)
+            RunQueryRequest request = new RunQueryRequest
+            {
+                ProjectId = "",
+                PartitionId = new PartitionId(),
+                ReadOptions = new ReadOptions(),
+            };
+            // Make the request
+            RunQueryResponse response = datastoreClient.RunQuery(request);
+            // End snippet
+        }
+
         public async Task BeginTransactionAsync()
         {
             // Snippet: BeginTransactionAsync(string,CallSettings)
@@ -145,6 +213,36 @@ namespace Google.Cloud.Datastore.V1.Snippets
             string projectId = "";
             // Make the request
             BeginTransactionResponse response = datastoreClient.BeginTransaction(projectId);
+            // End snippet
+        }
+
+        public async Task BeginTransactionAsync_RequestObject()
+        {
+            // Snippet: BeginTransactionAsync(BeginTransactionRequest,CallSettings)
+            // Create client
+            DatastoreClient datastoreClient = DatastoreClient.Create();
+            // Initialize request argument(s)
+            BeginTransactionRequest request = new BeginTransactionRequest
+            {
+                ProjectId = "",
+            };
+            // Make the request
+            BeginTransactionResponse response = await datastoreClient.BeginTransactionAsync(request);
+            // End snippet
+        }
+
+        public void BeginTransaction_RequestObject()
+        {
+            // Snippet: BeginTransaction(BeginTransactionRequest,CallSettings)
+            // Create client
+            DatastoreClient datastoreClient = DatastoreClient.Create();
+            // Initialize request argument(s)
+            BeginTransactionRequest request = new BeginTransactionRequest
+            {
+                ProjectId = "",
+            };
+            // Make the request
+            BeginTransactionResponse response = datastoreClient.BeginTransaction(request);
             // End snippet
         }
 
@@ -208,6 +306,40 @@ namespace Google.Cloud.Datastore.V1.Snippets
             // End snippet
         }
 
+        public async Task CommitAsync_RequestObject()
+        {
+            // Snippet: CommitAsync(CommitRequest,CallSettings)
+            // Create client
+            DatastoreClient datastoreClient = DatastoreClient.Create();
+            // Initialize request argument(s)
+            CommitRequest request = new CommitRequest
+            {
+                ProjectId = "",
+                Mode = CommitRequest.Types.Mode.Unspecified,
+                Mutations = { },
+            };
+            // Make the request
+            CommitResponse response = await datastoreClient.CommitAsync(request);
+            // End snippet
+        }
+
+        public void Commit_RequestObject()
+        {
+            // Snippet: Commit(CommitRequest,CallSettings)
+            // Create client
+            DatastoreClient datastoreClient = DatastoreClient.Create();
+            // Initialize request argument(s)
+            CommitRequest request = new CommitRequest
+            {
+                ProjectId = "",
+                Mode = CommitRequest.Types.Mode.Unspecified,
+                Mutations = { },
+            };
+            // Make the request
+            CommitResponse response = datastoreClient.Commit(request);
+            // End snippet
+        }
+
         public async Task RollbackAsync()
         {
             // Snippet: RollbackAsync(string,ByteString,CallSettings)
@@ -235,6 +367,38 @@ namespace Google.Cloud.Datastore.V1.Snippets
             // End snippet
         }
 
+        public async Task RollbackAsync_RequestObject()
+        {
+            // Snippet: RollbackAsync(RollbackRequest,CallSettings)
+            // Create client
+            DatastoreClient datastoreClient = DatastoreClient.Create();
+            // Initialize request argument(s)
+            RollbackRequest request = new RollbackRequest
+            {
+                ProjectId = "",
+                Transaction = ByteString.CopyFromUtf8(""),
+            };
+            // Make the request
+            RollbackResponse response = await datastoreClient.RollbackAsync(request);
+            // End snippet
+        }
+
+        public void Rollback_RequestObject()
+        {
+            // Snippet: Rollback(RollbackRequest,CallSettings)
+            // Create client
+            DatastoreClient datastoreClient = DatastoreClient.Create();
+            // Initialize request argument(s)
+            RollbackRequest request = new RollbackRequest
+            {
+                ProjectId = "",
+                Transaction = ByteString.CopyFromUtf8(""),
+            };
+            // Make the request
+            RollbackResponse response = datastoreClient.Rollback(request);
+            // End snippet
+        }
+
         public async Task AllocateIdsAsync()
         {
             // Snippet: AllocateIdsAsync(string,IEnumerable<Key>,CallSettings)
@@ -259,6 +423,38 @@ namespace Google.Cloud.Datastore.V1.Snippets
             IEnumerable<Key> keys = new List<Key>();
             // Make the request
             AllocateIdsResponse response = datastoreClient.AllocateIds(projectId, keys);
+            // End snippet
+        }
+
+        public async Task AllocateIdsAsync_RequestObject()
+        {
+            // Snippet: AllocateIdsAsync(AllocateIdsRequest,CallSettings)
+            // Create client
+            DatastoreClient datastoreClient = DatastoreClient.Create();
+            // Initialize request argument(s)
+            AllocateIdsRequest request = new AllocateIdsRequest
+            {
+                ProjectId = "",
+                Keys = { },
+            };
+            // Make the request
+            AllocateIdsResponse response = await datastoreClient.AllocateIdsAsync(request);
+            // End snippet
+        }
+
+        public void AllocateIds_RequestObject()
+        {
+            // Snippet: AllocateIds(AllocateIdsRequest,CallSettings)
+            // Create client
+            DatastoreClient datastoreClient = DatastoreClient.Create();
+            // Initialize request argument(s)
+            AllocateIdsRequest request = new AllocateIdsRequest
+            {
+                ProjectId = "",
+                Keys = { },
+            };
+            // Make the request
+            AllocateIdsResponse response = datastoreClient.AllocateIds(request);
             // End snippet
         }
 

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClient.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClient.cs
@@ -420,10 +420,14 @@ namespace Google.Cloud.Datastore.V1
             string projectId,
             ReadOptions readOptions,
             IEnumerable<Key> keys,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => LookupAsync(
+                new LookupRequest
+                {
+                    ProjectId = projectId,
+                    ReadOptions = readOptions,
+                    Keys = { keys },
+                },
+                callSettings);
 
         /// <summary>
         /// Looks up entities by key.
@@ -475,6 +479,48 @@ namespace Google.Cloud.Datastore.V1
             string projectId,
             ReadOptions readOptions,
             IEnumerable<Key> keys,
+            CallSettings callSettings = null) => Lookup(
+                new LookupRequest
+                {
+                    ProjectId = projectId,
+                    ReadOptions = readOptions,
+                    Keys = { keys },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Looks up entities by key.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<LookupResponse> LookupAsync(
+            LookupRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Looks up entities by key.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual LookupResponse Lookup(
+            LookupRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -509,10 +555,15 @@ namespace Google.Cloud.Datastore.V1
             PartitionId partitionId,
             ReadOptions readOptions,
             Query query,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => RunQueryAsync(
+                new RunQueryRequest
+                {
+                    ProjectId = projectId,
+                    PartitionId = partitionId,
+                    ReadOptions = readOptions,
+                    Query = query,
+                },
+                callSettings);
 
         /// <summary>
         /// Queries for entities.
@@ -579,10 +630,15 @@ namespace Google.Cloud.Datastore.V1
             PartitionId partitionId,
             ReadOptions readOptions,
             Query query,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => RunQuery(
+                new RunQueryRequest
+                {
+                    ProjectId = projectId,
+                    PartitionId = partitionId,
+                    ReadOptions = readOptions,
+                    Query = query,
+                },
+                callSettings);
 
         /// <summary>
         /// Queries for entities.
@@ -613,10 +669,15 @@ namespace Google.Cloud.Datastore.V1
             PartitionId partitionId,
             ReadOptions readOptions,
             GqlQuery gqlQuery,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => RunQueryAsync(
+                new RunQueryRequest
+                {
+                    ProjectId = projectId,
+                    PartitionId = partitionId,
+                    ReadOptions = readOptions,
+                    GqlQuery = gqlQuery,
+                },
+                callSettings);
 
         /// <summary>
         /// Queries for entities.
@@ -683,6 +744,49 @@ namespace Google.Cloud.Datastore.V1
             PartitionId partitionId,
             ReadOptions readOptions,
             GqlQuery gqlQuery,
+            CallSettings callSettings = null) => RunQuery(
+                new RunQueryRequest
+                {
+                    ProjectId = projectId,
+                    PartitionId = partitionId,
+                    ReadOptions = readOptions,
+                    GqlQuery = gqlQuery,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Queries for entities.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<RunQueryResponse> RunQueryAsync(
+            RunQueryRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Queries for entities.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual RunQueryResponse RunQuery(
+            RunQueryRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -702,10 +806,12 @@ namespace Google.Cloud.Datastore.V1
         /// </returns>
         public virtual Task<BeginTransactionResponse> BeginTransactionAsync(
             string projectId,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => BeginTransactionAsync(
+                new BeginTransactionRequest
+                {
+                    ProjectId = projectId,
+                },
+                callSettings);
 
         /// <summary>
         /// Begins a new transaction.
@@ -739,6 +845,46 @@ namespace Google.Cloud.Datastore.V1
         /// </returns>
         public virtual BeginTransactionResponse BeginTransaction(
             string projectId,
+            CallSettings callSettings = null) => BeginTransaction(
+                new BeginTransactionRequest
+                {
+                    ProjectId = projectId,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Begins a new transaction.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<BeginTransactionResponse> BeginTransactionAsync(
+            BeginTransactionRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Begins a new transaction.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual BeginTransactionResponse BeginTransaction(
+            BeginTransactionRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -785,10 +931,15 @@ namespace Google.Cloud.Datastore.V1
             CommitRequest.Types.Mode mode,
             ByteString transaction,
             IEnumerable<Mutation> mutations,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => CommitAsync(
+                new CommitRequest
+                {
+                    ProjectId = projectId,
+                    Mode = mode,
+                    Transaction = transaction,
+                    Mutations = { mutations },
+                },
+                callSettings);
 
         /// <summary>
         /// Commits a transaction, optionally creating, deleting or modifying some
@@ -879,10 +1030,15 @@ namespace Google.Cloud.Datastore.V1
             CommitRequest.Types.Mode mode,
             ByteString transaction,
             IEnumerable<Mutation> mutations,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => Commit(
+                new CommitRequest
+                {
+                    ProjectId = projectId,
+                    Mode = mode,
+                    Transaction = transaction,
+                    Mutations = { mutations },
+                },
+                callSettings);
 
         /// <summary>
         /// Commits a transaction, optionally creating, deleting or modifying some
@@ -919,10 +1075,14 @@ namespace Google.Cloud.Datastore.V1
             string projectId,
             CommitRequest.Types.Mode mode,
             IEnumerable<Mutation> mutations,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => CommitAsync(
+                new CommitRequest
+                {
+                    ProjectId = projectId,
+                    Mode = mode,
+                    Mutations = { mutations },
+                },
+                callSettings);
 
         /// <summary>
         /// Commits a transaction, optionally creating, deleting or modifying some
@@ -1000,6 +1160,50 @@ namespace Google.Cloud.Datastore.V1
             string projectId,
             CommitRequest.Types.Mode mode,
             IEnumerable<Mutation> mutations,
+            CallSettings callSettings = null) => Commit(
+                new CommitRequest
+                {
+                    ProjectId = projectId,
+                    Mode = mode,
+                    Mutations = { mutations },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Commits a transaction, optionally creating, deleting or modifying some
+        /// entities.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<CommitResponse> CommitAsync(
+            CommitRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Commits a transaction, optionally creating, deleting or modifying some
+        /// entities.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual CommitResponse Commit(
+            CommitRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1024,10 +1228,13 @@ namespace Google.Cloud.Datastore.V1
         public virtual Task<RollbackResponse> RollbackAsync(
             string projectId,
             ByteString transaction,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => RollbackAsync(
+                new RollbackRequest
+                {
+                    ProjectId = projectId,
+                    Transaction = transaction,
+                },
+                callSettings);
 
         /// <summary>
         /// Rolls back a transaction.
@@ -1072,6 +1279,47 @@ namespace Google.Cloud.Datastore.V1
         public virtual RollbackResponse Rollback(
             string projectId,
             ByteString transaction,
+            CallSettings callSettings = null) => Rollback(
+                new RollbackRequest
+                {
+                    ProjectId = projectId,
+                    Transaction = transaction,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Rolls back a transaction.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<RollbackResponse> RollbackAsync(
+            RollbackRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Rolls back a transaction.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual RollbackResponse Rollback(
+            RollbackRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1097,10 +1345,13 @@ namespace Google.Cloud.Datastore.V1
         public virtual Task<AllocateIdsResponse> AllocateIdsAsync(
             string projectId,
             IEnumerable<Key> keys,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => AllocateIdsAsync(
+                new AllocateIdsRequest
+                {
+                    ProjectId = projectId,
+                    Keys = { keys },
+                },
+                callSettings);
 
         /// <summary>
         /// Allocates IDs for the given keys, which is useful for referencing an entity
@@ -1147,6 +1398,49 @@ namespace Google.Cloud.Datastore.V1
         public virtual AllocateIdsResponse AllocateIds(
             string projectId,
             IEnumerable<Key> keys,
+            CallSettings callSettings = null) => AllocateIds(
+                new AllocateIdsRequest
+                {
+                    ProjectId = projectId,
+                    Keys = { keys },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Allocates IDs for the given keys, which is useful for referencing an entity
+        /// before it is inserted.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<AllocateIdsResponse> AllocateIdsAsync(
+            AllocateIdsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Allocates IDs for the given keys, which is useful for referencing an entity
+        /// before it is inserted.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual AllocateIdsResponse AllocateIds(
+            AllocateIdsRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1207,14 +1501,8 @@ namespace Google.Cloud.Datastore.V1
         /// <summary>
         /// Looks up entities by key.
         /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
-        /// </param>
-        /// <param name="readOptions">
-        /// The options for this lookup request.
-        /// </param>
-        /// <param name="keys">
-        /// Keys of entities to look up.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1223,17 +1511,9 @@ namespace Google.Cloud.Datastore.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<LookupResponse> LookupAsync(
-            string projectId,
-            ReadOptions readOptions,
-            IEnumerable<Key> keys,
+            LookupRequest request,
             CallSettings callSettings = null)
         {
-            LookupRequest request = new LookupRequest
-            {
-                ProjectId = projectId,
-                ReadOptions = readOptions,
-                Keys = { keys },
-            };
             Modify_LookupRequest(ref request, ref callSettings);
             return _callLookup.Async(request, callSettings);
         }
@@ -1241,14 +1521,8 @@ namespace Google.Cloud.Datastore.V1
         /// <summary>
         /// Looks up entities by key.
         /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
-        /// </param>
-        /// <param name="readOptions">
-        /// The options for this lookup request.
-        /// </param>
-        /// <param name="keys">
-        /// Keys of entities to look up.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1257,17 +1531,9 @@ namespace Google.Cloud.Datastore.V1
         /// The RPC response.
         /// </returns>
         public override LookupResponse Lookup(
-            string projectId,
-            ReadOptions readOptions,
-            IEnumerable<Key> keys,
+            LookupRequest request,
             CallSettings callSettings = null)
         {
-            LookupRequest request = new LookupRequest
-            {
-                ProjectId = projectId,
-                ReadOptions = readOptions,
-                Keys = { keys },
-            };
             Modify_LookupRequest(ref request, ref callSettings);
             return _callLookup.Sync(request, callSettings);
         }
@@ -1275,20 +1541,8 @@ namespace Google.Cloud.Datastore.V1
         /// <summary>
         /// Queries for entities.
         /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
-        /// </param>
-        /// <param name="partitionId">
-        /// Entities are partitioned into subsets, identified by a partition ID.
-        /// Queries are scoped to a single partition.
-        /// This partition ID is normalized with the standard default context
-        /// partition ID.
-        /// </param>
-        /// <param name="readOptions">
-        /// The options for this query.
-        /// </param>
-        /// <param name="query">
-        /// The query to run.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1297,19 +1551,9 @@ namespace Google.Cloud.Datastore.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<RunQueryResponse> RunQueryAsync(
-            string projectId,
-            PartitionId partitionId,
-            ReadOptions readOptions,
-            Query query,
+            RunQueryRequest request,
             CallSettings callSettings = null)
         {
-            RunQueryRequest request = new RunQueryRequest
-            {
-                ProjectId = projectId,
-                PartitionId = partitionId,
-                ReadOptions = readOptions,
-                Query = query,
-            };
             Modify_RunQueryRequest(ref request, ref callSettings);
             return _callRunQuery.Async(request, callSettings);
         }
@@ -1317,20 +1561,8 @@ namespace Google.Cloud.Datastore.V1
         /// <summary>
         /// Queries for entities.
         /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
-        /// </param>
-        /// <param name="partitionId">
-        /// Entities are partitioned into subsets, identified by a partition ID.
-        /// Queries are scoped to a single partition.
-        /// This partition ID is normalized with the standard default context
-        /// partition ID.
-        /// </param>
-        /// <param name="readOptions">
-        /// The options for this query.
-        /// </param>
-        /// <param name="query">
-        /// The query to run.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1339,103 +1571,9 @@ namespace Google.Cloud.Datastore.V1
         /// The RPC response.
         /// </returns>
         public override RunQueryResponse RunQuery(
-            string projectId,
-            PartitionId partitionId,
-            ReadOptions readOptions,
-            Query query,
+            RunQueryRequest request,
             CallSettings callSettings = null)
         {
-            RunQueryRequest request = new RunQueryRequest
-            {
-                ProjectId = projectId,
-                PartitionId = partitionId,
-                ReadOptions = readOptions,
-                Query = query,
-            };
-            Modify_RunQueryRequest(ref request, ref callSettings);
-            return _callRunQuery.Sync(request, callSettings);
-        }
-
-        /// <summary>
-        /// Queries for entities.
-        /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
-        /// </param>
-        /// <param name="partitionId">
-        /// Entities are partitioned into subsets, identified by a partition ID.
-        /// Queries are scoped to a single partition.
-        /// This partition ID is normalized with the standard default context
-        /// partition ID.
-        /// </param>
-        /// <param name="readOptions">
-        /// The options for this query.
-        /// </param>
-        /// <param name="gqlQuery">
-        /// The GQL query to run.
-        /// </param>
-        /// <param name="callSettings">
-        /// If not null, applies overrides to this RPC call.
-        /// </param>
-        /// <returns>
-        /// A Task containing the RPC response.
-        /// </returns>
-        public override Task<RunQueryResponse> RunQueryAsync(
-            string projectId,
-            PartitionId partitionId,
-            ReadOptions readOptions,
-            GqlQuery gqlQuery,
-            CallSettings callSettings = null)
-        {
-            RunQueryRequest request = new RunQueryRequest
-            {
-                ProjectId = projectId,
-                PartitionId = partitionId,
-                ReadOptions = readOptions,
-                GqlQuery = gqlQuery,
-            };
-            Modify_RunQueryRequest(ref request, ref callSettings);
-            return _callRunQuery.Async(request, callSettings);
-        }
-
-        /// <summary>
-        /// Queries for entities.
-        /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
-        /// </param>
-        /// <param name="partitionId">
-        /// Entities are partitioned into subsets, identified by a partition ID.
-        /// Queries are scoped to a single partition.
-        /// This partition ID is normalized with the standard default context
-        /// partition ID.
-        /// </param>
-        /// <param name="readOptions">
-        /// The options for this query.
-        /// </param>
-        /// <param name="gqlQuery">
-        /// The GQL query to run.
-        /// </param>
-        /// <param name="callSettings">
-        /// If not null, applies overrides to this RPC call.
-        /// </param>
-        /// <returns>
-        /// The RPC response.
-        /// </returns>
-        public override RunQueryResponse RunQuery(
-            string projectId,
-            PartitionId partitionId,
-            ReadOptions readOptions,
-            GqlQuery gqlQuery,
-            CallSettings callSettings = null)
-        {
-            RunQueryRequest request = new RunQueryRequest
-            {
-                ProjectId = projectId,
-                PartitionId = partitionId,
-                ReadOptions = readOptions,
-                GqlQuery = gqlQuery,
-            };
             Modify_RunQueryRequest(ref request, ref callSettings);
             return _callRunQuery.Sync(request, callSettings);
         }
@@ -1443,8 +1581,8 @@ namespace Google.Cloud.Datastore.V1
         /// <summary>
         /// Begins a new transaction.
         /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1453,13 +1591,9 @@ namespace Google.Cloud.Datastore.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<BeginTransactionResponse> BeginTransactionAsync(
-            string projectId,
+            BeginTransactionRequest request,
             CallSettings callSettings = null)
         {
-            BeginTransactionRequest request = new BeginTransactionRequest
-            {
-                ProjectId = projectId,
-            };
             Modify_BeginTransactionRequest(ref request, ref callSettings);
             return _callBeginTransaction.Async(request, callSettings);
         }
@@ -1467,8 +1601,8 @@ namespace Google.Cloud.Datastore.V1
         /// <summary>
         /// Begins a new transaction.
         /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1477,13 +1611,9 @@ namespace Google.Cloud.Datastore.V1
         /// The RPC response.
         /// </returns>
         public override BeginTransactionResponse BeginTransaction(
-            string projectId,
+            BeginTransactionRequest request,
             CallSettings callSettings = null)
         {
-            BeginTransactionRequest request = new BeginTransactionRequest
-            {
-                ProjectId = projectId,
-            };
             Modify_BeginTransactionRequest(ref request, ref callSettings);
             return _callBeginTransaction.Sync(request, callSettings);
         }
@@ -1492,31 +1622,8 @@ namespace Google.Cloud.Datastore.V1
         /// Commits a transaction, optionally creating, deleting or modifying some
         /// entities.
         /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
-        /// </param>
-        /// <param name="mode">
-        /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
-        /// </param>
-        /// <param name="transaction">
-        /// The identifier of the transaction associated with the commit. A
-        /// transaction identifier is returned by a call to
-        /// [Datastore.BeginTransaction][google.datastore.v1.Datastore.BeginTransaction].
-        /// </param>
-        /// <param name="mutations">
-        /// The mutations to perform.
-        ///
-        /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
-        /// applied in order. The following sequences of mutations affecting a single
-        /// entity are not permitted in a single `Commit` request:
-        ///
-        /// - `insert` followed by `insert`
-        /// - `update` followed by `insert`
-        /// - `upsert` followed by `insert`
-        /// - `delete` followed by `update`
-        ///
-        /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
-        /// entity.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1525,19 +1632,9 @@ namespace Google.Cloud.Datastore.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<CommitResponse> CommitAsync(
-            string projectId,
-            CommitRequest.Types.Mode mode,
-            ByteString transaction,
-            IEnumerable<Mutation> mutations,
+            CommitRequest request,
             CallSettings callSettings = null)
         {
-            CommitRequest request = new CommitRequest
-            {
-                ProjectId = projectId,
-                Mode = mode,
-                Transaction = transaction,
-                Mutations = { mutations },
-            };
             Modify_CommitRequest(ref request, ref callSettings);
             return _callCommit.Async(request, callSettings);
         }
@@ -1546,31 +1643,8 @@ namespace Google.Cloud.Datastore.V1
         /// Commits a transaction, optionally creating, deleting or modifying some
         /// entities.
         /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
-        /// </param>
-        /// <param name="mode">
-        /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
-        /// </param>
-        /// <param name="transaction">
-        /// The identifier of the transaction associated with the commit. A
-        /// transaction identifier is returned by a call to
-        /// [Datastore.BeginTransaction][google.datastore.v1.Datastore.BeginTransaction].
-        /// </param>
-        /// <param name="mutations">
-        /// The mutations to perform.
-        ///
-        /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
-        /// applied in order. The following sequences of mutations affecting a single
-        /// entity are not permitted in a single `Commit` request:
-        ///
-        /// - `insert` followed by `insert`
-        /// - `update` followed by `insert`
-        /// - `upsert` followed by `insert`
-        /// - `delete` followed by `update`
-        ///
-        /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
-        /// entity.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1579,113 +1653,9 @@ namespace Google.Cloud.Datastore.V1
         /// The RPC response.
         /// </returns>
         public override CommitResponse Commit(
-            string projectId,
-            CommitRequest.Types.Mode mode,
-            ByteString transaction,
-            IEnumerable<Mutation> mutations,
+            CommitRequest request,
             CallSettings callSettings = null)
         {
-            CommitRequest request = new CommitRequest
-            {
-                ProjectId = projectId,
-                Mode = mode,
-                Transaction = transaction,
-                Mutations = { mutations },
-            };
-            Modify_CommitRequest(ref request, ref callSettings);
-            return _callCommit.Sync(request, callSettings);
-        }
-
-        /// <summary>
-        /// Commits a transaction, optionally creating, deleting or modifying some
-        /// entities.
-        /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
-        /// </param>
-        /// <param name="mode">
-        /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
-        /// </param>
-        /// <param name="mutations">
-        /// The mutations to perform.
-        ///
-        /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
-        /// applied in order. The following sequences of mutations affecting a single
-        /// entity are not permitted in a single `Commit` request:
-        ///
-        /// - `insert` followed by `insert`
-        /// - `update` followed by `insert`
-        /// - `upsert` followed by `insert`
-        /// - `delete` followed by `update`
-        ///
-        /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
-        /// entity.
-        /// </param>
-        /// <param name="callSettings">
-        /// If not null, applies overrides to this RPC call.
-        /// </param>
-        /// <returns>
-        /// A Task containing the RPC response.
-        /// </returns>
-        public override Task<CommitResponse> CommitAsync(
-            string projectId,
-            CommitRequest.Types.Mode mode,
-            IEnumerable<Mutation> mutations,
-            CallSettings callSettings = null)
-        {
-            CommitRequest request = new CommitRequest
-            {
-                ProjectId = projectId,
-                Mode = mode,
-                Mutations = { mutations },
-            };
-            Modify_CommitRequest(ref request, ref callSettings);
-            return _callCommit.Async(request, callSettings);
-        }
-
-        /// <summary>
-        /// Commits a transaction, optionally creating, deleting or modifying some
-        /// entities.
-        /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
-        /// </param>
-        /// <param name="mode">
-        /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
-        /// </param>
-        /// <param name="mutations">
-        /// The mutations to perform.
-        ///
-        /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
-        /// applied in order. The following sequences of mutations affecting a single
-        /// entity are not permitted in a single `Commit` request:
-        ///
-        /// - `insert` followed by `insert`
-        /// - `update` followed by `insert`
-        /// - `upsert` followed by `insert`
-        /// - `delete` followed by `update`
-        ///
-        /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
-        /// entity.
-        /// </param>
-        /// <param name="callSettings">
-        /// If not null, applies overrides to this RPC call.
-        /// </param>
-        /// <returns>
-        /// The RPC response.
-        /// </returns>
-        public override CommitResponse Commit(
-            string projectId,
-            CommitRequest.Types.Mode mode,
-            IEnumerable<Mutation> mutations,
-            CallSettings callSettings = null)
-        {
-            CommitRequest request = new CommitRequest
-            {
-                ProjectId = projectId,
-                Mode = mode,
-                Mutations = { mutations },
-            };
             Modify_CommitRequest(ref request, ref callSettings);
             return _callCommit.Sync(request, callSettings);
         }
@@ -1693,12 +1663,8 @@ namespace Google.Cloud.Datastore.V1
         /// <summary>
         /// Rolls back a transaction.
         /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
-        /// </param>
-        /// <param name="transaction">
-        /// The transaction identifier, returned by a call to
-        /// [Datastore.BeginTransaction][google.datastore.v1.Datastore.BeginTransaction].
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1707,15 +1673,9 @@ namespace Google.Cloud.Datastore.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<RollbackResponse> RollbackAsync(
-            string projectId,
-            ByteString transaction,
+            RollbackRequest request,
             CallSettings callSettings = null)
         {
-            RollbackRequest request = new RollbackRequest
-            {
-                ProjectId = projectId,
-                Transaction = transaction,
-            };
             Modify_RollbackRequest(ref request, ref callSettings);
             return _callRollback.Async(request, callSettings);
         }
@@ -1723,12 +1683,8 @@ namespace Google.Cloud.Datastore.V1
         /// <summary>
         /// Rolls back a transaction.
         /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
-        /// </param>
-        /// <param name="transaction">
-        /// The transaction identifier, returned by a call to
-        /// [Datastore.BeginTransaction][google.datastore.v1.Datastore.BeginTransaction].
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1737,15 +1693,9 @@ namespace Google.Cloud.Datastore.V1
         /// The RPC response.
         /// </returns>
         public override RollbackResponse Rollback(
-            string projectId,
-            ByteString transaction,
+            RollbackRequest request,
             CallSettings callSettings = null)
         {
-            RollbackRequest request = new RollbackRequest
-            {
-                ProjectId = projectId,
-                Transaction = transaction,
-            };
             Modify_RollbackRequest(ref request, ref callSettings);
             return _callRollback.Sync(request, callSettings);
         }
@@ -1754,12 +1704,8 @@ namespace Google.Cloud.Datastore.V1
         /// Allocates IDs for the given keys, which is useful for referencing an entity
         /// before it is inserted.
         /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
-        /// </param>
-        /// <param name="keys">
-        /// A list of keys with incomplete key paths for which to allocate IDs.
-        /// No key may be reserved/read-only.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1768,15 +1714,9 @@ namespace Google.Cloud.Datastore.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<AllocateIdsResponse> AllocateIdsAsync(
-            string projectId,
-            IEnumerable<Key> keys,
+            AllocateIdsRequest request,
             CallSettings callSettings = null)
         {
-            AllocateIdsRequest request = new AllocateIdsRequest
-            {
-                ProjectId = projectId,
-                Keys = { keys },
-            };
             Modify_AllocateIdsRequest(ref request, ref callSettings);
             return _callAllocateIds.Async(request, callSettings);
         }
@@ -1785,12 +1725,8 @@ namespace Google.Cloud.Datastore.V1
         /// Allocates IDs for the given keys, which is useful for referencing an entity
         /// before it is inserted.
         /// </summary>
-        /// <param name="projectId">
-        /// The ID of the project against which to make the request.
-        /// </param>
-        /// <param name="keys">
-        /// A list of keys with incomplete key paths for which to allocate IDs.
-        /// No key may be reserved/read-only.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1799,15 +1735,9 @@ namespace Google.Cloud.Datastore.V1
         /// The RPC response.
         /// </returns>
         public override AllocateIdsResponse AllocateIds(
-            string projectId,
-            IEnumerable<Key> keys,
+            AllocateIdsRequest request,
             CallSettings callSettings = null)
         {
-            AllocateIdsRequest request = new AllocateIdsRequest
-            {
-                ProjectId = projectId,
-                Keys = { keys },
-            };
             Modify_AllocateIdsRequest(ref request, ref callSettings);
             return _callAllocateIds.Sync(request, callSettings);
         }

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ErrorGroupServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ErrorGroupServiceClientSnippets.g.cs
@@ -57,6 +57,36 @@ namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
             // End snippet
         }
 
+        public async Task GetGroupAsync_RequestObject()
+        {
+            // Snippet: GetGroupAsync(GetGroupRequest,CallSettings)
+            // Create client
+            ErrorGroupServiceClient errorGroupServiceClient = ErrorGroupServiceClient.Create();
+            // Initialize request argument(s)
+            GetGroupRequest request = new GetGroupRequest
+            {
+                GroupName = new GroupName("[PROJECT]", "[GROUP]").ToString(),
+            };
+            // Make the request
+            ErrorGroup response = await errorGroupServiceClient.GetGroupAsync(request);
+            // End snippet
+        }
+
+        public void GetGroup_RequestObject()
+        {
+            // Snippet: GetGroup(GetGroupRequest,CallSettings)
+            // Create client
+            ErrorGroupServiceClient errorGroupServiceClient = ErrorGroupServiceClient.Create();
+            // Initialize request argument(s)
+            GetGroupRequest request = new GetGroupRequest
+            {
+                GroupName = new GroupName("[PROJECT]", "[GROUP]").ToString(),
+            };
+            // Make the request
+            ErrorGroup response = errorGroupServiceClient.GetGroup(request);
+            // End snippet
+        }
+
         public async Task UpdateGroupAsync()
         {
             // Snippet: UpdateGroupAsync(ErrorGroup,CallSettings)
@@ -79,6 +109,36 @@ namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
             ErrorGroup group = new ErrorGroup();
             // Make the request
             ErrorGroup response = errorGroupServiceClient.UpdateGroup(group);
+            // End snippet
+        }
+
+        public async Task UpdateGroupAsync_RequestObject()
+        {
+            // Snippet: UpdateGroupAsync(UpdateGroupRequest,CallSettings)
+            // Create client
+            ErrorGroupServiceClient errorGroupServiceClient = ErrorGroupServiceClient.Create();
+            // Initialize request argument(s)
+            UpdateGroupRequest request = new UpdateGroupRequest
+            {
+                Group = new ErrorGroup(),
+            };
+            // Make the request
+            ErrorGroup response = await errorGroupServiceClient.UpdateGroupAsync(request);
+            // End snippet
+        }
+
+        public void UpdateGroup_RequestObject()
+        {
+            // Snippet: UpdateGroup(UpdateGroupRequest,CallSettings)
+            // Create client
+            ErrorGroupServiceClient errorGroupServiceClient = ErrorGroupServiceClient.Create();
+            // Initialize request argument(s)
+            UpdateGroupRequest request = new UpdateGroupRequest
+            {
+                Group = new ErrorGroup(),
+            };
+            // Make the request
+            ErrorGroup response = errorGroupServiceClient.UpdateGroup(request);
             // End snippet
         }
 

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ErrorStatsServiceClientSnippets.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ErrorStatsServiceClientSnippets.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
         {
             string projectId = _fixture.ProjectId;
 
-            // Snippet: ListGroupStats
+            // Snippet: ListGroupStats(*,*,*,*,*)
             ErrorStatsServiceClient client = ErrorStatsServiceClient.Create();
             string projectName = new ProjectName(projectId).ToString();
             PagedEnumerable<ListGroupStatsResponse, ErrorGroupStats> groupStats = client.ListGroupStats(

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ErrorStatsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ErrorStatsServiceClientSnippets.g.cs
@@ -120,6 +120,100 @@ namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
             // End snippet
         }
 
+        public async Task ListGroupStatsAsync_RequestObject()
+        {
+            // Snippet: ListGroupStatsAsync(ListGroupStatsRequest,CallSettings)
+            // Create client
+            ErrorStatsServiceClient errorStatsServiceClient = ErrorStatsServiceClient.Create();
+            // Initialize request argument(s)
+            ListGroupStatsRequest request = new ListGroupStatsRequest
+            {
+                ProjectName = new ProjectName("[PROJECT]").ToString(),
+                TimeRange = new QueryTimeRange(),
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListGroupStatsResponse,ErrorGroupStats> response =
+                errorStatsServiceClient.ListGroupStatsAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((ErrorGroupStats item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListGroupStatsResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (ErrorGroupStats item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<ErrorGroupStats> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (ErrorGroupStats item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListGroupStats_RequestObject()
+        {
+            // Snippet: ListGroupStats(ListGroupStatsRequest,CallSettings)
+            // Create client
+            ErrorStatsServiceClient errorStatsServiceClient = ErrorStatsServiceClient.Create();
+            // Initialize request argument(s)
+            ListGroupStatsRequest request = new ListGroupStatsRequest
+            {
+                ProjectName = new ProjectName("[PROJECT]").ToString(),
+                TimeRange = new QueryTimeRange(),
+            };
+            // Make the request
+            PagedEnumerable<ListGroupStatsResponse,ErrorGroupStats> response =
+                errorStatsServiceClient.ListGroupStats(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (ErrorGroupStats item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListGroupStatsResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (ErrorGroupStats item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<ErrorGroupStats> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (ErrorGroupStats item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
         public async Task ListEventsAsync()
         {
             // Snippet: ListEventsAsync(string,string,string,int?,CallSettings)
@@ -208,6 +302,100 @@ namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
             // End snippet
         }
 
+        public async Task ListEventsAsync_RequestObject()
+        {
+            // Snippet: ListEventsAsync(ListEventsRequest,CallSettings)
+            // Create client
+            ErrorStatsServiceClient errorStatsServiceClient = ErrorStatsServiceClient.Create();
+            // Initialize request argument(s)
+            ListEventsRequest request = new ListEventsRequest
+            {
+                ProjectName = new ProjectName("[PROJECT]").ToString(),
+                GroupId = "",
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListEventsResponse,ErrorEvent> response =
+                errorStatsServiceClient.ListEventsAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((ErrorEvent item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListEventsResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (ErrorEvent item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<ErrorEvent> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (ErrorEvent item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListEvents_RequestObject()
+        {
+            // Snippet: ListEvents(ListEventsRequest,CallSettings)
+            // Create client
+            ErrorStatsServiceClient errorStatsServiceClient = ErrorStatsServiceClient.Create();
+            // Initialize request argument(s)
+            ListEventsRequest request = new ListEventsRequest
+            {
+                ProjectName = new ProjectName("[PROJECT]").ToString(),
+                GroupId = "",
+            };
+            // Make the request
+            PagedEnumerable<ListEventsResponse,ErrorEvent> response =
+                errorStatsServiceClient.ListEvents(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (ErrorEvent item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListEventsResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (ErrorEvent item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<ErrorEvent> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (ErrorEvent item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
         public async Task DeleteEventsAsync()
         {
             // Snippet: DeleteEventsAsync(string,CallSettings)
@@ -230,6 +418,36 @@ namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
             string formattedProjectName = new ProjectName("[PROJECT]").ToString();
             // Make the request
             DeleteEventsResponse response = errorStatsServiceClient.DeleteEvents(formattedProjectName);
+            // End snippet
+        }
+
+        public async Task DeleteEventsAsync_RequestObject()
+        {
+            // Snippet: DeleteEventsAsync(DeleteEventsRequest,CallSettings)
+            // Create client
+            ErrorStatsServiceClient errorStatsServiceClient = ErrorStatsServiceClient.Create();
+            // Initialize request argument(s)
+            DeleteEventsRequest request = new DeleteEventsRequest
+            {
+                ProjectName = new ProjectName("[PROJECT]").ToString(),
+            };
+            // Make the request
+            DeleteEventsResponse response = await errorStatsServiceClient.DeleteEventsAsync(request);
+            // End snippet
+        }
+
+        public void DeleteEvents_RequestObject()
+        {
+            // Snippet: DeleteEvents(DeleteEventsRequest,CallSettings)
+            // Create client
+            ErrorStatsServiceClient errorStatsServiceClient = ErrorStatsServiceClient.Create();
+            // Initialize request argument(s)
+            DeleteEventsRequest request = new DeleteEventsRequest
+            {
+                ProjectName = new ProjectName("[PROJECT]").ToString(),
+            };
+            // Make the request
+            DeleteEventsResponse response = errorStatsServiceClient.DeleteEvents(request);
             // End snippet
         }
 

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ReportErrorsServiceClientSnippets.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ReportErrorsServiceClientSnippets.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
         {
             string projectId = _fixture.ProjectId;
 
-            // Snippet: ReportErrorEvent
+            // Snippet: ReportErrorEvent(*,*,*)
             ReportErrorsServiceClient client = ReportErrorsServiceClient.Create();
             string projectName = new ProjectName(projectId).ToString();
             ReportedErrorEvent error = new ReportedErrorEvent

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ReportErrorsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ReportErrorsServiceClientSnippets.g.cs
@@ -59,5 +59,37 @@ namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
             // End snippet
         }
 
+        public async Task ReportErrorEventAsync_RequestObject()
+        {
+            // Snippet: ReportErrorEventAsync(ReportErrorEventRequest,CallSettings)
+            // Create client
+            ReportErrorsServiceClient reportErrorsServiceClient = ReportErrorsServiceClient.Create();
+            // Initialize request argument(s)
+            ReportErrorEventRequest request = new ReportErrorEventRequest
+            {
+                ProjectName = new ProjectName("[PROJECT]").ToString(),
+                Event = new ReportedErrorEvent(),
+            };
+            // Make the request
+            ReportErrorEventResponse response = await reportErrorsServiceClient.ReportErrorEventAsync(request);
+            // End snippet
+        }
+
+        public void ReportErrorEvent_RequestObject()
+        {
+            // Snippet: ReportErrorEvent(ReportErrorEventRequest,CallSettings)
+            // Create client
+            ReportErrorsServiceClient reportErrorsServiceClient = ReportErrorsServiceClient.Create();
+            // Initialize request argument(s)
+            ReportErrorEventRequest request = new ReportErrorEventRequest
+            {
+                ProjectName = new ProjectName("[PROJECT]").ToString(),
+                Event = new ReportedErrorEvent(),
+            };
+            // Make the request
+            ReportErrorEventResponse response = reportErrorsServiceClient.ReportErrorEvent(request);
+            // End snippet
+        }
+
     }
 }

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceClient.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceClient.cs
@@ -296,10 +296,12 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </returns>
         public virtual Task<ErrorGroup> GetGroupAsync(
             string groupName,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => GetGroupAsync(
+                new GetGroupRequest
+                {
+                    GroupName = groupName,
+                },
+                callSettings);
 
         /// <summary>
         /// Get the specified group.
@@ -347,6 +349,46 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </returns>
         public virtual ErrorGroup GetGroup(
             string groupName,
+            CallSettings callSettings = null) => GetGroup(
+                new GetGroupRequest
+                {
+                    GroupName = groupName,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Get the specified group.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<ErrorGroup> GetGroupAsync(
+            GetGroupRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Get the specified group.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual ErrorGroup GetGroup(
+            GetGroupRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -367,10 +409,12 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </returns>
         public virtual Task<ErrorGroup> UpdateGroupAsync(
             ErrorGroup group,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => UpdateGroupAsync(
+                new UpdateGroupRequest
+                {
+                    Group = group,
+                },
+                callSettings);
 
         /// <summary>
         /// Replace the data for the specified group.
@@ -406,6 +450,48 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </returns>
         public virtual ErrorGroup UpdateGroup(
             ErrorGroup group,
+            CallSettings callSettings = null) => UpdateGroup(
+                new UpdateGroupRequest
+                {
+                    Group = group,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Replace the data for the specified group.
+        /// Fails if the group does not exist.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<ErrorGroup> UpdateGroupAsync(
+            UpdateGroupRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Replace the data for the specified group.
+        /// Fails if the group does not exist.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual ErrorGroup UpdateGroup(
+            UpdateGroupRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -450,15 +536,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <summary>
         /// Get the specified group.
         /// </summary>
-        /// <param name="groupName">
-        /// [Required] The group resource name. Written as
-        /// <code>projects/<var>projectID</var>/groups/<var>group_name</var></code>.
-        /// Call
-        /// <a href="/error-reporting/reference/rest/v1beta1/projects.groupStats/list">
-        /// <code>groupStats.list</code></a> to return a list of groups belonging to
-        /// this project.
-        ///
-        /// Example: <code>projects/my-project-123/groups/my-group</code>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -467,13 +546,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<ErrorGroup> GetGroupAsync(
-            string groupName,
+            GetGroupRequest request,
             CallSettings callSettings = null)
         {
-            GetGroupRequest request = new GetGroupRequest
-            {
-                GroupName = groupName,
-            };
             Modify_GetGroupRequest(ref request, ref callSettings);
             return _callGetGroup.Async(request, callSettings);
         }
@@ -481,15 +556,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <summary>
         /// Get the specified group.
         /// </summary>
-        /// <param name="groupName">
-        /// [Required] The group resource name. Written as
-        /// <code>projects/<var>projectID</var>/groups/<var>group_name</var></code>.
-        /// Call
-        /// <a href="/error-reporting/reference/rest/v1beta1/projects.groupStats/list">
-        /// <code>groupStats.list</code></a> to return a list of groups belonging to
-        /// this project.
-        ///
-        /// Example: <code>projects/my-project-123/groups/my-group</code>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -498,13 +566,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// The RPC response.
         /// </returns>
         public override ErrorGroup GetGroup(
-            string groupName,
+            GetGroupRequest request,
             CallSettings callSettings = null)
         {
-            GetGroupRequest request = new GetGroupRequest
-            {
-                GroupName = groupName,
-            };
             Modify_GetGroupRequest(ref request, ref callSettings);
             return _callGetGroup.Sync(request, callSettings);
         }
@@ -513,8 +577,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// Replace the data for the specified group.
         /// Fails if the group does not exist.
         /// </summary>
-        /// <param name="group">
-        /// [Required] The group which replaces the resource on the server.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -523,13 +587,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<ErrorGroup> UpdateGroupAsync(
-            ErrorGroup group,
+            UpdateGroupRequest request,
             CallSettings callSettings = null)
         {
-            UpdateGroupRequest request = new UpdateGroupRequest
-            {
-                Group = group,
-            };
             Modify_UpdateGroupRequest(ref request, ref callSettings);
             return _callUpdateGroup.Async(request, callSettings);
         }
@@ -538,8 +598,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// Replace the data for the specified group.
         /// Fails if the group does not exist.
         /// </summary>
-        /// <param name="group">
-        /// [Required] The group which replaces the resource on the server.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -548,13 +608,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// The RPC response.
         /// </returns>
         public override ErrorGroup UpdateGroup(
-            ErrorGroup group,
+            UpdateGroupRequest request,
             CallSettings callSettings = null)
         {
-            UpdateGroupRequest request = new UpdateGroupRequest
-            {
-                Group = group,
-            };
             Modify_UpdateGroupRequest(ref request, ref callSettings);
             return _callUpdateGroup.Sync(request, callSettings);
         }

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.cs
@@ -345,10 +345,15 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             QueryTimeRange timeRange,
             string pageToken = null,
             int? pageSize = null,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ListGroupStatsAsync(
+                new ListGroupStatsRequest
+                {
+                    ProjectName = projectName,
+                    TimeRange = timeRange,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
 
         /// <summary>
         /// Lists the specified groups.
@@ -389,6 +394,49 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             QueryTimeRange timeRange,
             string pageToken = null,
             int? pageSize = null,
+            CallSettings callSettings = null) => ListGroupStats(
+                new ListGroupStatsRequest
+                {
+                    ProjectName = projectName,
+                    TimeRange = timeRange,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists the specified groups.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="ErrorGroupStats"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListGroupStatsResponse, ErrorGroupStats> ListGroupStatsAsync(
+            ListGroupStatsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists the specified groups.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="ErrorGroupStats"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListGroupStatsResponse, ErrorGroupStats> ListGroupStats(
+            ListGroupStatsRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -426,10 +474,15 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             string groupId,
             string pageToken = null,
             int? pageSize = null,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ListEventsAsync(
+                new ListEventsRequest
+                {
+                    ProjectName = projectName,
+                    GroupId = groupId,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
 
         /// <summary>
         /// Lists the specified events.
@@ -463,6 +516,49 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             string groupId,
             string pageToken = null,
             int? pageSize = null,
+            CallSettings callSettings = null) => ListEvents(
+                new ListEventsRequest
+                {
+                    ProjectName = projectName,
+                    GroupId = groupId,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists the specified events.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="ErrorEvent"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListEventsResponse, ErrorEvent> ListEventsAsync(
+            ListEventsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists the specified events.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="ErrorEvent"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListEventsResponse, ErrorEvent> ListEvents(
+            ListEventsRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -486,10 +582,12 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </returns>
         public virtual Task<DeleteEventsResponse> DeleteEventsAsync(
             string projectName,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => DeleteEventsAsync(
+                new DeleteEventsRequest
+                {
+                    ProjectName = projectName,
+                },
+                callSettings);
 
         /// <summary>
         /// Deletes all error events of a given project.
@@ -531,6 +629,46 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </returns>
         public virtual DeleteEventsResponse DeleteEvents(
             string projectName,
+            CallSettings callSettings = null) => DeleteEvents(
+                new DeleteEventsRequest
+                {
+                    ProjectName = projectName,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes all error events of a given project.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<DeleteEventsResponse> DeleteEventsAsync(
+            DeleteEventsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Deletes all error events of a given project.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual DeleteEventsResponse DeleteEvents(
+            DeleteEventsRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -579,30 +717,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <summary>
         /// Lists the specified groups.
         /// </summary>
-        /// <param name="projectName">
-        /// [Required] The resource name of the Google Cloud Platform project. Written
-        /// as <code>projects/</code> plus the
-        /// <a href="https://support.google.com/cloud/answer/6158840">Google Cloud
-        /// Platform project ID</a>.
-        ///
-        /// Example: <code>projects/my-project-123</code>.
-        /// </param>
-        /// <param name="timeRange">
-        /// [Optional] List data for the given time range.
-        /// If not set a default time range is used. The field time_range_begin
-        /// in the response will specify the beginning of this time range.
-        /// Only <code>ErrorGroupStats</code> with a non-zero count in the given time
-        /// range are returned, unless the request contains an explicit group_id list.
-        /// If a group_id list is given, also <code>ErrorGroupStats</code> with zero
-        /// occurrences are returned.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -611,19 +727,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// A pageable asynchronous sequence of <see cref="ErrorGroupStats"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListGroupStatsResponse, ErrorGroupStats> ListGroupStatsAsync(
-            string projectName,
-            QueryTimeRange timeRange,
-            string pageToken = null,
-            int? pageSize = null,
+            ListGroupStatsRequest request,
             CallSettings callSettings = null)
         {
-            ListGroupStatsRequest request = new ListGroupStatsRequest
-            {
-                ProjectName = projectName,
-                TimeRange = timeRange,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListGroupStatsRequest(ref request, ref callSettings);
             return new GrpcPagedAsyncEnumerable<ListGroupStatsRequest, ListGroupStatsResponse, ErrorGroupStats>(_callListGroupStats, request, callSettings);
         }
@@ -631,30 +737,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <summary>
         /// Lists the specified groups.
         /// </summary>
-        /// <param name="projectName">
-        /// [Required] The resource name of the Google Cloud Platform project. Written
-        /// as <code>projects/</code> plus the
-        /// <a href="https://support.google.com/cloud/answer/6158840">Google Cloud
-        /// Platform project ID</a>.
-        ///
-        /// Example: <code>projects/my-project-123</code>.
-        /// </param>
-        /// <param name="timeRange">
-        /// [Optional] List data for the given time range.
-        /// If not set a default time range is used. The field time_range_begin
-        /// in the response will specify the beginning of this time range.
-        /// Only <code>ErrorGroupStats</code> with a non-zero count in the given time
-        /// range are returned, unless the request contains an explicit group_id list.
-        /// If a group_id list is given, also <code>ErrorGroupStats</code> with zero
-        /// occurrences are returned.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -663,19 +747,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// A pageable sequence of <see cref="ErrorGroupStats"/> resources.
         /// </returns>
         public override PagedEnumerable<ListGroupStatsResponse, ErrorGroupStats> ListGroupStats(
-            string projectName,
-            QueryTimeRange timeRange,
-            string pageToken = null,
-            int? pageSize = null,
+            ListGroupStatsRequest request,
             CallSettings callSettings = null)
         {
-            ListGroupStatsRequest request = new ListGroupStatsRequest
-            {
-                ProjectName = projectName,
-                TimeRange = timeRange,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListGroupStatsRequest(ref request, ref callSettings);
             return new GrpcPagedEnumerable<ListGroupStatsRequest, ListGroupStatsResponse, ErrorGroupStats>(_callListGroupStats, request, callSettings);
         }
@@ -683,23 +757,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <summary>
         /// Lists the specified events.
         /// </summary>
-        /// <param name="projectName">
-        /// [Required] The resource name of the Google Cloud Platform project. Written
-        /// as `projects/` plus the
-        /// [Google Cloud Platform project
-        /// ID](https://support.google.com/cloud/answer/6158840).
-        /// Example: `projects/my-project-123`.
-        /// </param>
-        /// <param name="groupId">
-        /// [Required] The group for which events shall be returned.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -708,19 +767,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// A pageable asynchronous sequence of <see cref="ErrorEvent"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListEventsResponse, ErrorEvent> ListEventsAsync(
-            string projectName,
-            string groupId,
-            string pageToken = null,
-            int? pageSize = null,
+            ListEventsRequest request,
             CallSettings callSettings = null)
         {
-            ListEventsRequest request = new ListEventsRequest
-            {
-                ProjectName = projectName,
-                GroupId = groupId,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListEventsRequest(ref request, ref callSettings);
             return new GrpcPagedAsyncEnumerable<ListEventsRequest, ListEventsResponse, ErrorEvent>(_callListEvents, request, callSettings);
         }
@@ -728,23 +777,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <summary>
         /// Lists the specified events.
         /// </summary>
-        /// <param name="projectName">
-        /// [Required] The resource name of the Google Cloud Platform project. Written
-        /// as `projects/` plus the
-        /// [Google Cloud Platform project
-        /// ID](https://support.google.com/cloud/answer/6158840).
-        /// Example: `projects/my-project-123`.
-        /// </param>
-        /// <param name="groupId">
-        /// [Required] The group for which events shall be returned.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -753,19 +787,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// A pageable sequence of <see cref="ErrorEvent"/> resources.
         /// </returns>
         public override PagedEnumerable<ListEventsResponse, ErrorEvent> ListEvents(
-            string projectName,
-            string groupId,
-            string pageToken = null,
-            int? pageSize = null,
+            ListEventsRequest request,
             CallSettings callSettings = null)
         {
-            ListEventsRequest request = new ListEventsRequest
-            {
-                ProjectName = projectName,
-                GroupId = groupId,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListEventsRequest(ref request, ref callSettings);
             return new GrpcPagedEnumerable<ListEventsRequest, ListEventsResponse, ErrorEvent>(_callListEvents, request, callSettings);
         }
@@ -773,12 +797,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <summary>
         /// Deletes all error events of a given project.
         /// </summary>
-        /// <param name="projectName">
-        /// [Required] The resource name of the Google Cloud Platform project. Written
-        /// as `projects/` plus the
-        /// [Google Cloud Platform project
-        /// ID](https://support.google.com/cloud/answer/6158840).
-        /// Example: `projects/my-project-123`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -787,13 +807,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<DeleteEventsResponse> DeleteEventsAsync(
-            string projectName,
+            DeleteEventsRequest request,
             CallSettings callSettings = null)
         {
-            DeleteEventsRequest request = new DeleteEventsRequest
-            {
-                ProjectName = projectName,
-            };
             Modify_DeleteEventsRequest(ref request, ref callSettings);
             return _callDeleteEvents.Async(request, callSettings);
         }
@@ -801,12 +817,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <summary>
         /// Deletes all error events of a given project.
         /// </summary>
-        /// <param name="projectName">
-        /// [Required] The resource name of the Google Cloud Platform project. Written
-        /// as `projects/` plus the
-        /// [Google Cloud Platform project
-        /// ID](https://support.google.com/cloud/answer/6158840).
-        /// Example: `projects/my-project-123`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -815,13 +827,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// The RPC response.
         /// </returns>
         public override DeleteEventsResponse DeleteEvents(
-            string projectName,
+            DeleteEventsRequest request,
             CallSettings callSettings = null)
         {
-            DeleteEventsRequest request = new DeleteEventsRequest
-            {
-                ProjectName = projectName,
-            };
             Modify_DeleteEventsRequest(ref request, ref callSettings);
             return _callDeleteEvents.Sync(request, callSettings);
         }

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceClient.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceClient.cs
@@ -271,10 +271,13 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         public virtual Task<ReportErrorEventResponse> ReportErrorEventAsync(
             string projectName,
             ReportedErrorEvent @event,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ReportErrorEventAsync(
+                new ReportErrorEventRequest
+                {
+                    ProjectName = projectName,
+                    Event = @event,
+                },
+                callSettings);
 
         /// <summary>
         /// Report an individual error event.
@@ -337,6 +340,61 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         public virtual ReportErrorEventResponse ReportErrorEvent(
             string projectName,
             ReportedErrorEvent @event,
+            CallSettings callSettings = null) => ReportErrorEvent(
+                new ReportErrorEventRequest
+                {
+                    ProjectName = projectName,
+                    Event = @event,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Report an individual error event.
+        ///
+        /// This endpoint accepts <strong>either</strong> an OAuth token,
+        /// <strong>or</strong> an
+        /// <a href="https://support.google.com/cloud/answer/6158862">API key</a>
+        /// for authentication. To use an API key, append it to the URL as the value of
+        /// a `key` parameter. For example:
+        /// <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<ReportErrorEventResponse> ReportErrorEventAsync(
+            ReportErrorEventRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Report an individual error event.
+        ///
+        /// This endpoint accepts <strong>either</strong> an OAuth token,
+        /// <strong>or</strong> an
+        /// <a href="https://support.google.com/cloud/answer/6158862">API key</a>
+        /// for authentication. To use an API key, append it to the URL as the value of
+        /// a `key` parameter. For example:
+        /// <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual ReportErrorEventResponse ReportErrorEvent(
+            ReportErrorEventRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -384,14 +442,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// a `key` parameter. For example:
         /// <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>
         /// </summary>
-        /// <param name="projectName">
-        /// [Required] The resource name of the Google Cloud Platform project. Written
-        /// as `projects/` plus the
-        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
-        /// Example: `projects/my-project-123`.
-        /// </param>
-        /// <param name="event">
-        /// [Required] The error event to be reported.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -400,15 +452,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<ReportErrorEventResponse> ReportErrorEventAsync(
-            string projectName,
-            ReportedErrorEvent @event,
+            ReportErrorEventRequest request,
             CallSettings callSettings = null)
         {
-            ReportErrorEventRequest request = new ReportErrorEventRequest
-            {
-                ProjectName = projectName,
-                Event = @event,
-            };
             Modify_ReportErrorEventRequest(ref request, ref callSettings);
             return _callReportErrorEvent.Async(request, callSettings);
         }
@@ -423,14 +469,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// a `key` parameter. For example:
         /// <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>
         /// </summary>
-        /// <param name="projectName">
-        /// [Required] The resource name of the Google Cloud Platform project. Written
-        /// as `projects/` plus the
-        /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
-        /// Example: `projects/my-project-123`.
-        /// </param>
-        /// <param name="event">
-        /// [Required] The error event to be reported.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -439,15 +479,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// The RPC response.
         /// </returns>
         public override ReportErrorEventResponse ReportErrorEvent(
-            string projectName,
-            ReportedErrorEvent @event,
+            ReportErrorEventRequest request,
             CallSettings callSettings = null)
         {
-            ReportErrorEventRequest request = new ReportErrorEventRequest
-            {
-                ProjectName = projectName,
-                Event = @event,
-            };
             Modify_ReportErrorEventRequest(ref request, ref callSettings);
             return _callReportErrorEvent.Sync(request, callSettings);
         }

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/LanguageServiceClientSnippets.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/LanguageServiceClientSnippets.cs
@@ -44,7 +44,7 @@ namespace Google.Cloud.Language.V1.Snippets
         [Fact]
         public void AnalyzeSentiment()
         {
-            // Snippet: AnalyzeSentiment
+            // Snippet: AnalyzeSentiment(Document,*)
             LanguageServiceClient client = LanguageServiceClient.Create();
             Document document = Document.FromPlainText("You're simply the best - better than all the rest.");
             AnalyzeSentimentResponse response = client.AnalyzeSentiment(document);

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/LanguageServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/LanguageServiceClientSnippets.g.cs
@@ -57,6 +57,36 @@ namespace Google.Cloud.Language.V1.Snippets
             // End snippet
         }
 
+        public async Task AnalyzeSentimentAsync_RequestObject()
+        {
+            // Snippet: AnalyzeSentimentAsync(AnalyzeSentimentRequest,CallSettings)
+            // Create client
+            LanguageServiceClient languageServiceClient = LanguageServiceClient.Create();
+            // Initialize request argument(s)
+            AnalyzeSentimentRequest request = new AnalyzeSentimentRequest
+            {
+                Document = new Document(),
+            };
+            // Make the request
+            AnalyzeSentimentResponse response = await languageServiceClient.AnalyzeSentimentAsync(request);
+            // End snippet
+        }
+
+        public void AnalyzeSentiment_RequestObject()
+        {
+            // Snippet: AnalyzeSentiment(AnalyzeSentimentRequest,CallSettings)
+            // Create client
+            LanguageServiceClient languageServiceClient = LanguageServiceClient.Create();
+            // Initialize request argument(s)
+            AnalyzeSentimentRequest request = new AnalyzeSentimentRequest
+            {
+                Document = new Document(),
+            };
+            // Make the request
+            AnalyzeSentimentResponse response = languageServiceClient.AnalyzeSentiment(request);
+            // End snippet
+        }
+
         public async Task AnalyzeEntitiesAsync()
         {
             // Snippet: AnalyzeEntitiesAsync(Document,EncodingType,CallSettings)
@@ -81,6 +111,38 @@ namespace Google.Cloud.Language.V1.Snippets
             EncodingType encodingType = EncodingType.None;
             // Make the request
             AnalyzeEntitiesResponse response = languageServiceClient.AnalyzeEntities(document, encodingType);
+            // End snippet
+        }
+
+        public async Task AnalyzeEntitiesAsync_RequestObject()
+        {
+            // Snippet: AnalyzeEntitiesAsync(AnalyzeEntitiesRequest,CallSettings)
+            // Create client
+            LanguageServiceClient languageServiceClient = LanguageServiceClient.Create();
+            // Initialize request argument(s)
+            AnalyzeEntitiesRequest request = new AnalyzeEntitiesRequest
+            {
+                Document = new Document(),
+                EncodingType = EncodingType.None,
+            };
+            // Make the request
+            AnalyzeEntitiesResponse response = await languageServiceClient.AnalyzeEntitiesAsync(request);
+            // End snippet
+        }
+
+        public void AnalyzeEntities_RequestObject()
+        {
+            // Snippet: AnalyzeEntities(AnalyzeEntitiesRequest,CallSettings)
+            // Create client
+            LanguageServiceClient languageServiceClient = LanguageServiceClient.Create();
+            // Initialize request argument(s)
+            AnalyzeEntitiesRequest request = new AnalyzeEntitiesRequest
+            {
+                Document = new Document(),
+                EncodingType = EncodingType.None,
+            };
+            // Make the request
+            AnalyzeEntitiesResponse response = languageServiceClient.AnalyzeEntities(request);
             // End snippet
         }
 
@@ -111,6 +173,38 @@ namespace Google.Cloud.Language.V1.Snippets
             // End snippet
         }
 
+        public async Task AnalyzeSyntaxAsync_RequestObject()
+        {
+            // Snippet: AnalyzeSyntaxAsync(AnalyzeSyntaxRequest,CallSettings)
+            // Create client
+            LanguageServiceClient languageServiceClient = LanguageServiceClient.Create();
+            // Initialize request argument(s)
+            AnalyzeSyntaxRequest request = new AnalyzeSyntaxRequest
+            {
+                Document = new Document(),
+                EncodingType = EncodingType.None,
+            };
+            // Make the request
+            AnalyzeSyntaxResponse response = await languageServiceClient.AnalyzeSyntaxAsync(request);
+            // End snippet
+        }
+
+        public void AnalyzeSyntax_RequestObject()
+        {
+            // Snippet: AnalyzeSyntax(AnalyzeSyntaxRequest,CallSettings)
+            // Create client
+            LanguageServiceClient languageServiceClient = LanguageServiceClient.Create();
+            // Initialize request argument(s)
+            AnalyzeSyntaxRequest request = new AnalyzeSyntaxRequest
+            {
+                Document = new Document(),
+                EncodingType = EncodingType.None,
+            };
+            // Make the request
+            AnalyzeSyntaxResponse response = languageServiceClient.AnalyzeSyntax(request);
+            // End snippet
+        }
+
         public async Task AnnotateTextAsync()
         {
             // Snippet: AnnotateTextAsync(Document,AnnotateTextRequest.Types.Features,EncodingType,CallSettings)
@@ -137,6 +231,40 @@ namespace Google.Cloud.Language.V1.Snippets
             EncodingType encodingType = EncodingType.None;
             // Make the request
             AnnotateTextResponse response = languageServiceClient.AnnotateText(document, features, encodingType);
+            // End snippet
+        }
+
+        public async Task AnnotateTextAsync_RequestObject()
+        {
+            // Snippet: AnnotateTextAsync(AnnotateTextRequest,CallSettings)
+            // Create client
+            LanguageServiceClient languageServiceClient = LanguageServiceClient.Create();
+            // Initialize request argument(s)
+            AnnotateTextRequest request = new AnnotateTextRequest
+            {
+                Document = new Document(),
+                Features = new AnnotateTextRequest.Types.Features(),
+                EncodingType = EncodingType.None,
+            };
+            // Make the request
+            AnnotateTextResponse response = await languageServiceClient.AnnotateTextAsync(request);
+            // End snippet
+        }
+
+        public void AnnotateText_RequestObject()
+        {
+            // Snippet: AnnotateText(AnnotateTextRequest,CallSettings)
+            // Create client
+            LanguageServiceClient languageServiceClient = LanguageServiceClient.Create();
+            // Initialize request argument(s)
+            AnnotateTextRequest request = new AnnotateTextRequest
+            {
+                Document = new Document(),
+                Features = new AnnotateTextRequest.Types.Features(),
+                EncodingType = EncodingType.None,
+            };
+            // Make the request
+            AnnotateTextResponse response = languageServiceClient.AnnotateText(request);
             // End snippet
         }
 

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.cs
@@ -352,10 +352,12 @@ namespace Google.Cloud.Language.V1
         /// </returns>
         public virtual Task<AnalyzeSentimentResponse> AnalyzeSentimentAsync(
             Document document,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => AnalyzeSentimentAsync(
+                new AnalyzeSentimentRequest
+                {
+                    Document = document,
+                },
+                callSettings);
 
         /// <summary>
         /// Analyzes the sentiment of the provided text.
@@ -391,6 +393,46 @@ namespace Google.Cloud.Language.V1
         /// </returns>
         public virtual AnalyzeSentimentResponse AnalyzeSentiment(
             Document document,
+            CallSettings callSettings = null) => AnalyzeSentiment(
+                new AnalyzeSentimentRequest
+                {
+                    Document = document,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Analyzes the sentiment of the provided text.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<AnalyzeSentimentResponse> AnalyzeSentimentAsync(
+            AnalyzeSentimentRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Analyzes the sentiment of the provided text.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual AnalyzeSentimentResponse AnalyzeSentiment(
+            AnalyzeSentimentRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -415,10 +457,13 @@ namespace Google.Cloud.Language.V1
         public virtual Task<AnalyzeEntitiesResponse> AnalyzeEntitiesAsync(
             Document document,
             EncodingType encodingType,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => AnalyzeEntitiesAsync(
+                new AnalyzeEntitiesRequest
+                {
+                    Document = document,
+                    EncodingType = encodingType,
+                },
+                callSettings);
 
         /// <summary>
         /// Finds named entities (currently finds proper names) in the text,
@@ -463,6 +508,49 @@ namespace Google.Cloud.Language.V1
         public virtual AnalyzeEntitiesResponse AnalyzeEntities(
             Document document,
             EncodingType encodingType,
+            CallSettings callSettings = null) => AnalyzeEntities(
+                new AnalyzeEntitiesRequest
+                {
+                    Document = document,
+                    EncodingType = encodingType,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Finds named entities (currently finds proper names) in the text,
+        /// entity types, salience, mentions for each entity, and other properties.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<AnalyzeEntitiesResponse> AnalyzeEntitiesAsync(
+            AnalyzeEntitiesRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Finds named entities (currently finds proper names) in the text,
+        /// entity types, salience, mentions for each entity, and other properties.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual AnalyzeEntitiesResponse AnalyzeEntities(
+            AnalyzeEntitiesRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -488,10 +576,13 @@ namespace Google.Cloud.Language.V1
         public virtual Task<AnalyzeSyntaxResponse> AnalyzeSyntaxAsync(
             Document document,
             EncodingType encodingType,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => AnalyzeSyntaxAsync(
+                new AnalyzeSyntaxRequest
+                {
+                    Document = document,
+                    EncodingType = encodingType,
+                },
+                callSettings);
 
         /// <summary>
         /// Analyzes the syntax of the text and provides sentence boundaries and
@@ -538,6 +629,51 @@ namespace Google.Cloud.Language.V1
         public virtual AnalyzeSyntaxResponse AnalyzeSyntax(
             Document document,
             EncodingType encodingType,
+            CallSettings callSettings = null) => AnalyzeSyntax(
+                new AnalyzeSyntaxRequest
+                {
+                    Document = document,
+                    EncodingType = encodingType,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Analyzes the syntax of the text and provides sentence boundaries and
+        /// tokenization along with part of speech tags, dependency trees, and other
+        /// properties.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<AnalyzeSyntaxResponse> AnalyzeSyntaxAsync(
+            AnalyzeSyntaxRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Analyzes the syntax of the text and provides sentence boundaries and
+        /// tokenization along with part of speech tags, dependency trees, and other
+        /// properties.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual AnalyzeSyntaxResponse AnalyzeSyntax(
+            AnalyzeSyntaxRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -566,10 +702,14 @@ namespace Google.Cloud.Language.V1
             Document document,
             AnnotateTextRequest.Types.Features features,
             EncodingType encodingType,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => AnnotateTextAsync(
+                new AnnotateTextRequest
+                {
+                    Document = document,
+                    Features = features,
+                    EncodingType = encodingType,
+                },
+                callSettings);
 
         /// <summary>
         /// A convenience method that provides all the features that analyzeSentiment,
@@ -623,6 +763,50 @@ namespace Google.Cloud.Language.V1
             Document document,
             AnnotateTextRequest.Types.Features features,
             EncodingType encodingType,
+            CallSettings callSettings = null) => AnnotateText(
+                new AnnotateTextRequest
+                {
+                    Document = document,
+                    Features = features,
+                    EncodingType = encodingType,
+                },
+                callSettings);
+
+        /// <summary>
+        /// A convenience method that provides all the features that analyzeSentiment,
+        /// analyzeEntities, and analyzeSyntax provide in one call.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<AnnotateTextResponse> AnnotateTextAsync(
+            AnnotateTextRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// A convenience method that provides all the features that analyzeSentiment,
+        /// analyzeEntities, and analyzeSyntax provide in one call.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual AnnotateTextResponse AnnotateText(
+            AnnotateTextRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -675,9 +859,8 @@ namespace Google.Cloud.Language.V1
         /// <summary>
         /// Analyzes the sentiment of the provided text.
         /// </summary>
-        /// <param name="document">
-        /// Input document. Currently, `analyzeSentiment` only supports English text
-        /// ([Document.language][google.cloud.language.v1.Document.language]="EN").
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -686,13 +869,9 @@ namespace Google.Cloud.Language.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<AnalyzeSentimentResponse> AnalyzeSentimentAsync(
-            Document document,
+            AnalyzeSentimentRequest request,
             CallSettings callSettings = null)
         {
-            AnalyzeSentimentRequest request = new AnalyzeSentimentRequest
-            {
-                Document = document,
-            };
             Modify_AnalyzeSentimentRequest(ref request, ref callSettings);
             return _callAnalyzeSentiment.Async(request, callSettings);
         }
@@ -700,9 +879,8 @@ namespace Google.Cloud.Language.V1
         /// <summary>
         /// Analyzes the sentiment of the provided text.
         /// </summary>
-        /// <param name="document">
-        /// Input document. Currently, `analyzeSentiment` only supports English text
-        /// ([Document.language][google.cloud.language.v1.Document.language]="EN").
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -711,13 +889,9 @@ namespace Google.Cloud.Language.V1
         /// The RPC response.
         /// </returns>
         public override AnalyzeSentimentResponse AnalyzeSentiment(
-            Document document,
+            AnalyzeSentimentRequest request,
             CallSettings callSettings = null)
         {
-            AnalyzeSentimentRequest request = new AnalyzeSentimentRequest
-            {
-                Document = document,
-            };
             Modify_AnalyzeSentimentRequest(ref request, ref callSettings);
             return _callAnalyzeSentiment.Sync(request, callSettings);
         }
@@ -726,11 +900,8 @@ namespace Google.Cloud.Language.V1
         /// Finds named entities (currently finds proper names) in the text,
         /// entity types, salience, mentions for each entity, and other properties.
         /// </summary>
-        /// <param name="document">
-        /// Input document.
-        /// </param>
-        /// <param name="encodingType">
-        /// The encoding type used by the API to calculate offsets.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -739,15 +910,9 @@ namespace Google.Cloud.Language.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<AnalyzeEntitiesResponse> AnalyzeEntitiesAsync(
-            Document document,
-            EncodingType encodingType,
+            AnalyzeEntitiesRequest request,
             CallSettings callSettings = null)
         {
-            AnalyzeEntitiesRequest request = new AnalyzeEntitiesRequest
-            {
-                Document = document,
-                EncodingType = encodingType,
-            };
             Modify_AnalyzeEntitiesRequest(ref request, ref callSettings);
             return _callAnalyzeEntities.Async(request, callSettings);
         }
@@ -756,11 +921,8 @@ namespace Google.Cloud.Language.V1
         /// Finds named entities (currently finds proper names) in the text,
         /// entity types, salience, mentions for each entity, and other properties.
         /// </summary>
-        /// <param name="document">
-        /// Input document.
-        /// </param>
-        /// <param name="encodingType">
-        /// The encoding type used by the API to calculate offsets.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -769,15 +931,9 @@ namespace Google.Cloud.Language.V1
         /// The RPC response.
         /// </returns>
         public override AnalyzeEntitiesResponse AnalyzeEntities(
-            Document document,
-            EncodingType encodingType,
+            AnalyzeEntitiesRequest request,
             CallSettings callSettings = null)
         {
-            AnalyzeEntitiesRequest request = new AnalyzeEntitiesRequest
-            {
-                Document = document,
-                EncodingType = encodingType,
-            };
             Modify_AnalyzeEntitiesRequest(ref request, ref callSettings);
             return _callAnalyzeEntities.Sync(request, callSettings);
         }
@@ -787,11 +943,8 @@ namespace Google.Cloud.Language.V1
         /// tokenization along with part of speech tags, dependency trees, and other
         /// properties.
         /// </summary>
-        /// <param name="document">
-        /// Input document.
-        /// </param>
-        /// <param name="encodingType">
-        /// The encoding type used by the API to calculate offsets.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -800,15 +953,9 @@ namespace Google.Cloud.Language.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<AnalyzeSyntaxResponse> AnalyzeSyntaxAsync(
-            Document document,
-            EncodingType encodingType,
+            AnalyzeSyntaxRequest request,
             CallSettings callSettings = null)
         {
-            AnalyzeSyntaxRequest request = new AnalyzeSyntaxRequest
-            {
-                Document = document,
-                EncodingType = encodingType,
-            };
             Modify_AnalyzeSyntaxRequest(ref request, ref callSettings);
             return _callAnalyzeSyntax.Async(request, callSettings);
         }
@@ -818,11 +965,8 @@ namespace Google.Cloud.Language.V1
         /// tokenization along with part of speech tags, dependency trees, and other
         /// properties.
         /// </summary>
-        /// <param name="document">
-        /// Input document.
-        /// </param>
-        /// <param name="encodingType">
-        /// The encoding type used by the API to calculate offsets.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -831,15 +975,9 @@ namespace Google.Cloud.Language.V1
         /// The RPC response.
         /// </returns>
         public override AnalyzeSyntaxResponse AnalyzeSyntax(
-            Document document,
-            EncodingType encodingType,
+            AnalyzeSyntaxRequest request,
             CallSettings callSettings = null)
         {
-            AnalyzeSyntaxRequest request = new AnalyzeSyntaxRequest
-            {
-                Document = document,
-                EncodingType = encodingType,
-            };
             Modify_AnalyzeSyntaxRequest(ref request, ref callSettings);
             return _callAnalyzeSyntax.Sync(request, callSettings);
         }
@@ -848,14 +986,8 @@ namespace Google.Cloud.Language.V1
         /// A convenience method that provides all the features that analyzeSentiment,
         /// analyzeEntities, and analyzeSyntax provide in one call.
         /// </summary>
-        /// <param name="document">
-        /// Input document.
-        /// </param>
-        /// <param name="features">
-        /// The enabled features.
-        /// </param>
-        /// <param name="encodingType">
-        /// The encoding type used by the API to calculate offsets.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -864,17 +996,9 @@ namespace Google.Cloud.Language.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<AnnotateTextResponse> AnnotateTextAsync(
-            Document document,
-            AnnotateTextRequest.Types.Features features,
-            EncodingType encodingType,
+            AnnotateTextRequest request,
             CallSettings callSettings = null)
         {
-            AnnotateTextRequest request = new AnnotateTextRequest
-            {
-                Document = document,
-                Features = features,
-                EncodingType = encodingType,
-            };
             Modify_AnnotateTextRequest(ref request, ref callSettings);
             return _callAnnotateText.Async(request, callSettings);
         }
@@ -883,14 +1007,8 @@ namespace Google.Cloud.Language.V1
         /// A convenience method that provides all the features that analyzeSentiment,
         /// analyzeEntities, and analyzeSyntax provide in one call.
         /// </summary>
-        /// <param name="document">
-        /// Input document.
-        /// </param>
-        /// <param name="features">
-        /// The enabled features.
-        /// </param>
-        /// <param name="encodingType">
-        /// The encoding type used by the API to calculate offsets.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -899,17 +1017,9 @@ namespace Google.Cloud.Language.V1
         /// The RPC response.
         /// </returns>
         public override AnnotateTextResponse AnnotateText(
-            Document document,
-            AnnotateTextRequest.Types.Features features,
-            EncodingType encodingType,
+            AnnotateTextRequest request,
             CallSettings callSettings = null)
         {
-            AnnotateTextRequest request = new AnnotateTextRequest
-            {
-                Document = document,
-                Features = features,
-                EncodingType = encodingType,
-            };
             Modify_AnnotateTextRequest(ref request, ref callSettings);
             return _callAnnotateText.Sync(request, callSettings);
         }

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/Log4NetTest.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/Log4NetTest.cs
@@ -80,15 +80,16 @@ namespace Google.Cloud.Logging.Log4Net.Tests
             int? maxMemoryCount = null, long? maxMemorySize = null, int? maxUploadBatchSize = null)
         {
             var fakeClient = new Mock<LoggingServiceV2Client>(MockBehavior.Strict);
-            fakeClient.Setup(x => x.WriteLogEntriesAsync("", null, It.IsAny<IDictionary<string, string>>(), It.IsAny<IEnumerable<LogEntry>>(), null))
-                .Returns<string, MonitoredResource, IDictionary<string, string>, IEnumerable<LogEntry>, CallSettings>((a, b, c, entries, d) => handlerFn(entries));
+            fakeClient.Setup(x => x.WriteLogEntriesAsync(LogNameOneof.From(new LogName(s_projectId, s_logId)),
+                null, It.IsAny<IDictionary<string, string>>(), It.IsAny<IEnumerable<LogEntry>>(), null))
+                .Returns<LogNameOneof, MonitoredResource, IDictionary<string, string>, IEnumerable<LogEntry>, CallSettings>((a, b, c, entries, d) => handlerFn(entries));
             var appender = new GoogleStackdriverAppender(fakeClient.Object,
                 scheduler ?? new NoDelayScheduler(), clock ?? new FakeClock())
             {
                 ErrorHandler = new ThrowingErrorHandler(),
                 Layout = new PatternLayout { ConversionPattern = "%message" },
-                ProjectId = "projectID",
-                LogId = "logId",
+                ProjectId = s_projectId,
+                LogId = s_logId,
             };
             if (maxMemoryCount != null) appender.MaxMemoryCount = maxMemoryCount.Value;
             if (maxMemorySize != null) appender.MaxMemorySize = maxMemorySize.Value;

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/LogUploader.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/LogUploader.cs
@@ -125,7 +125,9 @@ namespace Google.Cloud.Logging.Log4Net
                 // Upload entries to the Cloud Logging server
                 try
                 {
-                    await _client.WriteLogEntriesAsync("", null, s_emptyLabels, entries.Select(x => x.Entry));
+                    // TODO: We should be able to specify an empty log name here; all our log entries
+                    // have a log name. For now, take the log name from the first entry...
+                    await _client.WriteLogEntriesAsync(LogNameOneof.Parse(entries.First().Entry.LogName, false), null, s_emptyLabels, entries.Select(x => x.Entry));
                     await _logQ.RemoveUntilAsync(entries.Last().Id);
                     _emptyEvent.Set();
                     errorDelay = _serverErrorBackoffSettings.Delay;

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/ConfigServiceV2ClientSnippets.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/ConfigServiceV2ClientSnippets.g.cs
@@ -34,14 +34,14 @@ namespace Google.Cloud.Logging.V2.Snippets
     {
         public async Task ListSinksAsync()
         {
-            // Snippet: ListSinksAsync(string,string,int?,CallSettings)
+            // Snippet: ListSinksAsync(ParentNameOneof,string,int?,CallSettings)
             // Create client
             ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedParent = new ParentName("[PROJECT]").ToString();
+            ParentNameOneof parent = ParentNameOneof.From(new ProjectName("[PROJECT]"));
             // Make the request
             PagedAsyncEnumerable<ListSinksResponse,LogSink> response =
-                configServiceV2Client.ListSinksAsync(formattedParent);
+                configServiceV2Client.ListSinksAsync(parent);
 
             // Iterate over all response items, lazily performing RPCs as required
             await response.ForEachAsync((LogSink item) =>
@@ -77,14 +77,106 @@ namespace Google.Cloud.Logging.V2.Snippets
 
         public void ListSinks()
         {
-            // Snippet: ListSinks(string,string,int?,CallSettings)
+            // Snippet: ListSinks(ParentNameOneof,string,int?,CallSettings)
             // Create client
             ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedParent = new ParentName("[PROJECT]").ToString();
+            ParentNameOneof parent = ParentNameOneof.From(new ProjectName("[PROJECT]"));
             // Make the request
             PagedEnumerable<ListSinksResponse,LogSink> response =
-                configServiceV2Client.ListSinks(formattedParent);
+                configServiceV2Client.ListSinks(parent);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (LogSink item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListSinksResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (LogSink item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<LogSink> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (LogSink item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public async Task ListSinksAsync_RequestObject()
+        {
+            // Snippet: ListSinksAsync(ListSinksRequest,CallSettings)
+            // Create client
+            ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
+            // Initialize request argument(s)
+            ListSinksRequest request = new ListSinksRequest
+            {
+                ParentAsParentNameOneof = ParentNameOneof.From(new ProjectName("[PROJECT]")),
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListSinksResponse,LogSink> response =
+                configServiceV2Client.ListSinksAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((LogSink item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListSinksResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (LogSink item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<LogSink> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (LogSink item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListSinks_RequestObject()
+        {
+            // Snippet: ListSinks(ListSinksRequest,CallSettings)
+            // Create client
+            ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
+            // Initialize request argument(s)
+            ListSinksRequest request = new ListSinksRequest
+            {
+                ParentAsParentNameOneof = ParentNameOneof.From(new ProjectName("[PROJECT]")),
+            };
+            // Make the request
+            PagedEnumerable<ListSinksResponse,LogSink> response =
+                configServiceV2Client.ListSinks(request);
 
             // Iterate over all response items, lazily performing RPCs as required
             foreach (LogSink item in response)
@@ -120,105 +212,229 @@ namespace Google.Cloud.Logging.V2.Snippets
 
         public async Task GetSinkAsync()
         {
-            // Snippet: GetSinkAsync(string,CallSettings)
-            // Additional: GetSinkAsync(string,CancellationToken)
+            // Snippet: GetSinkAsync(SinkNameOneof,CallSettings)
+            // Additional: GetSinkAsync(SinkNameOneof,CancellationToken)
             // Create client
             ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedSinkName = new SinkName("[PROJECT]", "[SINK]").ToString();
+            SinkNameOneof sinkName = SinkNameOneof.From(new SinkName("[PROJECT]", "[SINK]"));
             // Make the request
-            LogSink response = await configServiceV2Client.GetSinkAsync(formattedSinkName);
+            LogSink response = await configServiceV2Client.GetSinkAsync(sinkName);
             // End snippet
         }
 
         public void GetSink()
         {
-            // Snippet: GetSink(string,CallSettings)
+            // Snippet: GetSink(SinkNameOneof,CallSettings)
             // Create client
             ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedSinkName = new SinkName("[PROJECT]", "[SINK]").ToString();
+            SinkNameOneof sinkName = SinkNameOneof.From(new SinkName("[PROJECT]", "[SINK]"));
             // Make the request
-            LogSink response = configServiceV2Client.GetSink(formattedSinkName);
+            LogSink response = configServiceV2Client.GetSink(sinkName);
+            // End snippet
+        }
+
+        public async Task GetSinkAsync_RequestObject()
+        {
+            // Snippet: GetSinkAsync(GetSinkRequest,CallSettings)
+            // Create client
+            ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
+            // Initialize request argument(s)
+            GetSinkRequest request = new GetSinkRequest
+            {
+                SinkNameAsSinkNameOneof = SinkNameOneof.From(new SinkName("[PROJECT]", "[SINK]")),
+            };
+            // Make the request
+            LogSink response = await configServiceV2Client.GetSinkAsync(request);
+            // End snippet
+        }
+
+        public void GetSink_RequestObject()
+        {
+            // Snippet: GetSink(GetSinkRequest,CallSettings)
+            // Create client
+            ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
+            // Initialize request argument(s)
+            GetSinkRequest request = new GetSinkRequest
+            {
+                SinkNameAsSinkNameOneof = SinkNameOneof.From(new SinkName("[PROJECT]", "[SINK]")),
+            };
+            // Make the request
+            LogSink response = configServiceV2Client.GetSink(request);
             // End snippet
         }
 
         public async Task CreateSinkAsync()
         {
-            // Snippet: CreateSinkAsync(string,LogSink,CallSettings)
-            // Additional: CreateSinkAsync(string,LogSink,CancellationToken)
+            // Snippet: CreateSinkAsync(ParentNameOneof,LogSink,CallSettings)
+            // Additional: CreateSinkAsync(ParentNameOneof,LogSink,CancellationToken)
             // Create client
             ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedParent = new ParentName("[PROJECT]").ToString();
+            ParentNameOneof parent = ParentNameOneof.From(new ProjectName("[PROJECT]"));
             LogSink sink = new LogSink();
             // Make the request
-            LogSink response = await configServiceV2Client.CreateSinkAsync(formattedParent, sink);
+            LogSink response = await configServiceV2Client.CreateSinkAsync(parent, sink);
             // End snippet
         }
 
         public void CreateSink()
         {
-            // Snippet: CreateSink(string,LogSink,CallSettings)
+            // Snippet: CreateSink(ParentNameOneof,LogSink,CallSettings)
             // Create client
             ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedParent = new ParentName("[PROJECT]").ToString();
+            ParentNameOneof parent = ParentNameOneof.From(new ProjectName("[PROJECT]"));
             LogSink sink = new LogSink();
             // Make the request
-            LogSink response = configServiceV2Client.CreateSink(formattedParent, sink);
+            LogSink response = configServiceV2Client.CreateSink(parent, sink);
+            // End snippet
+        }
+
+        public async Task CreateSinkAsync_RequestObject()
+        {
+            // Snippet: CreateSinkAsync(CreateSinkRequest,CallSettings)
+            // Create client
+            ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
+            // Initialize request argument(s)
+            CreateSinkRequest request = new CreateSinkRequest
+            {
+                ParentAsParentNameOneof = ParentNameOneof.From(new ProjectName("[PROJECT]")),
+                Sink = new LogSink(),
+            };
+            // Make the request
+            LogSink response = await configServiceV2Client.CreateSinkAsync(request);
+            // End snippet
+        }
+
+        public void CreateSink_RequestObject()
+        {
+            // Snippet: CreateSink(CreateSinkRequest,CallSettings)
+            // Create client
+            ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
+            // Initialize request argument(s)
+            CreateSinkRequest request = new CreateSinkRequest
+            {
+                ParentAsParentNameOneof = ParentNameOneof.From(new ProjectName("[PROJECT]")),
+                Sink = new LogSink(),
+            };
+            // Make the request
+            LogSink response = configServiceV2Client.CreateSink(request);
             // End snippet
         }
 
         public async Task UpdateSinkAsync()
         {
-            // Snippet: UpdateSinkAsync(string,LogSink,CallSettings)
-            // Additional: UpdateSinkAsync(string,LogSink,CancellationToken)
+            // Snippet: UpdateSinkAsync(SinkNameOneof,LogSink,CallSettings)
+            // Additional: UpdateSinkAsync(SinkNameOneof,LogSink,CancellationToken)
             // Create client
             ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedSinkName = new SinkName("[PROJECT]", "[SINK]").ToString();
+            SinkNameOneof sinkName = SinkNameOneof.From(new SinkName("[PROJECT]", "[SINK]"));
             LogSink sink = new LogSink();
             // Make the request
-            LogSink response = await configServiceV2Client.UpdateSinkAsync(formattedSinkName, sink);
+            LogSink response = await configServiceV2Client.UpdateSinkAsync(sinkName, sink);
             // End snippet
         }
 
         public void UpdateSink()
         {
-            // Snippet: UpdateSink(string,LogSink,CallSettings)
+            // Snippet: UpdateSink(SinkNameOneof,LogSink,CallSettings)
             // Create client
             ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedSinkName = new SinkName("[PROJECT]", "[SINK]").ToString();
+            SinkNameOneof sinkName = SinkNameOneof.From(new SinkName("[PROJECT]", "[SINK]"));
             LogSink sink = new LogSink();
             // Make the request
-            LogSink response = configServiceV2Client.UpdateSink(formattedSinkName, sink);
+            LogSink response = configServiceV2Client.UpdateSink(sinkName, sink);
+            // End snippet
+        }
+
+        public async Task UpdateSinkAsync_RequestObject()
+        {
+            // Snippet: UpdateSinkAsync(UpdateSinkRequest,CallSettings)
+            // Create client
+            ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
+            // Initialize request argument(s)
+            UpdateSinkRequest request = new UpdateSinkRequest
+            {
+                SinkNameAsSinkNameOneof = SinkNameOneof.From(new SinkName("[PROJECT]", "[SINK]")),
+                Sink = new LogSink(),
+            };
+            // Make the request
+            LogSink response = await configServiceV2Client.UpdateSinkAsync(request);
+            // End snippet
+        }
+
+        public void UpdateSink_RequestObject()
+        {
+            // Snippet: UpdateSink(UpdateSinkRequest,CallSettings)
+            // Create client
+            ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
+            // Initialize request argument(s)
+            UpdateSinkRequest request = new UpdateSinkRequest
+            {
+                SinkNameAsSinkNameOneof = SinkNameOneof.From(new SinkName("[PROJECT]", "[SINK]")),
+                Sink = new LogSink(),
+            };
+            // Make the request
+            LogSink response = configServiceV2Client.UpdateSink(request);
             // End snippet
         }
 
         public async Task DeleteSinkAsync()
         {
-            // Snippet: DeleteSinkAsync(string,CallSettings)
-            // Additional: DeleteSinkAsync(string,CancellationToken)
+            // Snippet: DeleteSinkAsync(SinkNameOneof,CallSettings)
+            // Additional: DeleteSinkAsync(SinkNameOneof,CancellationToken)
             // Create client
             ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedSinkName = new SinkName("[PROJECT]", "[SINK]").ToString();
+            SinkNameOneof sinkName = SinkNameOneof.From(new SinkName("[PROJECT]", "[SINK]"));
             // Make the request
-            await configServiceV2Client.DeleteSinkAsync(formattedSinkName);
+            await configServiceV2Client.DeleteSinkAsync(sinkName);
             // End snippet
         }
 
         public void DeleteSink()
         {
-            // Snippet: DeleteSink(string,CallSettings)
+            // Snippet: DeleteSink(SinkNameOneof,CallSettings)
             // Create client
             ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedSinkName = new SinkName("[PROJECT]", "[SINK]").ToString();
+            SinkNameOneof sinkName = SinkNameOneof.From(new SinkName("[PROJECT]", "[SINK]"));
             // Make the request
-            configServiceV2Client.DeleteSink(formattedSinkName);
+            configServiceV2Client.DeleteSink(sinkName);
+            // End snippet
+        }
+
+        public async Task DeleteSinkAsync_RequestObject()
+        {
+            // Snippet: DeleteSinkAsync(DeleteSinkRequest,CallSettings)
+            // Create client
+            ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
+            // Initialize request argument(s)
+            DeleteSinkRequest request = new DeleteSinkRequest
+            {
+                SinkNameAsSinkNameOneof = SinkNameOneof.From(new SinkName("[PROJECT]", "[SINK]")),
+            };
+            // Make the request
+            await configServiceV2Client.DeleteSinkAsync(request);
+            // End snippet
+        }
+
+        public void DeleteSink_RequestObject()
+        {
+            // Snippet: DeleteSink(DeleteSinkRequest,CallSettings)
+            // Create client
+            ConfigServiceV2Client configServiceV2Client = ConfigServiceV2Client.Create();
+            // Initialize request argument(s)
+            DeleteSinkRequest request = new DeleteSinkRequest
+            {
+                SinkNameAsSinkNameOneof = SinkNameOneof.From(new SinkName("[PROJECT]", "[SINK]")),
+            };
+            // Make the request
+            configServiceV2Client.DeleteSink(request);
             // End snippet
         }
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/LoggingServiceV2ClientSnippets.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/LoggingServiceV2ClientSnippets.g.cs
@@ -35,57 +35,117 @@ namespace Google.Cloud.Logging.V2.Snippets
     {
         public async Task DeleteLogAsync()
         {
-            // Snippet: DeleteLogAsync(string,CallSettings)
-            // Additional: DeleteLogAsync(string,CancellationToken)
+            // Snippet: DeleteLogAsync(LogNameOneof,CallSettings)
+            // Additional: DeleteLogAsync(LogNameOneof,CancellationToken)
             // Create client
             LoggingServiceV2Client loggingServiceV2Client = LoggingServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedLogName = new LogName("[PROJECT]", "[LOG]").ToString();
+            LogNameOneof logName = LogNameOneof.From(new LogName("[PROJECT]", "[LOG]"));
             // Make the request
-            await loggingServiceV2Client.DeleteLogAsync(formattedLogName);
+            await loggingServiceV2Client.DeleteLogAsync(logName);
             // End snippet
         }
 
         public void DeleteLog()
         {
-            // Snippet: DeleteLog(string,CallSettings)
+            // Snippet: DeleteLog(LogNameOneof,CallSettings)
             // Create client
             LoggingServiceV2Client loggingServiceV2Client = LoggingServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedLogName = new LogName("[PROJECT]", "[LOG]").ToString();
+            LogNameOneof logName = LogNameOneof.From(new LogName("[PROJECT]", "[LOG]"));
             // Make the request
-            loggingServiceV2Client.DeleteLog(formattedLogName);
+            loggingServiceV2Client.DeleteLog(logName);
+            // End snippet
+        }
+
+        public async Task DeleteLogAsync_RequestObject()
+        {
+            // Snippet: DeleteLogAsync(DeleteLogRequest,CallSettings)
+            // Create client
+            LoggingServiceV2Client loggingServiceV2Client = LoggingServiceV2Client.Create();
+            // Initialize request argument(s)
+            DeleteLogRequest request = new DeleteLogRequest
+            {
+                LogNameAsLogNameOneof = LogNameOneof.From(new LogName("[PROJECT]", "[LOG]")),
+            };
+            // Make the request
+            await loggingServiceV2Client.DeleteLogAsync(request);
+            // End snippet
+        }
+
+        public void DeleteLog_RequestObject()
+        {
+            // Snippet: DeleteLog(DeleteLogRequest,CallSettings)
+            // Create client
+            LoggingServiceV2Client loggingServiceV2Client = LoggingServiceV2Client.Create();
+            // Initialize request argument(s)
+            DeleteLogRequest request = new DeleteLogRequest
+            {
+                LogNameAsLogNameOneof = LogNameOneof.From(new LogName("[PROJECT]", "[LOG]")),
+            };
+            // Make the request
+            loggingServiceV2Client.DeleteLog(request);
             // End snippet
         }
 
         public async Task WriteLogEntriesAsync()
         {
-            // Snippet: WriteLogEntriesAsync(string,MonitoredResource,IDictionary<string, string>,IEnumerable<LogEntry>,CallSettings)
-            // Additional: WriteLogEntriesAsync(string,MonitoredResource,IDictionary<string, string>,IEnumerable<LogEntry>,CancellationToken)
+            // Snippet: WriteLogEntriesAsync(LogNameOneof,MonitoredResource,IDictionary<string, string>,IEnumerable<LogEntry>,CallSettings)
+            // Additional: WriteLogEntriesAsync(LogNameOneof,MonitoredResource,IDictionary<string, string>,IEnumerable<LogEntry>,CancellationToken)
             // Create client
             LoggingServiceV2Client loggingServiceV2Client = LoggingServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedLogName = new LogName("[PROJECT]", "[LOG]").ToString();
+            LogNameOneof logName = LogNameOneof.From(new LogName("[PROJECT]", "[LOG]"));
             MonitoredResource resource = new MonitoredResource();
             IDictionary<string, string> labels = new Dictionary<string, string>();
             IEnumerable<LogEntry> entries = new List<LogEntry>();
             // Make the request
-            WriteLogEntriesResponse response = await loggingServiceV2Client.WriteLogEntriesAsync(formattedLogName, resource, labels, entries);
+            WriteLogEntriesResponse response = await loggingServiceV2Client.WriteLogEntriesAsync(logName, resource, labels, entries);
             // End snippet
         }
 
         public void WriteLogEntries()
         {
-            // Snippet: WriteLogEntries(string,MonitoredResource,IDictionary<string, string>,IEnumerable<LogEntry>,CallSettings)
+            // Snippet: WriteLogEntries(LogNameOneof,MonitoredResource,IDictionary<string, string>,IEnumerable<LogEntry>,CallSettings)
             // Create client
             LoggingServiceV2Client loggingServiceV2Client = LoggingServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedLogName = new LogName("[PROJECT]", "[LOG]").ToString();
+            LogNameOneof logName = LogNameOneof.From(new LogName("[PROJECT]", "[LOG]"));
             MonitoredResource resource = new MonitoredResource();
             IDictionary<string, string> labels = new Dictionary<string, string>();
             IEnumerable<LogEntry> entries = new List<LogEntry>();
             // Make the request
-            WriteLogEntriesResponse response = loggingServiceV2Client.WriteLogEntries(formattedLogName, resource, labels, entries);
+            WriteLogEntriesResponse response = loggingServiceV2Client.WriteLogEntries(logName, resource, labels, entries);
+            // End snippet
+        }
+
+        public async Task WriteLogEntriesAsync_RequestObject()
+        {
+            // Snippet: WriteLogEntriesAsync(WriteLogEntriesRequest,CallSettings)
+            // Create client
+            LoggingServiceV2Client loggingServiceV2Client = LoggingServiceV2Client.Create();
+            // Initialize request argument(s)
+            WriteLogEntriesRequest request = new WriteLogEntriesRequest
+            {
+                Entries = { },
+            };
+            // Make the request
+            WriteLogEntriesResponse response = await loggingServiceV2Client.WriteLogEntriesAsync(request);
+            // End snippet
+        }
+
+        public void WriteLogEntries_RequestObject()
+        {
+            // Snippet: WriteLogEntries(WriteLogEntriesRequest,CallSettings)
+            // Create client
+            LoggingServiceV2Client loggingServiceV2Client = LoggingServiceV2Client.Create();
+            // Initialize request argument(s)
+            WriteLogEntriesRequest request = new WriteLogEntriesRequest
+            {
+                Entries = { },
+            };
+            // Make the request
+            WriteLogEntriesResponse response = loggingServiceV2Client.WriteLogEntries(request);
             // End snippet
         }
 
@@ -171,6 +231,184 @@ namespace Google.Cloud.Logging.V2.Snippets
             // Do something with the page of items
             Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
             foreach (LogEntry item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public async Task ListLogEntriesAsync_RequestObject()
+        {
+            // Snippet: ListLogEntriesAsync(ListLogEntriesRequest,CallSettings)
+            // Create client
+            LoggingServiceV2Client loggingServiceV2Client = LoggingServiceV2Client.Create();
+            // Initialize request argument(s)
+            ListLogEntriesRequest request = new ListLogEntriesRequest
+            {
+                ResourceNames = { },
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListLogEntriesResponse,LogEntry> response =
+                loggingServiceV2Client.ListLogEntriesAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((LogEntry item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListLogEntriesResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (LogEntry item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<LogEntry> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (LogEntry item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListLogEntries_RequestObject()
+        {
+            // Snippet: ListLogEntries(ListLogEntriesRequest,CallSettings)
+            // Create client
+            LoggingServiceV2Client loggingServiceV2Client = LoggingServiceV2Client.Create();
+            // Initialize request argument(s)
+            ListLogEntriesRequest request = new ListLogEntriesRequest
+            {
+                ResourceNames = { },
+            };
+            // Make the request
+            PagedEnumerable<ListLogEntriesResponse,LogEntry> response =
+                loggingServiceV2Client.ListLogEntries(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (LogEntry item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListLogEntriesResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (LogEntry item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<LogEntry> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (LogEntry item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public async Task ListMonitoredResourceDescriptorsAsync_RequestObject()
+        {
+            // Snippet: ListMonitoredResourceDescriptorsAsync(ListMonitoredResourceDescriptorsRequest,CallSettings)
+            // Create client
+            LoggingServiceV2Client loggingServiceV2Client = LoggingServiceV2Client.Create();
+            // Initialize request argument(s)
+            ListMonitoredResourceDescriptorsRequest request = new ListMonitoredResourceDescriptorsRequest();
+            // Make the request
+            PagedAsyncEnumerable<ListMonitoredResourceDescriptorsResponse,MonitoredResourceDescriptor> response =
+                loggingServiceV2Client.ListMonitoredResourceDescriptorsAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((MonitoredResourceDescriptor item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListMonitoredResourceDescriptorsResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (MonitoredResourceDescriptor item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<MonitoredResourceDescriptor> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (MonitoredResourceDescriptor item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListMonitoredResourceDescriptors_RequestObject()
+        {
+            // Snippet: ListMonitoredResourceDescriptors(ListMonitoredResourceDescriptorsRequest,CallSettings)
+            // Create client
+            LoggingServiceV2Client loggingServiceV2Client = LoggingServiceV2Client.Create();
+            // Initialize request argument(s)
+            ListMonitoredResourceDescriptorsRequest request = new ListMonitoredResourceDescriptorsRequest();
+            // Make the request
+            PagedEnumerable<ListMonitoredResourceDescriptorsResponse,MonitoredResourceDescriptor> response =
+                loggingServiceV2Client.ListMonitoredResourceDescriptors(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (MonitoredResourceDescriptor item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListMonitoredResourceDescriptorsResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (MonitoredResourceDescriptor item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<MonitoredResourceDescriptor> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (MonitoredResourceDescriptor item in singlePage)
             {
                 Console.WriteLine(item);
             }

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/MetricsServiceV2ClientSnippets.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/MetricsServiceV2ClientSnippets.g.cs
@@ -34,14 +34,14 @@ namespace Google.Cloud.Logging.V2.Snippets
     {
         public async Task ListLogMetricsAsync()
         {
-            // Snippet: ListLogMetricsAsync(string,string,int?,CallSettings)
+            // Snippet: ListLogMetricsAsync(ParentNameOneof,string,int?,CallSettings)
             // Create client
             MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedParent = new ParentName("[PROJECT]").ToString();
+            ParentNameOneof parent = ParentNameOneof.From(new ProjectName("[PROJECT]"));
             // Make the request
             PagedAsyncEnumerable<ListLogMetricsResponse,LogMetric> response =
-                metricsServiceV2Client.ListLogMetricsAsync(formattedParent);
+                metricsServiceV2Client.ListLogMetricsAsync(parent);
 
             // Iterate over all response items, lazily performing RPCs as required
             await response.ForEachAsync((LogMetric item) =>
@@ -77,14 +77,106 @@ namespace Google.Cloud.Logging.V2.Snippets
 
         public void ListLogMetrics()
         {
-            // Snippet: ListLogMetrics(string,string,int?,CallSettings)
+            // Snippet: ListLogMetrics(ParentNameOneof,string,int?,CallSettings)
             // Create client
             MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedParent = new ParentName("[PROJECT]").ToString();
+            ParentNameOneof parent = ParentNameOneof.From(new ProjectName("[PROJECT]"));
             // Make the request
             PagedEnumerable<ListLogMetricsResponse,LogMetric> response =
-                metricsServiceV2Client.ListLogMetrics(formattedParent);
+                metricsServiceV2Client.ListLogMetrics(parent);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (LogMetric item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListLogMetricsResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (LogMetric item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<LogMetric> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (LogMetric item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public async Task ListLogMetricsAsync_RequestObject()
+        {
+            // Snippet: ListLogMetricsAsync(ListLogMetricsRequest,CallSettings)
+            // Create client
+            MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
+            // Initialize request argument(s)
+            ListLogMetricsRequest request = new ListLogMetricsRequest
+            {
+                ParentAsParentNameOneof = ParentNameOneof.From(new ProjectName("[PROJECT]")),
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListLogMetricsResponse,LogMetric> response =
+                metricsServiceV2Client.ListLogMetricsAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((LogMetric item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListLogMetricsResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (LogMetric item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<LogMetric> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (LogMetric item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListLogMetrics_RequestObject()
+        {
+            // Snippet: ListLogMetrics(ListLogMetricsRequest,CallSettings)
+            // Create client
+            MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
+            // Initialize request argument(s)
+            ListLogMetricsRequest request = new ListLogMetricsRequest
+            {
+                ParentAsParentNameOneof = ParentNameOneof.From(new ProjectName("[PROJECT]")),
+            };
+            // Make the request
+            PagedEnumerable<ListLogMetricsResponse,LogMetric> response =
+                metricsServiceV2Client.ListLogMetrics(request);
 
             // Iterate over all response items, lazily performing RPCs as required
             foreach (LogMetric item in response)
@@ -120,105 +212,229 @@ namespace Google.Cloud.Logging.V2.Snippets
 
         public async Task GetLogMetricAsync()
         {
-            // Snippet: GetLogMetricAsync(string,CallSettings)
-            // Additional: GetLogMetricAsync(string,CancellationToken)
+            // Snippet: GetLogMetricAsync(MetricNameOneof,CallSettings)
+            // Additional: GetLogMetricAsync(MetricNameOneof,CancellationToken)
             // Create client
             MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedMetricName = new MetricName("[PROJECT]", "[METRIC]").ToString();
+            MetricNameOneof metricName = MetricNameOneof.From(new MetricName("[PROJECT]", "[METRIC]"));
             // Make the request
-            LogMetric response = await metricsServiceV2Client.GetLogMetricAsync(formattedMetricName);
+            LogMetric response = await metricsServiceV2Client.GetLogMetricAsync(metricName);
             // End snippet
         }
 
         public void GetLogMetric()
         {
-            // Snippet: GetLogMetric(string,CallSettings)
+            // Snippet: GetLogMetric(MetricNameOneof,CallSettings)
             // Create client
             MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedMetricName = new MetricName("[PROJECT]", "[METRIC]").ToString();
+            MetricNameOneof metricName = MetricNameOneof.From(new MetricName("[PROJECT]", "[METRIC]"));
             // Make the request
-            LogMetric response = metricsServiceV2Client.GetLogMetric(formattedMetricName);
+            LogMetric response = metricsServiceV2Client.GetLogMetric(metricName);
+            // End snippet
+        }
+
+        public async Task GetLogMetricAsync_RequestObject()
+        {
+            // Snippet: GetLogMetricAsync(GetLogMetricRequest,CallSettings)
+            // Create client
+            MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
+            // Initialize request argument(s)
+            GetLogMetricRequest request = new GetLogMetricRequest
+            {
+                MetricNameAsMetricNameOneof = MetricNameOneof.From(new MetricName("[PROJECT]", "[METRIC]")),
+            };
+            // Make the request
+            LogMetric response = await metricsServiceV2Client.GetLogMetricAsync(request);
+            // End snippet
+        }
+
+        public void GetLogMetric_RequestObject()
+        {
+            // Snippet: GetLogMetric(GetLogMetricRequest,CallSettings)
+            // Create client
+            MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
+            // Initialize request argument(s)
+            GetLogMetricRequest request = new GetLogMetricRequest
+            {
+                MetricNameAsMetricNameOneof = MetricNameOneof.From(new MetricName("[PROJECT]", "[METRIC]")),
+            };
+            // Make the request
+            LogMetric response = metricsServiceV2Client.GetLogMetric(request);
             // End snippet
         }
 
         public async Task CreateLogMetricAsync()
         {
-            // Snippet: CreateLogMetricAsync(string,LogMetric,CallSettings)
-            // Additional: CreateLogMetricAsync(string,LogMetric,CancellationToken)
+            // Snippet: CreateLogMetricAsync(ParentNameOneof,LogMetric,CallSettings)
+            // Additional: CreateLogMetricAsync(ParentNameOneof,LogMetric,CancellationToken)
             // Create client
             MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedParent = new ParentName("[PROJECT]").ToString();
+            ParentNameOneof parent = ParentNameOneof.From(new ProjectName("[PROJECT]"));
             LogMetric metric = new LogMetric();
             // Make the request
-            LogMetric response = await metricsServiceV2Client.CreateLogMetricAsync(formattedParent, metric);
+            LogMetric response = await metricsServiceV2Client.CreateLogMetricAsync(parent, metric);
             // End snippet
         }
 
         public void CreateLogMetric()
         {
-            // Snippet: CreateLogMetric(string,LogMetric,CallSettings)
+            // Snippet: CreateLogMetric(ParentNameOneof,LogMetric,CallSettings)
             // Create client
             MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedParent = new ParentName("[PROJECT]").ToString();
+            ParentNameOneof parent = ParentNameOneof.From(new ProjectName("[PROJECT]"));
             LogMetric metric = new LogMetric();
             // Make the request
-            LogMetric response = metricsServiceV2Client.CreateLogMetric(formattedParent, metric);
+            LogMetric response = metricsServiceV2Client.CreateLogMetric(parent, metric);
+            // End snippet
+        }
+
+        public async Task CreateLogMetricAsync_RequestObject()
+        {
+            // Snippet: CreateLogMetricAsync(CreateLogMetricRequest,CallSettings)
+            // Create client
+            MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
+            // Initialize request argument(s)
+            CreateLogMetricRequest request = new CreateLogMetricRequest
+            {
+                ParentAsParentNameOneof = ParentNameOneof.From(new ProjectName("[PROJECT]")),
+                Metric = new LogMetric(),
+            };
+            // Make the request
+            LogMetric response = await metricsServiceV2Client.CreateLogMetricAsync(request);
+            // End snippet
+        }
+
+        public void CreateLogMetric_RequestObject()
+        {
+            // Snippet: CreateLogMetric(CreateLogMetricRequest,CallSettings)
+            // Create client
+            MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
+            // Initialize request argument(s)
+            CreateLogMetricRequest request = new CreateLogMetricRequest
+            {
+                ParentAsParentNameOneof = ParentNameOneof.From(new ProjectName("[PROJECT]")),
+                Metric = new LogMetric(),
+            };
+            // Make the request
+            LogMetric response = metricsServiceV2Client.CreateLogMetric(request);
             // End snippet
         }
 
         public async Task UpdateLogMetricAsync()
         {
-            // Snippet: UpdateLogMetricAsync(string,LogMetric,CallSettings)
-            // Additional: UpdateLogMetricAsync(string,LogMetric,CancellationToken)
+            // Snippet: UpdateLogMetricAsync(MetricNameOneof,LogMetric,CallSettings)
+            // Additional: UpdateLogMetricAsync(MetricNameOneof,LogMetric,CancellationToken)
             // Create client
             MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedMetricName = new MetricName("[PROJECT]", "[METRIC]").ToString();
+            MetricNameOneof metricName = MetricNameOneof.From(new MetricName("[PROJECT]", "[METRIC]"));
             LogMetric metric = new LogMetric();
             // Make the request
-            LogMetric response = await metricsServiceV2Client.UpdateLogMetricAsync(formattedMetricName, metric);
+            LogMetric response = await metricsServiceV2Client.UpdateLogMetricAsync(metricName, metric);
             // End snippet
         }
 
         public void UpdateLogMetric()
         {
-            // Snippet: UpdateLogMetric(string,LogMetric,CallSettings)
+            // Snippet: UpdateLogMetric(MetricNameOneof,LogMetric,CallSettings)
             // Create client
             MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedMetricName = new MetricName("[PROJECT]", "[METRIC]").ToString();
+            MetricNameOneof metricName = MetricNameOneof.From(new MetricName("[PROJECT]", "[METRIC]"));
             LogMetric metric = new LogMetric();
             // Make the request
-            LogMetric response = metricsServiceV2Client.UpdateLogMetric(formattedMetricName, metric);
+            LogMetric response = metricsServiceV2Client.UpdateLogMetric(metricName, metric);
+            // End snippet
+        }
+
+        public async Task UpdateLogMetricAsync_RequestObject()
+        {
+            // Snippet: UpdateLogMetricAsync(UpdateLogMetricRequest,CallSettings)
+            // Create client
+            MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
+            // Initialize request argument(s)
+            UpdateLogMetricRequest request = new UpdateLogMetricRequest
+            {
+                MetricNameAsMetricNameOneof = MetricNameOneof.From(new MetricName("[PROJECT]", "[METRIC]")),
+                Metric = new LogMetric(),
+            };
+            // Make the request
+            LogMetric response = await metricsServiceV2Client.UpdateLogMetricAsync(request);
+            // End snippet
+        }
+
+        public void UpdateLogMetric_RequestObject()
+        {
+            // Snippet: UpdateLogMetric(UpdateLogMetricRequest,CallSettings)
+            // Create client
+            MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
+            // Initialize request argument(s)
+            UpdateLogMetricRequest request = new UpdateLogMetricRequest
+            {
+                MetricNameAsMetricNameOneof = MetricNameOneof.From(new MetricName("[PROJECT]", "[METRIC]")),
+                Metric = new LogMetric(),
+            };
+            // Make the request
+            LogMetric response = metricsServiceV2Client.UpdateLogMetric(request);
             // End snippet
         }
 
         public async Task DeleteLogMetricAsync()
         {
-            // Snippet: DeleteLogMetricAsync(string,CallSettings)
-            // Additional: DeleteLogMetricAsync(string,CancellationToken)
+            // Snippet: DeleteLogMetricAsync(MetricNameOneof,CallSettings)
+            // Additional: DeleteLogMetricAsync(MetricNameOneof,CancellationToken)
             // Create client
             MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedMetricName = new MetricName("[PROJECT]", "[METRIC]").ToString();
+            MetricNameOneof metricName = MetricNameOneof.From(new MetricName("[PROJECT]", "[METRIC]"));
             // Make the request
-            await metricsServiceV2Client.DeleteLogMetricAsync(formattedMetricName);
+            await metricsServiceV2Client.DeleteLogMetricAsync(metricName);
             // End snippet
         }
 
         public void DeleteLogMetric()
         {
-            // Snippet: DeleteLogMetric(string,CallSettings)
+            // Snippet: DeleteLogMetric(MetricNameOneof,CallSettings)
             // Create client
             MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
             // Initialize request argument(s)
-            string formattedMetricName = new MetricName("[PROJECT]", "[METRIC]").ToString();
+            MetricNameOneof metricName = MetricNameOneof.From(new MetricName("[PROJECT]", "[METRIC]"));
             // Make the request
-            metricsServiceV2Client.DeleteLogMetric(formattedMetricName);
+            metricsServiceV2Client.DeleteLogMetric(metricName);
+            // End snippet
+        }
+
+        public async Task DeleteLogMetricAsync_RequestObject()
+        {
+            // Snippet: DeleteLogMetricAsync(DeleteLogMetricRequest,CallSettings)
+            // Create client
+            MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
+            // Initialize request argument(s)
+            DeleteLogMetricRequest request = new DeleteLogMetricRequest
+            {
+                MetricNameAsMetricNameOneof = MetricNameOneof.From(new MetricName("[PROJECT]", "[METRIC]")),
+            };
+            // Make the request
+            await metricsServiceV2Client.DeleteLogMetricAsync(request);
+            // End snippet
+        }
+
+        public void DeleteLogMetric_RequestObject()
+        {
+            // Snippet: DeleteLogMetric(DeleteLogMetricRequest,CallSettings)
+            // Create client
+            MetricsServiceV2Client metricsServiceV2Client = MetricsServiceV2Client.Create();
+            // Initialize request argument(s)
+            DeleteLogMetricRequest request = new DeleteLogMetricRequest
+            {
+                MetricNameAsMetricNameOneof = MetricNameOneof.From(new MetricName("[PROJECT]", "[METRIC]")),
+            };
+            // Make the request
+            metricsServiceV2Client.DeleteLogMetric(request);
             // End snippet
         }
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ConfigServiceV2Client.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ConfigServiceV2Client.cs
@@ -398,13 +398,17 @@ namespace Google.Cloud.Logging.V2
         /// A pageable asynchronous sequence of <see cref="LogSink"/> resources.
         /// </returns>
         public virtual PagedAsyncEnumerable<ListSinksResponse, LogSink> ListSinksAsync(
-            string parent,
+            ParentNameOneof parent,
             string pageToken = null,
             int? pageSize = null,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ListSinksAsync(
+                new ListSinksRequest
+                {
+                    ParentAsParentNameOneof = parent,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
 
         /// <summary>
         /// Lists sinks.
@@ -430,9 +434,51 @@ namespace Google.Cloud.Logging.V2
         /// A pageable sequence of <see cref="LogSink"/> resources.
         /// </returns>
         public virtual PagedEnumerable<ListSinksResponse, LogSink> ListSinks(
-            string parent,
+            ParentNameOneof parent,
             string pageToken = null,
             int? pageSize = null,
+            CallSettings callSettings = null) => ListSinks(
+                new ListSinksRequest
+                {
+                    ParentAsParentNameOneof = parent,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists sinks.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="LogSink"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListSinksResponse, LogSink> ListSinksAsync(
+            ListSinksRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists sinks.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="LogSink"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListSinksResponse, LogSink> ListSinks(
+            ListSinksRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -454,11 +500,13 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task<LogSink> GetSinkAsync(
-            string sinkName,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            SinkNameOneof sinkName,
+            CallSettings callSettings = null) => GetSinkAsync(
+                new GetSinkRequest
+                {
+                    SinkNameAsSinkNameOneof = sinkName,
+                },
+                callSettings);
 
         /// <summary>
         /// Gets a sink.
@@ -476,7 +524,7 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task<LogSink> GetSinkAsync(
-            string sinkName,
+            SinkNameOneof sinkName,
             CancellationToken cancellationToken) => GetSinkAsync(
                 sinkName,
                 CallSettings.FromCancellationToken(cancellationToken));
@@ -497,7 +545,47 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public virtual LogSink GetSink(
-            string sinkName,
+            SinkNameOneof sinkName,
+            CallSettings callSettings = null) => GetSink(
+                new GetSinkRequest
+                {
+                    SinkNameAsSinkNameOneof = sinkName,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a sink.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<LogSink> GetSinkAsync(
+            GetSinkRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets a sink.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual LogSink GetSink(
+            GetSinkRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -523,12 +611,15 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task<LogSink> CreateSinkAsync(
-            string parent,
+            ParentNameOneof parent,
             LogSink sink,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => CreateSinkAsync(
+                new CreateSinkRequest
+                {
+                    ParentAsParentNameOneof = parent,
+                    Sink = sink,
+                },
+                callSettings);
 
         /// <summary>
         /// Creates a sink.
@@ -550,7 +641,7 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task<LogSink> CreateSinkAsync(
-            string parent,
+            ParentNameOneof parent,
             LogSink sink,
             CancellationToken cancellationToken) => CreateSinkAsync(
                 parent,
@@ -577,8 +668,49 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public virtual LogSink CreateSink(
-            string parent,
+            ParentNameOneof parent,
             LogSink sink,
+            CallSettings callSettings = null) => CreateSink(
+                new CreateSinkRequest
+                {
+                    ParentAsParentNameOneof = parent,
+                    Sink = sink,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates a sink.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<LogSink> CreateSinkAsync(
+            CreateSinkRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Creates a sink.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual LogSink CreateSink(
+            CreateSinkRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -608,12 +740,15 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task<LogSink> UpdateSinkAsync(
-            string sinkName,
+            SinkNameOneof sinkName,
             LogSink sink,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => UpdateSinkAsync(
+                new UpdateSinkRequest
+                {
+                    SinkNameAsSinkNameOneof = sinkName,
+                    Sink = sink,
+                },
+                callSettings);
 
         /// <summary>
         /// Updates or creates a sink.
@@ -639,7 +774,7 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task<LogSink> UpdateSinkAsync(
-            string sinkName,
+            SinkNameOneof sinkName,
             LogSink sink,
             CancellationToken cancellationToken) => UpdateSinkAsync(
                 sinkName,
@@ -670,8 +805,49 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public virtual LogSink UpdateSink(
-            string sinkName,
+            SinkNameOneof sinkName,
             LogSink sink,
+            CallSettings callSettings = null) => UpdateSink(
+                new UpdateSinkRequest
+                {
+                    SinkNameAsSinkNameOneof = sinkName,
+                    Sink = sink,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates or creates a sink.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<LogSink> UpdateSinkAsync(
+            UpdateSinkRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Updates or creates a sink.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual LogSink UpdateSink(
+            UpdateSinkRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -696,11 +872,13 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task DeleteSinkAsync(
-            string sinkName,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            SinkNameOneof sinkName,
+            CallSettings callSettings = null) => DeleteSinkAsync(
+                new DeleteSinkRequest
+                {
+                    SinkNameAsSinkNameOneof = sinkName,
+                },
+                callSettings);
 
         /// <summary>
         /// Deletes a sink.
@@ -721,7 +899,7 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task DeleteSinkAsync(
-            string sinkName,
+            SinkNameOneof sinkName,
             CancellationToken cancellationToken) => DeleteSinkAsync(
                 sinkName,
                 CallSettings.FromCancellationToken(cancellationToken));
@@ -745,7 +923,47 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public virtual void DeleteSink(
-            string sinkName,
+            SinkNameOneof sinkName,
+            CallSettings callSettings = null) => DeleteSink(
+                new DeleteSinkRequest
+                {
+                    SinkNameAsSinkNameOneof = sinkName,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes a sink.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task DeleteSinkAsync(
+            DeleteSinkRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Deletes a sink.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual void DeleteSink(
+            DeleteSinkRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -802,19 +1020,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Lists sinks.
         /// </summary>
-        /// <param name="parent">
-        /// Required. The resource name where this sink was created:
-        ///
-        ///     "projects/[PROJECT_ID]"
-        ///     "organizations/[ORGANIZATION_ID]"
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -823,17 +1030,9 @@ namespace Google.Cloud.Logging.V2
         /// A pageable asynchronous sequence of <see cref="LogSink"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListSinksResponse, LogSink> ListSinksAsync(
-            string parent,
-            string pageToken = null,
-            int? pageSize = null,
+            ListSinksRequest request,
             CallSettings callSettings = null)
         {
-            ListSinksRequest request = new ListSinksRequest
-            {
-                Parent = parent,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListSinksRequest(ref request, ref callSettings);
             return new GrpcPagedAsyncEnumerable<ListSinksRequest, ListSinksResponse, LogSink>(_callListSinks, request, callSettings);
         }
@@ -841,19 +1040,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Lists sinks.
         /// </summary>
-        /// <param name="parent">
-        /// Required. The resource name where this sink was created:
-        ///
-        ///     "projects/[PROJECT_ID]"
-        ///     "organizations/[ORGANIZATION_ID]"
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -862,17 +1050,9 @@ namespace Google.Cloud.Logging.V2
         /// A pageable sequence of <see cref="LogSink"/> resources.
         /// </returns>
         public override PagedEnumerable<ListSinksResponse, LogSink> ListSinks(
-            string parent,
-            string pageToken = null,
-            int? pageSize = null,
+            ListSinksRequest request,
             CallSettings callSettings = null)
         {
-            ListSinksRequest request = new ListSinksRequest
-            {
-                Parent = parent,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListSinksRequest(ref request, ref callSettings);
             return new GrpcPagedEnumerable<ListSinksRequest, ListSinksResponse, LogSink>(_callListSinks, request, callSettings);
         }
@@ -880,11 +1060,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Gets a sink.
         /// </summary>
-        /// <param name="sinkName">
-        /// Required. The resource name of the sink to return:
-        ///
-        ///     "projects/[PROJECT_ID]/sinks/[SINK_ID]"
-        ///     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -893,13 +1070,9 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<LogSink> GetSinkAsync(
-            string sinkName,
+            GetSinkRequest request,
             CallSettings callSettings = null)
         {
-            GetSinkRequest request = new GetSinkRequest
-            {
-                SinkName = sinkName,
-            };
             Modify_GetSinkRequest(ref request, ref callSettings);
             return _callGetSink.Async(request, callSettings);
         }
@@ -907,11 +1080,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Gets a sink.
         /// </summary>
-        /// <param name="sinkName">
-        /// Required. The resource name of the sink to return:
-        ///
-        ///     "projects/[PROJECT_ID]/sinks/[SINK_ID]"
-        ///     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -920,13 +1090,9 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public override LogSink GetSink(
-            string sinkName,
+            GetSinkRequest request,
             CallSettings callSettings = null)
         {
-            GetSinkRequest request = new GetSinkRequest
-            {
-                SinkName = sinkName,
-            };
             Modify_GetSinkRequest(ref request, ref callSettings);
             return _callGetSink.Sync(request, callSettings);
         }
@@ -934,15 +1100,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Creates a sink.
         /// </summary>
-        /// <param name="parent">
-        /// Required. The resource in which to create the sink:
-        ///
-        ///     "projects/[PROJECT_ID]"
-        ///     "organizations/[ORGANIZATION_ID]"
-        /// </param>
-        /// <param name="sink">
-        /// Required. The new sink, whose `name` parameter is a sink identifier that
-        /// is not already in use.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -951,15 +1110,9 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<LogSink> CreateSinkAsync(
-            string parent,
-            LogSink sink,
+            CreateSinkRequest request,
             CallSettings callSettings = null)
         {
-            CreateSinkRequest request = new CreateSinkRequest
-            {
-                Parent = parent,
-                Sink = sink,
-            };
             Modify_CreateSinkRequest(ref request, ref callSettings);
             return _callCreateSink.Async(request, callSettings);
         }
@@ -967,15 +1120,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Creates a sink.
         /// </summary>
-        /// <param name="parent">
-        /// Required. The resource in which to create the sink:
-        ///
-        ///     "projects/[PROJECT_ID]"
-        ///     "organizations/[ORGANIZATION_ID]"
-        /// </param>
-        /// <param name="sink">
-        /// Required. The new sink, whose `name` parameter is a sink identifier that
-        /// is not already in use.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -984,15 +1130,9 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public override LogSink CreateSink(
-            string parent,
-            LogSink sink,
+            CreateSinkRequest request,
             CallSettings callSettings = null)
         {
-            CreateSinkRequest request = new CreateSinkRequest
-            {
-                Parent = parent,
-                Sink = sink,
-            };
             Modify_CreateSinkRequest(ref request, ref callSettings);
             return _callCreateSink.Sync(request, callSettings);
         }
@@ -1000,19 +1140,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Updates or creates a sink.
         /// </summary>
-        /// <param name="sinkName">
-        /// Required. The resource name of the sink to update, including the parent
-        /// resource and the sink identifier:
-        ///
-        ///     "projects/[PROJECT_ID]/sinks/[SINK_ID]"
-        ///     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
-        ///
-        /// Example: `"projects/my-project-id/sinks/my-sink-id"`.
-        /// </param>
-        /// <param name="sink">
-        /// Required. The updated sink, whose name is the same identifier that appears
-        /// as part of `sinkName`.  If `sinkName` does not exist, then
-        /// this method creates a new sink.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1021,15 +1150,9 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<LogSink> UpdateSinkAsync(
-            string sinkName,
-            LogSink sink,
+            UpdateSinkRequest request,
             CallSettings callSettings = null)
         {
-            UpdateSinkRequest request = new UpdateSinkRequest
-            {
-                SinkName = sinkName,
-                Sink = sink,
-            };
             Modify_UpdateSinkRequest(ref request, ref callSettings);
             return _callUpdateSink.Async(request, callSettings);
         }
@@ -1037,19 +1160,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Updates or creates a sink.
         /// </summary>
-        /// <param name="sinkName">
-        /// Required. The resource name of the sink to update, including the parent
-        /// resource and the sink identifier:
-        ///
-        ///     "projects/[PROJECT_ID]/sinks/[SINK_ID]"
-        ///     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
-        ///
-        /// Example: `"projects/my-project-id/sinks/my-sink-id"`.
-        /// </param>
-        /// <param name="sink">
-        /// Required. The updated sink, whose name is the same identifier that appears
-        /// as part of `sinkName`.  If `sinkName` does not exist, then
-        /// this method creates a new sink.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1058,15 +1170,9 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public override LogSink UpdateSink(
-            string sinkName,
-            LogSink sink,
+            UpdateSinkRequest request,
             CallSettings callSettings = null)
         {
-            UpdateSinkRequest request = new UpdateSinkRequest
-            {
-                SinkName = sinkName,
-                Sink = sink,
-            };
             Modify_UpdateSinkRequest(ref request, ref callSettings);
             return _callUpdateSink.Sync(request, callSettings);
         }
@@ -1074,14 +1180,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Deletes a sink.
         /// </summary>
-        /// <param name="sinkName">
-        /// Required. The resource name of the sink to delete, including the parent
-        /// resource and the sink identifier:
-        ///
-        ///     "projects/[PROJECT_ID]/sinks/[SINK_ID]"
-        ///     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
-        ///
-        /// It is an error if the sink does not exist.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1090,13 +1190,9 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public override Task DeleteSinkAsync(
-            string sinkName,
+            DeleteSinkRequest request,
             CallSettings callSettings = null)
         {
-            DeleteSinkRequest request = new DeleteSinkRequest
-            {
-                SinkName = sinkName,
-            };
             Modify_DeleteSinkRequest(ref request, ref callSettings);
             return _callDeleteSink.Async(request, callSettings);
         }
@@ -1104,14 +1200,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Deletes a sink.
         /// </summary>
-        /// <param name="sinkName">
-        /// Required. The resource name of the sink to delete, including the parent
-        /// resource and the sink identifier:
-        ///
-        ///     "projects/[PROJECT_ID]/sinks/[SINK_ID]"
-        ///     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
-        ///
-        /// It is an error if the sink does not exist.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1120,13 +1210,9 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public override void DeleteSink(
-            string sinkName,
+            DeleteSinkRequest request,
             CallSettings callSettings = null)
         {
-            DeleteSinkRequest request = new DeleteSinkRequest
-            {
-                SinkName = sinkName,
-            };
             Modify_DeleteSinkRequest(ref request, ref callSettings);
             _callDeleteSink.Sync(request, callSettings);
         }

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingServiceV2Client.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingServiceV2Client.cs
@@ -408,11 +408,13 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task DeleteLogAsync(
-            string logName,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            LogNameOneof logName,
+            CallSettings callSettings = null) => DeleteLogAsync(
+                new DeleteLogRequest
+                {
+                    LogNameAsLogNameOneof = logName,
+                },
+                callSettings);
 
         /// <summary>
         /// Deletes all the log entries in a log.
@@ -437,7 +439,7 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task DeleteLogAsync(
-            string logName,
+            LogNameOneof logName,
             CancellationToken cancellationToken) => DeleteLogAsync(
                 logName,
                 CallSettings.FromCancellationToken(cancellationToken));
@@ -465,7 +467,49 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public virtual void DeleteLog(
-            string logName,
+            LogNameOneof logName,
+            CallSettings callSettings = null) => DeleteLog(
+                new DeleteLogRequest
+                {
+                    LogNameAsLogNameOneof = logName,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes all the log entries in a log.
+        /// The log reappears if it receives new entries.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task DeleteLogAsync(
+            DeleteLogRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Deletes all the log entries in a log.
+        /// The log reappears if it receives new entries.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual void DeleteLog(
+            DeleteLogRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -522,14 +566,19 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task<WriteLogEntriesResponse> WriteLogEntriesAsync(
-            string logName,
+            LogNameOneof logName,
             MonitoredResource resource,
             IDictionary<string, string> labels,
             IEnumerable<LogEntry> entries,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => WriteLogEntriesAsync(
+                new WriteLogEntriesRequest
+                {
+                    LogNameAsLogNameOneof = logName,
+                    Resource = resource,
+                    Labels = { labels },
+                    Entries = { entries },
+                },
+                callSettings);
 
         /// <summary>
         /// Writes log entries to Stackdriver Logging.  All log entries are
@@ -582,7 +631,7 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task<WriteLogEntriesResponse> WriteLogEntriesAsync(
-            string logName,
+            LogNameOneof logName,
             MonitoredResource resource,
             IDictionary<string, string> labels,
             IEnumerable<LogEntry> entries,
@@ -644,10 +693,55 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public virtual WriteLogEntriesResponse WriteLogEntries(
-            string logName,
+            LogNameOneof logName,
             MonitoredResource resource,
             IDictionary<string, string> labels,
             IEnumerable<LogEntry> entries,
+            CallSettings callSettings = null) => WriteLogEntries(
+                new WriteLogEntriesRequest
+                {
+                    LogNameAsLogNameOneof = logName,
+                    Resource = resource,
+                    Labels = { labels },
+                    Entries = { entries },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Writes log entries to Stackdriver Logging.  All log entries are
+        /// written by this method.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<WriteLogEntriesResponse> WriteLogEntriesAsync(
+            WriteLogEntriesRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Writes log entries to Stackdriver Logging.  All log entries are
+        /// written by this method.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual WriteLogEntriesResponse WriteLogEntries(
+            WriteLogEntriesRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -701,10 +795,16 @@ namespace Google.Cloud.Logging.V2
             string orderBy,
             string pageToken = null,
             int? pageSize = null,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ListLogEntriesAsync(
+                new ListLogEntriesRequest
+                {
+                    ResourceNames = { resourceNames },
+                    Filter = filter,
+                    OrderBy = orderBy,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
 
         /// <summary>
         /// Lists log entries.  Use this method to retrieve log entries from Cloud
@@ -754,6 +854,92 @@ namespace Google.Cloud.Logging.V2
             string orderBy,
             string pageToken = null,
             int? pageSize = null,
+            CallSettings callSettings = null) => ListLogEntries(
+                new ListLogEntriesRequest
+                {
+                    ResourceNames = { resourceNames },
+                    Filter = filter,
+                    OrderBy = orderBy,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists log entries.  Use this method to retrieve log entries from Cloud
+        /// Logging.  For ways to export log entries, see
+        /// [Exporting Logs](/logging/docs/export).
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="LogEntry"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListLogEntriesResponse, LogEntry> ListLogEntriesAsync(
+            ListLogEntriesRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists log entries.  Use this method to retrieve log entries from Cloud
+        /// Logging.  For ways to export log entries, see
+        /// [Exporting Logs](/logging/docs/export).
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="LogEntry"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListLogEntriesResponse, LogEntry> ListLogEntries(
+            ListLogEntriesRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists the monitored resource descriptors used by Stackdriver Logging.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="MonitoredResourceDescriptor"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListMonitoredResourceDescriptorsResponse, MonitoredResourceDescriptor> ListMonitoredResourceDescriptorsAsync(
+            ListMonitoredResourceDescriptorsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists the monitored resource descriptors used by Stackdriver Logging.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="MonitoredResourceDescriptor"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListMonitoredResourceDescriptorsResponse, MonitoredResourceDescriptor> ListMonitoredResourceDescriptors(
+            ListMonitoredResourceDescriptorsRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -807,17 +993,8 @@ namespace Google.Cloud.Logging.V2
         /// Deletes all the log entries in a log.
         /// The log reappears if it receives new entries.
         /// </summary>
-        /// <param name="logName">
-        /// Required. The resource name of the log to delete:
-        ///
-        ///     "projects/[PROJECT_ID]/logs/[LOG_ID]"
-        ///     "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
-        ///
-        /// `[LOG_ID]` must be URL-encoded. For example,
-        /// `"projects/my-project-id/logs/syslog"`,
-        /// `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
-        /// For more information about log names, see
-        /// [LogEntry][google.logging.v2.LogEntry].
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -826,13 +1003,9 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public override Task DeleteLogAsync(
-            string logName,
+            DeleteLogRequest request,
             CallSettings callSettings = null)
         {
-            DeleteLogRequest request = new DeleteLogRequest
-            {
-                LogName = logName,
-            };
             Modify_DeleteLogRequest(ref request, ref callSettings);
             return _callDeleteLog.Async(request, callSettings);
         }
@@ -841,17 +1014,8 @@ namespace Google.Cloud.Logging.V2
         /// Deletes all the log entries in a log.
         /// The log reappears if it receives new entries.
         /// </summary>
-        /// <param name="logName">
-        /// Required. The resource name of the log to delete:
-        ///
-        ///     "projects/[PROJECT_ID]/logs/[LOG_ID]"
-        ///     "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
-        ///
-        /// `[LOG_ID]` must be URL-encoded. For example,
-        /// `"projects/my-project-id/logs/syslog"`,
-        /// `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
-        /// For more information about log names, see
-        /// [LogEntry][google.logging.v2.LogEntry].
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -860,13 +1024,9 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public override void DeleteLog(
-            string logName,
+            DeleteLogRequest request,
             CallSettings callSettings = null)
         {
-            DeleteLogRequest request = new DeleteLogRequest
-            {
-                LogName = logName,
-            };
             Modify_DeleteLogRequest(ref request, ref callSettings);
             _callDeleteLog.Sync(request, callSettings);
         }
@@ -875,45 +1035,8 @@ namespace Google.Cloud.Logging.V2
         /// Writes log entries to Stackdriver Logging.  All log entries are
         /// written by this method.
         /// </summary>
-        /// <param name="logName">
-        /// Optional. A default log resource name that is assigned to all log entries
-        /// in `entries` that do not specify a value for `log_name`:
-        ///
-        ///     "projects/[PROJECT_ID]/logs/[LOG_ID]"
-        ///     "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
-        ///
-        /// `[LOG_ID]` must be URL-encoded. For example,
-        /// `"projects/my-project-id/logs/syslog"` or
-        /// `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
-        /// For more information about log names, see
-        /// [LogEntry][google.logging.v2.LogEntry].
-        /// </param>
-        /// <param name="resource">
-        /// Optional. A default monitored resource object that is assigned to all log
-        /// entries in `entries` that do not specify a value for `resource`. Example:
-        ///
-        ///     { "type": "gce_instance",
-        ///       "labels": {
-        ///         "zone": "us-central1-a", "instance_id": "00000000000000000000" }}
-        ///
-        /// See [LogEntry][google.logging.v2.LogEntry].
-        /// </param>
-        /// <param name="labels">
-        /// Optional. Default labels that are added to the `labels` field of all log
-        /// entries in `entries`. If a log entry already has a label with the same key
-        /// as a label in this parameter, then the log entry's label is not changed.
-        /// See [LogEntry][google.logging.v2.LogEntry].
-        /// </param>
-        /// <param name="entries">
-        /// Required. The log entries to write. Values supplied for the fields
-        /// `log_name`, `resource`, and `labels` in this `entries.write` request are
-        /// added to those log entries that do not provide their own values for the
-        /// fields.
-        ///
-        /// To improve throughput and to avoid exceeding the
-        /// [quota limit](/logging/quota-policy) for calls to `entries.write`,
-        /// you should write multiple log entries at once rather than
-        /// calling this method for each individual log entry.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -922,19 +1045,9 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<WriteLogEntriesResponse> WriteLogEntriesAsync(
-            string logName,
-            MonitoredResource resource,
-            IDictionary<string, string> labels,
-            IEnumerable<LogEntry> entries,
+            WriteLogEntriesRequest request,
             CallSettings callSettings = null)
         {
-            WriteLogEntriesRequest request = new WriteLogEntriesRequest
-            {
-                LogName = logName,
-                Resource = resource,
-                Labels = { labels },
-                Entries = { entries },
-            };
             Modify_WriteLogEntriesRequest(ref request, ref callSettings);
             return _callWriteLogEntries.Async(request, callSettings);
         }
@@ -943,45 +1056,8 @@ namespace Google.Cloud.Logging.V2
         /// Writes log entries to Stackdriver Logging.  All log entries are
         /// written by this method.
         /// </summary>
-        /// <param name="logName">
-        /// Optional. A default log resource name that is assigned to all log entries
-        /// in `entries` that do not specify a value for `log_name`:
-        ///
-        ///     "projects/[PROJECT_ID]/logs/[LOG_ID]"
-        ///     "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
-        ///
-        /// `[LOG_ID]` must be URL-encoded. For example,
-        /// `"projects/my-project-id/logs/syslog"` or
-        /// `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
-        /// For more information about log names, see
-        /// [LogEntry][google.logging.v2.LogEntry].
-        /// </param>
-        /// <param name="resource">
-        /// Optional. A default monitored resource object that is assigned to all log
-        /// entries in `entries` that do not specify a value for `resource`. Example:
-        ///
-        ///     { "type": "gce_instance",
-        ///       "labels": {
-        ///         "zone": "us-central1-a", "instance_id": "00000000000000000000" }}
-        ///
-        /// See [LogEntry][google.logging.v2.LogEntry].
-        /// </param>
-        /// <param name="labels">
-        /// Optional. Default labels that are added to the `labels` field of all log
-        /// entries in `entries`. If a log entry already has a label with the same key
-        /// as a label in this parameter, then the log entry's label is not changed.
-        /// See [LogEntry][google.logging.v2.LogEntry].
-        /// </param>
-        /// <param name="entries">
-        /// Required. The log entries to write. Values supplied for the fields
-        /// `log_name`, `resource`, and `labels` in this `entries.write` request are
-        /// added to those log entries that do not provide their own values for the
-        /// fields.
-        ///
-        /// To improve throughput and to avoid exceeding the
-        /// [quota limit](/logging/quota-policy) for calls to `entries.write`,
-        /// you should write multiple log entries at once rather than
-        /// calling this method for each individual log entry.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -990,19 +1066,9 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public override WriteLogEntriesResponse WriteLogEntries(
-            string logName,
-            MonitoredResource resource,
-            IDictionary<string, string> labels,
-            IEnumerable<LogEntry> entries,
+            WriteLogEntriesRequest request,
             CallSettings callSettings = null)
         {
-            WriteLogEntriesRequest request = new WriteLogEntriesRequest
-            {
-                LogName = logName,
-                Resource = resource,
-                Labels = { labels },
-                Entries = { entries },
-            };
             Modify_WriteLogEntriesRequest(ref request, ref callSettings);
             return _callWriteLogEntries.Sync(request, callSettings);
         }
@@ -1012,36 +1078,8 @@ namespace Google.Cloud.Logging.V2
         /// Logging.  For ways to export log entries, see
         /// [Exporting Logs](/logging/docs/export).
         /// </summary>
-        /// <param name="resourceNames">
-        /// Required. One or more cloud resources from which to retrieve log
-        /// entries:
-        ///
-        ///     "projects/[PROJECT_ID]"
-        ///     "organizations/[ORGANIZATION_ID]"
-        ///
-        /// Projects listed in the `project_ids` field are added to this list.
-        /// </param>
-        /// <param name="filter">
-        /// Optional. A filter that chooses which log entries to return.  See [Advanced
-        /// Logs Filters](/logging/docs/view/advanced_filters).  Only log entries that
-        /// match the filter are returned.  An empty filter matches all log entries.
-        /// The maximum length of the filter is 20000 characters.
-        /// </param>
-        /// <param name="orderBy">
-        /// Optional. How the results should be sorted.  Presently, the only permitted
-        /// values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
-        /// option returns entries in order of increasing values of
-        /// `LogEntry.timestamp` (oldest first), and the second option returns entries
-        /// in order of decreasing timestamps (newest first).  Entries with equal
-        /// timestamps are returned in order of `LogEntry.insertId`.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1050,21 +1088,9 @@ namespace Google.Cloud.Logging.V2
         /// A pageable asynchronous sequence of <see cref="LogEntry"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListLogEntriesResponse, LogEntry> ListLogEntriesAsync(
-            IEnumerable<string> resourceNames,
-            string filter,
-            string orderBy,
-            string pageToken = null,
-            int? pageSize = null,
+            ListLogEntriesRequest request,
             CallSettings callSettings = null)
         {
-            ListLogEntriesRequest request = new ListLogEntriesRequest
-            {
-                ResourceNames = { resourceNames },
-                Filter = filter,
-                OrderBy = orderBy,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListLogEntriesRequest(ref request, ref callSettings);
             return new GrpcPagedAsyncEnumerable<ListLogEntriesRequest, ListLogEntriesResponse, LogEntry>(_callListLogEntries, request, callSettings);
         }
@@ -1074,36 +1100,8 @@ namespace Google.Cloud.Logging.V2
         /// Logging.  For ways to export log entries, see
         /// [Exporting Logs](/logging/docs/export).
         /// </summary>
-        /// <param name="resourceNames">
-        /// Required. One or more cloud resources from which to retrieve log
-        /// entries:
-        ///
-        ///     "projects/[PROJECT_ID]"
-        ///     "organizations/[ORGANIZATION_ID]"
-        ///
-        /// Projects listed in the `project_ids` field are added to this list.
-        /// </param>
-        /// <param name="filter">
-        /// Optional. A filter that chooses which log entries to return.  See [Advanced
-        /// Logs Filters](/logging/docs/view/advanced_filters).  Only log entries that
-        /// match the filter are returned.  An empty filter matches all log entries.
-        /// The maximum length of the filter is 20000 characters.
-        /// </param>
-        /// <param name="orderBy">
-        /// Optional. How the results should be sorted.  Presently, the only permitted
-        /// values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
-        /// option returns entries in order of increasing values of
-        /// `LogEntry.timestamp` (oldest first), and the second option returns entries
-        /// in order of decreasing timestamps (newest first).  Entries with equal
-        /// timestamps are returned in order of `LogEntry.insertId`.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1112,23 +1110,51 @@ namespace Google.Cloud.Logging.V2
         /// A pageable sequence of <see cref="LogEntry"/> resources.
         /// </returns>
         public override PagedEnumerable<ListLogEntriesResponse, LogEntry> ListLogEntries(
-            IEnumerable<string> resourceNames,
-            string filter,
-            string orderBy,
-            string pageToken = null,
-            int? pageSize = null,
+            ListLogEntriesRequest request,
             CallSettings callSettings = null)
         {
-            ListLogEntriesRequest request = new ListLogEntriesRequest
-            {
-                ResourceNames = { resourceNames },
-                Filter = filter,
-                OrderBy = orderBy,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListLogEntriesRequest(ref request, ref callSettings);
             return new GrpcPagedEnumerable<ListLogEntriesRequest, ListLogEntriesResponse, LogEntry>(_callListLogEntries, request, callSettings);
+        }
+
+        /// <summary>
+        /// Lists the monitored resource descriptors used by Stackdriver Logging.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="MonitoredResourceDescriptor"/> resources.
+        /// </returns>
+        public override PagedAsyncEnumerable<ListMonitoredResourceDescriptorsResponse, MonitoredResourceDescriptor> ListMonitoredResourceDescriptorsAsync(
+            ListMonitoredResourceDescriptorsRequest request,
+            CallSettings callSettings = null)
+        {
+            Modify_ListMonitoredResourceDescriptorsRequest(ref request, ref callSettings);
+            return new GrpcPagedAsyncEnumerable<ListMonitoredResourceDescriptorsRequest, ListMonitoredResourceDescriptorsResponse, MonitoredResourceDescriptor>(_callListMonitoredResourceDescriptors, request, callSettings);
+        }
+
+        /// <summary>
+        /// Lists the monitored resource descriptors used by Stackdriver Logging.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="MonitoredResourceDescriptor"/> resources.
+        /// </returns>
+        public override PagedEnumerable<ListMonitoredResourceDescriptorsResponse, MonitoredResourceDescriptor> ListMonitoredResourceDescriptors(
+            ListMonitoredResourceDescriptorsRequest request,
+            CallSettings callSettings = null)
+        {
+            Modify_ListMonitoredResourceDescriptorsRequest(ref request, ref callSettings);
+            return new GrpcPagedEnumerable<ListMonitoredResourceDescriptorsRequest, ListMonitoredResourceDescriptorsResponse, MonitoredResourceDescriptor>(_callListMonitoredResourceDescriptors, request, callSettings);
         }
 
     }
@@ -1142,6 +1168,18 @@ namespace Google.Cloud.Logging.V2
         /// Returns an enumerator that iterates through the resources in this response.
         /// </summary>
         public IEnumerator<LogEntry> GetEnumerator() => Entries.GetEnumerator();
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public partial class ListMonitoredResourceDescriptorsRequest : IPageRequest { }
+    public partial class ListMonitoredResourceDescriptorsResponse : IPageResponse<MonitoredResourceDescriptor>
+    {
+        /// <summary>
+        /// Returns an enumerator that iterates through the resources in this response.
+        /// </summary>
+        public IEnumerator<MonitoredResourceDescriptor> GetEnumerator() => ResourceDescriptors.GetEnumerator();
 
         /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/MetricsServiceV2Client.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/MetricsServiceV2Client.cs
@@ -397,13 +397,17 @@ namespace Google.Cloud.Logging.V2
         /// A pageable asynchronous sequence of <see cref="LogMetric"/> resources.
         /// </returns>
         public virtual PagedAsyncEnumerable<ListLogMetricsResponse, LogMetric> ListLogMetricsAsync(
-            string parent,
+            ParentNameOneof parent,
             string pageToken = null,
             int? pageSize = null,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ListLogMetricsAsync(
+                new ListLogMetricsRequest
+                {
+                    ParentAsParentNameOneof = parent,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
 
         /// <summary>
         /// Lists logs-based metrics.
@@ -428,9 +432,51 @@ namespace Google.Cloud.Logging.V2
         /// A pageable sequence of <see cref="LogMetric"/> resources.
         /// </returns>
         public virtual PagedEnumerable<ListLogMetricsResponse, LogMetric> ListLogMetrics(
-            string parent,
+            ParentNameOneof parent,
             string pageToken = null,
             int? pageSize = null,
+            CallSettings callSettings = null) => ListLogMetrics(
+                new ListLogMetricsRequest
+                {
+                    ParentAsParentNameOneof = parent,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists logs-based metrics.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="LogMetric"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListLogMetricsResponse, LogMetric> ListLogMetricsAsync(
+            ListLogMetricsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists logs-based metrics.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="LogMetric"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListLogMetricsResponse, LogMetric> ListLogMetrics(
+            ListLogMetricsRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -451,11 +497,13 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task<LogMetric> GetLogMetricAsync(
-            string metricName,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            MetricNameOneof metricName,
+            CallSettings callSettings = null) => GetLogMetricAsync(
+                new GetLogMetricRequest
+                {
+                    MetricNameAsMetricNameOneof = metricName,
+                },
+                callSettings);
 
         /// <summary>
         /// Gets a logs-based metric.
@@ -472,7 +520,7 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task<LogMetric> GetLogMetricAsync(
-            string metricName,
+            MetricNameOneof metricName,
             CancellationToken cancellationToken) => GetLogMetricAsync(
                 metricName,
                 CallSettings.FromCancellationToken(cancellationToken));
@@ -492,7 +540,47 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public virtual LogMetric GetLogMetric(
-            string metricName,
+            MetricNameOneof metricName,
+            CallSettings callSettings = null) => GetLogMetric(
+                new GetLogMetricRequest
+                {
+                    MetricNameAsMetricNameOneof = metricName,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a logs-based metric.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<LogMetric> GetLogMetricAsync(
+            GetLogMetricRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets a logs-based metric.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual LogMetric GetLogMetric(
+            GetLogMetricRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -519,12 +607,15 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task<LogMetric> CreateLogMetricAsync(
-            string parent,
+            ParentNameOneof parent,
             LogMetric metric,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => CreateLogMetricAsync(
+                new CreateLogMetricRequest
+                {
+                    ParentAsParentNameOneof = parent,
+                    Metric = metric,
+                },
+                callSettings);
 
         /// <summary>
         /// Creates a logs-based metric.
@@ -547,7 +638,7 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task<LogMetric> CreateLogMetricAsync(
-            string parent,
+            ParentNameOneof parent,
             LogMetric metric,
             CancellationToken cancellationToken) => CreateLogMetricAsync(
                 parent,
@@ -575,8 +666,49 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public virtual LogMetric CreateLogMetric(
-            string parent,
+            ParentNameOneof parent,
             LogMetric metric,
+            CallSettings callSettings = null) => CreateLogMetric(
+                new CreateLogMetricRequest
+                {
+                    ParentAsParentNameOneof = parent,
+                    Metric = metric,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates a logs-based metric.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<LogMetric> CreateLogMetricAsync(
+            CreateLogMetricRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Creates a logs-based metric.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual LogMetric CreateLogMetric(
+            CreateLogMetricRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -604,12 +736,15 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task<LogMetric> UpdateLogMetricAsync(
-            string metricName,
+            MetricNameOneof metricName,
             LogMetric metric,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => UpdateLogMetricAsync(
+                new UpdateLogMetricRequest
+                {
+                    MetricNameAsMetricNameOneof = metricName,
+                    Metric = metric,
+                },
+                callSettings);
 
         /// <summary>
         /// Creates or updates a logs-based metric.
@@ -633,7 +768,7 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task<LogMetric> UpdateLogMetricAsync(
-            string metricName,
+            MetricNameOneof metricName,
             LogMetric metric,
             CancellationToken cancellationToken) => UpdateLogMetricAsync(
                 metricName,
@@ -662,8 +797,49 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public virtual LogMetric UpdateLogMetric(
-            string metricName,
+            MetricNameOneof metricName,
             LogMetric metric,
+            CallSettings callSettings = null) => UpdateLogMetric(
+                new UpdateLogMetricRequest
+                {
+                    MetricNameAsMetricNameOneof = metricName,
+                    Metric = metric,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates or updates a logs-based metric.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<LogMetric> UpdateLogMetricAsync(
+            UpdateLogMetricRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Creates or updates a logs-based metric.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual LogMetric UpdateLogMetric(
+            UpdateLogMetricRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -684,11 +860,13 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task DeleteLogMetricAsync(
-            string metricName,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            MetricNameOneof metricName,
+            CallSettings callSettings = null) => DeleteLogMetricAsync(
+                new DeleteLogMetricRequest
+                {
+                    MetricNameAsMetricNameOneof = metricName,
+                },
+                callSettings);
 
         /// <summary>
         /// Deletes a logs-based metric.
@@ -705,7 +883,7 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual Task DeleteLogMetricAsync(
-            string metricName,
+            MetricNameOneof metricName,
             CancellationToken cancellationToken) => DeleteLogMetricAsync(
                 metricName,
                 CallSettings.FromCancellationToken(cancellationToken));
@@ -725,7 +903,47 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public virtual void DeleteLogMetric(
-            string metricName,
+            MetricNameOneof metricName,
+            CallSettings callSettings = null) => DeleteLogMetric(
+                new DeleteLogMetricRequest
+                {
+                    MetricNameAsMetricNameOneof = metricName,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes a logs-based metric.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task DeleteLogMetricAsync(
+            DeleteLogMetricRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Deletes a logs-based metric.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual void DeleteLogMetric(
+            DeleteLogMetricRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -782,18 +1000,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Lists logs-based metrics.
         /// </summary>
-        /// <param name="parent">
-        /// Required. The name of the project containing the metrics:
-        ///
-        ///     "projects/[PROJECT_ID]"
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -802,17 +1010,9 @@ namespace Google.Cloud.Logging.V2
         /// A pageable asynchronous sequence of <see cref="LogMetric"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListLogMetricsResponse, LogMetric> ListLogMetricsAsync(
-            string parent,
-            string pageToken = null,
-            int? pageSize = null,
+            ListLogMetricsRequest request,
             CallSettings callSettings = null)
         {
-            ListLogMetricsRequest request = new ListLogMetricsRequest
-            {
-                Parent = parent,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListLogMetricsRequest(ref request, ref callSettings);
             return new GrpcPagedAsyncEnumerable<ListLogMetricsRequest, ListLogMetricsResponse, LogMetric>(_callListLogMetrics, request, callSettings);
         }
@@ -820,18 +1020,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Lists logs-based metrics.
         /// </summary>
-        /// <param name="parent">
-        /// Required. The name of the project containing the metrics:
-        ///
-        ///     "projects/[PROJECT_ID]"
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -840,17 +1030,9 @@ namespace Google.Cloud.Logging.V2
         /// A pageable sequence of <see cref="LogMetric"/> resources.
         /// </returns>
         public override PagedEnumerable<ListLogMetricsResponse, LogMetric> ListLogMetrics(
-            string parent,
-            string pageToken = null,
-            int? pageSize = null,
+            ListLogMetricsRequest request,
             CallSettings callSettings = null)
         {
-            ListLogMetricsRequest request = new ListLogMetricsRequest
-            {
-                Parent = parent,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListLogMetricsRequest(ref request, ref callSettings);
             return new GrpcPagedEnumerable<ListLogMetricsRequest, ListLogMetricsResponse, LogMetric>(_callListLogMetrics, request, callSettings);
         }
@@ -858,10 +1040,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Gets a logs-based metric.
         /// </summary>
-        /// <param name="metricName">
-        /// The resource name of the desired metric:
-        ///
-        ///     "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -870,13 +1050,9 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<LogMetric> GetLogMetricAsync(
-            string metricName,
+            GetLogMetricRequest request,
             CallSettings callSettings = null)
         {
-            GetLogMetricRequest request = new GetLogMetricRequest
-            {
-                MetricName = metricName,
-            };
             Modify_GetLogMetricRequest(ref request, ref callSettings);
             return _callGetLogMetric.Async(request, callSettings);
         }
@@ -884,10 +1060,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Gets a logs-based metric.
         /// </summary>
-        /// <param name="metricName">
-        /// The resource name of the desired metric:
-        ///
-        ///     "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -896,13 +1070,9 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public override LogMetric GetLogMetric(
-            string metricName,
+            GetLogMetricRequest request,
             CallSettings callSettings = null)
         {
-            GetLogMetricRequest request = new GetLogMetricRequest
-            {
-                MetricName = metricName,
-            };
             Modify_GetLogMetricRequest(ref request, ref callSettings);
             return _callGetLogMetric.Sync(request, callSettings);
         }
@@ -910,16 +1080,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Creates a logs-based metric.
         /// </summary>
-        /// <param name="parent">
-        /// The resource name of the project in which to create the metric:
-        ///
-        ///     "projects/[PROJECT_ID]"
-        ///
-        /// The new metric must be provided in the request.
-        /// </param>
-        /// <param name="metric">
-        /// The new logs-based metric, which must not have an identifier that
-        /// already exists.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -928,15 +1090,9 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<LogMetric> CreateLogMetricAsync(
-            string parent,
-            LogMetric metric,
+            CreateLogMetricRequest request,
             CallSettings callSettings = null)
         {
-            CreateLogMetricRequest request = new CreateLogMetricRequest
-            {
-                Parent = parent,
-                Metric = metric,
-            };
             Modify_CreateLogMetricRequest(ref request, ref callSettings);
             return _callCreateLogMetric.Async(request, callSettings);
         }
@@ -944,16 +1100,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Creates a logs-based metric.
         /// </summary>
-        /// <param name="parent">
-        /// The resource name of the project in which to create the metric:
-        ///
-        ///     "projects/[PROJECT_ID]"
-        ///
-        /// The new metric must be provided in the request.
-        /// </param>
-        /// <param name="metric">
-        /// The new logs-based metric, which must not have an identifier that
-        /// already exists.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -962,15 +1110,9 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public override LogMetric CreateLogMetric(
-            string parent,
-            LogMetric metric,
+            CreateLogMetricRequest request,
             CallSettings callSettings = null)
         {
-            CreateLogMetricRequest request = new CreateLogMetricRequest
-            {
-                Parent = parent,
-                Metric = metric,
-            };
             Modify_CreateLogMetricRequest(ref request, ref callSettings);
             return _callCreateLogMetric.Sync(request, callSettings);
         }
@@ -978,17 +1120,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Creates or updates a logs-based metric.
         /// </summary>
-        /// <param name="metricName">
-        /// The resource name of the metric to update:
-        ///
-        ///     "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-        ///
-        /// The updated metric must be provided in the request and it's
-        /// `name` field must be the same as `[METRIC_ID]` If the metric
-        /// does not exist in `[PROJECT_ID]`, then a new metric is created.
-        /// </param>
-        /// <param name="metric">
-        /// The updated metric.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -997,15 +1130,9 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<LogMetric> UpdateLogMetricAsync(
-            string metricName,
-            LogMetric metric,
+            UpdateLogMetricRequest request,
             CallSettings callSettings = null)
         {
-            UpdateLogMetricRequest request = new UpdateLogMetricRequest
-            {
-                MetricName = metricName,
-                Metric = metric,
-            };
             Modify_UpdateLogMetricRequest(ref request, ref callSettings);
             return _callUpdateLogMetric.Async(request, callSettings);
         }
@@ -1013,17 +1140,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Creates or updates a logs-based metric.
         /// </summary>
-        /// <param name="metricName">
-        /// The resource name of the metric to update:
-        ///
-        ///     "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-        ///
-        /// The updated metric must be provided in the request and it's
-        /// `name` field must be the same as `[METRIC_ID]` If the metric
-        /// does not exist in `[PROJECT_ID]`, then a new metric is created.
-        /// </param>
-        /// <param name="metric">
-        /// The updated metric.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1032,15 +1150,9 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public override LogMetric UpdateLogMetric(
-            string metricName,
-            LogMetric metric,
+            UpdateLogMetricRequest request,
             CallSettings callSettings = null)
         {
-            UpdateLogMetricRequest request = new UpdateLogMetricRequest
-            {
-                MetricName = metricName,
-                Metric = metric,
-            };
             Modify_UpdateLogMetricRequest(ref request, ref callSettings);
             return _callUpdateLogMetric.Sync(request, callSettings);
         }
@@ -1048,10 +1160,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Deletes a logs-based metric.
         /// </summary>
-        /// <param name="metricName">
-        /// The resource name of the metric to delete:
-        ///
-        ///     "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1060,13 +1170,9 @@ namespace Google.Cloud.Logging.V2
         /// A Task containing the RPC response.
         /// </returns>
         public override Task DeleteLogMetricAsync(
-            string metricName,
+            DeleteLogMetricRequest request,
             CallSettings callSettings = null)
         {
-            DeleteLogMetricRequest request = new DeleteLogMetricRequest
-            {
-                MetricName = metricName,
-            };
             Modify_DeleteLogMetricRequest(ref request, ref callSettings);
             return _callDeleteLogMetric.Async(request, callSettings);
         }
@@ -1074,10 +1180,8 @@ namespace Google.Cloud.Logging.V2
         /// <summary>
         /// Deletes a logs-based metric.
         /// </summary>
-        /// <param name="metricName">
-        /// The resource name of the metric to delete:
-        ///
-        ///     "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1086,13 +1190,9 @@ namespace Google.Cloud.Logging.V2
         /// The RPC response.
         /// </returns>
         public override void DeleteLogMetric(
-            string metricName,
+            DeleteLogMetricRequest request,
             CallSettings callSettings = null)
         {
-            DeleteLogMetricRequest request = new DeleteLogMetricRequest
-            {
-                MetricName = metricName,
-            };
             Modify_DeleteLogMetricRequest(ref request, ref callSettings);
             _callDeleteLogMetric.Sync(request, callSettings);
         }

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ResourceNames.cs
@@ -21,42 +21,42 @@ using System.Linq;
 namespace Google.Cloud.Logging.V2
 {
     /// <summary>
-    /// Resource name for the 'parent' resource.
+    /// Resource name for the 'project' resource.
     /// </summary>
-    public sealed partial class ParentName : IResourceName, IEquatable<ParentName>
+    public sealed partial class ProjectName : IResourceName, IEquatable<ProjectName>
     {
         private static readonly PathTemplate s_template = new PathTemplate("projects/{project}");
 
         /// <summary>
-        /// Parses a parent resource name in string form into a <see cref="ParentName"/>.
+        /// Parses a project resource name in string form into a <see cref="ProjectName"/>.
         /// </summary>
-        /// <param name="parentName">The parent resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="ParentName"/> if successful.</returns>
-        public static ParentName Parse(string parentName)
+        /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ProjectName"/> if successful.</returns>
+        public static ProjectName Parse(string projectName)
         {
-            GaxPreconditions.CheckNotNull(parentName, nameof(parentName));
-            TemplatedResourceName resourceName = s_template.ParseName(parentName);
-            return new ParentName(resourceName[0]);
+            GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
+            TemplatedResourceName resourceName = s_template.ParseName(projectName);
+            return new ProjectName(resourceName[0]);
         }
 
         /// <summary>
-        /// Tries to parse parent resource name in string form into a <see cref="ParentName"/>/
+        /// Tries to parse project resource name in string form into a <see cref="ProjectName"/>/
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="parentName"/> is null,
+        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="projectName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="parentName">The parent resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="ParentName"/>,
+        /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ProjectName"/>,
         /// or <c>null</c> if parsing fails.</param>
         /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string parentName, out ParentName result)
+        public static bool TryParse(string projectName, out ProjectName result)
         {
-            GaxPreconditions.CheckNotNull(parentName, nameof(parentName));
+            GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
             TemplatedResourceName resourceName;
-            if (s_template.TryParseName(parentName, out resourceName))
+            if (s_template.TryParseName(projectName, out resourceName))
             {
-                result = new ParentName(resourceName[0]);
+                result = new ProjectName(resourceName[0]);
                 return true;
             }
             else
@@ -67,10 +67,10 @@ namespace Google.Cloud.Logging.V2
         }
 
         /// <summary>
-        /// Constructs a parent name from its component parts.
+        /// Constructs a project name from its component parts.
         /// </summary>
         /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        public ParentName(string projectId)
+        public ProjectName(string projectId)
         {
             ProjectId = GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
         }
@@ -90,16 +90,105 @@ namespace Google.Cloud.Logging.V2
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ParentName);
+        public override bool Equals(object obj) => Equals(obj as ProjectName);
 
         /// <inheritdoc />
-        public bool Equals(ParentName other) => ToString() == other?.ToString();
+        public bool Equals(ProjectName other) => ToString() == other?.ToString();
 
         /// <inheritdoc />
-        public static bool operator ==(ParentName a, ParentName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(ProjectName a, ProjectName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc />
-        public static bool operator !=(ParentName a, ParentName b) => !(a == b);
+        public static bool operator !=(ProjectName a, ProjectName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'log' resource.
+    /// </summary>
+    public sealed partial class LogName : IResourceName, IEquatable<LogName>
+    {
+        private static readonly PathTemplate s_template = new PathTemplate("projects/{project}/logs/{log}");
+
+        /// <summary>
+        /// Parses a log resource name in string form into a <see cref="LogName"/>.
+        /// </summary>
+        /// <param name="logName">The log resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="LogName"/> if successful.</returns>
+        public static LogName Parse(string logName)
+        {
+            GaxPreconditions.CheckNotNull(logName, nameof(logName));
+            TemplatedResourceName resourceName = s_template.ParseName(logName);
+            return new LogName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse log resource name in string form into a <see cref="LogName"/>/
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="logName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="logName">The log resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="LogName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string logName, out LogName result)
+        {
+            GaxPreconditions.CheckNotNull(logName, nameof(logName));
+            TemplatedResourceName resourceName;
+            if (s_template.TryParseName(logName, out resourceName))
+            {
+                result = new LogName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a log name from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="logId">The log ID. Must not be <c>null</c>.</param>
+        public LogName(string projectId, string logId)
+        {
+            ProjectId = GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            LogId = GaxPreconditions.CheckNotNull(logId, nameof(logId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The log ID. Never <c>null</c>.
+        /// </summary>
+        public string LogId { get; }
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, LogId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as LogName);
+
+        /// <inheritdoc />
+        public bool Equals(LogName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(LogName a, LogName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(LogName a, LogName b) => !(a == b);
     }
 
     /// <summary>
@@ -281,42 +370,42 @@ namespace Google.Cloud.Logging.V2
     }
 
     /// <summary>
-    /// Resource name for the 'log' resource.
+    /// Resource name for the 'organization' resource.
     /// </summary>
-    public sealed partial class LogName : IResourceName, IEquatable<LogName>
+    public sealed partial class OrganizationName : IResourceName, IEquatable<OrganizationName>
     {
-        private static readonly PathTemplate s_template = new PathTemplate("projects/{project}/logs/{log}");
+        private static readonly PathTemplate s_template = new PathTemplate("organizations/{organization}");
 
         /// <summary>
-        /// Parses a log resource name in string form into a <see cref="LogName"/>.
+        /// Parses a organization resource name in string form into a <see cref="OrganizationName"/>.
         /// </summary>
-        /// <param name="logName">The log resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="LogName"/> if successful.</returns>
-        public static LogName Parse(string logName)
+        /// <param name="organizationName">The organization resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="OrganizationName"/> if successful.</returns>
+        public static OrganizationName Parse(string organizationName)
         {
-            GaxPreconditions.CheckNotNull(logName, nameof(logName));
-            TemplatedResourceName resourceName = s_template.ParseName(logName);
-            return new LogName(resourceName[0], resourceName[1]);
+            GaxPreconditions.CheckNotNull(organizationName, nameof(organizationName));
+            TemplatedResourceName resourceName = s_template.ParseName(organizationName);
+            return new OrganizationName(resourceName[0]);
         }
 
         /// <summary>
-        /// Tries to parse log resource name in string form into a <see cref="LogName"/>/
+        /// Tries to parse organization resource name in string form into a <see cref="OrganizationName"/>/
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="logName"/> is null,
+        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="organizationName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="logName">The log resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="LogName"/>,
+        /// <param name="organizationName">The organization resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="OrganizationName"/>,
         /// or <c>null</c> if parsing fails.</param>
         /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string logName, out LogName result)
+        public static bool TryParse(string organizationName, out OrganizationName result)
         {
-            GaxPreconditions.CheckNotNull(logName, nameof(logName));
+            GaxPreconditions.CheckNotNull(organizationName, nameof(organizationName));
             TemplatedResourceName resourceName;
-            if (s_template.TryParseName(logName, out resourceName))
+            if (s_template.TryParseName(organizationName, out resourceName))
             {
-                result = new LogName(resourceName[0], resourceName[1]);
+                result = new OrganizationName(resourceName[0]);
                 return true;
             }
             else
@@ -327,20 +416,102 @@ namespace Google.Cloud.Logging.V2
         }
 
         /// <summary>
-        /// Constructs a log name from its component parts.
+        /// Constructs a organization name from its component parts.
         /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="logId">The log ID. Must not be <c>null</c>.</param>
-        public LogName(string projectId, string logId)
+        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
+        public OrganizationName(string organizationId)
         {
-            ProjectId = GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            OrganizationId = GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
+        }
+
+        /// <summary>
+        /// The organization ID. Never <c>null</c>.
+        /// </summary>
+        public string OrganizationId { get; }
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(OrganizationId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as OrganizationName);
+
+        /// <inheritdoc />
+        public bool Equals(OrganizationName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(OrganizationName a, OrganizationName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(OrganizationName a, OrganizationName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'organization_log' resource.
+    /// </summary>
+    public sealed partial class OrganizationLogName : IResourceName, IEquatable<OrganizationLogName>
+    {
+        private static readonly PathTemplate s_template = new PathTemplate("organizations/{organization}/logs/{log}");
+
+        /// <summary>
+        /// Parses a organization_log resource name in string form into a <see cref="OrganizationLogName"/>.
+        /// </summary>
+        /// <param name="organizationLogName">The organization_log resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="OrganizationLogName"/> if successful.</returns>
+        public static OrganizationLogName Parse(string organizationLogName)
+        {
+            GaxPreconditions.CheckNotNull(organizationLogName, nameof(organizationLogName));
+            TemplatedResourceName resourceName = s_template.ParseName(organizationLogName);
+            return new OrganizationLogName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse organization_log resource name in string form into a <see cref="OrganizationLogName"/>/
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="organizationLogName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="organizationLogName">The organization_log resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="OrganizationLogName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string organizationLogName, out OrganizationLogName result)
+        {
+            GaxPreconditions.CheckNotNull(organizationLogName, nameof(organizationLogName));
+            TemplatedResourceName resourceName;
+            if (s_template.TryParseName(organizationLogName, out resourceName))
+            {
+                result = new OrganizationLogName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a organization_log name from its component parts.
+        /// </summary>
+        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
+        /// <param name="logId">The log ID. Must not be <c>null</c>.</param>
+        public OrganizationLogName(string organizationId, string logId)
+        {
+            OrganizationId = GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
             LogId = GaxPreconditions.CheckNotNull(logId, nameof(logId));
         }
 
         /// <summary>
-        /// The project ID. Never <c>null</c>.
+        /// The organization ID. Never <c>null</c>.
         /// </summary>
-        public string ProjectId { get; }
+        public string OrganizationId { get; }
 
         /// <summary>
         /// The log ID. Never <c>null</c>.
@@ -351,24 +522,1769 @@ namespace Google.Cloud.Logging.V2
         public ResourceNameKind Kind => ResourceNameKind.Simple;
 
         /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, LogId);
+        public override string ToString() => s_template.Expand(OrganizationId, LogId);
 
         /// <inheritdoc />
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as LogName);
+        public override bool Equals(object obj) => Equals(obj as OrganizationLogName);
 
         /// <inheritdoc />
-        public bool Equals(LogName other) => ToString() == other?.ToString();
+        public bool Equals(OrganizationLogName other) => ToString() == other?.ToString();
 
         /// <inheritdoc />
-        public static bool operator ==(LogName a, LogName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(OrganizationLogName a, OrganizationLogName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc />
-        public static bool operator !=(LogName a, LogName b) => !(a == b);
+        public static bool operator !=(OrganizationLogName a, OrganizationLogName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'organization_sink' resource.
+    /// </summary>
+    public sealed partial class OrganizationSinkName : IResourceName, IEquatable<OrganizationSinkName>
+    {
+        private static readonly PathTemplate s_template = new PathTemplate("organizations/{organization}/sinks/{sink}");
+
+        /// <summary>
+        /// Parses a organization_sink resource name in string form into a <see cref="OrganizationSinkName"/>.
+        /// </summary>
+        /// <param name="organizationSinkName">The organization_sink resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="OrganizationSinkName"/> if successful.</returns>
+        public static OrganizationSinkName Parse(string organizationSinkName)
+        {
+            GaxPreconditions.CheckNotNull(organizationSinkName, nameof(organizationSinkName));
+            TemplatedResourceName resourceName = s_template.ParseName(organizationSinkName);
+            return new OrganizationSinkName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse organization_sink resource name in string form into a <see cref="OrganizationSinkName"/>/
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="organizationSinkName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="organizationSinkName">The organization_sink resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="OrganizationSinkName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string organizationSinkName, out OrganizationSinkName result)
+        {
+            GaxPreconditions.CheckNotNull(organizationSinkName, nameof(organizationSinkName));
+            TemplatedResourceName resourceName;
+            if (s_template.TryParseName(organizationSinkName, out resourceName))
+            {
+                result = new OrganizationSinkName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a organization_sink name from its component parts.
+        /// </summary>
+        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
+        /// <param name="sinkId">The sink ID. Must not be <c>null</c>.</param>
+        public OrganizationSinkName(string organizationId, string sinkId)
+        {
+            OrganizationId = GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
+            SinkId = GaxPreconditions.CheckNotNull(sinkId, nameof(sinkId));
+        }
+
+        /// <summary>
+        /// The organization ID. Never <c>null</c>.
+        /// </summary>
+        public string OrganizationId { get; }
+
+        /// <summary>
+        /// The sink ID. Never <c>null</c>.
+        /// </summary>
+        public string SinkId { get; }
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(OrganizationId, SinkId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as OrganizationSinkName);
+
+        /// <inheritdoc />
+        public bool Equals(OrganizationSinkName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(OrganizationSinkName a, OrganizationSinkName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(OrganizationSinkName a, OrganizationSinkName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'folder' resource.
+    /// </summary>
+    public sealed partial class FolderName : IResourceName, IEquatable<FolderName>
+    {
+        private static readonly PathTemplate s_template = new PathTemplate("folders/{folder}");
+
+        /// <summary>
+        /// Parses a folder resource name in string form into a <see cref="FolderName"/>.
+        /// </summary>
+        /// <param name="folderName">The folder resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="FolderName"/> if successful.</returns>
+        public static FolderName Parse(string folderName)
+        {
+            GaxPreconditions.CheckNotNull(folderName, nameof(folderName));
+            TemplatedResourceName resourceName = s_template.ParseName(folderName);
+            return new FolderName(resourceName[0]);
+        }
+
+        /// <summary>
+        /// Tries to parse folder resource name in string form into a <see cref="FolderName"/>/
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="folderName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="folderName">The folder resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="FolderName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string folderName, out FolderName result)
+        {
+            GaxPreconditions.CheckNotNull(folderName, nameof(folderName));
+            TemplatedResourceName resourceName;
+            if (s_template.TryParseName(folderName, out resourceName))
+            {
+                result = new FolderName(resourceName[0]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a folder name from its component parts.
+        /// </summary>
+        /// <param name="folderId">The folder ID. Must not be <c>null</c>.</param>
+        public FolderName(string folderId)
+        {
+            FolderId = GaxPreconditions.CheckNotNull(folderId, nameof(folderId));
+        }
+
+        /// <summary>
+        /// The folder ID. Never <c>null</c>.
+        /// </summary>
+        public string FolderId { get; }
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(FolderId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as FolderName);
+
+        /// <inheritdoc />
+        public bool Equals(FolderName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(FolderName a, FolderName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(FolderName a, FolderName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'folder_log' resource.
+    /// </summary>
+    public sealed partial class FolderLogName : IResourceName, IEquatable<FolderLogName>
+    {
+        private static readonly PathTemplate s_template = new PathTemplate("folders/{folder}/logs/{log}");
+
+        /// <summary>
+        /// Parses a folder_log resource name in string form into a <see cref="FolderLogName"/>.
+        /// </summary>
+        /// <param name="folderLogName">The folder_log resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="FolderLogName"/> if successful.</returns>
+        public static FolderLogName Parse(string folderLogName)
+        {
+            GaxPreconditions.CheckNotNull(folderLogName, nameof(folderLogName));
+            TemplatedResourceName resourceName = s_template.ParseName(folderLogName);
+            return new FolderLogName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse folder_log resource name in string form into a <see cref="FolderLogName"/>/
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="folderLogName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="folderLogName">The folder_log resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="FolderLogName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string folderLogName, out FolderLogName result)
+        {
+            GaxPreconditions.CheckNotNull(folderLogName, nameof(folderLogName));
+            TemplatedResourceName resourceName;
+            if (s_template.TryParseName(folderLogName, out resourceName))
+            {
+                result = new FolderLogName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a folder_log name from its component parts.
+        /// </summary>
+        /// <param name="folderId">The folder ID. Must not be <c>null</c>.</param>
+        /// <param name="logId">The log ID. Must not be <c>null</c>.</param>
+        public FolderLogName(string folderId, string logId)
+        {
+            FolderId = GaxPreconditions.CheckNotNull(folderId, nameof(folderId));
+            LogId = GaxPreconditions.CheckNotNull(logId, nameof(logId));
+        }
+
+        /// <summary>
+        /// The folder ID. Never <c>null</c>.
+        /// </summary>
+        public string FolderId { get; }
+
+        /// <summary>
+        /// The log ID. Never <c>null</c>.
+        /// </summary>
+        public string LogId { get; }
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(FolderId, LogId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as FolderLogName);
+
+        /// <inheritdoc />
+        public bool Equals(FolderLogName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(FolderLogName a, FolderLogName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(FolderLogName a, FolderLogName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'folder_sink' resource.
+    /// </summary>
+    public sealed partial class FolderSinkName : IResourceName, IEquatable<FolderSinkName>
+    {
+        private static readonly PathTemplate s_template = new PathTemplate("folders/{folder}/sinks/{sink}");
+
+        /// <summary>
+        /// Parses a folder_sink resource name in string form into a <see cref="FolderSinkName"/>.
+        /// </summary>
+        /// <param name="folderSinkName">The folder_sink resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="FolderSinkName"/> if successful.</returns>
+        public static FolderSinkName Parse(string folderSinkName)
+        {
+            GaxPreconditions.CheckNotNull(folderSinkName, nameof(folderSinkName));
+            TemplatedResourceName resourceName = s_template.ParseName(folderSinkName);
+            return new FolderSinkName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse folder_sink resource name in string form into a <see cref="FolderSinkName"/>/
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="folderSinkName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="folderSinkName">The folder_sink resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="FolderSinkName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string folderSinkName, out FolderSinkName result)
+        {
+            GaxPreconditions.CheckNotNull(folderSinkName, nameof(folderSinkName));
+            TemplatedResourceName resourceName;
+            if (s_template.TryParseName(folderSinkName, out resourceName))
+            {
+                result = new FolderSinkName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a folder_sink name from its component parts.
+        /// </summary>
+        /// <param name="folderId">The folder ID. Must not be <c>null</c>.</param>
+        /// <param name="sinkId">The sink ID. Must not be <c>null</c>.</param>
+        public FolderSinkName(string folderId, string sinkId)
+        {
+            FolderId = GaxPreconditions.CheckNotNull(folderId, nameof(folderId));
+            SinkId = GaxPreconditions.CheckNotNull(sinkId, nameof(sinkId));
+        }
+
+        /// <summary>
+        /// The folder ID. Never <c>null</c>.
+        /// </summary>
+        public string FolderId { get; }
+
+        /// <summary>
+        /// The sink ID. Never <c>null</c>.
+        /// </summary>
+        public string SinkId { get; }
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(FolderId, SinkId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as FolderSinkName);
+
+        /// <inheritdoc />
+        public bool Equals(FolderSinkName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(FolderSinkName a, FolderSinkName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(FolderSinkName a, FolderSinkName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'billing' resource.
+    /// </summary>
+    public sealed partial class BillingName : IResourceName, IEquatable<BillingName>
+    {
+        private static readonly PathTemplate s_template = new PathTemplate("billingAccounts/{billing_account}");
+
+        /// <summary>
+        /// Parses a billing resource name in string form into a <see cref="BillingName"/>.
+        /// </summary>
+        /// <param name="billingName">The billing resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="BillingName"/> if successful.</returns>
+        public static BillingName Parse(string billingName)
+        {
+            GaxPreconditions.CheckNotNull(billingName, nameof(billingName));
+            TemplatedResourceName resourceName = s_template.ParseName(billingName);
+            return new BillingName(resourceName[0]);
+        }
+
+        /// <summary>
+        /// Tries to parse billing resource name in string form into a <see cref="BillingName"/>/
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="billingName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="billingName">The billing resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="BillingName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string billingName, out BillingName result)
+        {
+            GaxPreconditions.CheckNotNull(billingName, nameof(billingName));
+            TemplatedResourceName resourceName;
+            if (s_template.TryParseName(billingName, out resourceName))
+            {
+                result = new BillingName(resourceName[0]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a billing name from its component parts.
+        /// </summary>
+        /// <param name="billingAccountId">The billingAccount ID. Must not be <c>null</c>.</param>
+        public BillingName(string billingAccountId)
+        {
+            BillingAccountId = GaxPreconditions.CheckNotNull(billingAccountId, nameof(billingAccountId));
+        }
+
+        /// <summary>
+        /// The billingAccount ID. Never <c>null</c>.
+        /// </summary>
+        public string BillingAccountId { get; }
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(BillingAccountId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as BillingName);
+
+        /// <inheritdoc />
+        public bool Equals(BillingName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(BillingName a, BillingName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(BillingName a, BillingName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'billing_log' resource.
+    /// </summary>
+    public sealed partial class BillingLogName : IResourceName, IEquatable<BillingLogName>
+    {
+        private static readonly PathTemplate s_template = new PathTemplate("billingAccounts/{billing_account}/logs/{log}");
+
+        /// <summary>
+        /// Parses a billing_log resource name in string form into a <see cref="BillingLogName"/>.
+        /// </summary>
+        /// <param name="billingLogName">The billing_log resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="BillingLogName"/> if successful.</returns>
+        public static BillingLogName Parse(string billingLogName)
+        {
+            GaxPreconditions.CheckNotNull(billingLogName, nameof(billingLogName));
+            TemplatedResourceName resourceName = s_template.ParseName(billingLogName);
+            return new BillingLogName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse billing_log resource name in string form into a <see cref="BillingLogName"/>/
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="billingLogName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="billingLogName">The billing_log resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="BillingLogName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string billingLogName, out BillingLogName result)
+        {
+            GaxPreconditions.CheckNotNull(billingLogName, nameof(billingLogName));
+            TemplatedResourceName resourceName;
+            if (s_template.TryParseName(billingLogName, out resourceName))
+            {
+                result = new BillingLogName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a billing_log name from its component parts.
+        /// </summary>
+        /// <param name="billingAccountId">The billingAccount ID. Must not be <c>null</c>.</param>
+        /// <param name="logId">The log ID. Must not be <c>null</c>.</param>
+        public BillingLogName(string billingAccountId, string logId)
+        {
+            BillingAccountId = GaxPreconditions.CheckNotNull(billingAccountId, nameof(billingAccountId));
+            LogId = GaxPreconditions.CheckNotNull(logId, nameof(logId));
+        }
+
+        /// <summary>
+        /// The billingAccount ID. Never <c>null</c>.
+        /// </summary>
+        public string BillingAccountId { get; }
+
+        /// <summary>
+        /// The log ID. Never <c>null</c>.
+        /// </summary>
+        public string LogId { get; }
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(BillingAccountId, LogId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as BillingLogName);
+
+        /// <inheritdoc />
+        public bool Equals(BillingLogName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(BillingLogName a, BillingLogName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(BillingLogName a, BillingLogName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'billing_sink' resource.
+    /// </summary>
+    public sealed partial class BillingSinkName : IResourceName, IEquatable<BillingSinkName>
+    {
+        private static readonly PathTemplate s_template = new PathTemplate("billingAccounts/{billing_account}/sinks/{sink}");
+
+        /// <summary>
+        /// Parses a billing_sink resource name in string form into a <see cref="BillingSinkName"/>.
+        /// </summary>
+        /// <param name="billingSinkName">The billing_sink resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="BillingSinkName"/> if successful.</returns>
+        public static BillingSinkName Parse(string billingSinkName)
+        {
+            GaxPreconditions.CheckNotNull(billingSinkName, nameof(billingSinkName));
+            TemplatedResourceName resourceName = s_template.ParseName(billingSinkName);
+            return new BillingSinkName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse billing_sink resource name in string form into a <see cref="BillingSinkName"/>/
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="billingSinkName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="billingSinkName">The billing_sink resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="BillingSinkName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string billingSinkName, out BillingSinkName result)
+        {
+            GaxPreconditions.CheckNotNull(billingSinkName, nameof(billingSinkName));
+            TemplatedResourceName resourceName;
+            if (s_template.TryParseName(billingSinkName, out resourceName))
+            {
+                result = new BillingSinkName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a billing_sink name from its component parts.
+        /// </summary>
+        /// <param name="billingAccountId">The billingAccount ID. Must not be <c>null</c>.</param>
+        /// <param name="sinkId">The sink ID. Must not be <c>null</c>.</param>
+        public BillingSinkName(string billingAccountId, string sinkId)
+        {
+            BillingAccountId = GaxPreconditions.CheckNotNull(billingAccountId, nameof(billingAccountId));
+            SinkId = GaxPreconditions.CheckNotNull(sinkId, nameof(sinkId));
+        }
+
+        /// <summary>
+        /// The billingAccount ID. Never <c>null</c>.
+        /// </summary>
+        public string BillingAccountId { get; }
+
+        /// <summary>
+        /// The sink ID. Never <c>null</c>.
+        /// </summary>
+        public string SinkId { get; }
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(BillingAccountId, SinkId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as BillingSinkName);
+
+        /// <inheritdoc />
+        public bool Equals(BillingSinkName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(BillingSinkName a, BillingSinkName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(BillingSinkName a, BillingSinkName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name which will contain one of a choice of resource names.
+    /// </summary>
+    /// <remarks>
+    /// This resource name will contain one of the following:
+    /// <list type="bullet">
+    /// <item><description>ProjectName: A resource of type 'project'.</description></item>
+    /// <item><description>OrganizationName: A resource of type 'organization'.</description></item>
+    /// <item><description>FolderName: A resource of type 'folder'.</description></item>
+    /// <item><description>BillingName: A resource of type 'billing'.</description></item>
+    /// </list>
+    /// </remarks>
+    public sealed partial class ParentNameOneof : IResourceName, IEquatable<ParentNameOneof>
+    {
+        /// <summary>
+        /// The possible contents of <see cref="ParentNameOneof"/>.
+        /// </summary>
+        public enum OneofType
+        {
+            /// <summary>
+            /// A resource of an unknown type.
+            /// </summary>
+            Unknown = 0,
+
+            /// <summary>
+            /// A resource of type 'project'.
+            /// </summary>
+            ProjectName = 1,
+
+            /// <summary>
+            /// A resource of type 'organization'.
+            /// </summary>
+            OrganizationName = 2,
+
+            /// <summary>
+            /// A resource of type 'folder'.
+            /// </summary>
+            FolderName = 3,
+
+            /// <summary>
+            /// A resource of type 'billing'.
+            /// </summary>
+            BillingName = 4,
+        }
+
+        /// <summary>
+        /// Parses a resource name in string form into a <see cref="ParentNameOneof"/>.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>ProjectName: A resource of type 'project'.</description></item>
+        /// <item><description>OrganizationName: A resource of type 'organization'.</description></item>
+        /// <item><description>FolderName: A resource of type 'folder'.</description></item>
+        /// <item><description>BillingName: A resource of type 'billing'.</description></item>
+        /// </list>
+        /// Or an <see cref="UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="UnknownResourceName"/>.</param>
+        /// <returns>The parsed <see cref="ParentNameOneof"/> if successful.</returns>
+        public static ParentNameOneof Parse(string name, bool allowUnknown)
+        {
+            ParentNameOneof result;
+            if (TryParse(name, allowUnknown, out result))
+            {
+                return result;
+            }
+            throw new ArgumentException("Invalid name", nameof(name));
+        }
+
+        /// <summary>
+        /// Tries to parse a resource name in string form into a <see cref="ParentNameOneof"/>.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>ProjectName: A resource of type 'project'.</description></item>
+        /// <item><description>OrganizationName: A resource of type 'organization'.</description></item>
+        /// <item><description>FolderName: A resource of type 'folder'.</description></item>
+        /// <item><description>BillingName: A resource of type 'billing'.</description></item>
+        /// </list>
+        /// Or an <see cref="UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="UnknownResourceName"/>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ParentNameOneof"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string name, bool allowUnknown, out ParentNameOneof result)
+        {
+            GaxPreconditions.CheckNotNull(name, nameof(name));
+            ProjectName projectName;
+            if (ProjectName.TryParse(name, out projectName))
+            {
+                result = new ParentNameOneof(OneofType.ProjectName, projectName);
+                return true;
+            }
+            OrganizationName organizationName;
+            if (OrganizationName.TryParse(name, out organizationName))
+            {
+                result = new ParentNameOneof(OneofType.OrganizationName, organizationName);
+                return true;
+            }
+            FolderName folderName;
+            if (FolderName.TryParse(name, out folderName))
+            {
+                result = new ParentNameOneof(OneofType.FolderName, folderName);
+                return true;
+            }
+            BillingName billingName;
+            if (BillingName.TryParse(name, out billingName))
+            {
+                result = new ParentNameOneof(OneofType.BillingName, billingName);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                UnknownResourceName unknownResourceName;
+                if (UnknownResourceName.TryParse(name, out unknownResourceName))
+                {
+                    result = new ParentNameOneof(OneofType.Unknown, unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Construct an instance of <see cref="ParentNameOneof"/> from the provided <see cref="ProjectName"/>
+        /// </summary>
+        /// <param name="projectName">The <see cref="ProjectName"/> to be contained within
+        /// the returned <see cref="ParentNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="ParentNameOneof"/>, containing <paramref name="projectName"/>.</returns>
+        public static ParentNameOneof From(ProjectName projectName) => new ParentNameOneof(OneofType.ProjectName, projectName);
+
+        /// <summary>
+        /// Construct an instance of <see cref="ParentNameOneof"/> from the provided <see cref="OrganizationName"/>
+        /// </summary>
+        /// <param name="organizationName">The <see cref="OrganizationName"/> to be contained within
+        /// the returned <see cref="ParentNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="ParentNameOneof"/>, containing <paramref name="organizationName"/>.</returns>
+        public static ParentNameOneof From(OrganizationName organizationName) => new ParentNameOneof(OneofType.OrganizationName, organizationName);
+
+        /// <summary>
+        /// Construct an instance of <see cref="ParentNameOneof"/> from the provided <see cref="FolderName"/>
+        /// </summary>
+        /// <param name="folderName">The <see cref="FolderName"/> to be contained within
+        /// the returned <see cref="ParentNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="ParentNameOneof"/>, containing <paramref name="folderName"/>.</returns>
+        public static ParentNameOneof From(FolderName folderName) => new ParentNameOneof(OneofType.FolderName, folderName);
+
+        /// <summary>
+        /// Construct an instance of <see cref="ParentNameOneof"/> from the provided <see cref="BillingName"/>
+        /// </summary>
+        /// <param name="billingName">The <see cref="BillingName"/> to be contained within
+        /// the returned <see cref="ParentNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="ParentNameOneof"/>, containing <paramref name="billingName"/>.</returns>
+        public static ParentNameOneof From(BillingName billingName) => new ParentNameOneof(OneofType.BillingName, billingName);
+
+        private static bool IsValid(OneofType type, IResourceName name)
+        {
+            switch (type)
+            {
+                case OneofType.Unknown: return true; // Anything goes with Unknown.
+                case OneofType.ProjectName: return name is ProjectName;
+                case OneofType.OrganizationName: return name is OrganizationName;
+                case OneofType.FolderName: return name is FolderName;
+                case OneofType.BillingName: return name is BillingName;
+                default: return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a {resource.docName} resource name from a suitable <see cref="IResourceName"/> instance.
+        /// </summary>
+        public ParentNameOneof(OneofType type, IResourceName name)
+        {
+            Type = GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
+            Name = GaxPreconditions.CheckNotNull(name, nameof(name));
+            if (!IsValid(type, name))
+            {
+                throw new ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="OneofType"/> of the Name contained in this instance.
+        /// </summary>
+        public OneofType Type { get; }
+
+        /// <summary>
+        /// The <see cref="IResourceName"/> contained in this instance.
+        /// </summary>
+        public IResourceName Name { get; }
+
+        private T CheckAndReturn<T>(OneofType type)
+        {
+            if (Type != type)
+            {
+                throw new InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+            }
+            return (T)Name;
+        }
+
+        /// <summary>
+        /// Get the contained <see cref="IResourceName"/> as <see cref="ProjectName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="ProjectName"/>.
+        /// </remarks>
+        public ProjectName ProjectName => CheckAndReturn<ProjectName>(OneofType.ProjectName);
+
+        /// <summary>
+        /// Get the contained <see cref="IResourceName"/> as <see cref="OrganizationName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="OrganizationName"/>.
+        /// </remarks>
+        public OrganizationName OrganizationName => CheckAndReturn<OrganizationName>(OneofType.OrganizationName);
+
+        /// <summary>
+        /// Get the contained <see cref="IResourceName"/> as <see cref="FolderName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="FolderName"/>.
+        /// </remarks>
+        public FolderName FolderName => CheckAndReturn<FolderName>(OneofType.FolderName);
+
+        /// <summary>
+        /// Get the contained <see cref="IResourceName"/> as <see cref="BillingName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="BillingName"/>.
+        /// </remarks>
+        public BillingName BillingName => CheckAndReturn<BillingName>(OneofType.BillingName);
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Oneof;
+
+        /// <inheritdoc />
+        public override string ToString() => Name.ToString();
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as ParentNameOneof);
+
+        /// <inheritdoc />
+        public bool Equals(ParentNameOneof other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(ParentNameOneof a, ParentNameOneof b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(ParentNameOneof a, ParentNameOneof b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name which will contain one of a choice of resource names.
+    /// </summary>
+    /// <remarks>
+    /// This resource name will contain one of the following:
+    /// <list type="bullet">
+    /// <item><description>SinkName: A resource of type 'sink'.</description></item>
+    /// <item><description>OrganizationSinkName: A resource of type 'organization_sink'.</description></item>
+    /// <item><description>FolderSinkName: A resource of type 'folder_sink'.</description></item>
+    /// <item><description>BillingSinkName: A resource of type 'billing_sink'.</description></item>
+    /// </list>
+    /// </remarks>
+    public sealed partial class SinkNameOneof : IResourceName, IEquatable<SinkNameOneof>
+    {
+        /// <summary>
+        /// The possible contents of <see cref="SinkNameOneof"/>.
+        /// </summary>
+        public enum OneofType
+        {
+            /// <summary>
+            /// A resource of an unknown type.
+            /// </summary>
+            Unknown = 0,
+
+            /// <summary>
+            /// A resource of type 'sink'.
+            /// </summary>
+            SinkName = 1,
+
+            /// <summary>
+            /// A resource of type 'organization_sink'.
+            /// </summary>
+            OrganizationSinkName = 2,
+
+            /// <summary>
+            /// A resource of type 'folder_sink'.
+            /// </summary>
+            FolderSinkName = 3,
+
+            /// <summary>
+            /// A resource of type 'billing_sink'.
+            /// </summary>
+            BillingSinkName = 4,
+        }
+
+        /// <summary>
+        /// Parses a resource name in string form into a <see cref="SinkNameOneof"/>.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>SinkName: A resource of type 'sink'.</description></item>
+        /// <item><description>OrganizationSinkName: A resource of type 'organization_sink'.</description></item>
+        /// <item><description>FolderSinkName: A resource of type 'folder_sink'.</description></item>
+        /// <item><description>BillingSinkName: A resource of type 'billing_sink'.</description></item>
+        /// </list>
+        /// Or an <see cref="UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="UnknownResourceName"/>.</param>
+        /// <returns>The parsed <see cref="SinkNameOneof"/> if successful.</returns>
+        public static SinkNameOneof Parse(string name, bool allowUnknown)
+        {
+            SinkNameOneof result;
+            if (TryParse(name, allowUnknown, out result))
+            {
+                return result;
+            }
+            throw new ArgumentException("Invalid name", nameof(name));
+        }
+
+        /// <summary>
+        /// Tries to parse a resource name in string form into a <see cref="SinkNameOneof"/>.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>SinkName: A resource of type 'sink'.</description></item>
+        /// <item><description>OrganizationSinkName: A resource of type 'organization_sink'.</description></item>
+        /// <item><description>FolderSinkName: A resource of type 'folder_sink'.</description></item>
+        /// <item><description>BillingSinkName: A resource of type 'billing_sink'.</description></item>
+        /// </list>
+        /// Or an <see cref="UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="UnknownResourceName"/>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="SinkNameOneof"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string name, bool allowUnknown, out SinkNameOneof result)
+        {
+            GaxPreconditions.CheckNotNull(name, nameof(name));
+            SinkName sinkName;
+            if (SinkName.TryParse(name, out sinkName))
+            {
+                result = new SinkNameOneof(OneofType.SinkName, sinkName);
+                return true;
+            }
+            OrganizationSinkName organizationSinkName;
+            if (OrganizationSinkName.TryParse(name, out organizationSinkName))
+            {
+                result = new SinkNameOneof(OneofType.OrganizationSinkName, organizationSinkName);
+                return true;
+            }
+            FolderSinkName folderSinkName;
+            if (FolderSinkName.TryParse(name, out folderSinkName))
+            {
+                result = new SinkNameOneof(OneofType.FolderSinkName, folderSinkName);
+                return true;
+            }
+            BillingSinkName billingSinkName;
+            if (BillingSinkName.TryParse(name, out billingSinkName))
+            {
+                result = new SinkNameOneof(OneofType.BillingSinkName, billingSinkName);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                UnknownResourceName unknownResourceName;
+                if (UnknownResourceName.TryParse(name, out unknownResourceName))
+                {
+                    result = new SinkNameOneof(OneofType.Unknown, unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Construct an instance of <see cref="SinkNameOneof"/> from the provided <see cref="SinkName"/>
+        /// </summary>
+        /// <param name="sinkName">The <see cref="SinkName"/> to be contained within
+        /// the returned <see cref="SinkNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="SinkNameOneof"/>, containing <paramref name="sinkName"/>.</returns>
+        public static SinkNameOneof From(SinkName sinkName) => new SinkNameOneof(OneofType.SinkName, sinkName);
+
+        /// <summary>
+        /// Construct an instance of <see cref="SinkNameOneof"/> from the provided <see cref="OrganizationSinkName"/>
+        /// </summary>
+        /// <param name="organizationSinkName">The <see cref="OrganizationSinkName"/> to be contained within
+        /// the returned <see cref="SinkNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="SinkNameOneof"/>, containing <paramref name="organizationSinkName"/>.</returns>
+        public static SinkNameOneof From(OrganizationSinkName organizationSinkName) => new SinkNameOneof(OneofType.OrganizationSinkName, organizationSinkName);
+
+        /// <summary>
+        /// Construct an instance of <see cref="SinkNameOneof"/> from the provided <see cref="FolderSinkName"/>
+        /// </summary>
+        /// <param name="folderSinkName">The <see cref="FolderSinkName"/> to be contained within
+        /// the returned <see cref="SinkNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="SinkNameOneof"/>, containing <paramref name="folderSinkName"/>.</returns>
+        public static SinkNameOneof From(FolderSinkName folderSinkName) => new SinkNameOneof(OneofType.FolderSinkName, folderSinkName);
+
+        /// <summary>
+        /// Construct an instance of <see cref="SinkNameOneof"/> from the provided <see cref="BillingSinkName"/>
+        /// </summary>
+        /// <param name="billingSinkName">The <see cref="BillingSinkName"/> to be contained within
+        /// the returned <see cref="SinkNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="SinkNameOneof"/>, containing <paramref name="billingSinkName"/>.</returns>
+        public static SinkNameOneof From(BillingSinkName billingSinkName) => new SinkNameOneof(OneofType.BillingSinkName, billingSinkName);
+
+        private static bool IsValid(OneofType type, IResourceName name)
+        {
+            switch (type)
+            {
+                case OneofType.Unknown: return true; // Anything goes with Unknown.
+                case OneofType.SinkName: return name is SinkName;
+                case OneofType.OrganizationSinkName: return name is OrganizationSinkName;
+                case OneofType.FolderSinkName: return name is FolderSinkName;
+                case OneofType.BillingSinkName: return name is BillingSinkName;
+                default: return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a {resource.docName} resource name from a suitable <see cref="IResourceName"/> instance.
+        /// </summary>
+        public SinkNameOneof(OneofType type, IResourceName name)
+        {
+            Type = GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
+            Name = GaxPreconditions.CheckNotNull(name, nameof(name));
+            if (!IsValid(type, name))
+            {
+                throw new ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="OneofType"/> of the Name contained in this instance.
+        /// </summary>
+        public OneofType Type { get; }
+
+        /// <summary>
+        /// The <see cref="IResourceName"/> contained in this instance.
+        /// </summary>
+        public IResourceName Name { get; }
+
+        private T CheckAndReturn<T>(OneofType type)
+        {
+            if (Type != type)
+            {
+                throw new InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+            }
+            return (T)Name;
+        }
+
+        /// <summary>
+        /// Get the contained <see cref="IResourceName"/> as <see cref="SinkName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="SinkName"/>.
+        /// </remarks>
+        public SinkName SinkName => CheckAndReturn<SinkName>(OneofType.SinkName);
+
+        /// <summary>
+        /// Get the contained <see cref="IResourceName"/> as <see cref="OrganizationSinkName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="OrganizationSinkName"/>.
+        /// </remarks>
+        public OrganizationSinkName OrganizationSinkName => CheckAndReturn<OrganizationSinkName>(OneofType.OrganizationSinkName);
+
+        /// <summary>
+        /// Get the contained <see cref="IResourceName"/> as <see cref="FolderSinkName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="FolderSinkName"/>.
+        /// </remarks>
+        public FolderSinkName FolderSinkName => CheckAndReturn<FolderSinkName>(OneofType.FolderSinkName);
+
+        /// <summary>
+        /// Get the contained <see cref="IResourceName"/> as <see cref="BillingSinkName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="BillingSinkName"/>.
+        /// </remarks>
+        public BillingSinkName BillingSinkName => CheckAndReturn<BillingSinkName>(OneofType.BillingSinkName);
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Oneof;
+
+        /// <inheritdoc />
+        public override string ToString() => Name.ToString();
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as SinkNameOneof);
+
+        /// <inheritdoc />
+        public bool Equals(SinkNameOneof other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(SinkNameOneof a, SinkNameOneof b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(SinkNameOneof a, SinkNameOneof b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name which will contain one of a choice of resource names.
+    /// </summary>
+    /// <remarks>
+    /// This resource name will contain one of the following:
+    /// <list type="bullet">
+    /// <item><description>LogName: A resource of type 'log'.</description></item>
+    /// <item><description>OrganizationLogName: A resource of type 'organization_log'.</description></item>
+    /// <item><description>FolderLogName: A resource of type 'folder_log'.</description></item>
+    /// <item><description>BillingLogName: A resource of type 'billing_log'.</description></item>
+    /// </list>
+    /// </remarks>
+    public sealed partial class LogNameOneof : IResourceName, IEquatable<LogNameOneof>
+    {
+        /// <summary>
+        /// The possible contents of <see cref="LogNameOneof"/>.
+        /// </summary>
+        public enum OneofType
+        {
+            /// <summary>
+            /// A resource of an unknown type.
+            /// </summary>
+            Unknown = 0,
+
+            /// <summary>
+            /// A resource of type 'log'.
+            /// </summary>
+            LogName = 1,
+
+            /// <summary>
+            /// A resource of type 'organization_log'.
+            /// </summary>
+            OrganizationLogName = 2,
+
+            /// <summary>
+            /// A resource of type 'folder_log'.
+            /// </summary>
+            FolderLogName = 3,
+
+            /// <summary>
+            /// A resource of type 'billing_log'.
+            /// </summary>
+            BillingLogName = 4,
+        }
+
+        /// <summary>
+        /// Parses a resource name in string form into a <see cref="LogNameOneof"/>.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>LogName: A resource of type 'log'.</description></item>
+        /// <item><description>OrganizationLogName: A resource of type 'organization_log'.</description></item>
+        /// <item><description>FolderLogName: A resource of type 'folder_log'.</description></item>
+        /// <item><description>BillingLogName: A resource of type 'billing_log'.</description></item>
+        /// </list>
+        /// Or an <see cref="UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="UnknownResourceName"/>.</param>
+        /// <returns>The parsed <see cref="LogNameOneof"/> if successful.</returns>
+        public static LogNameOneof Parse(string name, bool allowUnknown)
+        {
+            LogNameOneof result;
+            if (TryParse(name, allowUnknown, out result))
+            {
+                return result;
+            }
+            throw new ArgumentException("Invalid name", nameof(name));
+        }
+
+        /// <summary>
+        /// Tries to parse a resource name in string form into a <see cref="LogNameOneof"/>.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>LogName: A resource of type 'log'.</description></item>
+        /// <item><description>OrganizationLogName: A resource of type 'organization_log'.</description></item>
+        /// <item><description>FolderLogName: A resource of type 'folder_log'.</description></item>
+        /// <item><description>BillingLogName: A resource of type 'billing_log'.</description></item>
+        /// </list>
+        /// Or an <see cref="UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="UnknownResourceName"/>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="LogNameOneof"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string name, bool allowUnknown, out LogNameOneof result)
+        {
+            GaxPreconditions.CheckNotNull(name, nameof(name));
+            LogName logName;
+            if (LogName.TryParse(name, out logName))
+            {
+                result = new LogNameOneof(OneofType.LogName, logName);
+                return true;
+            }
+            OrganizationLogName organizationLogName;
+            if (OrganizationLogName.TryParse(name, out organizationLogName))
+            {
+                result = new LogNameOneof(OneofType.OrganizationLogName, organizationLogName);
+                return true;
+            }
+            FolderLogName folderLogName;
+            if (FolderLogName.TryParse(name, out folderLogName))
+            {
+                result = new LogNameOneof(OneofType.FolderLogName, folderLogName);
+                return true;
+            }
+            BillingLogName billingLogName;
+            if (BillingLogName.TryParse(name, out billingLogName))
+            {
+                result = new LogNameOneof(OneofType.BillingLogName, billingLogName);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                UnknownResourceName unknownResourceName;
+                if (UnknownResourceName.TryParse(name, out unknownResourceName))
+                {
+                    result = new LogNameOneof(OneofType.Unknown, unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Construct an instance of <see cref="LogNameOneof"/> from the provided <see cref="LogName"/>
+        /// </summary>
+        /// <param name="logName">The <see cref="LogName"/> to be contained within
+        /// the returned <see cref="LogNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="LogNameOneof"/>, containing <paramref name="logName"/>.</returns>
+        public static LogNameOneof From(LogName logName) => new LogNameOneof(OneofType.LogName, logName);
+
+        /// <summary>
+        /// Construct an instance of <see cref="LogNameOneof"/> from the provided <see cref="OrganizationLogName"/>
+        /// </summary>
+        /// <param name="organizationLogName">The <see cref="OrganizationLogName"/> to be contained within
+        /// the returned <see cref="LogNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="LogNameOneof"/>, containing <paramref name="organizationLogName"/>.</returns>
+        public static LogNameOneof From(OrganizationLogName organizationLogName) => new LogNameOneof(OneofType.OrganizationLogName, organizationLogName);
+
+        /// <summary>
+        /// Construct an instance of <see cref="LogNameOneof"/> from the provided <see cref="FolderLogName"/>
+        /// </summary>
+        /// <param name="folderLogName">The <see cref="FolderLogName"/> to be contained within
+        /// the returned <see cref="LogNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="LogNameOneof"/>, containing <paramref name="folderLogName"/>.</returns>
+        public static LogNameOneof From(FolderLogName folderLogName) => new LogNameOneof(OneofType.FolderLogName, folderLogName);
+
+        /// <summary>
+        /// Construct an instance of <see cref="LogNameOneof"/> from the provided <see cref="BillingLogName"/>
+        /// </summary>
+        /// <param name="billingLogName">The <see cref="BillingLogName"/> to be contained within
+        /// the returned <see cref="LogNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="LogNameOneof"/>, containing <paramref name="billingLogName"/>.</returns>
+        public static LogNameOneof From(BillingLogName billingLogName) => new LogNameOneof(OneofType.BillingLogName, billingLogName);
+
+        private static bool IsValid(OneofType type, IResourceName name)
+        {
+            switch (type)
+            {
+                case OneofType.Unknown: return true; // Anything goes with Unknown.
+                case OneofType.LogName: return name is LogName;
+                case OneofType.OrganizationLogName: return name is OrganizationLogName;
+                case OneofType.FolderLogName: return name is FolderLogName;
+                case OneofType.BillingLogName: return name is BillingLogName;
+                default: return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a {resource.docName} resource name from a suitable <see cref="IResourceName"/> instance.
+        /// </summary>
+        public LogNameOneof(OneofType type, IResourceName name)
+        {
+            Type = GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
+            Name = GaxPreconditions.CheckNotNull(name, nameof(name));
+            if (!IsValid(type, name))
+            {
+                throw new ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="OneofType"/> of the Name contained in this instance.
+        /// </summary>
+        public OneofType Type { get; }
+
+        /// <summary>
+        /// The <see cref="IResourceName"/> contained in this instance.
+        /// </summary>
+        public IResourceName Name { get; }
+
+        private T CheckAndReturn<T>(OneofType type)
+        {
+            if (Type != type)
+            {
+                throw new InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+            }
+            return (T)Name;
+        }
+
+        /// <summary>
+        /// Get the contained <see cref="IResourceName"/> as <see cref="LogName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="LogName"/>.
+        /// </remarks>
+        public LogName LogName => CheckAndReturn<LogName>(OneofType.LogName);
+
+        /// <summary>
+        /// Get the contained <see cref="IResourceName"/> as <see cref="OrganizationLogName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="OrganizationLogName"/>.
+        /// </remarks>
+        public OrganizationLogName OrganizationLogName => CheckAndReturn<OrganizationLogName>(OneofType.OrganizationLogName);
+
+        /// <summary>
+        /// Get the contained <see cref="IResourceName"/> as <see cref="FolderLogName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="FolderLogName"/>.
+        /// </remarks>
+        public FolderLogName FolderLogName => CheckAndReturn<FolderLogName>(OneofType.FolderLogName);
+
+        /// <summary>
+        /// Get the contained <see cref="IResourceName"/> as <see cref="BillingLogName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="BillingLogName"/>.
+        /// </remarks>
+        public BillingLogName BillingLogName => CheckAndReturn<BillingLogName>(OneofType.BillingLogName);
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Oneof;
+
+        /// <inheritdoc />
+        public override string ToString() => Name.ToString();
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as LogNameOneof);
+
+        /// <inheritdoc />
+        public bool Equals(LogNameOneof other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(LogNameOneof a, LogNameOneof b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(LogNameOneof a, LogNameOneof b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name which will contain one of a choice of resource names.
+    /// </summary>
+    /// <remarks>
+    /// This resource name will contain one of the following:
+    /// <list type="bullet">
+    /// <item><description>MetricName: A resource of type 'metric'.</description></item>
+    /// </list>
+    /// </remarks>
+    public sealed partial class MetricNameOneof : IResourceName, IEquatable<MetricNameOneof>
+    {
+        /// <summary>
+        /// The possible contents of <see cref="MetricNameOneof"/>.
+        /// </summary>
+        public enum OneofType
+        {
+            /// <summary>
+            /// A resource of an unknown type.
+            /// </summary>
+            Unknown = 0,
+
+            /// <summary>
+            /// A resource of type 'metric'.
+            /// </summary>
+            MetricName = 1,
+        }
+
+        /// <summary>
+        /// Parses a resource name in string form into a <see cref="MetricNameOneof"/>.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>MetricName: A resource of type 'metric'.</description></item>
+        /// </list>
+        /// Or an <see cref="UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="UnknownResourceName"/>.</param>
+        /// <returns>The parsed <see cref="MetricNameOneof"/> if successful.</returns>
+        public static MetricNameOneof Parse(string name, bool allowUnknown)
+        {
+            MetricNameOneof result;
+            if (TryParse(name, allowUnknown, out result))
+            {
+                return result;
+            }
+            throw new ArgumentException("Invalid name", nameof(name));
+        }
+
+        /// <summary>
+        /// Tries to parse a resource name in string form into a <see cref="MetricNameOneof"/>.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>MetricName: A resource of type 'metric'.</description></item>
+        /// </list>
+        /// Or an <see cref="UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="UnknownResourceName"/>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="MetricNameOneof"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string name, bool allowUnknown, out MetricNameOneof result)
+        {
+            GaxPreconditions.CheckNotNull(name, nameof(name));
+            MetricName metricName;
+            if (MetricName.TryParse(name, out metricName))
+            {
+                result = new MetricNameOneof(OneofType.MetricName, metricName);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                UnknownResourceName unknownResourceName;
+                if (UnknownResourceName.TryParse(name, out unknownResourceName))
+                {
+                    result = new MetricNameOneof(OneofType.Unknown, unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Construct an instance of <see cref="MetricNameOneof"/> from the provided <see cref="MetricName"/>
+        /// </summary>
+        /// <param name="metricName">The <see cref="MetricName"/> to be contained within
+        /// the returned <see cref="MetricNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="MetricNameOneof"/>, containing <paramref name="metricName"/>.</returns>
+        public static MetricNameOneof From(MetricName metricName) => new MetricNameOneof(OneofType.MetricName, metricName);
+
+        private static bool IsValid(OneofType type, IResourceName name)
+        {
+            switch (type)
+            {
+                case OneofType.Unknown: return true; // Anything goes with Unknown.
+                case OneofType.MetricName: return name is MetricName;
+                default: return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a {resource.docName} resource name from a suitable <see cref="IResourceName"/> instance.
+        /// </summary>
+        public MetricNameOneof(OneofType type, IResourceName name)
+        {
+            Type = GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
+            Name = GaxPreconditions.CheckNotNull(name, nameof(name));
+            if (!IsValid(type, name))
+            {
+                throw new ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="OneofType"/> of the Name contained in this instance.
+        /// </summary>
+        public OneofType Type { get; }
+
+        /// <summary>
+        /// The <see cref="IResourceName"/> contained in this instance.
+        /// </summary>
+        public IResourceName Name { get; }
+
+        private T CheckAndReturn<T>(OneofType type)
+        {
+            if (Type != type)
+            {
+                throw new InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+            }
+            return (T)Name;
+        }
+
+        /// <summary>
+        /// Get the contained <see cref="IResourceName"/> as <see cref="MetricName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="MetricName"/>.
+        /// </remarks>
+        public MetricName MetricName => CheckAndReturn<MetricName>(OneofType.MetricName);
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Oneof;
+
+        /// <inheritdoc />
+        public override string ToString() => Name.ToString();
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as MetricNameOneof);
+
+        /// <inheritdoc />
+        public bool Equals(MetricNameOneof other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(MetricNameOneof a, MetricNameOneof b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(MetricNameOneof a, MetricNameOneof b) => !(a == b);
     }
 
 
+    public partial class CreateLogMetricRequest
+    {
+        /// <summary>
+        /// A <see cref="ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// </summary>
+        public ParentNameOneof ParentAsParentNameOneof
+        {
+            get { return ParentNameOneof.Parse(Parent, true); }
+            set { Parent = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+        }
+
+    }
+
+    public partial class CreateSinkRequest
+    {
+        /// <summary>
+        /// A <see cref="ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// </summary>
+        public ParentNameOneof ParentAsParentNameOneof
+        {
+            get { return ParentNameOneof.Parse(Parent, true); }
+            set { Parent = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+        }
+
+    }
+
+    public partial class DeleteLogMetricRequest
+    {
+        /// <summary>
+        /// A <see cref="MetricNameOneof"/>-typed view over the <see cref="MetricName"/> resource name property.
+        /// </summary>
+        public MetricNameOneof MetricNameAsMetricNameOneof
+        {
+            get { return MetricNameOneof.Parse(MetricName, true); }
+            set { MetricName = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+        }
+
+    }
+
+    public partial class DeleteLogRequest
+    {
+        /// <summary>
+        /// A <see cref="LogNameOneof"/>-typed view over the <see cref="LogName"/> resource name property.
+        /// </summary>
+        public LogNameOneof LogNameAsLogNameOneof
+        {
+            get { return LogNameOneof.Parse(LogName, true); }
+            set { LogName = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+        }
+
+    }
+
+    public partial class DeleteSinkRequest
+    {
+        /// <summary>
+        /// A <see cref="SinkNameOneof"/>-typed view over the <see cref="SinkName"/> resource name property.
+        /// </summary>
+        public SinkNameOneof SinkNameAsSinkNameOneof
+        {
+            get { return SinkNameOneof.Parse(SinkName, true); }
+            set { SinkName = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+        }
+
+    }
+
+    public partial class GetLogMetricRequest
+    {
+        /// <summary>
+        /// A <see cref="MetricNameOneof"/>-typed view over the <see cref="MetricName"/> resource name property.
+        /// </summary>
+        public MetricNameOneof MetricNameAsMetricNameOneof
+        {
+            get { return MetricNameOneof.Parse(MetricName, true); }
+            set { MetricName = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+        }
+
+    }
+
+    public partial class GetSinkRequest
+    {
+        /// <summary>
+        /// A <see cref="SinkNameOneof"/>-typed view over the <see cref="SinkName"/> resource name property.
+        /// </summary>
+        public SinkNameOneof SinkNameAsSinkNameOneof
+        {
+            get { return SinkNameOneof.Parse(SinkName, true); }
+            set { SinkName = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+        }
+
+    }
+
+    public partial class ListLogMetricsRequest
+    {
+        /// <summary>
+        /// A <see cref="ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// </summary>
+        public ParentNameOneof ParentAsParentNameOneof
+        {
+            get { return ParentNameOneof.Parse(Parent, true); }
+            set { Parent = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+        }
+
+    }
+
+    public partial class ListSinksRequest
+    {
+        /// <summary>
+        /// A <see cref="ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// </summary>
+        public ParentNameOneof ParentAsParentNameOneof
+        {
+            get { return ParentNameOneof.Parse(Parent, true); }
+            set { Parent = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+        }
+
+    }
+
+    public partial class LogSink
+    {
+        /// <summary>
+        /// A <see cref="IResourceName"/>-typed view over the <see cref="Destination"/> resource name property.
+        /// </summary>
+        public IResourceName DestinationAsResourceName
+        {
+            get { return UnknownResourceName.Parse(Destination); }
+            set { Destination = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+        }
+
+    }
+
+    public partial class UpdateLogMetricRequest
+    {
+        /// <summary>
+        /// A <see cref="MetricNameOneof"/>-typed view over the <see cref="MetricName"/> resource name property.
+        /// </summary>
+        public MetricNameOneof MetricNameAsMetricNameOneof
+        {
+            get { return MetricNameOneof.Parse(MetricName, true); }
+            set { MetricName = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+        }
+
+    }
+
+    public partial class UpdateSinkRequest
+    {
+        /// <summary>
+        /// A <see cref="SinkNameOneof"/>-typed view over the <see cref="SinkName"/> resource name property.
+        /// </summary>
+        public SinkNameOneof SinkNameAsSinkNameOneof
+        {
+            get { return SinkNameOneof.Parse(SinkName, true); }
+            set { SinkName = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+        }
+
+    }
+
+    public partial class WriteLogEntriesRequest
+    {
+        /// <summary>
+        /// A <see cref="LogNameOneof"/>-typed view over the <see cref="LogName"/> resource name property.
+        /// </summary>
+        public LogNameOneof LogNameAsLogNameOneof
+        {
+            get { return LogNameOneof.Parse(LogName, true); }
+            set { LogName = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+        }
+
+    }
 
 }

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/GroupServiceClientSnippets.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/GroupServiceClientSnippets.cs
@@ -29,22 +29,21 @@ namespace Google.Cloud.Monitoring.V3
             _fixture = fixture;
         }
 
-        /* TODO: Reinstate when ListGroups is present again.
         [Fact]
         public void ListGroups()
         {
             string projectId = _fixture.ProjectId;
 
-            // FIXME:Snippet: ListGroups
+            // Snippet: ListGroups(*,*)
             GroupServiceClient client = GroupServiceClient.Create();
-            string projectName = MetricServiceClient.FormatProjectName(projectId);
-            PagedEnumerable<ListGroupsResponse, Group> groups = client.ListGroups(projectName, "", "", "");
+            ProjectName projectName = new ProjectName(projectId);
+            ListGroupsRequest request = new ListGroupsRequest { Name = projectName.ToString() };
+            PagedEnumerable<ListGroupsResponse, Group> groups = client.ListGroups(request);
             foreach (Group group in groups.Take(10))
             {
                 Console.WriteLine($"{group.Name}: {group.DisplayName}");
             }
-            // FIXME:End snippet
+            // End snippet
         }
-        */
     }
 }

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/GroupServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/GroupServiceClientSnippets.g.cs
@@ -33,6 +33,98 @@ namespace Google.Cloud.Monitoring.V3.Snippets
 {
     public class GeneratedGroupServiceClientSnippets
     {
+        public async Task ListGroupsAsync_RequestObject()
+        {
+            // Snippet: ListGroupsAsync(ListGroupsRequest,CallSettings)
+            // Create client
+            GroupServiceClient groupServiceClient = GroupServiceClient.Create();
+            // Initialize request argument(s)
+            ListGroupsRequest request = new ListGroupsRequest
+            {
+                Name = new ProjectName("[PROJECT]").ToString(),
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListGroupsResponse,Group> response =
+                groupServiceClient.ListGroupsAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((Group item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListGroupsResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Group item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Group> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Group item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListGroups_RequestObject()
+        {
+            // Snippet: ListGroups(ListGroupsRequest,CallSettings)
+            // Create client
+            GroupServiceClient groupServiceClient = GroupServiceClient.Create();
+            // Initialize request argument(s)
+            ListGroupsRequest request = new ListGroupsRequest
+            {
+                Name = new ProjectName("[PROJECT]").ToString(),
+            };
+            // Make the request
+            PagedEnumerable<ListGroupsResponse,Group> response =
+                groupServiceClient.ListGroups(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (Group item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListGroupsResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Group item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Group> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Group item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
         public async Task GetGroupAsync()
         {
             // Snippet: GetGroupAsync(string,CallSettings)
@@ -55,6 +147,36 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             string formattedName = new GroupName("[PROJECT]", "[GROUP]").ToString();
             // Make the request
             Group response = groupServiceClient.GetGroup(formattedName);
+            // End snippet
+        }
+
+        public async Task GetGroupAsync_RequestObject()
+        {
+            // Snippet: GetGroupAsync(GetGroupRequest,CallSettings)
+            // Create client
+            GroupServiceClient groupServiceClient = GroupServiceClient.Create();
+            // Initialize request argument(s)
+            GetGroupRequest request = new GetGroupRequest
+            {
+                Name = new GroupName("[PROJECT]", "[GROUP]").ToString(),
+            };
+            // Make the request
+            Group response = await groupServiceClient.GetGroupAsync(request);
+            // End snippet
+        }
+
+        public void GetGroup_RequestObject()
+        {
+            // Snippet: GetGroup(GetGroupRequest,CallSettings)
+            // Create client
+            GroupServiceClient groupServiceClient = GroupServiceClient.Create();
+            // Initialize request argument(s)
+            GetGroupRequest request = new GetGroupRequest
+            {
+                Name = new GroupName("[PROJECT]", "[GROUP]").ToString(),
+            };
+            // Make the request
+            Group response = groupServiceClient.GetGroup(request);
             // End snippet
         }
 
@@ -85,6 +207,38 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
+        public async Task CreateGroupAsync_RequestObject()
+        {
+            // Snippet: CreateGroupAsync(CreateGroupRequest,CallSettings)
+            // Create client
+            GroupServiceClient groupServiceClient = GroupServiceClient.Create();
+            // Initialize request argument(s)
+            CreateGroupRequest request = new CreateGroupRequest
+            {
+                Name = new ProjectName("[PROJECT]").ToString(),
+                Group = new Group(),
+            };
+            // Make the request
+            Group response = await groupServiceClient.CreateGroupAsync(request);
+            // End snippet
+        }
+
+        public void CreateGroup_RequestObject()
+        {
+            // Snippet: CreateGroup(CreateGroupRequest,CallSettings)
+            // Create client
+            GroupServiceClient groupServiceClient = GroupServiceClient.Create();
+            // Initialize request argument(s)
+            CreateGroupRequest request = new CreateGroupRequest
+            {
+                Name = new ProjectName("[PROJECT]").ToString(),
+                Group = new Group(),
+            };
+            // Make the request
+            Group response = groupServiceClient.CreateGroup(request);
+            // End snippet
+        }
+
         public async Task UpdateGroupAsync()
         {
             // Snippet: UpdateGroupAsync(Group,CallSettings)
@@ -110,6 +264,36 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
+        public async Task UpdateGroupAsync_RequestObject()
+        {
+            // Snippet: UpdateGroupAsync(UpdateGroupRequest,CallSettings)
+            // Create client
+            GroupServiceClient groupServiceClient = GroupServiceClient.Create();
+            // Initialize request argument(s)
+            UpdateGroupRequest request = new UpdateGroupRequest
+            {
+                Group = new Group(),
+            };
+            // Make the request
+            Group response = await groupServiceClient.UpdateGroupAsync(request);
+            // End snippet
+        }
+
+        public void UpdateGroup_RequestObject()
+        {
+            // Snippet: UpdateGroup(UpdateGroupRequest,CallSettings)
+            // Create client
+            GroupServiceClient groupServiceClient = GroupServiceClient.Create();
+            // Initialize request argument(s)
+            UpdateGroupRequest request = new UpdateGroupRequest
+            {
+                Group = new Group(),
+            };
+            // Make the request
+            Group response = groupServiceClient.UpdateGroup(request);
+            // End snippet
+        }
+
         public async Task DeleteGroupAsync()
         {
             // Snippet: DeleteGroupAsync(string,CallSettings)
@@ -132,6 +316,36 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             string formattedName = new GroupName("[PROJECT]", "[GROUP]").ToString();
             // Make the request
             groupServiceClient.DeleteGroup(formattedName);
+            // End snippet
+        }
+
+        public async Task DeleteGroupAsync_RequestObject()
+        {
+            // Snippet: DeleteGroupAsync(DeleteGroupRequest,CallSettings)
+            // Create client
+            GroupServiceClient groupServiceClient = GroupServiceClient.Create();
+            // Initialize request argument(s)
+            DeleteGroupRequest request = new DeleteGroupRequest
+            {
+                Name = new GroupName("[PROJECT]", "[GROUP]").ToString(),
+            };
+            // Make the request
+            await groupServiceClient.DeleteGroupAsync(request);
+            // End snippet
+        }
+
+        public void DeleteGroup_RequestObject()
+        {
+            // Snippet: DeleteGroup(DeleteGroupRequest,CallSettings)
+            // Create client
+            GroupServiceClient groupServiceClient = GroupServiceClient.Create();
+            // Initialize request argument(s)
+            DeleteGroupRequest request = new DeleteGroupRequest
+            {
+                Name = new GroupName("[PROJECT]", "[GROUP]").ToString(),
+            };
+            // Make the request
+            groupServiceClient.DeleteGroup(request);
             // End snippet
         }
 
@@ -188,6 +402,98 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // Make the request
             PagedEnumerable<ListGroupMembersResponse,MonitoredResource> response =
                 groupServiceClient.ListGroupMembers(formattedName);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (MonitoredResource item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListGroupMembersResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (MonitoredResource item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<MonitoredResource> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (MonitoredResource item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public async Task ListGroupMembersAsync_RequestObject()
+        {
+            // Snippet: ListGroupMembersAsync(ListGroupMembersRequest,CallSettings)
+            // Create client
+            GroupServiceClient groupServiceClient = GroupServiceClient.Create();
+            // Initialize request argument(s)
+            ListGroupMembersRequest request = new ListGroupMembersRequest
+            {
+                Name = new GroupName("[PROJECT]", "[GROUP]").ToString(),
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListGroupMembersResponse,MonitoredResource> response =
+                groupServiceClient.ListGroupMembersAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((MonitoredResource item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListGroupMembersResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (MonitoredResource item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<MonitoredResource> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (MonitoredResource item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListGroupMembers_RequestObject()
+        {
+            // Snippet: ListGroupMembers(ListGroupMembersRequest,CallSettings)
+            // Create client
+            GroupServiceClient groupServiceClient = GroupServiceClient.Create();
+            // Initialize request argument(s)
+            ListGroupMembersRequest request = new ListGroupMembersRequest
+            {
+                Name = new GroupName("[PROJECT]", "[GROUP]").ToString(),
+            };
+            // Make the request
+            PagedEnumerable<ListGroupMembersResponse,MonitoredResource> response =
+                groupServiceClient.ListGroupMembers(request);
 
             // Iterate over all response items, lazily performing RPCs as required
             foreach (MonitoredResource item in response)

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/MetricServiceClientSnippets.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/MetricServiceClientSnippets.cs
@@ -35,11 +35,10 @@ namespace Google.Cloud.Monitoring.V3
         {
             string projectId = _fixture.ProjectId;
 
-            // Snippet: ListMetricDescriptors
+            // Snippet: ListMetricDescriptors(*,*,*,*)
             MetricServiceClient client = MetricServiceClient.Create();
             string projectName = new ProjectName(projectId).ToString();
-            string filter = "";
-            PagedEnumerable<ListMetricDescriptorsResponse, MetricDescriptor> metrics = client.ListMetricDescriptors(projectName, filter);
+            PagedEnumerable<ListMetricDescriptorsResponse, MetricDescriptor> metrics = client.ListMetricDescriptors(projectName);
             foreach (MetricDescriptor metric in metrics.Take(10))
             {
                 Console.WriteLine($"{metric.Name}: {metric.DisplayName}");

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/MetricServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/MetricServiceClientSnippets.g.cs
@@ -119,6 +119,98 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
+        public async Task ListMonitoredResourceDescriptorsAsync_RequestObject()
+        {
+            // Snippet: ListMonitoredResourceDescriptorsAsync(ListMonitoredResourceDescriptorsRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            ListMonitoredResourceDescriptorsRequest request = new ListMonitoredResourceDescriptorsRequest
+            {
+                Name = new ProjectName("[PROJECT]").ToString(),
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListMonitoredResourceDescriptorsResponse,MonitoredResourceDescriptor> response =
+                metricServiceClient.ListMonitoredResourceDescriptorsAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((MonitoredResourceDescriptor item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListMonitoredResourceDescriptorsResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (MonitoredResourceDescriptor item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<MonitoredResourceDescriptor> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (MonitoredResourceDescriptor item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListMonitoredResourceDescriptors_RequestObject()
+        {
+            // Snippet: ListMonitoredResourceDescriptors(ListMonitoredResourceDescriptorsRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            ListMonitoredResourceDescriptorsRequest request = new ListMonitoredResourceDescriptorsRequest
+            {
+                Name = new ProjectName("[PROJECT]").ToString(),
+            };
+            // Make the request
+            PagedEnumerable<ListMonitoredResourceDescriptorsResponse,MonitoredResourceDescriptor> response =
+                metricServiceClient.ListMonitoredResourceDescriptors(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (MonitoredResourceDescriptor item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListMonitoredResourceDescriptorsResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (MonitoredResourceDescriptor item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<MonitoredResourceDescriptor> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (MonitoredResourceDescriptor item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
         public async Task GetMonitoredResourceDescriptorAsync()
         {
             // Snippet: GetMonitoredResourceDescriptorAsync(string,CallSettings)
@@ -141,6 +233,36 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             string formattedName = new MonitoredResourceDescriptorName("[PROJECT]", "[MONITORED_RESOURCE_DESCRIPTOR]").ToString();
             // Make the request
             MonitoredResourceDescriptor response = metricServiceClient.GetMonitoredResourceDescriptor(formattedName);
+            // End snippet
+        }
+
+        public async Task GetMonitoredResourceDescriptorAsync_RequestObject()
+        {
+            // Snippet: GetMonitoredResourceDescriptorAsync(GetMonitoredResourceDescriptorRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            GetMonitoredResourceDescriptorRequest request = new GetMonitoredResourceDescriptorRequest
+            {
+                Name = new MonitoredResourceDescriptorName("[PROJECT]", "[MONITORED_RESOURCE_DESCRIPTOR]").ToString(),
+            };
+            // Make the request
+            MonitoredResourceDescriptor response = await metricServiceClient.GetMonitoredResourceDescriptorAsync(request);
+            // End snippet
+        }
+
+        public void GetMonitoredResourceDescriptor_RequestObject()
+        {
+            // Snippet: GetMonitoredResourceDescriptor(GetMonitoredResourceDescriptorRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            GetMonitoredResourceDescriptorRequest request = new GetMonitoredResourceDescriptorRequest
+            {
+                Name = new MonitoredResourceDescriptorName("[PROJECT]", "[MONITORED_RESOURCE_DESCRIPTOR]").ToString(),
+            };
+            // Make the request
+            MonitoredResourceDescriptor response = metricServiceClient.GetMonitoredResourceDescriptor(request);
             // End snippet
         }
 
@@ -230,6 +352,98 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
+        public async Task ListMetricDescriptorsAsync_RequestObject()
+        {
+            // Snippet: ListMetricDescriptorsAsync(ListMetricDescriptorsRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            ListMetricDescriptorsRequest request = new ListMetricDescriptorsRequest
+            {
+                Name = new ProjectName("[PROJECT]").ToString(),
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListMetricDescriptorsResponse,MetricDescriptor> response =
+                metricServiceClient.ListMetricDescriptorsAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((MetricDescriptor item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListMetricDescriptorsResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (MetricDescriptor item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<MetricDescriptor> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (MetricDescriptor item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListMetricDescriptors_RequestObject()
+        {
+            // Snippet: ListMetricDescriptors(ListMetricDescriptorsRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            ListMetricDescriptorsRequest request = new ListMetricDescriptorsRequest
+            {
+                Name = new ProjectName("[PROJECT]").ToString(),
+            };
+            // Make the request
+            PagedEnumerable<ListMetricDescriptorsResponse,MetricDescriptor> response =
+                metricServiceClient.ListMetricDescriptors(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (MetricDescriptor item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListMetricDescriptorsResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (MetricDescriptor item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<MetricDescriptor> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (MetricDescriptor item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
         public async Task GetMetricDescriptorAsync()
         {
             // Snippet: GetMetricDescriptorAsync(string,CallSettings)
@@ -252,6 +466,36 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             string formattedName = new MetricDescriptorName("[PROJECT]", "[METRIC_DESCRIPTOR]").ToString();
             // Make the request
             MetricDescriptor response = metricServiceClient.GetMetricDescriptor(formattedName);
+            // End snippet
+        }
+
+        public async Task GetMetricDescriptorAsync_RequestObject()
+        {
+            // Snippet: GetMetricDescriptorAsync(GetMetricDescriptorRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            GetMetricDescriptorRequest request = new GetMetricDescriptorRequest
+            {
+                Name = new MetricDescriptorName("[PROJECT]", "[METRIC_DESCRIPTOR]").ToString(),
+            };
+            // Make the request
+            MetricDescriptor response = await metricServiceClient.GetMetricDescriptorAsync(request);
+            // End snippet
+        }
+
+        public void GetMetricDescriptor_RequestObject()
+        {
+            // Snippet: GetMetricDescriptor(GetMetricDescriptorRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            GetMetricDescriptorRequest request = new GetMetricDescriptorRequest
+            {
+                Name = new MetricDescriptorName("[PROJECT]", "[METRIC_DESCRIPTOR]").ToString(),
+            };
+            // Make the request
+            MetricDescriptor response = metricServiceClient.GetMetricDescriptor(request);
             // End snippet
         }
 
@@ -282,6 +526,38 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
+        public async Task CreateMetricDescriptorAsync_RequestObject()
+        {
+            // Snippet: CreateMetricDescriptorAsync(CreateMetricDescriptorRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            CreateMetricDescriptorRequest request = new CreateMetricDescriptorRequest
+            {
+                Name = new ProjectName("[PROJECT]").ToString(),
+                MetricDescriptor = new MetricDescriptor(),
+            };
+            // Make the request
+            MetricDescriptor response = await metricServiceClient.CreateMetricDescriptorAsync(request);
+            // End snippet
+        }
+
+        public void CreateMetricDescriptor_RequestObject()
+        {
+            // Snippet: CreateMetricDescriptor(CreateMetricDescriptorRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            CreateMetricDescriptorRequest request = new CreateMetricDescriptorRequest
+            {
+                Name = new ProjectName("[PROJECT]").ToString(),
+                MetricDescriptor = new MetricDescriptor(),
+            };
+            // Make the request
+            MetricDescriptor response = metricServiceClient.CreateMetricDescriptor(request);
+            // End snippet
+        }
+
         public async Task DeleteMetricDescriptorAsync()
         {
             // Snippet: DeleteMetricDescriptorAsync(string,CallSettings)
@@ -304,6 +580,36 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             string formattedName = new MetricDescriptorName("[PROJECT]", "[METRIC_DESCRIPTOR]").ToString();
             // Make the request
             metricServiceClient.DeleteMetricDescriptor(formattedName);
+            // End snippet
+        }
+
+        public async Task DeleteMetricDescriptorAsync_RequestObject()
+        {
+            // Snippet: DeleteMetricDescriptorAsync(DeleteMetricDescriptorRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            DeleteMetricDescriptorRequest request = new DeleteMetricDescriptorRequest
+            {
+                Name = new MetricDescriptorName("[PROJECT]", "[METRIC_DESCRIPTOR]").ToString(),
+            };
+            // Make the request
+            await metricServiceClient.DeleteMetricDescriptorAsync(request);
+            // End snippet
+        }
+
+        public void DeleteMetricDescriptor_RequestObject()
+        {
+            // Snippet: DeleteMetricDescriptor(DeleteMetricDescriptorRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            DeleteMetricDescriptorRequest request = new DeleteMetricDescriptorRequest
+            {
+                Name = new MetricDescriptorName("[PROJECT]", "[METRIC_DESCRIPTOR]").ToString(),
+            };
+            // Make the request
+            metricServiceClient.DeleteMetricDescriptor(request);
             // End snippet
         }
 
@@ -399,6 +705,104 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
+        public async Task ListTimeSeriesAsync_RequestObject()
+        {
+            // Snippet: ListTimeSeriesAsync(ListTimeSeriesRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            ListTimeSeriesRequest request = new ListTimeSeriesRequest
+            {
+                Name = new ProjectName("[PROJECT]").ToString(),
+                Filter = "",
+                Interval = new TimeInterval(),
+                View = ListTimeSeriesRequest.Types.TimeSeriesView.Full,
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListTimeSeriesResponse,TimeSeries> response =
+                metricServiceClient.ListTimeSeriesAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((TimeSeries item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListTimeSeriesResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (TimeSeries item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<TimeSeries> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (TimeSeries item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListTimeSeries_RequestObject()
+        {
+            // Snippet: ListTimeSeries(ListTimeSeriesRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            ListTimeSeriesRequest request = new ListTimeSeriesRequest
+            {
+                Name = new ProjectName("[PROJECT]").ToString(),
+                Filter = "",
+                Interval = new TimeInterval(),
+                View = ListTimeSeriesRequest.Types.TimeSeriesView.Full,
+            };
+            // Make the request
+            PagedEnumerable<ListTimeSeriesResponse,TimeSeries> response =
+                metricServiceClient.ListTimeSeries(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (TimeSeries item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListTimeSeriesResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (TimeSeries item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<TimeSeries> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (TimeSeries item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
         public async Task CreateTimeSeriesAsync()
         {
             // Snippet: CreateTimeSeriesAsync(string,IEnumerable<TimeSeries>,CallSettings)
@@ -423,6 +827,38 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             IEnumerable<TimeSeries> timeSeries = new List<TimeSeries>();
             // Make the request
             metricServiceClient.CreateTimeSeries(formattedName, timeSeries);
+            // End snippet
+        }
+
+        public async Task CreateTimeSeriesAsync_RequestObject()
+        {
+            // Snippet: CreateTimeSeriesAsync(CreateTimeSeriesRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            CreateTimeSeriesRequest request = new CreateTimeSeriesRequest
+            {
+                Name = new ProjectName("[PROJECT]").ToString(),
+                TimeSeries = { },
+            };
+            // Make the request
+            await metricServiceClient.CreateTimeSeriesAsync(request);
+            // End snippet
+        }
+
+        public void CreateTimeSeries_RequestObject()
+        {
+            // Snippet: CreateTimeSeries(CreateTimeSeriesRequest,CallSettings)
+            // Create client
+            MetricServiceClient metricServiceClient = MetricServiceClient.Create();
+            // Initialize request argument(s)
+            CreateTimeSeriesRequest request = new CreateTimeSeriesRequest
+            {
+                Name = new ProjectName("[PROJECT]").ToString(),
+                TimeSeries = { },
+            };
+            // Make the request
+            metricServiceClient.CreateTimeSeries(request);
             // End snippet
         }
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceClient.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceClient.cs
@@ -406,6 +406,44 @@ namespace Google.Cloud.Monitoring.V3
         }
 
         /// <summary>
+        /// Lists the existing groups.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="Group"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListGroupsResponse, Group> ListGroupsAsync(
+            ListGroupsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists the existing groups.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="Group"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListGroupsResponse, Group> ListGroups(
+            ListGroupsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Gets a single group.
         /// </summary>
         /// <param name="name">
@@ -420,10 +458,12 @@ namespace Google.Cloud.Monitoring.V3
         /// </returns>
         public virtual Task<Group> GetGroupAsync(
             string name,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => GetGroupAsync(
+                new GetGroupRequest
+                {
+                    Name = name,
+                },
+                callSettings);
 
         /// <summary>
         /// Gets a single group.
@@ -459,6 +499,46 @@ namespace Google.Cloud.Monitoring.V3
         /// </returns>
         public virtual Group GetGroup(
             string name,
+            CallSettings callSettings = null) => GetGroup(
+                new GetGroupRequest
+                {
+                    Name = name,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a single group.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Group> GetGroupAsync(
+            GetGroupRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets a single group.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Group GetGroup(
+            GetGroupRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -484,10 +564,13 @@ namespace Google.Cloud.Monitoring.V3
         public virtual Task<Group> CreateGroupAsync(
             string name,
             Group group,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => CreateGroupAsync(
+                new CreateGroupRequest
+                {
+                    Name = name,
+                    Group = group,
+                },
+                callSettings);
 
         /// <summary>
         /// Creates a new group.
@@ -534,6 +617,47 @@ namespace Google.Cloud.Monitoring.V3
         public virtual Group CreateGroup(
             string name,
             Group group,
+            CallSettings callSettings = null) => CreateGroup(
+                new CreateGroupRequest
+                {
+                    Name = name,
+                    Group = group,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates a new group.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Group> CreateGroupAsync(
+            CreateGroupRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Creates a new group.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Group CreateGroup(
+            CreateGroupRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -555,10 +679,12 @@ namespace Google.Cloud.Monitoring.V3
         /// </returns>
         public virtual Task<Group> UpdateGroupAsync(
             Group group,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => UpdateGroupAsync(
+                new UpdateGroupRequest
+                {
+                    Group = group,
+                },
+                callSettings);
 
         /// <summary>
         /// Updates an existing group.
@@ -596,6 +722,48 @@ namespace Google.Cloud.Monitoring.V3
         /// </returns>
         public virtual Group UpdateGroup(
             Group group,
+            CallSettings callSettings = null) => UpdateGroup(
+                new UpdateGroupRequest
+                {
+                    Group = group,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates an existing group.
+        /// You can change any group attributes except `name`.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Group> UpdateGroupAsync(
+            UpdateGroupRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Updates an existing group.
+        /// You can change any group attributes except `name`.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Group UpdateGroup(
+            UpdateGroupRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -616,10 +784,12 @@ namespace Google.Cloud.Monitoring.V3
         /// </returns>
         public virtual Task DeleteGroupAsync(
             string name,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => DeleteGroupAsync(
+                new DeleteGroupRequest
+                {
+                    Name = name,
+                },
+                callSettings);
 
         /// <summary>
         /// Deletes an existing group.
@@ -655,6 +825,46 @@ namespace Google.Cloud.Monitoring.V3
         /// </returns>
         public virtual void DeleteGroup(
             string name,
+            CallSettings callSettings = null) => DeleteGroup(
+                new DeleteGroupRequest
+                {
+                    Name = name,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes an existing group.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task DeleteGroupAsync(
+            DeleteGroupRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Deletes an existing group.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual void DeleteGroup(
+            DeleteGroupRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -685,10 +895,14 @@ namespace Google.Cloud.Monitoring.V3
             string name,
             string pageToken = null,
             int? pageSize = null,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ListGroupMembersAsync(
+                new ListGroupMembersRequest
+                {
+                    Name = name,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
 
         /// <summary>
         /// Lists the monitored resources that are members of a group.
@@ -715,6 +929,48 @@ namespace Google.Cloud.Monitoring.V3
             string name,
             string pageToken = null,
             int? pageSize = null,
+            CallSettings callSettings = null) => ListGroupMembers(
+                new ListGroupMembersRequest
+                {
+                    Name = name,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists the monitored resources that are members of a group.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="MonitoredResource"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListGroupMembersResponse, MonitoredResource> ListGroupMembersAsync(
+            ListGroupMembersRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists the monitored resources that are members of a group.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="MonitoredResource"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListGroupMembersResponse, MonitoredResource> ListGroupMembers(
+            ListGroupMembersRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -773,11 +1029,50 @@ namespace Google.Cloud.Monitoring.V3
         partial void Modify_ListGroupMembersRequest(ref ListGroupMembersRequest request, ref CallSettings settings);
 
         /// <summary>
+        /// Lists the existing groups.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="Group"/> resources.
+        /// </returns>
+        public override PagedAsyncEnumerable<ListGroupsResponse, Group> ListGroupsAsync(
+            ListGroupsRequest request,
+            CallSettings callSettings = null)
+        {
+            Modify_ListGroupsRequest(ref request, ref callSettings);
+            return new GrpcPagedAsyncEnumerable<ListGroupsRequest, ListGroupsResponse, Group>(_callListGroups, request, callSettings);
+        }
+
+        /// <summary>
+        /// Lists the existing groups.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="Group"/> resources.
+        /// </returns>
+        public override PagedEnumerable<ListGroupsResponse, Group> ListGroups(
+            ListGroupsRequest request,
+            CallSettings callSettings = null)
+        {
+            Modify_ListGroupsRequest(ref request, ref callSettings);
+            return new GrpcPagedEnumerable<ListGroupsRequest, ListGroupsResponse, Group>(_callListGroups, request, callSettings);
+        }
+
+        /// <summary>
         /// Gets a single group.
         /// </summary>
-        /// <param name="name">
-        /// The group to retrieve. The format is
-        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -786,13 +1081,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<Group> GetGroupAsync(
-            string name,
+            GetGroupRequest request,
             CallSettings callSettings = null)
         {
-            GetGroupRequest request = new GetGroupRequest
-            {
-                Name = name,
-            };
             Modify_GetGroupRequest(ref request, ref callSettings);
             return _callGetGroup.Async(request, callSettings);
         }
@@ -800,9 +1091,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Gets a single group.
         /// </summary>
-        /// <param name="name">
-        /// The group to retrieve. The format is
-        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -811,13 +1101,9 @@ namespace Google.Cloud.Monitoring.V3
         /// The RPC response.
         /// </returns>
         public override Group GetGroup(
-            string name,
+            GetGroupRequest request,
             CallSettings callSettings = null)
         {
-            GetGroupRequest request = new GetGroupRequest
-            {
-                Name = name,
-            };
             Modify_GetGroupRequest(ref request, ref callSettings);
             return _callGetGroup.Sync(request, callSettings);
         }
@@ -825,13 +1111,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Creates a new group.
         /// </summary>
-        /// <param name="name">
-        /// The project in which to create the group. The format is
-        /// `"projects/{project_id_or_number}"`.
-        /// </param>
-        /// <param name="group">
-        /// A group definition. It is an error to define the `name` field because
-        /// the system assigns the name.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -840,15 +1121,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<Group> CreateGroupAsync(
-            string name,
-            Group group,
+            CreateGroupRequest request,
             CallSettings callSettings = null)
         {
-            CreateGroupRequest request = new CreateGroupRequest
-            {
-                Name = name,
-                Group = group,
-            };
             Modify_CreateGroupRequest(ref request, ref callSettings);
             return _callCreateGroup.Async(request, callSettings);
         }
@@ -856,13 +1131,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Creates a new group.
         /// </summary>
-        /// <param name="name">
-        /// The project in which to create the group. The format is
-        /// `"projects/{project_id_or_number}"`.
-        /// </param>
-        /// <param name="group">
-        /// A group definition. It is an error to define the `name` field because
-        /// the system assigns the name.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -871,15 +1141,9 @@ namespace Google.Cloud.Monitoring.V3
         /// The RPC response.
         /// </returns>
         public override Group CreateGroup(
-            string name,
-            Group group,
+            CreateGroupRequest request,
             CallSettings callSettings = null)
         {
-            CreateGroupRequest request = new CreateGroupRequest
-            {
-                Name = name,
-                Group = group,
-            };
             Modify_CreateGroupRequest(ref request, ref callSettings);
             return _callCreateGroup.Sync(request, callSettings);
         }
@@ -888,9 +1152,8 @@ namespace Google.Cloud.Monitoring.V3
         /// Updates an existing group.
         /// You can change any group attributes except `name`.
         /// </summary>
-        /// <param name="group">
-        /// The new definition of the group.  All fields of the existing group,
-        /// excepting `name`, are replaced with the corresponding fields of this group.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -899,13 +1162,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<Group> UpdateGroupAsync(
-            Group group,
+            UpdateGroupRequest request,
             CallSettings callSettings = null)
         {
-            UpdateGroupRequest request = new UpdateGroupRequest
-            {
-                Group = group,
-            };
             Modify_UpdateGroupRequest(ref request, ref callSettings);
             return _callUpdateGroup.Async(request, callSettings);
         }
@@ -914,9 +1173,8 @@ namespace Google.Cloud.Monitoring.V3
         /// Updates an existing group.
         /// You can change any group attributes except `name`.
         /// </summary>
-        /// <param name="group">
-        /// The new definition of the group.  All fields of the existing group,
-        /// excepting `name`, are replaced with the corresponding fields of this group.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -925,13 +1183,9 @@ namespace Google.Cloud.Monitoring.V3
         /// The RPC response.
         /// </returns>
         public override Group UpdateGroup(
-            Group group,
+            UpdateGroupRequest request,
             CallSettings callSettings = null)
         {
-            UpdateGroupRequest request = new UpdateGroupRequest
-            {
-                Group = group,
-            };
             Modify_UpdateGroupRequest(ref request, ref callSettings);
             return _callUpdateGroup.Sync(request, callSettings);
         }
@@ -939,9 +1193,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Deletes an existing group.
         /// </summary>
-        /// <param name="name">
-        /// The group to delete. The format is
-        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -950,13 +1203,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A Task containing the RPC response.
         /// </returns>
         public override Task DeleteGroupAsync(
-            string name,
+            DeleteGroupRequest request,
             CallSettings callSettings = null)
         {
-            DeleteGroupRequest request = new DeleteGroupRequest
-            {
-                Name = name,
-            };
             Modify_DeleteGroupRequest(ref request, ref callSettings);
             return _callDeleteGroup.Async(request, callSettings);
         }
@@ -964,9 +1213,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Deletes an existing group.
         /// </summary>
-        /// <param name="name">
-        /// The group to delete. The format is
-        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -975,13 +1223,9 @@ namespace Google.Cloud.Monitoring.V3
         /// The RPC response.
         /// </returns>
         public override void DeleteGroup(
-            string name,
+            DeleteGroupRequest request,
             CallSettings callSettings = null)
         {
-            DeleteGroupRequest request = new DeleteGroupRequest
-            {
-                Name = name,
-            };
             Modify_DeleteGroupRequest(ref request, ref callSettings);
             _callDeleteGroup.Sync(request, callSettings);
         }
@@ -989,17 +1233,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Lists the monitored resources that are members of a group.
         /// </summary>
-        /// <param name="name">
-        /// The group whose members are listed. The format is
-        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1008,17 +1243,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A pageable asynchronous sequence of <see cref="MonitoredResource"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListGroupMembersResponse, MonitoredResource> ListGroupMembersAsync(
-            string name,
-            string pageToken = null,
-            int? pageSize = null,
+            ListGroupMembersRequest request,
             CallSettings callSettings = null)
         {
-            ListGroupMembersRequest request = new ListGroupMembersRequest
-            {
-                Name = name,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListGroupMembersRequest(ref request, ref callSettings);
             return new GrpcPagedAsyncEnumerable<ListGroupMembersRequest, ListGroupMembersResponse, MonitoredResource>(_callListGroupMembers, request, callSettings);
         }
@@ -1026,17 +1253,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Lists the monitored resources that are members of a group.
         /// </summary>
-        /// <param name="name">
-        /// The group whose members are listed. The format is
-        /// `"projects/{project_id_or_number}/groups/{group_id}"`.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1045,17 +1263,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A pageable sequence of <see cref="MonitoredResource"/> resources.
         /// </returns>
         public override PagedEnumerable<ListGroupMembersResponse, MonitoredResource> ListGroupMembers(
-            string name,
-            string pageToken = null,
-            int? pageSize = null,
+            ListGroupMembersRequest request,
             CallSettings callSettings = null)
         {
-            ListGroupMembersRequest request = new ListGroupMembersRequest
-            {
-                Name = name,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListGroupMembersRequest(ref request, ref callSettings);
             return new GrpcPagedEnumerable<ListGroupMembersRequest, ListGroupMembersResponse, MonitoredResource>(_callListGroupMembers, request, callSettings);
         }
@@ -1063,6 +1273,18 @@ namespace Google.Cloud.Monitoring.V3
     }
 
     // Partial classes to enable page-streaming
+
+    public partial class ListGroupsRequest : IPageRequest { }
+    public partial class ListGroupsResponse : IPageResponse<Group>
+    {
+        /// <summary>
+        /// Returns an enumerator that iterates through the resources in this response.
+        /// </summary>
+        public IEnumerator<Group> GetEnumerator() => Group.GetEnumerator();
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
     public partial class ListGroupMembersRequest : IPageRequest { }
     public partial class ListGroupMembersResponse : IPageResponse<MonitoredResource>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceClient.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceClient.cs
@@ -491,10 +491,14 @@ namespace Google.Cloud.Monitoring.V3
             string name,
             string pageToken = null,
             int? pageSize = null,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ListMonitoredResourceDescriptorsAsync(
+                new ListMonitoredResourceDescriptorsRequest
+                {
+                    Name = name,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
 
         /// <summary>
         /// Lists monitored resource descriptors that match a filter. This method does not require a Stackdriver account.
@@ -521,6 +525,48 @@ namespace Google.Cloud.Monitoring.V3
             string name,
             string pageToken = null,
             int? pageSize = null,
+            CallSettings callSettings = null) => ListMonitoredResourceDescriptors(
+                new ListMonitoredResourceDescriptorsRequest
+                {
+                    Name = name,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists monitored resource descriptors that match a filter. This method does not require a Stackdriver account.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="MonitoredResourceDescriptor"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListMonitoredResourceDescriptorsResponse, MonitoredResourceDescriptor> ListMonitoredResourceDescriptorsAsync(
+            ListMonitoredResourceDescriptorsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists monitored resource descriptors that match a filter. This method does not require a Stackdriver account.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="MonitoredResourceDescriptor"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListMonitoredResourceDescriptorsResponse, MonitoredResourceDescriptor> ListMonitoredResourceDescriptors(
+            ListMonitoredResourceDescriptorsRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -543,10 +589,12 @@ namespace Google.Cloud.Monitoring.V3
         /// </returns>
         public virtual Task<MonitoredResourceDescriptor> GetMonitoredResourceDescriptorAsync(
             string name,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => GetMonitoredResourceDescriptorAsync(
+                new GetMonitoredResourceDescriptorRequest
+                {
+                    Name = name,
+                },
+                callSettings);
 
         /// <summary>
         /// Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
@@ -586,6 +634,46 @@ namespace Google.Cloud.Monitoring.V3
         /// </returns>
         public virtual MonitoredResourceDescriptor GetMonitoredResourceDescriptor(
             string name,
+            CallSettings callSettings = null) => GetMonitoredResourceDescriptor(
+                new GetMonitoredResourceDescriptorRequest
+                {
+                    Name = name,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<MonitoredResourceDescriptor> GetMonitoredResourceDescriptorAsync(
+            GetMonitoredResourceDescriptorRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual MonitoredResourceDescriptor GetMonitoredResourceDescriptor(
+            GetMonitoredResourceDescriptorRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -616,10 +704,14 @@ namespace Google.Cloud.Monitoring.V3
             string name,
             string pageToken = null,
             int? pageSize = null,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ListMetricDescriptorsAsync(
+                new ListMetricDescriptorsRequest
+                {
+                    Name = name,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
 
         /// <summary>
         /// Lists metric descriptors that match a filter. This method does not require a Stackdriver account.
@@ -646,6 +738,48 @@ namespace Google.Cloud.Monitoring.V3
             string name,
             string pageToken = null,
             int? pageSize = null,
+            CallSettings callSettings = null) => ListMetricDescriptors(
+                new ListMetricDescriptorsRequest
+                {
+                    Name = name,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists metric descriptors that match a filter. This method does not require a Stackdriver account.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="MetricDescriptor"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListMetricDescriptorsResponse, MetricDescriptor> ListMetricDescriptorsAsync(
+            ListMetricDescriptorsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists metric descriptors that match a filter. This method does not require a Stackdriver account.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="MetricDescriptor"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListMetricDescriptorsResponse, MetricDescriptor> ListMetricDescriptors(
+            ListMetricDescriptorsRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -668,10 +802,12 @@ namespace Google.Cloud.Monitoring.V3
         /// </returns>
         public virtual Task<MetricDescriptor> GetMetricDescriptorAsync(
             string name,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => GetMetricDescriptorAsync(
+                new GetMetricDescriptorRequest
+                {
+                    Name = name,
+                },
+                callSettings);
 
         /// <summary>
         /// Gets a single metric descriptor. This method does not require a Stackdriver account.
@@ -711,6 +847,46 @@ namespace Google.Cloud.Monitoring.V3
         /// </returns>
         public virtual MetricDescriptor GetMetricDescriptor(
             string name,
+            CallSettings callSettings = null) => GetMetricDescriptor(
+                new GetMetricDescriptorRequest
+                {
+                    Name = name,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a single metric descriptor. This method does not require a Stackdriver account.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<MetricDescriptor> GetMetricDescriptorAsync(
+            GetMetricDescriptorRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets a single metric descriptor. This method does not require a Stackdriver account.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual MetricDescriptor GetMetricDescriptor(
+            GetMetricDescriptorRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -738,10 +914,13 @@ namespace Google.Cloud.Monitoring.V3
         public virtual Task<MetricDescriptor> CreateMetricDescriptorAsync(
             string name,
             MetricDescriptor metricDescriptor,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => CreateMetricDescriptorAsync(
+                new CreateMetricDescriptorRequest
+                {
+                    Name = name,
+                    MetricDescriptor = metricDescriptor,
+                },
+                callSettings);
 
         /// <summary>
         /// Creates a new metric descriptor.
@@ -792,6 +971,51 @@ namespace Google.Cloud.Monitoring.V3
         public virtual MetricDescriptor CreateMetricDescriptor(
             string name,
             MetricDescriptor metricDescriptor,
+            CallSettings callSettings = null) => CreateMetricDescriptor(
+                new CreateMetricDescriptorRequest
+                {
+                    Name = name,
+                    MetricDescriptor = metricDescriptor,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates a new metric descriptor.
+        /// User-created metric descriptors define
+        /// [custom metrics](/monitoring/custom-metrics).
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<MetricDescriptor> CreateMetricDescriptorAsync(
+            CreateMetricDescriptorRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Creates a new metric descriptor.
+        /// User-created metric descriptors define
+        /// [custom metrics](/monitoring/custom-metrics).
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual MetricDescriptor CreateMetricDescriptor(
+            CreateMetricDescriptorRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -815,10 +1039,12 @@ namespace Google.Cloud.Monitoring.V3
         /// </returns>
         public virtual Task DeleteMetricDescriptorAsync(
             string name,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => DeleteMetricDescriptorAsync(
+                new DeleteMetricDescriptorRequest
+                {
+                    Name = name,
+                },
+                callSettings);
 
         /// <summary>
         /// Deletes a metric descriptor. Only user-created
@@ -860,6 +1086,48 @@ namespace Google.Cloud.Monitoring.V3
         /// </returns>
         public virtual void DeleteMetricDescriptor(
             string name,
+            CallSettings callSettings = null) => DeleteMetricDescriptor(
+                new DeleteMetricDescriptorRequest
+                {
+                    Name = name,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes a metric descriptor. Only user-created
+        /// [custom metrics](/monitoring/custom-metrics) can be deleted.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task DeleteMetricDescriptorAsync(
+            DeleteMetricDescriptorRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Deletes a metric descriptor. Only user-created
+        /// [custom metrics](/monitoring/custom-metrics) can be deleted.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual void DeleteMetricDescriptor(
+            DeleteMetricDescriptorRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -910,10 +1178,17 @@ namespace Google.Cloud.Monitoring.V3
             ListTimeSeriesRequest.Types.TimeSeriesView view,
             string pageToken = null,
             int? pageSize = null,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ListTimeSeriesAsync(
+                new ListTimeSeriesRequest
+                {
+                    Name = name,
+                    Filter = filter,
+                    Interval = interval,
+                    View = view,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
 
         /// <summary>
         /// Lists time series that match a filter. This method does not require a Stackdriver account.
@@ -960,6 +1235,51 @@ namespace Google.Cloud.Monitoring.V3
             ListTimeSeriesRequest.Types.TimeSeriesView view,
             string pageToken = null,
             int? pageSize = null,
+            CallSettings callSettings = null) => ListTimeSeries(
+                new ListTimeSeriesRequest
+                {
+                    Name = name,
+                    Filter = filter,
+                    Interval = interval,
+                    View = view,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists time series that match a filter. This method does not require a Stackdriver account.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="TimeSeries"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListTimeSeriesResponse, TimeSeries> ListTimeSeriesAsync(
+            ListTimeSeriesRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists time series that match a filter. This method does not require a Stackdriver account.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="TimeSeries"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListTimeSeriesResponse, TimeSeries> ListTimeSeries(
+            ListTimeSeriesRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -991,10 +1311,13 @@ namespace Google.Cloud.Monitoring.V3
         public virtual Task CreateTimeSeriesAsync(
             string name,
             IEnumerable<TimeSeries> timeSeries,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => CreateTimeSeriesAsync(
+                new CreateTimeSeriesRequest
+                {
+                    Name = name,
+                    TimeSeries = { timeSeries },
+                },
+                callSettings);
 
         /// <summary>
         /// Creates or adds data to one or more time series.
@@ -1053,6 +1376,53 @@ namespace Google.Cloud.Monitoring.V3
         public virtual void CreateTimeSeries(
             string name,
             IEnumerable<TimeSeries> timeSeries,
+            CallSettings callSettings = null) => CreateTimeSeries(
+                new CreateTimeSeriesRequest
+                {
+                    Name = name,
+                    TimeSeries = { timeSeries },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates or adds data to one or more time series.
+        /// The response is empty if all time series in the request were written.
+        /// If any time series could not be written, a corresponding failure message is
+        /// included in the error response.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task CreateTimeSeriesAsync(
+            CreateTimeSeriesRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Creates or adds data to one or more time series.
+        /// The response is empty if all time series in the request were written.
+        /// If any time series could not be written, a corresponding failure message is
+        /// included in the error response.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual void CreateTimeSeries(
+            CreateTimeSeriesRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1121,17 +1491,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Lists monitored resource descriptors that match a filter. This method does not require a Stackdriver account.
         /// </summary>
-        /// <param name="name">
-        /// The project on which to execute the request. The format is
-        /// `"projects/{project_id_or_number}"`.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1140,17 +1501,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A pageable asynchronous sequence of <see cref="MonitoredResourceDescriptor"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListMonitoredResourceDescriptorsResponse, MonitoredResourceDescriptor> ListMonitoredResourceDescriptorsAsync(
-            string name,
-            string pageToken = null,
-            int? pageSize = null,
+            ListMonitoredResourceDescriptorsRequest request,
             CallSettings callSettings = null)
         {
-            ListMonitoredResourceDescriptorsRequest request = new ListMonitoredResourceDescriptorsRequest
-            {
-                Name = name,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListMonitoredResourceDescriptorsRequest(ref request, ref callSettings);
             return new GrpcPagedAsyncEnumerable<ListMonitoredResourceDescriptorsRequest, ListMonitoredResourceDescriptorsResponse, MonitoredResourceDescriptor>(_callListMonitoredResourceDescriptors, request, callSettings);
         }
@@ -1158,17 +1511,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Lists monitored resource descriptors that match a filter. This method does not require a Stackdriver account.
         /// </summary>
-        /// <param name="name">
-        /// The project on which to execute the request. The format is
-        /// `"projects/{project_id_or_number}"`.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1177,17 +1521,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A pageable sequence of <see cref="MonitoredResourceDescriptor"/> resources.
         /// </returns>
         public override PagedEnumerable<ListMonitoredResourceDescriptorsResponse, MonitoredResourceDescriptor> ListMonitoredResourceDescriptors(
-            string name,
-            string pageToken = null,
-            int? pageSize = null,
+            ListMonitoredResourceDescriptorsRequest request,
             CallSettings callSettings = null)
         {
-            ListMonitoredResourceDescriptorsRequest request = new ListMonitoredResourceDescriptorsRequest
-            {
-                Name = name,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListMonitoredResourceDescriptorsRequest(ref request, ref callSettings);
             return new GrpcPagedEnumerable<ListMonitoredResourceDescriptorsRequest, ListMonitoredResourceDescriptorsResponse, MonitoredResourceDescriptor>(_callListMonitoredResourceDescriptors, request, callSettings);
         }
@@ -1195,11 +1531,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
         /// </summary>
-        /// <param name="name">
-        /// The monitored resource descriptor to get.  The format is
-        /// `"projects/{project_id_or_number}/monitoredResourceDescriptors/{resource_type}"`.
-        /// The `{resource_type}` is a predefined type, such as
-        /// `cloudsql_database`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1208,13 +1541,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<MonitoredResourceDescriptor> GetMonitoredResourceDescriptorAsync(
-            string name,
+            GetMonitoredResourceDescriptorRequest request,
             CallSettings callSettings = null)
         {
-            GetMonitoredResourceDescriptorRequest request = new GetMonitoredResourceDescriptorRequest
-            {
-                Name = name,
-            };
             Modify_GetMonitoredResourceDescriptorRequest(ref request, ref callSettings);
             return _callGetMonitoredResourceDescriptor.Async(request, callSettings);
         }
@@ -1222,11 +1551,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
         /// </summary>
-        /// <param name="name">
-        /// The monitored resource descriptor to get.  The format is
-        /// `"projects/{project_id_or_number}/monitoredResourceDescriptors/{resource_type}"`.
-        /// The `{resource_type}` is a predefined type, such as
-        /// `cloudsql_database`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1235,13 +1561,9 @@ namespace Google.Cloud.Monitoring.V3
         /// The RPC response.
         /// </returns>
         public override MonitoredResourceDescriptor GetMonitoredResourceDescriptor(
-            string name,
+            GetMonitoredResourceDescriptorRequest request,
             CallSettings callSettings = null)
         {
-            GetMonitoredResourceDescriptorRequest request = new GetMonitoredResourceDescriptorRequest
-            {
-                Name = name,
-            };
             Modify_GetMonitoredResourceDescriptorRequest(ref request, ref callSettings);
             return _callGetMonitoredResourceDescriptor.Sync(request, callSettings);
         }
@@ -1249,17 +1571,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Lists metric descriptors that match a filter. This method does not require a Stackdriver account.
         /// </summary>
-        /// <param name="name">
-        /// The project on which to execute the request. The format is
-        /// `"projects/{project_id_or_number}"`.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1268,17 +1581,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A pageable asynchronous sequence of <see cref="MetricDescriptor"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListMetricDescriptorsResponse, MetricDescriptor> ListMetricDescriptorsAsync(
-            string name,
-            string pageToken = null,
-            int? pageSize = null,
+            ListMetricDescriptorsRequest request,
             CallSettings callSettings = null)
         {
-            ListMetricDescriptorsRequest request = new ListMetricDescriptorsRequest
-            {
-                Name = name,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListMetricDescriptorsRequest(ref request, ref callSettings);
             return new GrpcPagedAsyncEnumerable<ListMetricDescriptorsRequest, ListMetricDescriptorsResponse, MetricDescriptor>(_callListMetricDescriptors, request, callSettings);
         }
@@ -1286,17 +1591,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Lists metric descriptors that match a filter. This method does not require a Stackdriver account.
         /// </summary>
-        /// <param name="name">
-        /// The project on which to execute the request. The format is
-        /// `"projects/{project_id_or_number}"`.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1305,17 +1601,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A pageable sequence of <see cref="MetricDescriptor"/> resources.
         /// </returns>
         public override PagedEnumerable<ListMetricDescriptorsResponse, MetricDescriptor> ListMetricDescriptors(
-            string name,
-            string pageToken = null,
-            int? pageSize = null,
+            ListMetricDescriptorsRequest request,
             CallSettings callSettings = null)
         {
-            ListMetricDescriptorsRequest request = new ListMetricDescriptorsRequest
-            {
-                Name = name,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListMetricDescriptorsRequest(ref request, ref callSettings);
             return new GrpcPagedEnumerable<ListMetricDescriptorsRequest, ListMetricDescriptorsResponse, MetricDescriptor>(_callListMetricDescriptors, request, callSettings);
         }
@@ -1323,11 +1611,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Gets a single metric descriptor. This method does not require a Stackdriver account.
         /// </summary>
-        /// <param name="name">
-        /// The metric descriptor on which to execute the request. The format is
-        /// `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
-        /// An example value of `{metric_id}` is
-        /// `"compute.googleapis.com/instance/disk/read_bytes_count"`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1336,13 +1621,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<MetricDescriptor> GetMetricDescriptorAsync(
-            string name,
+            GetMetricDescriptorRequest request,
             CallSettings callSettings = null)
         {
-            GetMetricDescriptorRequest request = new GetMetricDescriptorRequest
-            {
-                Name = name,
-            };
             Modify_GetMetricDescriptorRequest(ref request, ref callSettings);
             return _callGetMetricDescriptor.Async(request, callSettings);
         }
@@ -1350,11 +1631,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Gets a single metric descriptor. This method does not require a Stackdriver account.
         /// </summary>
-        /// <param name="name">
-        /// The metric descriptor on which to execute the request. The format is
-        /// `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
-        /// An example value of `{metric_id}` is
-        /// `"compute.googleapis.com/instance/disk/read_bytes_count"`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1363,13 +1641,9 @@ namespace Google.Cloud.Monitoring.V3
         /// The RPC response.
         /// </returns>
         public override MetricDescriptor GetMetricDescriptor(
-            string name,
+            GetMetricDescriptorRequest request,
             CallSettings callSettings = null)
         {
-            GetMetricDescriptorRequest request = new GetMetricDescriptorRequest
-            {
-                Name = name,
-            };
             Modify_GetMetricDescriptorRequest(ref request, ref callSettings);
             return _callGetMetricDescriptor.Sync(request, callSettings);
         }
@@ -1379,13 +1653,8 @@ namespace Google.Cloud.Monitoring.V3
         /// User-created metric descriptors define
         /// [custom metrics](/monitoring/custom-metrics).
         /// </summary>
-        /// <param name="name">
-        /// The project on which to execute the request. The format is
-        /// `"projects/{project_id_or_number}"`.
-        /// </param>
-        /// <param name="metricDescriptor">
-        /// The new [custom metric](/monitoring/custom-metrics)
-        /// descriptor.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1394,15 +1663,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<MetricDescriptor> CreateMetricDescriptorAsync(
-            string name,
-            MetricDescriptor metricDescriptor,
+            CreateMetricDescriptorRequest request,
             CallSettings callSettings = null)
         {
-            CreateMetricDescriptorRequest request = new CreateMetricDescriptorRequest
-            {
-                Name = name,
-                MetricDescriptor = metricDescriptor,
-            };
             Modify_CreateMetricDescriptorRequest(ref request, ref callSettings);
             return _callCreateMetricDescriptor.Async(request, callSettings);
         }
@@ -1412,13 +1675,8 @@ namespace Google.Cloud.Monitoring.V3
         /// User-created metric descriptors define
         /// [custom metrics](/monitoring/custom-metrics).
         /// </summary>
-        /// <param name="name">
-        /// The project on which to execute the request. The format is
-        /// `"projects/{project_id_or_number}"`.
-        /// </param>
-        /// <param name="metricDescriptor">
-        /// The new [custom metric](/monitoring/custom-metrics)
-        /// descriptor.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1427,15 +1685,9 @@ namespace Google.Cloud.Monitoring.V3
         /// The RPC response.
         /// </returns>
         public override MetricDescriptor CreateMetricDescriptor(
-            string name,
-            MetricDescriptor metricDescriptor,
+            CreateMetricDescriptorRequest request,
             CallSettings callSettings = null)
         {
-            CreateMetricDescriptorRequest request = new CreateMetricDescriptorRequest
-            {
-                Name = name,
-                MetricDescriptor = metricDescriptor,
-            };
             Modify_CreateMetricDescriptorRequest(ref request, ref callSettings);
             return _callCreateMetricDescriptor.Sync(request, callSettings);
         }
@@ -1444,11 +1696,8 @@ namespace Google.Cloud.Monitoring.V3
         /// Deletes a metric descriptor. Only user-created
         /// [custom metrics](/monitoring/custom-metrics) can be deleted.
         /// </summary>
-        /// <param name="name">
-        /// The metric descriptor on which to execute the request. The format is
-        /// `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
-        /// An example of `{metric_id}` is:
-        /// `"custom.googleapis.com/my_test_metric"`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1457,13 +1706,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A Task containing the RPC response.
         /// </returns>
         public override Task DeleteMetricDescriptorAsync(
-            string name,
+            DeleteMetricDescriptorRequest request,
             CallSettings callSettings = null)
         {
-            DeleteMetricDescriptorRequest request = new DeleteMetricDescriptorRequest
-            {
-                Name = name,
-            };
             Modify_DeleteMetricDescriptorRequest(ref request, ref callSettings);
             return _callDeleteMetricDescriptor.Async(request, callSettings);
         }
@@ -1472,11 +1717,8 @@ namespace Google.Cloud.Monitoring.V3
         /// Deletes a metric descriptor. Only user-created
         /// [custom metrics](/monitoring/custom-metrics) can be deleted.
         /// </summary>
-        /// <param name="name">
-        /// The metric descriptor on which to execute the request. The format is
-        /// `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
-        /// An example of `{metric_id}` is:
-        /// `"custom.googleapis.com/my_test_metric"`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1485,13 +1727,9 @@ namespace Google.Cloud.Monitoring.V3
         /// The RPC response.
         /// </returns>
         public override void DeleteMetricDescriptor(
-            string name,
+            DeleteMetricDescriptorRequest request,
             CallSettings callSettings = null)
         {
-            DeleteMetricDescriptorRequest request = new DeleteMetricDescriptorRequest
-            {
-                Name = name,
-            };
             Modify_DeleteMetricDescriptorRequest(ref request, ref callSettings);
             _callDeleteMetricDescriptor.Sync(request, callSettings);
         }
@@ -1499,34 +1737,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Lists time series that match a filter. This method does not require a Stackdriver account.
         /// </summary>
-        /// <param name="name">
-        /// The project on which to execute the request. The format is
-        /// "projects/{project_id_or_number}".
-        /// </param>
-        /// <param name="filter">
-        /// A [monitoring filter](/monitoring/api/v3/filters) that specifies which time
-        /// series should be returned.  The filter must specify a single metric type,
-        /// and can additionally specify metric labels and other information. For
-        /// example:
-        ///
-        ///     metric.type = "compute.googleapis.com/instance/cpu/usage_time" AND
-        ///         metric.label.instance_name = "my-instance-name"
-        /// </param>
-        /// <param name="interval">
-        /// The time interval for which results should be returned. Only time series
-        /// that contain data points in the specified interval are included
-        /// in the response.
-        /// </param>
-        /// <param name="view">
-        /// Specifies which information is returned about the time series.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1535,23 +1747,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A pageable asynchronous sequence of <see cref="TimeSeries"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListTimeSeriesResponse, TimeSeries> ListTimeSeriesAsync(
-            string name,
-            string filter,
-            TimeInterval interval,
-            ListTimeSeriesRequest.Types.TimeSeriesView view,
-            string pageToken = null,
-            int? pageSize = null,
+            ListTimeSeriesRequest request,
             CallSettings callSettings = null)
         {
-            ListTimeSeriesRequest request = new ListTimeSeriesRequest
-            {
-                Name = name,
-                Filter = filter,
-                Interval = interval,
-                View = view,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListTimeSeriesRequest(ref request, ref callSettings);
             return new GrpcPagedAsyncEnumerable<ListTimeSeriesRequest, ListTimeSeriesResponse, TimeSeries>(_callListTimeSeries, request, callSettings);
         }
@@ -1559,34 +1757,8 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>
         /// Lists time series that match a filter. This method does not require a Stackdriver account.
         /// </summary>
-        /// <param name="name">
-        /// The project on which to execute the request. The format is
-        /// "projects/{project_id_or_number}".
-        /// </param>
-        /// <param name="filter">
-        /// A [monitoring filter](/monitoring/api/v3/filters) that specifies which time
-        /// series should be returned.  The filter must specify a single metric type,
-        /// and can additionally specify metric labels and other information. For
-        /// example:
-        ///
-        ///     metric.type = "compute.googleapis.com/instance/cpu/usage_time" AND
-        ///         metric.label.instance_name = "my-instance-name"
-        /// </param>
-        /// <param name="interval">
-        /// The time interval for which results should be returned. Only time series
-        /// that contain data points in the specified interval are included
-        /// in the response.
-        /// </param>
-        /// <param name="view">
-        /// Specifies which information is returned about the time series.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1595,23 +1767,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A pageable sequence of <see cref="TimeSeries"/> resources.
         /// </returns>
         public override PagedEnumerable<ListTimeSeriesResponse, TimeSeries> ListTimeSeries(
-            string name,
-            string filter,
-            TimeInterval interval,
-            ListTimeSeriesRequest.Types.TimeSeriesView view,
-            string pageToken = null,
-            int? pageSize = null,
+            ListTimeSeriesRequest request,
             CallSettings callSettings = null)
         {
-            ListTimeSeriesRequest request = new ListTimeSeriesRequest
-            {
-                Name = name,
-                Filter = filter,
-                Interval = interval,
-                View = view,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListTimeSeriesRequest(ref request, ref callSettings);
             return new GrpcPagedEnumerable<ListTimeSeriesRequest, ListTimeSeriesResponse, TimeSeries>(_callListTimeSeries, request, callSettings);
         }
@@ -1622,16 +1780,8 @@ namespace Google.Cloud.Monitoring.V3
         /// If any time series could not be written, a corresponding failure message is
         /// included in the error response.
         /// </summary>
-        /// <param name="name">
-        /// The project on which to execute the request. The format is
-        /// `"projects/{project_id_or_number}"`.
-        /// </param>
-        /// <param name="timeSeries">
-        /// The new data to be added to a list of time series.
-        /// Adds at most one data point to each of several time series.  The new data
-        /// point must be more recent than any other point in its time series.  Each
-        /// `TimeSeries` value must fully specify a unique time series by supplying
-        /// all label values for the metric and the monitored resource.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1640,15 +1790,9 @@ namespace Google.Cloud.Monitoring.V3
         /// A Task containing the RPC response.
         /// </returns>
         public override Task CreateTimeSeriesAsync(
-            string name,
-            IEnumerable<TimeSeries> timeSeries,
+            CreateTimeSeriesRequest request,
             CallSettings callSettings = null)
         {
-            CreateTimeSeriesRequest request = new CreateTimeSeriesRequest
-            {
-                Name = name,
-                TimeSeries = { timeSeries },
-            };
             Modify_CreateTimeSeriesRequest(ref request, ref callSettings);
             return _callCreateTimeSeries.Async(request, callSettings);
         }
@@ -1659,16 +1803,8 @@ namespace Google.Cloud.Monitoring.V3
         /// If any time series could not be written, a corresponding failure message is
         /// included in the error response.
         /// </summary>
-        /// <param name="name">
-        /// The project on which to execute the request. The format is
-        /// `"projects/{project_id_or_number}"`.
-        /// </param>
-        /// <param name="timeSeries">
-        /// The new data to be added to a list of time series.
-        /// Adds at most one data point to each of several time series.  The new data
-        /// point must be more recent than any other point in its time series.  Each
-        /// `TimeSeries` value must fully specify a unique time series by supplying
-        /// all label values for the metric and the monitored resource.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1677,15 +1813,9 @@ namespace Google.Cloud.Monitoring.V3
         /// The RPC response.
         /// </returns>
         public override void CreateTimeSeries(
-            string name,
-            IEnumerable<TimeSeries> timeSeries,
+            CreateTimeSeriesRequest request,
             CallSettings callSettings = null)
         {
-            CreateTimeSeriesRequest request = new CreateTimeSeriesRequest
-            {
-                Name = name,
-                TimeSeries = { timeSeries },
-            };
             Modify_CreateTimeSeriesRequest(ref request, ref callSettings);
             _callCreateTimeSeries.Sync(request, callSettings);
         }

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/PublisherClientSnippets.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/PublisherClientSnippets.cs
@@ -37,7 +37,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
         {
             string projectId = _fixture.ProjectId;
 
-            // Snippet: ListTopics
+            // Snippet: ListTopics(*,*,*,*)
             PublisherClient client = PublisherClient.Create();
 
             ProjectName projectName = new ProjectName(projectId);
@@ -53,7 +53,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
         {
             string projectId = _fixture.ProjectId;
 
-            // Snippet: ListTopicsAsync
+            // Snippet: ListTopicsAsync(*,*,*,*)
             PublisherClient client = PublisherClient.Create();
 
             ProjectName projectName = new ProjectName(projectId);
@@ -71,7 +71,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             string projectId = _fixture.ProjectId;
             string topicId = _fixture.CreateTopicId();
 
-            // Snippet: CreateTopic
+            // Snippet: CreateTopic(TopicName,*)
             PublisherClient client = PublisherClient.Create();
 
             TopicName topicName = new TopicName(projectId, topicId);
@@ -102,7 +102,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             string projectId = _fixture.ProjectId;
             string topicId = _fixture.CreateTopicId();
 
-            // Snippet: Publish
+            // Snippet: Publish(*,*,*)
             PublisherClient client = PublisherClient.Create();
             // Make sure we have a topic to publish to
             TopicName topicName = new TopicName(projectId, topicId);
@@ -158,7 +158,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
 
             PublisherClient.Create().CreateTopic(new TopicName(projectId, topicId));
 
-            // Snippet: DeleteTopic
+            // Snippet: DeleteTopic(TopicName,*)
             PublisherClient client = PublisherClient.Create();
 
             TopicName topicName = new TopicName(projectId, topicId);
@@ -193,7 +193,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
 
             PublisherClient.Create().CreateTopic(new TopicName(projectId, topicId));
 
-            // Snippet: GetIamPolicy
+            // Snippet: GetIamPolicy(string,*)
             PublisherClient client = PublisherClient.Create();
             string topicName = new TopicName(projectId, topicId).ToString();
             Policy policy = client.GetIamPolicy(topicName);

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/PublisherClientSnippets.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/PublisherClientSnippets.g.cs
@@ -58,6 +58,36 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
+        public async Task CreateTopicAsync_RequestObject()
+        {
+            // Snippet: CreateTopicAsync(Topic,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            Topic request = new Topic
+            {
+                TopicName = new TopicName("[PROJECT]", "[TOPIC]"),
+            };
+            // Make the request
+            Topic response = await publisherClient.CreateTopicAsync(request);
+            // End snippet
+        }
+
+        public void CreateTopic_RequestObject()
+        {
+            // Snippet: CreateTopic(Topic,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            Topic request = new Topic
+            {
+                TopicName = new TopicName("[PROJECT]", "[TOPIC]"),
+            };
+            // Make the request
+            Topic response = publisherClient.CreateTopic(request);
+            // End snippet
+        }
+
         public async Task PublishAsync()
         {
             // Snippet: PublishAsync(TopicName,IEnumerable<PubsubMessage>,CallSettings)
@@ -97,6 +127,48 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
+        public async Task PublishAsync_RequestObject()
+        {
+            // Snippet: PublishAsync(PublishRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            PublishRequest request = new PublishRequest
+            {
+                TopicAsTopicName = new TopicName("[PROJECT]", "[TOPIC]"),
+                Messages = {
+                               new PubsubMessage
+                               {
+                                   Data = ByteString.CopyFromUtf8(""),
+                               },
+                           },
+            };
+            // Make the request
+            PublishResponse response = await publisherClient.PublishAsync(request);
+            // End snippet
+        }
+
+        public void Publish_RequestObject()
+        {
+            // Snippet: Publish(PublishRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            PublishRequest request = new PublishRequest
+            {
+                TopicAsTopicName = new TopicName("[PROJECT]", "[TOPIC]"),
+                Messages = {
+                               new PubsubMessage
+                               {
+                                   Data = ByteString.CopyFromUtf8(""),
+                               },
+                           },
+            };
+            // Make the request
+            PublishResponse response = publisherClient.Publish(request);
+            // End snippet
+        }
+
         public async Task GetTopicAsync()
         {
             // Snippet: GetTopicAsync(TopicName,CallSettings)
@@ -119,6 +191,36 @@ namespace Google.Cloud.PubSub.V1.Snippets
             TopicName topic = new TopicName("[PROJECT]", "[TOPIC]");
             // Make the request
             Topic response = publisherClient.GetTopic(topic);
+            // End snippet
+        }
+
+        public async Task GetTopicAsync_RequestObject()
+        {
+            // Snippet: GetTopicAsync(GetTopicRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            GetTopicRequest request = new GetTopicRequest
+            {
+                TopicAsTopicName = new TopicName("[PROJECT]", "[TOPIC]"),
+            };
+            // Make the request
+            Topic response = await publisherClient.GetTopicAsync(request);
+            // End snippet
+        }
+
+        public void GetTopic_RequestObject()
+        {
+            // Snippet: GetTopic(GetTopicRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            GetTopicRequest request = new GetTopicRequest
+            {
+                TopicAsTopicName = new TopicName("[PROJECT]", "[TOPIC]"),
+            };
+            // Make the request
+            Topic response = publisherClient.GetTopic(request);
             // End snippet
         }
 
@@ -175,6 +277,98 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // Make the request
             PagedEnumerable<ListTopicsResponse,Topic> response =
                 publisherClient.ListTopics(project);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (Topic item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListTopicsResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Topic item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Topic> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Topic item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public async Task ListTopicsAsync_RequestObject()
+        {
+            // Snippet: ListTopicsAsync(ListTopicsRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            ListTopicsRequest request = new ListTopicsRequest
+            {
+                ProjectAsProjectName = new ProjectName("[PROJECT]"),
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListTopicsResponse,Topic> response =
+                publisherClient.ListTopicsAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((Topic item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListTopicsResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Topic item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Topic> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Topic item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListTopics_RequestObject()
+        {
+            // Snippet: ListTopics(ListTopicsRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            ListTopicsRequest request = new ListTopicsRequest
+            {
+                ProjectAsProjectName = new ProjectName("[PROJECT]"),
+            };
+            // Make the request
+            PagedEnumerable<ListTopicsResponse,Topic> response =
+                publisherClient.ListTopics(request);
 
             // Iterate over all response items, lazily performing RPCs as required
             foreach (Topic item in response)
@@ -294,6 +488,98 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
+        public async Task ListTopicSubscriptionsAsync_RequestObject()
+        {
+            // Snippet: ListTopicSubscriptionsAsync(ListTopicSubscriptionsRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            ListTopicSubscriptionsRequest request = new ListTopicSubscriptionsRequest
+            {
+                TopicAsTopicName = new TopicName("[PROJECT]", "[TOPIC]"),
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListTopicSubscriptionsResponse,SubscriptionName> response =
+                publisherClient.ListTopicSubscriptionsAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((SubscriptionName item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListTopicSubscriptionsResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (SubscriptionName item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<SubscriptionName> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (SubscriptionName item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListTopicSubscriptions_RequestObject()
+        {
+            // Snippet: ListTopicSubscriptions(ListTopicSubscriptionsRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            ListTopicSubscriptionsRequest request = new ListTopicSubscriptionsRequest
+            {
+                TopicAsTopicName = new TopicName("[PROJECT]", "[TOPIC]"),
+            };
+            // Make the request
+            PagedEnumerable<ListTopicSubscriptionsResponse,SubscriptionName> response =
+                publisherClient.ListTopicSubscriptions(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (SubscriptionName item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListTopicSubscriptionsResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (SubscriptionName item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<SubscriptionName> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (SubscriptionName item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
         public async Task DeleteTopicAsync()
         {
             // Snippet: DeleteTopicAsync(TopicName,CallSettings)
@@ -316,6 +602,36 @@ namespace Google.Cloud.PubSub.V1.Snippets
             TopicName topic = new TopicName("[PROJECT]", "[TOPIC]");
             // Make the request
             publisherClient.DeleteTopic(topic);
+            // End snippet
+        }
+
+        public async Task DeleteTopicAsync_RequestObject()
+        {
+            // Snippet: DeleteTopicAsync(DeleteTopicRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            DeleteTopicRequest request = new DeleteTopicRequest
+            {
+                TopicAsTopicName = new TopicName("[PROJECT]", "[TOPIC]"),
+            };
+            // Make the request
+            await publisherClient.DeleteTopicAsync(request);
+            // End snippet
+        }
+
+        public void DeleteTopic_RequestObject()
+        {
+            // Snippet: DeleteTopic(DeleteTopicRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            DeleteTopicRequest request = new DeleteTopicRequest
+            {
+                TopicAsTopicName = new TopicName("[PROJECT]", "[TOPIC]"),
+            };
+            // Make the request
+            publisherClient.DeleteTopic(request);
             // End snippet
         }
 
@@ -346,6 +662,38 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
+        public async Task SetIamPolicyAsync_RequestObject()
+        {
+            // Snippet: SetIamPolicyAsync(SetIamPolicyRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            SetIamPolicyRequest request = new SetIamPolicyRequest
+            {
+                Resource = new TopicName("[PROJECT]", "[TOPIC]").ToString(),
+                Policy = new Policy(),
+            };
+            // Make the request
+            Policy response = await publisherClient.SetIamPolicyAsync(request);
+            // End snippet
+        }
+
+        public void SetIamPolicy_RequestObject()
+        {
+            // Snippet: SetIamPolicy(SetIamPolicyRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            SetIamPolicyRequest request = new SetIamPolicyRequest
+            {
+                Resource = new TopicName("[PROJECT]", "[TOPIC]").ToString(),
+                Policy = new Policy(),
+            };
+            // Make the request
+            Policy response = publisherClient.SetIamPolicy(request);
+            // End snippet
+        }
+
         public async Task GetIamPolicyAsync()
         {
             // Snippet: GetIamPolicyAsync(string,CallSettings)
@@ -368,6 +716,36 @@ namespace Google.Cloud.PubSub.V1.Snippets
             string formattedResource = new TopicName("[PROJECT]", "[TOPIC]").ToString();
             // Make the request
             Policy response = publisherClient.GetIamPolicy(formattedResource);
+            // End snippet
+        }
+
+        public async Task GetIamPolicyAsync_RequestObject()
+        {
+            // Snippet: GetIamPolicyAsync(GetIamPolicyRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            GetIamPolicyRequest request = new GetIamPolicyRequest
+            {
+                Resource = new TopicName("[PROJECT]", "[TOPIC]").ToString(),
+            };
+            // Make the request
+            Policy response = await publisherClient.GetIamPolicyAsync(request);
+            // End snippet
+        }
+
+        public void GetIamPolicy_RequestObject()
+        {
+            // Snippet: GetIamPolicy(GetIamPolicyRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            GetIamPolicyRequest request = new GetIamPolicyRequest
+            {
+                Resource = new TopicName("[PROJECT]", "[TOPIC]").ToString(),
+            };
+            // Make the request
+            Policy response = publisherClient.GetIamPolicy(request);
             // End snippet
         }
 
@@ -395,6 +773,38 @@ namespace Google.Cloud.PubSub.V1.Snippets
             IEnumerable<string> permissions = new List<string>();
             // Make the request
             TestIamPermissionsResponse response = publisherClient.TestIamPermissions(formattedResource, permissions);
+            // End snippet
+        }
+
+        public async Task TestIamPermissionsAsync_RequestObject()
+        {
+            // Snippet: TestIamPermissionsAsync(TestIamPermissionsRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            TestIamPermissionsRequest request = new TestIamPermissionsRequest
+            {
+                Resource = new TopicName("[PROJECT]", "[TOPIC]").ToString(),
+                Permissions = { },
+            };
+            // Make the request
+            TestIamPermissionsResponse response = await publisherClient.TestIamPermissionsAsync(request);
+            // End snippet
+        }
+
+        public void TestIamPermissions_RequestObject()
+        {
+            // Snippet: TestIamPermissions(TestIamPermissionsRequest,CallSettings)
+            // Create client
+            PublisherClient publisherClient = PublisherClient.Create();
+            // Initialize request argument(s)
+            TestIamPermissionsRequest request = new TestIamPermissionsRequest
+            {
+                Resource = new TopicName("[PROJECT]", "[TOPIC]").ToString(),
+                Permissions = { },
+            };
+            // Make the request
+            TestIamPermissionsResponse response = publisherClient.TestIamPermissions(request);
             // End snippet
         }
 

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SubscriberClientSnippets.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SubscriberClientSnippets.cs
@@ -92,7 +92,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
         {
             string projectId = _fixture.ProjectId;
 
-            // Snippet: ListSubscriptions
+            // Snippet: ListSubscriptions(*,*,*,*)
             SubscriberClient client = SubscriberClient.Create();
 
             ProjectName projectName = new ProjectName(projectId);
@@ -108,7 +108,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
         {
             string projectId = _fixture.ProjectId;
 
-            // Snippet: ListSubscriptionsAsync
+            // Snippet: ListSubscriptionsAsync(*,*,*,*)
             SubscriberClient client = SubscriberClient.Create();
 
             ProjectName projectName = new ProjectName(projectId);
@@ -129,7 +129,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
 
             PublisherClient.Create().CreateTopic(new TopicName(projectId, topicId));
 
-            // Snippet: CreateSubscription
+            // Snippet: CreateSubscription(*,*,*,*,*)
             SubscriberClient client = SubscriberClient.Create();
 
             SubscriptionName subscriptionName = new SubscriptionName(projectId, subscriptionId);
@@ -175,7 +175,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             SubscriberClient.Create().CreateSubscription(new SubscriptionName(projectId, subscriptionId), topicName, null, 60);
             publisher.Publish(topicName, new[] { newMessage });
 
-            // Snippet: Pull
+            // Snippet: Pull(*,*,*,*)
             SubscriberClient client = SubscriberClient.Create();
 
             SubscriptionName subscriptionName = new SubscriptionName(projectId, subscriptionId);

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SubscriberClientSnippets.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SubscriberClientSnippets.g.cs
@@ -64,6 +64,38 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
+        public async Task CreateSubscriptionAsync_RequestObject()
+        {
+            // Snippet: CreateSubscriptionAsync(Subscription,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            Subscription request = new Subscription
+            {
+                SubscriptionName = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]"),
+                TopicAsTopicNameOneof = TopicNameOneof.From(new TopicName("[PROJECT]", "[TOPIC]")),
+            };
+            // Make the request
+            Subscription response = await subscriberClient.CreateSubscriptionAsync(request);
+            // End snippet
+        }
+
+        public void CreateSubscription_RequestObject()
+        {
+            // Snippet: CreateSubscription(Subscription,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            Subscription request = new Subscription
+            {
+                SubscriptionName = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]"),
+                TopicAsTopicNameOneof = TopicNameOneof.From(new TopicName("[PROJECT]", "[TOPIC]")),
+            };
+            // Make the request
+            Subscription response = subscriberClient.CreateSubscription(request);
+            // End snippet
+        }
+
         public async Task GetSubscriptionAsync()
         {
             // Snippet: GetSubscriptionAsync(SubscriptionName,CallSettings)
@@ -86,6 +118,36 @@ namespace Google.Cloud.PubSub.V1.Snippets
             SubscriptionName subscription = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]");
             // Make the request
             Subscription response = subscriberClient.GetSubscription(subscription);
+            // End snippet
+        }
+
+        public async Task GetSubscriptionAsync_RequestObject()
+        {
+            // Snippet: GetSubscriptionAsync(GetSubscriptionRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            GetSubscriptionRequest request = new GetSubscriptionRequest
+            {
+                SubscriptionAsSubscriptionName = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]"),
+            };
+            // Make the request
+            Subscription response = await subscriberClient.GetSubscriptionAsync(request);
+            // End snippet
+        }
+
+        public void GetSubscription_RequestObject()
+        {
+            // Snippet: GetSubscription(GetSubscriptionRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            GetSubscriptionRequest request = new GetSubscriptionRequest
+            {
+                SubscriptionAsSubscriptionName = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]"),
+            };
+            // Make the request
+            Subscription response = subscriberClient.GetSubscription(request);
             // End snippet
         }
 
@@ -175,6 +237,98 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
+        public async Task ListSubscriptionsAsync_RequestObject()
+        {
+            // Snippet: ListSubscriptionsAsync(ListSubscriptionsRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            ListSubscriptionsRequest request = new ListSubscriptionsRequest
+            {
+                ProjectAsProjectName = new ProjectName("[PROJECT]"),
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListSubscriptionsResponse,Subscription> response =
+                subscriberClient.ListSubscriptionsAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((Subscription item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListSubscriptionsResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Subscription item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Subscription> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Subscription item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListSubscriptions_RequestObject()
+        {
+            // Snippet: ListSubscriptions(ListSubscriptionsRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            ListSubscriptionsRequest request = new ListSubscriptionsRequest
+            {
+                ProjectAsProjectName = new ProjectName("[PROJECT]"),
+            };
+            // Make the request
+            PagedEnumerable<ListSubscriptionsResponse,Subscription> response =
+                subscriberClient.ListSubscriptions(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (Subscription item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListSubscriptionsResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Subscription item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Subscription> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Subscription item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
         public async Task DeleteSubscriptionAsync()
         {
             // Snippet: DeleteSubscriptionAsync(SubscriptionName,CallSettings)
@@ -197,6 +351,36 @@ namespace Google.Cloud.PubSub.V1.Snippets
             SubscriptionName subscription = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]");
             // Make the request
             subscriberClient.DeleteSubscription(subscription);
+            // End snippet
+        }
+
+        public async Task DeleteSubscriptionAsync_RequestObject()
+        {
+            // Snippet: DeleteSubscriptionAsync(DeleteSubscriptionRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            DeleteSubscriptionRequest request = new DeleteSubscriptionRequest
+            {
+                SubscriptionAsSubscriptionName = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]"),
+            };
+            // Make the request
+            await subscriberClient.DeleteSubscriptionAsync(request);
+            // End snippet
+        }
+
+        public void DeleteSubscription_RequestObject()
+        {
+            // Snippet: DeleteSubscription(DeleteSubscriptionRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            DeleteSubscriptionRequest request = new DeleteSubscriptionRequest
+            {
+                SubscriptionAsSubscriptionName = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]"),
+            };
+            // Make the request
+            subscriberClient.DeleteSubscription(request);
             // End snippet
         }
 
@@ -229,6 +413,40 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
+        public async Task ModifyAckDeadlineAsync_RequestObject()
+        {
+            // Snippet: ModifyAckDeadlineAsync(ModifyAckDeadlineRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            ModifyAckDeadlineRequest request = new ModifyAckDeadlineRequest
+            {
+                SubscriptionAsSubscriptionName = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]"),
+                AckIds = { },
+                AckDeadlineSeconds = 0,
+            };
+            // Make the request
+            await subscriberClient.ModifyAckDeadlineAsync(request);
+            // End snippet
+        }
+
+        public void ModifyAckDeadline_RequestObject()
+        {
+            // Snippet: ModifyAckDeadline(ModifyAckDeadlineRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            ModifyAckDeadlineRequest request = new ModifyAckDeadlineRequest
+            {
+                SubscriptionAsSubscriptionName = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]"),
+                AckIds = { },
+                AckDeadlineSeconds = 0,
+            };
+            // Make the request
+            subscriberClient.ModifyAckDeadline(request);
+            // End snippet
+        }
+
         public async Task AcknowledgeAsync()
         {
             // Snippet: AcknowledgeAsync(SubscriptionName,IEnumerable<string>,CallSettings)
@@ -253,6 +471,38 @@ namespace Google.Cloud.PubSub.V1.Snippets
             IEnumerable<string> ackIds = new List<string>();
             // Make the request
             subscriberClient.Acknowledge(subscription, ackIds);
+            // End snippet
+        }
+
+        public async Task AcknowledgeAsync_RequestObject()
+        {
+            // Snippet: AcknowledgeAsync(AcknowledgeRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            AcknowledgeRequest request = new AcknowledgeRequest
+            {
+                SubscriptionAsSubscriptionName = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]"),
+                AckIds = { },
+            };
+            // Make the request
+            await subscriberClient.AcknowledgeAsync(request);
+            // End snippet
+        }
+
+        public void Acknowledge_RequestObject()
+        {
+            // Snippet: Acknowledge(AcknowledgeRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            AcknowledgeRequest request = new AcknowledgeRequest
+            {
+                SubscriptionAsSubscriptionName = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]"),
+                AckIds = { },
+            };
+            // Make the request
+            subscriberClient.Acknowledge(request);
             // End snippet
         }
 
@@ -285,6 +535,38 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
+        public async Task PullAsync_RequestObject()
+        {
+            // Snippet: PullAsync(PullRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            PullRequest request = new PullRequest
+            {
+                SubscriptionAsSubscriptionName = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]"),
+                MaxMessages = 0,
+            };
+            // Make the request
+            PullResponse response = await subscriberClient.PullAsync(request);
+            // End snippet
+        }
+
+        public void Pull_RequestObject()
+        {
+            // Snippet: Pull(PullRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            PullRequest request = new PullRequest
+            {
+                SubscriptionAsSubscriptionName = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]"),
+                MaxMessages = 0,
+            };
+            // Make the request
+            PullResponse response = subscriberClient.Pull(request);
+            // End snippet
+        }
+
         public async Task ModifyPushConfigAsync()
         {
             // Snippet: ModifyPushConfigAsync(SubscriptionName,PushConfig,CallSettings)
@@ -309,6 +591,38 @@ namespace Google.Cloud.PubSub.V1.Snippets
             PushConfig pushConfig = new PushConfig();
             // Make the request
             subscriberClient.ModifyPushConfig(subscription, pushConfig);
+            // End snippet
+        }
+
+        public async Task ModifyPushConfigAsync_RequestObject()
+        {
+            // Snippet: ModifyPushConfigAsync(ModifyPushConfigRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            ModifyPushConfigRequest request = new ModifyPushConfigRequest
+            {
+                SubscriptionAsSubscriptionName = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]"),
+                PushConfig = new PushConfig(),
+            };
+            // Make the request
+            await subscriberClient.ModifyPushConfigAsync(request);
+            // End snippet
+        }
+
+        public void ModifyPushConfig_RequestObject()
+        {
+            // Snippet: ModifyPushConfig(ModifyPushConfigRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            ModifyPushConfigRequest request = new ModifyPushConfigRequest
+            {
+                SubscriptionAsSubscriptionName = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]"),
+                PushConfig = new PushConfig(),
+            };
+            // Make the request
+            subscriberClient.ModifyPushConfig(request);
             // End snippet
         }
 
@@ -339,6 +653,38 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
+        public async Task SetIamPolicyAsync_RequestObject()
+        {
+            // Snippet: SetIamPolicyAsync(SetIamPolicyRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            SetIamPolicyRequest request = new SetIamPolicyRequest
+            {
+                Resource = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]").ToString(),
+                Policy = new Policy(),
+            };
+            // Make the request
+            Policy response = await subscriberClient.SetIamPolicyAsync(request);
+            // End snippet
+        }
+
+        public void SetIamPolicy_RequestObject()
+        {
+            // Snippet: SetIamPolicy(SetIamPolicyRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            SetIamPolicyRequest request = new SetIamPolicyRequest
+            {
+                Resource = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]").ToString(),
+                Policy = new Policy(),
+            };
+            // Make the request
+            Policy response = subscriberClient.SetIamPolicy(request);
+            // End snippet
+        }
+
         public async Task GetIamPolicyAsync()
         {
             // Snippet: GetIamPolicyAsync(string,CallSettings)
@@ -361,6 +707,36 @@ namespace Google.Cloud.PubSub.V1.Snippets
             string formattedResource = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]").ToString();
             // Make the request
             Policy response = subscriberClient.GetIamPolicy(formattedResource);
+            // End snippet
+        }
+
+        public async Task GetIamPolicyAsync_RequestObject()
+        {
+            // Snippet: GetIamPolicyAsync(GetIamPolicyRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            GetIamPolicyRequest request = new GetIamPolicyRequest
+            {
+                Resource = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]").ToString(),
+            };
+            // Make the request
+            Policy response = await subscriberClient.GetIamPolicyAsync(request);
+            // End snippet
+        }
+
+        public void GetIamPolicy_RequestObject()
+        {
+            // Snippet: GetIamPolicy(GetIamPolicyRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            GetIamPolicyRequest request = new GetIamPolicyRequest
+            {
+                Resource = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]").ToString(),
+            };
+            // Make the request
+            Policy response = subscriberClient.GetIamPolicy(request);
             // End snippet
         }
 
@@ -388,6 +764,38 @@ namespace Google.Cloud.PubSub.V1.Snippets
             IEnumerable<string> permissions = new List<string>();
             // Make the request
             TestIamPermissionsResponse response = subscriberClient.TestIamPermissions(formattedResource, permissions);
+            // End snippet
+        }
+
+        public async Task TestIamPermissionsAsync_RequestObject()
+        {
+            // Snippet: TestIamPermissionsAsync(TestIamPermissionsRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            TestIamPermissionsRequest request = new TestIamPermissionsRequest
+            {
+                Resource = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]").ToString(),
+                Permissions = { },
+            };
+            // Make the request
+            TestIamPermissionsResponse response = await subscriberClient.TestIamPermissionsAsync(request);
+            // End snippet
+        }
+
+        public void TestIamPermissions_RequestObject()
+        {
+            // Snippet: TestIamPermissions(TestIamPermissionsRequest,CallSettings)
+            // Create client
+            SubscriberClient subscriberClient = SubscriberClient.Create();
+            // Initialize request argument(s)
+            TestIamPermissionsRequest request = new TestIamPermissionsRequest
+            {
+                Resource = new SubscriptionName("[PROJECT]", "[SUBSCRIPTION]").ToString(),
+                Permissions = { },
+            };
+            // Make the request
+            TestIamPermissionsResponse response = subscriberClient.TestIamPermissions(request);
             // End snippet
         }
 

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClient.cs
@@ -566,10 +566,12 @@ namespace Google.Cloud.PubSub.V1
         /// </returns>
         public virtual Task<Topic> CreateTopicAsync(
             TopicName name,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => CreateTopicAsync(
+                new Topic
+                {
+                    TopicName = name,
+                },
+                callSettings);
 
         /// <summary>
         /// Creates the given topic with the given name.
@@ -613,6 +615,46 @@ namespace Google.Cloud.PubSub.V1
         /// </returns>
         public virtual Topic CreateTopic(
             TopicName name,
+            CallSettings callSettings = null) => CreateTopic(
+                new Topic
+                {
+                    TopicName = name,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates the given topic with the given name.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Topic> CreateTopicAsync(
+            Topic request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Creates the given topic with the given name.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Topic CreateTopic(
+            Topic request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -639,10 +681,13 @@ namespace Google.Cloud.PubSub.V1
         public virtual Task<PublishResponse> PublishAsync(
             TopicName topic,
             IEnumerable<PubsubMessage> messages,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => PublishAsync(
+                new PublishRequest
+                {
+                    TopicAsTopicName = topic,
+                    Messages = { messages },
+                },
+                callSettings);
 
         /// <summary>
         /// Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
@@ -691,6 +736,51 @@ namespace Google.Cloud.PubSub.V1
         public virtual PublishResponse Publish(
             TopicName topic,
             IEnumerable<PubsubMessage> messages,
+            CallSettings callSettings = null) => Publish(
+                new PublishRequest
+                {
+                    TopicAsTopicName = topic,
+                    Messages = { messages },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
+        /// does not exist. The message payload must not be empty; it must contain
+        ///  either a non-empty data field, or at least one attribute.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<PublishResponse> PublishAsync(
+            PublishRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
+        /// does not exist. The message payload must not be empty; it must contain
+        ///  either a non-empty data field, or at least one attribute.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual PublishResponse Publish(
+            PublishRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -711,10 +801,12 @@ namespace Google.Cloud.PubSub.V1
         /// </returns>
         public virtual Task<Topic> GetTopicAsync(
             TopicName topic,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => GetTopicAsync(
+                new GetTopicRequest
+                {
+                    TopicAsTopicName = topic,
+                },
+                callSettings);
 
         /// <summary>
         /// Gets the configuration of a topic.
@@ -750,6 +842,46 @@ namespace Google.Cloud.PubSub.V1
         /// </returns>
         public virtual Topic GetTopic(
             TopicName topic,
+            CallSettings callSettings = null) => GetTopic(
+                new GetTopicRequest
+                {
+                    TopicAsTopicName = topic,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets the configuration of a topic.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Topic> GetTopicAsync(
+            GetTopicRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets the configuration of a topic.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Topic GetTopic(
+            GetTopicRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -780,10 +912,14 @@ namespace Google.Cloud.PubSub.V1
             ProjectName project,
             string pageToken = null,
             int? pageSize = null,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ListTopicsAsync(
+                new ListTopicsRequest
+                {
+                    ProjectAsProjectName = project,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
 
         /// <summary>
         /// Lists matching topics.
@@ -810,6 +946,48 @@ namespace Google.Cloud.PubSub.V1
             ProjectName project,
             string pageToken = null,
             int? pageSize = null,
+            CallSettings callSettings = null) => ListTopics(
+                new ListTopicsRequest
+                {
+                    ProjectAsProjectName = project,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists matching topics.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="Topic"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListTopicsResponse, Topic> ListTopicsAsync(
+            ListTopicsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists matching topics.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="Topic"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListTopicsResponse, Topic> ListTopics(
+            ListTopicsRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -840,10 +1018,14 @@ namespace Google.Cloud.PubSub.V1
             TopicName topic,
             string pageToken = null,
             int? pageSize = null,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ListTopicSubscriptionsAsync(
+                new ListTopicSubscriptionsRequest
+                {
+                    TopicAsTopicName = topic,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
 
         /// <summary>
         /// Lists the name of the subscriptions for this topic.
@@ -870,6 +1052,48 @@ namespace Google.Cloud.PubSub.V1
             TopicName topic,
             string pageToken = null,
             int? pageSize = null,
+            CallSettings callSettings = null) => ListTopicSubscriptions(
+                new ListTopicSubscriptionsRequest
+                {
+                    TopicAsTopicName = topic,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists the name of the subscriptions for this topic.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="string"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListTopicSubscriptionsResponse, SubscriptionName> ListTopicSubscriptionsAsync(
+            ListTopicSubscriptionsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists the name of the subscriptions for this topic.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="string"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListTopicSubscriptionsResponse, SubscriptionName> ListTopicSubscriptions(
+            ListTopicSubscriptionsRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -894,10 +1118,12 @@ namespace Google.Cloud.PubSub.V1
         /// </returns>
         public virtual Task DeleteTopicAsync(
             TopicName topic,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => DeleteTopicAsync(
+                new DeleteTopicRequest
+                {
+                    TopicAsTopicName = topic,
+                },
+                callSettings);
 
         /// <summary>
         /// Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
@@ -941,6 +1167,54 @@ namespace Google.Cloud.PubSub.V1
         /// </returns>
         public virtual void DeleteTopic(
             TopicName topic,
+            CallSettings callSettings = null) => DeleteTopic(
+                new DeleteTopicRequest
+                {
+                    TopicAsTopicName = topic,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
+        /// does not exist. After a topic is deleted, a new topic may be created with
+        /// the same name; this is an entirely new topic with none of the old
+        /// configuration or subscriptions. Existing subscriptions to this topic are
+        /// not deleted, but their `topic` field is set to `_deleted-topic_`.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task DeleteTopicAsync(
+            DeleteTopicRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
+        /// does not exist. After a topic is deleted, a new topic may be created with
+        /// the same name; this is an entirely new topic with none of the old
+        /// configuration or subscriptions. Existing subscriptions to this topic are
+        /// not deleted, but their `topic` field is set to `_deleted-topic_`.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual void DeleteTopic(
+            DeleteTopicRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -970,10 +1244,13 @@ namespace Google.Cloud.PubSub.V1
         public virtual Task<Policy> SetIamPolicyAsync(
             string resource,
             Policy policy,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => SetIamPolicyAsync(
+                new SetIamPolicyRequest
+                {
+                    Resource = resource,
+                    Policy = policy,
+                },
+                callSettings);
 
         /// <summary>
         /// Sets the access control policy on the specified resource. Replaces any
@@ -1028,6 +1305,49 @@ namespace Google.Cloud.PubSub.V1
         public virtual Policy SetIamPolicy(
             string resource,
             Policy policy,
+            CallSettings callSettings = null) => SetIamPolicy(
+                new SetIamPolicyRequest
+                {
+                    Resource = resource,
+                    Policy = policy,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Sets the access control policy on the specified resource. Replaces any
+        /// existing policy.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Policy> SetIamPolicyAsync(
+            SetIamPolicyRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Sets the access control policy on the specified resource. Replaces any
+        /// existing policy.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Policy SetIamPolicy(
+            SetIamPolicyRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1051,10 +1371,12 @@ namespace Google.Cloud.PubSub.V1
         /// </returns>
         public virtual Task<Policy> GetIamPolicyAsync(
             string resource,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => GetIamPolicyAsync(
+                new GetIamPolicyRequest
+                {
+                    Resource = resource,
+                },
+                callSettings);
 
         /// <summary>
         /// Gets the access control policy for a resource.
@@ -1096,6 +1418,50 @@ namespace Google.Cloud.PubSub.V1
         /// </returns>
         public virtual Policy GetIamPolicy(
             string resource,
+            CallSettings callSettings = null) => GetIamPolicy(
+                new GetIamPolicyRequest
+                {
+                    Resource = resource,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets the access control policy for a resource.
+        /// Returns an empty policy if the resource exists and does not have a policy
+        /// set.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Policy> GetIamPolicyAsync(
+            GetIamPolicyRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets the access control policy for a resource.
+        /// Returns an empty policy if the resource exists and does not have a policy
+        /// set.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Policy GetIamPolicy(
+            GetIamPolicyRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1126,10 +1492,13 @@ namespace Google.Cloud.PubSub.V1
         public virtual Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
             string resource,
             IEnumerable<string> permissions,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => TestIamPermissionsAsync(
+                new TestIamPermissionsRequest
+                {
+                    Resource = resource,
+                    Permissions = { permissions },
+                },
+                callSettings);
 
         /// <summary>
         /// Returns permissions that a caller has on the specified resource.
@@ -1186,6 +1555,51 @@ namespace Google.Cloud.PubSub.V1
         public virtual TestIamPermissionsResponse TestIamPermissions(
             string resource,
             IEnumerable<string> permissions,
+            CallSettings callSettings = null) => TestIamPermissions(
+                new TestIamPermissionsRequest
+                {
+                    Resource = resource,
+                    Permissions = { permissions },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Returns permissions that a caller has on the specified resource.
+        /// If the resource does not exist, this will return an empty set of
+        /// permissions, not a NOT_FOUND error.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
+            TestIamPermissionsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns permissions that a caller has on the specified resource.
+        /// If the resource does not exist, this will return an empty set of
+        /// permissions, not a NOT_FOUND error.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual TestIamPermissionsResponse TestIamPermissions(
+            TestIamPermissionsRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1259,13 +1673,8 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>
         /// Creates the given topic with the given name.
         /// </summary>
-        /// <param name="name">
-        /// The name of the topic. It must have the format
-        /// `"projects/{project}/topics/{topic}"`. `{topic}` must start with a letter,
-        /// and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`),
-        /// underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
-        /// signs (`%`). It must be between 3 and 255 characters in length, and it
-        /// must not start with `"goog"`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1274,13 +1683,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<Topic> CreateTopicAsync(
-            TopicName name,
+            Topic request,
             CallSettings callSettings = null)
         {
-            Topic request = new Topic
-            {
-                TopicName = name,
-            };
             Modify_Topic(ref request, ref callSettings);
             return _callCreateTopic.Async(request, callSettings);
         }
@@ -1288,13 +1693,8 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>
         /// Creates the given topic with the given name.
         /// </summary>
-        /// <param name="name">
-        /// The name of the topic. It must have the format
-        /// `"projects/{project}/topics/{topic}"`. `{topic}` must start with a letter,
-        /// and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`),
-        /// underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
-        /// signs (`%`). It must be between 3 and 255 characters in length, and it
-        /// must not start with `"goog"`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1303,13 +1703,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override Topic CreateTopic(
-            TopicName name,
+            Topic request,
             CallSettings callSettings = null)
         {
-            Topic request = new Topic
-            {
-                TopicName = name,
-            };
             Modify_Topic(ref request, ref callSettings);
             return _callCreateTopic.Sync(request, callSettings);
         }
@@ -1319,12 +1715,8 @@ namespace Google.Cloud.PubSub.V1
         /// does not exist. The message payload must not be empty; it must contain
         ///  either a non-empty data field, or at least one attribute.
         /// </summary>
-        /// <param name="topic">
-        /// The messages in the request will be published on this topic.
-        /// Format is `projects/{project}/topics/{topic}`.
-        /// </param>
-        /// <param name="messages">
-        /// The messages to publish.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1333,15 +1725,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<PublishResponse> PublishAsync(
-            TopicName topic,
-            IEnumerable<PubsubMessage> messages,
+            PublishRequest request,
             CallSettings callSettings = null)
         {
-            PublishRequest request = new PublishRequest
-            {
-                TopicAsTopicName = topic,
-                Messages = { messages },
-            };
             Modify_PublishRequest(ref request, ref callSettings);
             return _callPublish.Async(request, callSettings);
         }
@@ -1351,12 +1737,8 @@ namespace Google.Cloud.PubSub.V1
         /// does not exist. The message payload must not be empty; it must contain
         ///  either a non-empty data field, or at least one attribute.
         /// </summary>
-        /// <param name="topic">
-        /// The messages in the request will be published on this topic.
-        /// Format is `projects/{project}/topics/{topic}`.
-        /// </param>
-        /// <param name="messages">
-        /// The messages to publish.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1365,15 +1747,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override PublishResponse Publish(
-            TopicName topic,
-            IEnumerable<PubsubMessage> messages,
+            PublishRequest request,
             CallSettings callSettings = null)
         {
-            PublishRequest request = new PublishRequest
-            {
-                TopicAsTopicName = topic,
-                Messages = { messages },
-            };
             Modify_PublishRequest(ref request, ref callSettings);
             return _callPublish.Sync(request, callSettings);
         }
@@ -1381,9 +1757,8 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>
         /// Gets the configuration of a topic.
         /// </summary>
-        /// <param name="topic">
-        /// The name of the topic to get.
-        /// Format is `projects/{project}/topics/{topic}`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1392,13 +1767,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<Topic> GetTopicAsync(
-            TopicName topic,
+            GetTopicRequest request,
             CallSettings callSettings = null)
         {
-            GetTopicRequest request = new GetTopicRequest
-            {
-                TopicAsTopicName = topic,
-            };
             Modify_GetTopicRequest(ref request, ref callSettings);
             return _callGetTopic.Async(request, callSettings);
         }
@@ -1406,9 +1777,8 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>
         /// Gets the configuration of a topic.
         /// </summary>
-        /// <param name="topic">
-        /// The name of the topic to get.
-        /// Format is `projects/{project}/topics/{topic}`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1417,13 +1787,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override Topic GetTopic(
-            TopicName topic,
+            GetTopicRequest request,
             CallSettings callSettings = null)
         {
-            GetTopicRequest request = new GetTopicRequest
-            {
-                TopicAsTopicName = topic,
-            };
             Modify_GetTopicRequest(ref request, ref callSettings);
             return _callGetTopic.Sync(request, callSettings);
         }
@@ -1431,17 +1797,8 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>
         /// Lists matching topics.
         /// </summary>
-        /// <param name="project">
-        /// The name of the cloud project that topics belong to.
-        /// Format is `projects/{project}`.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1450,17 +1807,9 @@ namespace Google.Cloud.PubSub.V1
         /// A pageable asynchronous sequence of <see cref="Topic"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListTopicsResponse, Topic> ListTopicsAsync(
-            ProjectName project,
-            string pageToken = null,
-            int? pageSize = null,
+            ListTopicsRequest request,
             CallSettings callSettings = null)
         {
-            ListTopicsRequest request = new ListTopicsRequest
-            {
-                ProjectAsProjectName = project,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListTopicsRequest(ref request, ref callSettings);
             return new GrpcPagedAsyncEnumerable<ListTopicsRequest, ListTopicsResponse, Topic>(_callListTopics, request, callSettings);
         }
@@ -1468,17 +1817,8 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>
         /// Lists matching topics.
         /// </summary>
-        /// <param name="project">
-        /// The name of the cloud project that topics belong to.
-        /// Format is `projects/{project}`.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1487,17 +1827,9 @@ namespace Google.Cloud.PubSub.V1
         /// A pageable sequence of <see cref="Topic"/> resources.
         /// </returns>
         public override PagedEnumerable<ListTopicsResponse, Topic> ListTopics(
-            ProjectName project,
-            string pageToken = null,
-            int? pageSize = null,
+            ListTopicsRequest request,
             CallSettings callSettings = null)
         {
-            ListTopicsRequest request = new ListTopicsRequest
-            {
-                ProjectAsProjectName = project,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListTopicsRequest(ref request, ref callSettings);
             return new GrpcPagedEnumerable<ListTopicsRequest, ListTopicsResponse, Topic>(_callListTopics, request, callSettings);
         }
@@ -1505,17 +1837,8 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>
         /// Lists the name of the subscriptions for this topic.
         /// </summary>
-        /// <param name="topic">
-        /// The name of the topic that subscriptions are attached to.
-        /// Format is `projects/{project}/topics/{topic}`.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1524,17 +1847,9 @@ namespace Google.Cloud.PubSub.V1
         /// A pageable asynchronous sequence of <see cref="string"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListTopicSubscriptionsResponse, SubscriptionName> ListTopicSubscriptionsAsync(
-            TopicName topic,
-            string pageToken = null,
-            int? pageSize = null,
+            ListTopicSubscriptionsRequest request,
             CallSettings callSettings = null)
         {
-            ListTopicSubscriptionsRequest request = new ListTopicSubscriptionsRequest
-            {
-                TopicAsTopicName = topic,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListTopicSubscriptionsRequest(ref request, ref callSettings);
             return new GrpcPagedAsyncEnumerable<ListTopicSubscriptionsRequest, ListTopicSubscriptionsResponse, SubscriptionName>(_callListTopicSubscriptions, request, callSettings);
         }
@@ -1542,17 +1857,8 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>
         /// Lists the name of the subscriptions for this topic.
         /// </summary>
-        /// <param name="topic">
-        /// The name of the topic that subscriptions are attached to.
-        /// Format is `projects/{project}/topics/{topic}`.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1561,17 +1867,9 @@ namespace Google.Cloud.PubSub.V1
         /// A pageable sequence of <see cref="string"/> resources.
         /// </returns>
         public override PagedEnumerable<ListTopicSubscriptionsResponse, SubscriptionName> ListTopicSubscriptions(
-            TopicName topic,
-            string pageToken = null,
-            int? pageSize = null,
+            ListTopicSubscriptionsRequest request,
             CallSettings callSettings = null)
         {
-            ListTopicSubscriptionsRequest request = new ListTopicSubscriptionsRequest
-            {
-                TopicAsTopicName = topic,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListTopicSubscriptionsRequest(ref request, ref callSettings);
             return new GrpcPagedEnumerable<ListTopicSubscriptionsRequest, ListTopicSubscriptionsResponse, SubscriptionName>(_callListTopicSubscriptions, request, callSettings);
         }
@@ -1583,9 +1881,8 @@ namespace Google.Cloud.PubSub.V1
         /// configuration or subscriptions. Existing subscriptions to this topic are
         /// not deleted, but their `topic` field is set to `_deleted-topic_`.
         /// </summary>
-        /// <param name="topic">
-        /// Name of the topic to delete.
-        /// Format is `projects/{project}/topics/{topic}`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1594,13 +1891,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task DeleteTopicAsync(
-            TopicName topic,
+            DeleteTopicRequest request,
             CallSettings callSettings = null)
         {
-            DeleteTopicRequest request = new DeleteTopicRequest
-            {
-                TopicAsTopicName = topic,
-            };
             Modify_DeleteTopicRequest(ref request, ref callSettings);
             return _callDeleteTopic.Async(request, callSettings);
         }
@@ -1612,9 +1905,8 @@ namespace Google.Cloud.PubSub.V1
         /// configuration or subscriptions. Existing subscriptions to this topic are
         /// not deleted, but their `topic` field is set to `_deleted-topic_`.
         /// </summary>
-        /// <param name="topic">
-        /// Name of the topic to delete.
-        /// Format is `projects/{project}/topics/{topic}`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1623,13 +1915,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override void DeleteTopic(
-            TopicName topic,
+            DeleteTopicRequest request,
             CallSettings callSettings = null)
         {
-            DeleteTopicRequest request = new DeleteTopicRequest
-            {
-                TopicAsTopicName = topic,
-            };
             Modify_DeleteTopicRequest(ref request, ref callSettings);
             _callDeleteTopic.Sync(request, callSettings);
         }
@@ -1638,16 +1926,8 @@ namespace Google.Cloud.PubSub.V1
         /// Sets the access control policy on the specified resource. Replaces any
         /// existing policy.
         /// </summary>
-        /// <param name="resource">
-        /// REQUIRED: The resource for which the policy is being specified.
-        /// `resource` is usually specified as a path. For example, a Project
-        /// resource is specified as `projects/{project}`.
-        /// </param>
-        /// <param name="policy">
-        /// REQUIRED: The complete policy to be applied to the `resource`. The size of
-        /// the policy is limited to a few 10s of KB. An empty policy is a
-        /// valid policy but certain Cloud Platform services (such as Projects)
-        /// might reject them.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1656,15 +1936,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<Policy> SetIamPolicyAsync(
-            string resource,
-            Policy policy,
+            SetIamPolicyRequest request,
             CallSettings callSettings = null)
         {
-            SetIamPolicyRequest request = new SetIamPolicyRequest
-            {
-                Resource = resource,
-                Policy = policy,
-            };
             Modify_SetIamPolicyRequest(ref request, ref callSettings);
             return _callSetIamPolicy.Async(request, callSettings);
         }
@@ -1673,16 +1947,8 @@ namespace Google.Cloud.PubSub.V1
         /// Sets the access control policy on the specified resource. Replaces any
         /// existing policy.
         /// </summary>
-        /// <param name="resource">
-        /// REQUIRED: The resource for which the policy is being specified.
-        /// `resource` is usually specified as a path. For example, a Project
-        /// resource is specified as `projects/{project}`.
-        /// </param>
-        /// <param name="policy">
-        /// REQUIRED: The complete policy to be applied to the `resource`. The size of
-        /// the policy is limited to a few 10s of KB. An empty policy is a
-        /// valid policy but certain Cloud Platform services (such as Projects)
-        /// might reject them.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1691,15 +1957,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override Policy SetIamPolicy(
-            string resource,
-            Policy policy,
+            SetIamPolicyRequest request,
             CallSettings callSettings = null)
         {
-            SetIamPolicyRequest request = new SetIamPolicyRequest
-            {
-                Resource = resource,
-                Policy = policy,
-            };
             Modify_SetIamPolicyRequest(ref request, ref callSettings);
             return _callSetIamPolicy.Sync(request, callSettings);
         }
@@ -1709,10 +1969,8 @@ namespace Google.Cloud.PubSub.V1
         /// Returns an empty policy if the resource exists and does not have a policy
         /// set.
         /// </summary>
-        /// <param name="resource">
-        /// REQUIRED: The resource for which the policy is being requested.
-        /// `resource` is usually specified as a path. For example, a Project
-        /// resource is specified as `projects/{project}`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1721,13 +1979,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<Policy> GetIamPolicyAsync(
-            string resource,
+            GetIamPolicyRequest request,
             CallSettings callSettings = null)
         {
-            GetIamPolicyRequest request = new GetIamPolicyRequest
-            {
-                Resource = resource,
-            };
             Modify_GetIamPolicyRequest(ref request, ref callSettings);
             return _callGetIamPolicy.Async(request, callSettings);
         }
@@ -1737,10 +1991,8 @@ namespace Google.Cloud.PubSub.V1
         /// Returns an empty policy if the resource exists and does not have a policy
         /// set.
         /// </summary>
-        /// <param name="resource">
-        /// REQUIRED: The resource for which the policy is being requested.
-        /// `resource` is usually specified as a path. For example, a Project
-        /// resource is specified as `projects/{project}`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1749,13 +2001,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override Policy GetIamPolicy(
-            string resource,
+            GetIamPolicyRequest request,
             CallSettings callSettings = null)
         {
-            GetIamPolicyRequest request = new GetIamPolicyRequest
-            {
-                Resource = resource,
-            };
             Modify_GetIamPolicyRequest(ref request, ref callSettings);
             return _callGetIamPolicy.Sync(request, callSettings);
         }
@@ -1765,16 +2013,8 @@ namespace Google.Cloud.PubSub.V1
         /// If the resource does not exist, this will return an empty set of
         /// permissions, not a NOT_FOUND error.
         /// </summary>
-        /// <param name="resource">
-        /// REQUIRED: The resource for which the policy detail is being requested.
-        /// `resource` is usually specified as a path. For example, a Project
-        /// resource is specified as `projects/{project}`.
-        /// </param>
-        /// <param name="permissions">
-        /// The set of permissions to check for the `resource`. Permissions with
-        /// wildcards (such as '*' or 'storage.*') are not allowed. For more
-        /// information see
-        /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1783,15 +2023,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
-            string resource,
-            IEnumerable<string> permissions,
+            TestIamPermissionsRequest request,
             CallSettings callSettings = null)
         {
-            TestIamPermissionsRequest request = new TestIamPermissionsRequest
-            {
-                Resource = resource,
-                Permissions = { permissions },
-            };
             Modify_TestIamPermissionsRequest(ref request, ref callSettings);
             return _callTestIamPermissions.Async(request, callSettings);
         }
@@ -1801,16 +2035,8 @@ namespace Google.Cloud.PubSub.V1
         /// If the resource does not exist, this will return an empty set of
         /// permissions, not a NOT_FOUND error.
         /// </summary>
-        /// <param name="resource">
-        /// REQUIRED: The resource for which the policy detail is being requested.
-        /// `resource` is usually specified as a path. For example, a Project
-        /// resource is specified as `projects/{project}`.
-        /// </param>
-        /// <param name="permissions">
-        /// The set of permissions to check for the `resource`. Permissions with
-        /// wildcards (such as '*' or 'storage.*') are not allowed. For more
-        /// information see
-        /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1819,15 +2045,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override TestIamPermissionsResponse TestIamPermissions(
-            string resource,
-            IEnumerable<string> permissions,
+            TestIamPermissionsRequest request,
             CallSettings callSettings = null)
         {
-            TestIamPermissionsRequest request = new TestIamPermissionsRequest
-            {
-                Resource = resource,
-                Permissions = { permissions },
-            };
             Modify_TestIamPermissionsRequest(ref request, ref callSettings);
             return _callTestIamPermissions.Sync(request, callSettings);
         }

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
@@ -654,10 +654,15 @@ namespace Google.Cloud.PubSub.V1
             TopicName topic,
             PushConfig pushConfig,
             int ackDeadlineSeconds,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => CreateSubscriptionAsync(
+                new Subscription
+                {
+                    SubscriptionName = name,
+                    TopicAsTopicNameOneof = TopicNameOneof.From(topic),
+                    PushConfig = pushConfig,
+                    AckDeadlineSeconds = ackDeadlineSeconds,
+                },
+                callSettings);
 
         /// <summary>
         /// Creates a subscription to a given topic.
@@ -792,6 +797,67 @@ namespace Google.Cloud.PubSub.V1
             TopicName topic,
             PushConfig pushConfig,
             int ackDeadlineSeconds,
+            CallSettings callSettings = null) => CreateSubscription(
+                new Subscription
+                {
+                    SubscriptionName = name,
+                    TopicAsTopicNameOneof = TopicNameOneof.From(topic),
+                    PushConfig = pushConfig,
+                    AckDeadlineSeconds = ackDeadlineSeconds,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates a subscription to a given topic.
+        /// If the subscription already exists, returns `ALREADY_EXISTS`.
+        /// If the corresponding topic doesn't exist, returns `NOT_FOUND`.
+        ///
+        /// If the name is not provided in the request, the server will assign a random
+        /// name for this subscription on the same project as the topic, conforming
+        /// to the
+        /// [resource name format](https://cloud.google.com/pubsub/docs/overview#names).
+        /// The generated name is populated in the returned Subscription object.
+        /// Note that for REST API requests, you must specify a name in the request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Subscription> CreateSubscriptionAsync(
+            Subscription request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Creates a subscription to a given topic.
+        /// If the subscription already exists, returns `ALREADY_EXISTS`.
+        /// If the corresponding topic doesn't exist, returns `NOT_FOUND`.
+        ///
+        /// If the name is not provided in the request, the server will assign a random
+        /// name for this subscription on the same project as the topic, conforming
+        /// to the
+        /// [resource name format](https://cloud.google.com/pubsub/docs/overview#names).
+        /// The generated name is populated in the returned Subscription object.
+        /// Note that for REST API requests, you must specify a name in the request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Subscription CreateSubscription(
+            Subscription request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -812,10 +878,12 @@ namespace Google.Cloud.PubSub.V1
         /// </returns>
         public virtual Task<Subscription> GetSubscriptionAsync(
             SubscriptionName subscription,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => GetSubscriptionAsync(
+                new GetSubscriptionRequest
+                {
+                    SubscriptionAsSubscriptionName = subscription,
+                },
+                callSettings);
 
         /// <summary>
         /// Gets the configuration details of a subscription.
@@ -851,6 +919,46 @@ namespace Google.Cloud.PubSub.V1
         /// </returns>
         public virtual Subscription GetSubscription(
             SubscriptionName subscription,
+            CallSettings callSettings = null) => GetSubscription(
+                new GetSubscriptionRequest
+                {
+                    SubscriptionAsSubscriptionName = subscription,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets the configuration details of a subscription.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Subscription> GetSubscriptionAsync(
+            GetSubscriptionRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets the configuration details of a subscription.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Subscription GetSubscription(
+            GetSubscriptionRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -881,10 +989,14 @@ namespace Google.Cloud.PubSub.V1
             ProjectName project,
             string pageToken = null,
             int? pageSize = null,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ListSubscriptionsAsync(
+                new ListSubscriptionsRequest
+                {
+                    ProjectAsProjectName = project,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
 
         /// <summary>
         /// Lists matching subscriptions.
@@ -911,6 +1023,48 @@ namespace Google.Cloud.PubSub.V1
             ProjectName project,
             string pageToken = null,
             int? pageSize = null,
+            CallSettings callSettings = null) => ListSubscriptions(
+                new ListSubscriptionsRequest
+                {
+                    ProjectAsProjectName = project,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists matching subscriptions.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="Subscription"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListSubscriptionsResponse, Subscription> ListSubscriptionsAsync(
+            ListSubscriptionsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists matching subscriptions.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="Subscription"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListSubscriptionsResponse, Subscription> ListSubscriptions(
+            ListSubscriptionsRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -935,10 +1089,12 @@ namespace Google.Cloud.PubSub.V1
         /// </returns>
         public virtual Task DeleteSubscriptionAsync(
             SubscriptionName subscription,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => DeleteSubscriptionAsync(
+                new DeleteSubscriptionRequest
+                {
+                    SubscriptionAsSubscriptionName = subscription,
+                },
+                callSettings);
 
         /// <summary>
         /// Deletes an existing subscription. All messages retained in the subscription
@@ -982,6 +1138,54 @@ namespace Google.Cloud.PubSub.V1
         /// </returns>
         public virtual void DeleteSubscription(
             SubscriptionName subscription,
+            CallSettings callSettings = null) => DeleteSubscription(
+                new DeleteSubscriptionRequest
+                {
+                    SubscriptionAsSubscriptionName = subscription,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes an existing subscription. All messages retained in the subscription
+        /// are immediately dropped. Calls to `Pull` after deletion will return
+        /// `NOT_FOUND`. After a subscription is deleted, a new one may be created with
+        /// the same name, but the new one has no association with the old
+        /// subscription or its topic unless the same topic is specified.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task DeleteSubscriptionAsync(
+            DeleteSubscriptionRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Deletes an existing subscription. All messages retained in the subscription
+        /// are immediately dropped. Calls to `Pull` after deletion will return
+        /// `NOT_FOUND`. After a subscription is deleted, a new one may be created with
+        /// the same name, but the new one has no association with the old
+        /// subscription or its topic unless the same topic is specified.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual void DeleteSubscription(
+            DeleteSubscriptionRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1020,10 +1224,14 @@ namespace Google.Cloud.PubSub.V1
             SubscriptionName subscription,
             IEnumerable<string> ackIds,
             int ackDeadlineSeconds,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ModifyAckDeadlineAsync(
+                new ModifyAckDeadlineRequest
+                {
+                    SubscriptionAsSubscriptionName = subscription,
+                    AckIds = { ackIds },
+                    AckDeadlineSeconds = ackDeadlineSeconds,
+                },
+                callSettings);
 
         /// <summary>
         /// Modifies the ack deadline for a specific message. This method is useful
@@ -1097,6 +1305,56 @@ namespace Google.Cloud.PubSub.V1
             SubscriptionName subscription,
             IEnumerable<string> ackIds,
             int ackDeadlineSeconds,
+            CallSettings callSettings = null) => ModifyAckDeadline(
+                new ModifyAckDeadlineRequest
+                {
+                    SubscriptionAsSubscriptionName = subscription,
+                    AckIds = { ackIds },
+                    AckDeadlineSeconds = ackDeadlineSeconds,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Modifies the ack deadline for a specific message. This method is useful
+        /// to indicate that more time is needed to process a message by the
+        /// subscriber, or to make the message available for redelivery if the
+        /// processing was interrupted. Note that this does not modify the
+        /// subscription-level `ackDeadlineSeconds` used for subsequent messages.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task ModifyAckDeadlineAsync(
+            ModifyAckDeadlineRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Modifies the ack deadline for a specific message. This method is useful
+        /// to indicate that more time is needed to process a message by the
+        /// subscriber, or to make the message available for redelivery if the
+        /// processing was interrupted. Note that this does not modify the
+        /// subscription-level `ackDeadlineSeconds` used for subsequent messages.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual void ModifyAckDeadline(
+            ModifyAckDeadlineRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1128,10 +1386,13 @@ namespace Google.Cloud.PubSub.V1
         public virtual Task AcknowledgeAsync(
             SubscriptionName subscription,
             IEnumerable<string> ackIds,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => AcknowledgeAsync(
+                new AcknowledgeRequest
+                {
+                    SubscriptionAsSubscriptionName = subscription,
+                    AckIds = { ackIds },
+                },
+                callSettings);
 
         /// <summary>
         /// Acknowledges the messages associated with the `ack_ids` in the
@@ -1190,6 +1451,59 @@ namespace Google.Cloud.PubSub.V1
         public virtual void Acknowledge(
             SubscriptionName subscription,
             IEnumerable<string> ackIds,
+            CallSettings callSettings = null) => Acknowledge(
+                new AcknowledgeRequest
+                {
+                    SubscriptionAsSubscriptionName = subscription,
+                    AckIds = { ackIds },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Acknowledges the messages associated with the `ack_ids` in the
+        /// `AcknowledgeRequest`. The Pub/Sub system can remove the relevant messages
+        /// from the subscription.
+        ///
+        /// Acknowledging a message whose ack deadline has expired may succeed,
+        /// but such a message may be redelivered later. Acknowledging a message more
+        /// than once will not result in an error.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task AcknowledgeAsync(
+            AcknowledgeRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Acknowledges the messages associated with the `ack_ids` in the
+        /// `AcknowledgeRequest`. The Pub/Sub system can remove the relevant messages
+        /// from the subscription.
+        ///
+        /// Acknowledging a message whose ack deadline has expired may succeed,
+        /// but such a message may be redelivered later. Acknowledging a message more
+        /// than once will not result in an error.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual void Acknowledge(
+            AcknowledgeRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1227,10 +1541,14 @@ namespace Google.Cloud.PubSub.V1
             SubscriptionName subscription,
             bool returnImmediately,
             int maxMessages,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => PullAsync(
+                new PullRequest
+                {
+                    SubscriptionAsSubscriptionName = subscription,
+                    ReturnImmediately = returnImmediately,
+                    MaxMessages = maxMessages,
+                },
+                callSettings);
 
         /// <summary>
         /// Pulls messages from the server. Returns an empty list if there are no
@@ -1302,6 +1620,54 @@ namespace Google.Cloud.PubSub.V1
             SubscriptionName subscription,
             bool returnImmediately,
             int maxMessages,
+            CallSettings callSettings = null) => Pull(
+                new PullRequest
+                {
+                    SubscriptionAsSubscriptionName = subscription,
+                    ReturnImmediately = returnImmediately,
+                    MaxMessages = maxMessages,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Pulls messages from the server. Returns an empty list if there are no
+        /// messages available in the backlog. The server may return `UNAVAILABLE` if
+        /// there are too many concurrent pull requests pending for the given
+        /// subscription.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<PullResponse> PullAsync(
+            PullRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Pulls messages from the server. Returns an empty list if there are no
+        /// messages available in the backlog. The server may return `UNAVAILABLE` if
+        /// there are too many concurrent pull requests pending for the given
+        /// subscription.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual PullResponse Pull(
+            PullRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1336,10 +1702,13 @@ namespace Google.Cloud.PubSub.V1
         public virtual Task ModifyPushConfigAsync(
             SubscriptionName subscription,
             PushConfig pushConfig,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ModifyPushConfigAsync(
+                new ModifyPushConfigRequest
+                {
+                    SubscriptionAsSubscriptionName = subscription,
+                    PushConfig = pushConfig,
+                },
+                callSettings);
 
         /// <summary>
         /// Modifies the `PushConfig` for a specified subscription.
@@ -1404,6 +1773,57 @@ namespace Google.Cloud.PubSub.V1
         public virtual void ModifyPushConfig(
             SubscriptionName subscription,
             PushConfig pushConfig,
+            CallSettings callSettings = null) => ModifyPushConfig(
+                new ModifyPushConfigRequest
+                {
+                    SubscriptionAsSubscriptionName = subscription,
+                    PushConfig = pushConfig,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Modifies the `PushConfig` for a specified subscription.
+        ///
+        /// This may be used to change a push subscription to a pull one (signified by
+        /// an empty `PushConfig`) or vice versa, or change the endpoint URL and other
+        /// attributes of a push subscription. Messages will accumulate for delivery
+        /// continuously through the call regardless of changes to the `PushConfig`.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task ModifyPushConfigAsync(
+            ModifyPushConfigRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Modifies the `PushConfig` for a specified subscription.
+        ///
+        /// This may be used to change a push subscription to a pull one (signified by
+        /// an empty `PushConfig`) or vice versa, or change the endpoint URL and other
+        /// attributes of a push subscription. Messages will accumulate for delivery
+        /// continuously through the call regardless of changes to the `PushConfig`.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual void ModifyPushConfig(
+            ModifyPushConfigRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1433,10 +1853,13 @@ namespace Google.Cloud.PubSub.V1
         public virtual Task<Policy> SetIamPolicyAsync(
             string resource,
             Policy policy,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => SetIamPolicyAsync(
+                new SetIamPolicyRequest
+                {
+                    Resource = resource,
+                    Policy = policy,
+                },
+                callSettings);
 
         /// <summary>
         /// Sets the access control policy on the specified resource. Replaces any
@@ -1491,6 +1914,49 @@ namespace Google.Cloud.PubSub.V1
         public virtual Policy SetIamPolicy(
             string resource,
             Policy policy,
+            CallSettings callSettings = null) => SetIamPolicy(
+                new SetIamPolicyRequest
+                {
+                    Resource = resource,
+                    Policy = policy,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Sets the access control policy on the specified resource. Replaces any
+        /// existing policy.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Policy> SetIamPolicyAsync(
+            SetIamPolicyRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Sets the access control policy on the specified resource. Replaces any
+        /// existing policy.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Policy SetIamPolicy(
+            SetIamPolicyRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1514,10 +1980,12 @@ namespace Google.Cloud.PubSub.V1
         /// </returns>
         public virtual Task<Policy> GetIamPolicyAsync(
             string resource,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => GetIamPolicyAsync(
+                new GetIamPolicyRequest
+                {
+                    Resource = resource,
+                },
+                callSettings);
 
         /// <summary>
         /// Gets the access control policy for a resource.
@@ -1559,6 +2027,50 @@ namespace Google.Cloud.PubSub.V1
         /// </returns>
         public virtual Policy GetIamPolicy(
             string resource,
+            CallSettings callSettings = null) => GetIamPolicy(
+                new GetIamPolicyRequest
+                {
+                    Resource = resource,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets the access control policy for a resource.
+        /// Returns an empty policy if the resource exists and does not have a policy
+        /// set.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Policy> GetIamPolicyAsync(
+            GetIamPolicyRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets the access control policy for a resource.
+        /// Returns an empty policy if the resource exists and does not have a policy
+        /// set.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Policy GetIamPolicy(
+            GetIamPolicyRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1589,10 +2101,13 @@ namespace Google.Cloud.PubSub.V1
         public virtual Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
             string resource,
             IEnumerable<string> permissions,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => TestIamPermissionsAsync(
+                new TestIamPermissionsRequest
+                {
+                    Resource = resource,
+                    Permissions = { permissions },
+                },
+                callSettings);
 
         /// <summary>
         /// Returns permissions that a caller has on the specified resource.
@@ -1649,6 +2164,51 @@ namespace Google.Cloud.PubSub.V1
         public virtual TestIamPermissionsResponse TestIamPermissions(
             string resource,
             IEnumerable<string> permissions,
+            CallSettings callSettings = null) => TestIamPermissions(
+                new TestIamPermissionsRequest
+                {
+                    Resource = resource,
+                    Permissions = { permissions },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Returns permissions that a caller has on the specified resource.
+        /// If the resource does not exist, this will return an empty set of
+        /// permissions, not a NOT_FOUND error.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
+            TestIamPermissionsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns permissions that a caller has on the specified resource.
+        /// If the resource does not exist, this will return an empty set of
+        /// permissions, not a NOT_FOUND error.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual TestIamPermissionsResponse TestIamPermissions(
+            TestIamPermissionsRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -1739,45 +2299,8 @@ namespace Google.Cloud.PubSub.V1
         /// The generated name is populated in the returned Subscription object.
         /// Note that for REST API requests, you must specify a name in the request.
         /// </summary>
-        /// <param name="name">
-        /// The name of the subscription. It must have the format
-        /// `"projects/{project}/subscriptions/{subscription}"`. `{subscription}` must
-        /// start with a letter, and contain only letters (`[A-Za-z]`), numbers
-        /// (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`),
-        /// plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters
-        /// in length, and it must not start with `"goog"`.
-        /// </param>
-        /// <param name="topic">
-        /// The name of the topic from which this subscription is receiving messages.
-        /// Format is `projects/{project}/topics/{topic}`.
-        /// The value of this field will be `_deleted-topic_` if the topic has been
-        /// deleted.
-        /// </param>
-        /// <param name="pushConfig">
-        /// If push delivery is used with this subscription, this field is
-        /// used to configure it. An empty `pushConfig` signifies that the subscriber
-        /// will pull and ack messages using API methods.
-        /// </param>
-        /// <param name="ackDeadlineSeconds">
-        /// This value is the maximum time after a subscriber receives a message
-        /// before the subscriber should acknowledge the message. After message
-        /// delivery but before the ack deadline expires and before the message is
-        /// acknowledged, it is an outstanding message and will not be delivered
-        /// again during that time (on a best-effort basis).
-        ///
-        /// For pull subscriptions, this value is used as the initial value for the ack
-        /// deadline. To override this value for a given message, call
-        /// `ModifyAckDeadline` with the corresponding `ack_id` if using
-        /// pull.
-        /// The minimum custom deadline you can specify is 10 seconds.
-        /// The maximum custom deadline you can specify is 600 seconds (10 minutes).
-        /// If this parameter is 0, a default value of 10 seconds is used.
-        ///
-        /// For push delivery, this value is also used to set the request timeout for
-        /// the call to the push endpoint.
-        ///
-        /// If the subscriber never acknowledges the message, the Pub/Sub
-        /// system will eventually redeliver the message.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1786,19 +2309,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<Subscription> CreateSubscriptionAsync(
-            SubscriptionName name,
-            TopicName topic,
-            PushConfig pushConfig,
-            int ackDeadlineSeconds,
+            Subscription request,
             CallSettings callSettings = null)
         {
-            Subscription request = new Subscription
-            {
-                SubscriptionName = name,
-                TopicAsTopicNameOneof = TopicNameOneof.From(topic),
-                PushConfig = pushConfig,
-                AckDeadlineSeconds = ackDeadlineSeconds,
-            };
             Modify_Subscription(ref request, ref callSettings);
             return _callCreateSubscription.Async(request, callSettings);
         }
@@ -1815,45 +2328,8 @@ namespace Google.Cloud.PubSub.V1
         /// The generated name is populated in the returned Subscription object.
         /// Note that for REST API requests, you must specify a name in the request.
         /// </summary>
-        /// <param name="name">
-        /// The name of the subscription. It must have the format
-        /// `"projects/{project}/subscriptions/{subscription}"`. `{subscription}` must
-        /// start with a letter, and contain only letters (`[A-Za-z]`), numbers
-        /// (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`),
-        /// plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters
-        /// in length, and it must not start with `"goog"`.
-        /// </param>
-        /// <param name="topic">
-        /// The name of the topic from which this subscription is receiving messages.
-        /// Format is `projects/{project}/topics/{topic}`.
-        /// The value of this field will be `_deleted-topic_` if the topic has been
-        /// deleted.
-        /// </param>
-        /// <param name="pushConfig">
-        /// If push delivery is used with this subscription, this field is
-        /// used to configure it. An empty `pushConfig` signifies that the subscriber
-        /// will pull and ack messages using API methods.
-        /// </param>
-        /// <param name="ackDeadlineSeconds">
-        /// This value is the maximum time after a subscriber receives a message
-        /// before the subscriber should acknowledge the message. After message
-        /// delivery but before the ack deadline expires and before the message is
-        /// acknowledged, it is an outstanding message and will not be delivered
-        /// again during that time (on a best-effort basis).
-        ///
-        /// For pull subscriptions, this value is used as the initial value for the ack
-        /// deadline. To override this value for a given message, call
-        /// `ModifyAckDeadline` with the corresponding `ack_id` if using
-        /// pull.
-        /// The minimum custom deadline you can specify is 10 seconds.
-        /// The maximum custom deadline you can specify is 600 seconds (10 minutes).
-        /// If this parameter is 0, a default value of 10 seconds is used.
-        ///
-        /// For push delivery, this value is also used to set the request timeout for
-        /// the call to the push endpoint.
-        ///
-        /// If the subscriber never acknowledges the message, the Pub/Sub
-        /// system will eventually redeliver the message.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1862,19 +2338,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override Subscription CreateSubscription(
-            SubscriptionName name,
-            TopicName topic,
-            PushConfig pushConfig,
-            int ackDeadlineSeconds,
+            Subscription request,
             CallSettings callSettings = null)
         {
-            Subscription request = new Subscription
-            {
-                SubscriptionName = name,
-                TopicAsTopicNameOneof = TopicNameOneof.From(topic),
-                PushConfig = pushConfig,
-                AckDeadlineSeconds = ackDeadlineSeconds,
-            };
             Modify_Subscription(ref request, ref callSettings);
             return _callCreateSubscription.Sync(request, callSettings);
         }
@@ -1882,9 +2348,8 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>
         /// Gets the configuration details of a subscription.
         /// </summary>
-        /// <param name="subscription">
-        /// The name of the subscription to get.
-        /// Format is `projects/{project}/subscriptions/{sub}`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1893,13 +2358,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<Subscription> GetSubscriptionAsync(
-            SubscriptionName subscription,
+            GetSubscriptionRequest request,
             CallSettings callSettings = null)
         {
-            GetSubscriptionRequest request = new GetSubscriptionRequest
-            {
-                SubscriptionAsSubscriptionName = subscription,
-            };
             Modify_GetSubscriptionRequest(ref request, ref callSettings);
             return _callGetSubscription.Async(request, callSettings);
         }
@@ -1907,9 +2368,8 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>
         /// Gets the configuration details of a subscription.
         /// </summary>
-        /// <param name="subscription">
-        /// The name of the subscription to get.
-        /// Format is `projects/{project}/subscriptions/{sub}`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1918,13 +2378,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override Subscription GetSubscription(
-            SubscriptionName subscription,
+            GetSubscriptionRequest request,
             CallSettings callSettings = null)
         {
-            GetSubscriptionRequest request = new GetSubscriptionRequest
-            {
-                SubscriptionAsSubscriptionName = subscription,
-            };
             Modify_GetSubscriptionRequest(ref request, ref callSettings);
             return _callGetSubscription.Sync(request, callSettings);
         }
@@ -1932,17 +2388,8 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>
         /// Lists matching subscriptions.
         /// </summary>
-        /// <param name="project">
-        /// The name of the cloud project that subscriptions belong to.
-        /// Format is `projects/{project}`.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1951,17 +2398,9 @@ namespace Google.Cloud.PubSub.V1
         /// A pageable asynchronous sequence of <see cref="Subscription"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListSubscriptionsResponse, Subscription> ListSubscriptionsAsync(
-            ProjectName project,
-            string pageToken = null,
-            int? pageSize = null,
+            ListSubscriptionsRequest request,
             CallSettings callSettings = null)
         {
-            ListSubscriptionsRequest request = new ListSubscriptionsRequest
-            {
-                ProjectAsProjectName = project,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListSubscriptionsRequest(ref request, ref callSettings);
             return new GrpcPagedAsyncEnumerable<ListSubscriptionsRequest, ListSubscriptionsResponse, Subscription>(_callListSubscriptions, request, callSettings);
         }
@@ -1969,17 +2408,8 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>
         /// Lists matching subscriptions.
         /// </summary>
-        /// <param name="project">
-        /// The name of the cloud project that subscriptions belong to.
-        /// Format is `projects/{project}`.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -1988,17 +2418,9 @@ namespace Google.Cloud.PubSub.V1
         /// A pageable sequence of <see cref="Subscription"/> resources.
         /// </returns>
         public override PagedEnumerable<ListSubscriptionsResponse, Subscription> ListSubscriptions(
-            ProjectName project,
-            string pageToken = null,
-            int? pageSize = null,
+            ListSubscriptionsRequest request,
             CallSettings callSettings = null)
         {
-            ListSubscriptionsRequest request = new ListSubscriptionsRequest
-            {
-                ProjectAsProjectName = project,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListSubscriptionsRequest(ref request, ref callSettings);
             return new GrpcPagedEnumerable<ListSubscriptionsRequest, ListSubscriptionsResponse, Subscription>(_callListSubscriptions, request, callSettings);
         }
@@ -2010,9 +2432,8 @@ namespace Google.Cloud.PubSub.V1
         /// the same name, but the new one has no association with the old
         /// subscription or its topic unless the same topic is specified.
         /// </summary>
-        /// <param name="subscription">
-        /// The subscription to delete.
-        /// Format is `projects/{project}/subscriptions/{sub}`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2021,13 +2442,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task DeleteSubscriptionAsync(
-            SubscriptionName subscription,
+            DeleteSubscriptionRequest request,
             CallSettings callSettings = null)
         {
-            DeleteSubscriptionRequest request = new DeleteSubscriptionRequest
-            {
-                SubscriptionAsSubscriptionName = subscription,
-            };
             Modify_DeleteSubscriptionRequest(ref request, ref callSettings);
             return _callDeleteSubscription.Async(request, callSettings);
         }
@@ -2039,9 +2456,8 @@ namespace Google.Cloud.PubSub.V1
         /// the same name, but the new one has no association with the old
         /// subscription or its topic unless the same topic is specified.
         /// </summary>
-        /// <param name="subscription">
-        /// The subscription to delete.
-        /// Format is `projects/{project}/subscriptions/{sub}`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2050,13 +2466,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override void DeleteSubscription(
-            SubscriptionName subscription,
+            DeleteSubscriptionRequest request,
             CallSettings callSettings = null)
         {
-            DeleteSubscriptionRequest request = new DeleteSubscriptionRequest
-            {
-                SubscriptionAsSubscriptionName = subscription,
-            };
             Modify_DeleteSubscriptionRequest(ref request, ref callSettings);
             _callDeleteSubscription.Sync(request, callSettings);
         }
@@ -2068,21 +2480,8 @@ namespace Google.Cloud.PubSub.V1
         /// processing was interrupted. Note that this does not modify the
         /// subscription-level `ackDeadlineSeconds` used for subsequent messages.
         /// </summary>
-        /// <param name="subscription">
-        /// The name of the subscription.
-        /// Format is `projects/{project}/subscriptions/{sub}`.
-        /// </param>
-        /// <param name="ackIds">
-        /// List of acknowledgment IDs.
-        /// </param>
-        /// <param name="ackDeadlineSeconds">
-        /// The new ack deadline with respect to the time this request was sent to
-        /// the Pub/Sub system. For example, if the value is 10, the new
-        /// ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
-        /// was made. Specifying zero may immediately make the message available for
-        /// another pull request.
-        /// The minimum deadline you can specify is 0 seconds.
-        /// The maximum deadline you can specify is 600 seconds (10 minutes).
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2091,17 +2490,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task ModifyAckDeadlineAsync(
-            SubscriptionName subscription,
-            IEnumerable<string> ackIds,
-            int ackDeadlineSeconds,
+            ModifyAckDeadlineRequest request,
             CallSettings callSettings = null)
         {
-            ModifyAckDeadlineRequest request = new ModifyAckDeadlineRequest
-            {
-                SubscriptionAsSubscriptionName = subscription,
-                AckIds = { ackIds },
-                AckDeadlineSeconds = ackDeadlineSeconds,
-            };
             Modify_ModifyAckDeadlineRequest(ref request, ref callSettings);
             return _callModifyAckDeadline.Async(request, callSettings);
         }
@@ -2113,21 +2504,8 @@ namespace Google.Cloud.PubSub.V1
         /// processing was interrupted. Note that this does not modify the
         /// subscription-level `ackDeadlineSeconds` used for subsequent messages.
         /// </summary>
-        /// <param name="subscription">
-        /// The name of the subscription.
-        /// Format is `projects/{project}/subscriptions/{sub}`.
-        /// </param>
-        /// <param name="ackIds">
-        /// List of acknowledgment IDs.
-        /// </param>
-        /// <param name="ackDeadlineSeconds">
-        /// The new ack deadline with respect to the time this request was sent to
-        /// the Pub/Sub system. For example, if the value is 10, the new
-        /// ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
-        /// was made. Specifying zero may immediately make the message available for
-        /// another pull request.
-        /// The minimum deadline you can specify is 0 seconds.
-        /// The maximum deadline you can specify is 600 seconds (10 minutes).
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2136,17 +2514,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override void ModifyAckDeadline(
-            SubscriptionName subscription,
-            IEnumerable<string> ackIds,
-            int ackDeadlineSeconds,
+            ModifyAckDeadlineRequest request,
             CallSettings callSettings = null)
         {
-            ModifyAckDeadlineRequest request = new ModifyAckDeadlineRequest
-            {
-                SubscriptionAsSubscriptionName = subscription,
-                AckIds = { ackIds },
-                AckDeadlineSeconds = ackDeadlineSeconds,
-            };
             Modify_ModifyAckDeadlineRequest(ref request, ref callSettings);
             _callModifyAckDeadline.Sync(request, callSettings);
         }
@@ -2160,13 +2530,8 @@ namespace Google.Cloud.PubSub.V1
         /// but such a message may be redelivered later. Acknowledging a message more
         /// than once will not result in an error.
         /// </summary>
-        /// <param name="subscription">
-        /// The subscription whose message is being acknowledged.
-        /// Format is `projects/{project}/subscriptions/{sub}`.
-        /// </param>
-        /// <param name="ackIds">
-        /// The acknowledgment ID for the messages being acknowledged that was returned
-        /// by the Pub/Sub system in the `Pull` response. Must not be empty.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2175,15 +2540,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task AcknowledgeAsync(
-            SubscriptionName subscription,
-            IEnumerable<string> ackIds,
+            AcknowledgeRequest request,
             CallSettings callSettings = null)
         {
-            AcknowledgeRequest request = new AcknowledgeRequest
-            {
-                SubscriptionAsSubscriptionName = subscription,
-                AckIds = { ackIds },
-            };
             Modify_AcknowledgeRequest(ref request, ref callSettings);
             return _callAcknowledge.Async(request, callSettings);
         }
@@ -2197,13 +2556,8 @@ namespace Google.Cloud.PubSub.V1
         /// but such a message may be redelivered later. Acknowledging a message more
         /// than once will not result in an error.
         /// </summary>
-        /// <param name="subscription">
-        /// The subscription whose message is being acknowledged.
-        /// Format is `projects/{project}/subscriptions/{sub}`.
-        /// </param>
-        /// <param name="ackIds">
-        /// The acknowledgment ID for the messages being acknowledged that was returned
-        /// by the Pub/Sub system in the `Pull` response. Must not be empty.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2212,15 +2566,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override void Acknowledge(
-            SubscriptionName subscription,
-            IEnumerable<string> ackIds,
+            AcknowledgeRequest request,
             CallSettings callSettings = null)
         {
-            AcknowledgeRequest request = new AcknowledgeRequest
-            {
-                SubscriptionAsSubscriptionName = subscription,
-                AckIds = { ackIds },
-            };
             Modify_AcknowledgeRequest(ref request, ref callSettings);
             _callAcknowledge.Sync(request, callSettings);
         }
@@ -2231,21 +2579,8 @@ namespace Google.Cloud.PubSub.V1
         /// there are too many concurrent pull requests pending for the given
         /// subscription.
         /// </summary>
-        /// <param name="subscription">
-        /// The subscription from which messages should be pulled.
-        /// Format is `projects/{project}/subscriptions/{sub}`.
-        /// </param>
-        /// <param name="returnImmediately">
-        /// If this field set to true, the system will respond immediately even if
-        /// it there are no messages available to return in the `Pull` response.
-        /// Otherwise, the system may wait (for a bounded amount of time) until at
-        /// least one message is available, rather than returning no messages. The
-        /// client may cancel the request if it does not wish to wait any longer for
-        /// the response.
-        /// </param>
-        /// <param name="maxMessages">
-        /// The maximum number of messages returned for this request. The Pub/Sub
-        /// system may return fewer than the number specified.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2254,17 +2589,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<PullResponse> PullAsync(
-            SubscriptionName subscription,
-            bool returnImmediately,
-            int maxMessages,
+            PullRequest request,
             CallSettings callSettings = null)
         {
-            PullRequest request = new PullRequest
-            {
-                SubscriptionAsSubscriptionName = subscription,
-                ReturnImmediately = returnImmediately,
-                MaxMessages = maxMessages,
-            };
             Modify_PullRequest(ref request, ref callSettings);
             return _callPull.Async(request, callSettings);
         }
@@ -2275,21 +2602,8 @@ namespace Google.Cloud.PubSub.V1
         /// there are too many concurrent pull requests pending for the given
         /// subscription.
         /// </summary>
-        /// <param name="subscription">
-        /// The subscription from which messages should be pulled.
-        /// Format is `projects/{project}/subscriptions/{sub}`.
-        /// </param>
-        /// <param name="returnImmediately">
-        /// If this field set to true, the system will respond immediately even if
-        /// it there are no messages available to return in the `Pull` response.
-        /// Otherwise, the system may wait (for a bounded amount of time) until at
-        /// least one message is available, rather than returning no messages. The
-        /// client may cancel the request if it does not wish to wait any longer for
-        /// the response.
-        /// </param>
-        /// <param name="maxMessages">
-        /// The maximum number of messages returned for this request. The Pub/Sub
-        /// system may return fewer than the number specified.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2298,17 +2612,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override PullResponse Pull(
-            SubscriptionName subscription,
-            bool returnImmediately,
-            int maxMessages,
+            PullRequest request,
             CallSettings callSettings = null)
         {
-            PullRequest request = new PullRequest
-            {
-                SubscriptionAsSubscriptionName = subscription,
-                ReturnImmediately = returnImmediately,
-                MaxMessages = maxMessages,
-            };
             Modify_PullRequest(ref request, ref callSettings);
             return _callPull.Sync(request, callSettings);
         }
@@ -2321,17 +2627,8 @@ namespace Google.Cloud.PubSub.V1
         /// attributes of a push subscription. Messages will accumulate for delivery
         /// continuously through the call regardless of changes to the `PushConfig`.
         /// </summary>
-        /// <param name="subscription">
-        /// The name of the subscription.
-        /// Format is `projects/{project}/subscriptions/{sub}`.
-        /// </param>
-        /// <param name="pushConfig">
-        /// The push configuration for future deliveries.
-        ///
-        /// An empty `pushConfig` indicates that the Pub/Sub system should
-        /// stop pushing messages from the given subscription and allow
-        /// messages to be pulled and acknowledged - effectively pausing
-        /// the subscription if `Pull` is not called.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2340,15 +2637,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task ModifyPushConfigAsync(
-            SubscriptionName subscription,
-            PushConfig pushConfig,
+            ModifyPushConfigRequest request,
             CallSettings callSettings = null)
         {
-            ModifyPushConfigRequest request = new ModifyPushConfigRequest
-            {
-                SubscriptionAsSubscriptionName = subscription,
-                PushConfig = pushConfig,
-            };
             Modify_ModifyPushConfigRequest(ref request, ref callSettings);
             return _callModifyPushConfig.Async(request, callSettings);
         }
@@ -2361,17 +2652,8 @@ namespace Google.Cloud.PubSub.V1
         /// attributes of a push subscription. Messages will accumulate for delivery
         /// continuously through the call regardless of changes to the `PushConfig`.
         /// </summary>
-        /// <param name="subscription">
-        /// The name of the subscription.
-        /// Format is `projects/{project}/subscriptions/{sub}`.
-        /// </param>
-        /// <param name="pushConfig">
-        /// The push configuration for future deliveries.
-        ///
-        /// An empty `pushConfig` indicates that the Pub/Sub system should
-        /// stop pushing messages from the given subscription and allow
-        /// messages to be pulled and acknowledged - effectively pausing
-        /// the subscription if `Pull` is not called.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2380,15 +2662,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override void ModifyPushConfig(
-            SubscriptionName subscription,
-            PushConfig pushConfig,
+            ModifyPushConfigRequest request,
             CallSettings callSettings = null)
         {
-            ModifyPushConfigRequest request = new ModifyPushConfigRequest
-            {
-                SubscriptionAsSubscriptionName = subscription,
-                PushConfig = pushConfig,
-            };
             Modify_ModifyPushConfigRequest(ref request, ref callSettings);
             _callModifyPushConfig.Sync(request, callSettings);
         }
@@ -2397,16 +2673,8 @@ namespace Google.Cloud.PubSub.V1
         /// Sets the access control policy on the specified resource. Replaces any
         /// existing policy.
         /// </summary>
-        /// <param name="resource">
-        /// REQUIRED: The resource for which the policy is being specified.
-        /// `resource` is usually specified as a path. For example, a Project
-        /// resource is specified as `projects/{project}`.
-        /// </param>
-        /// <param name="policy">
-        /// REQUIRED: The complete policy to be applied to the `resource`. The size of
-        /// the policy is limited to a few 10s of KB. An empty policy is a
-        /// valid policy but certain Cloud Platform services (such as Projects)
-        /// might reject them.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2415,15 +2683,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<Policy> SetIamPolicyAsync(
-            string resource,
-            Policy policy,
+            SetIamPolicyRequest request,
             CallSettings callSettings = null)
         {
-            SetIamPolicyRequest request = new SetIamPolicyRequest
-            {
-                Resource = resource,
-                Policy = policy,
-            };
             Modify_SetIamPolicyRequest(ref request, ref callSettings);
             return _callSetIamPolicy.Async(request, callSettings);
         }
@@ -2432,16 +2694,8 @@ namespace Google.Cloud.PubSub.V1
         /// Sets the access control policy on the specified resource. Replaces any
         /// existing policy.
         /// </summary>
-        /// <param name="resource">
-        /// REQUIRED: The resource for which the policy is being specified.
-        /// `resource` is usually specified as a path. For example, a Project
-        /// resource is specified as `projects/{project}`.
-        /// </param>
-        /// <param name="policy">
-        /// REQUIRED: The complete policy to be applied to the `resource`. The size of
-        /// the policy is limited to a few 10s of KB. An empty policy is a
-        /// valid policy but certain Cloud Platform services (such as Projects)
-        /// might reject them.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2450,15 +2704,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override Policy SetIamPolicy(
-            string resource,
-            Policy policy,
+            SetIamPolicyRequest request,
             CallSettings callSettings = null)
         {
-            SetIamPolicyRequest request = new SetIamPolicyRequest
-            {
-                Resource = resource,
-                Policy = policy,
-            };
             Modify_SetIamPolicyRequest(ref request, ref callSettings);
             return _callSetIamPolicy.Sync(request, callSettings);
         }
@@ -2468,10 +2716,8 @@ namespace Google.Cloud.PubSub.V1
         /// Returns an empty policy if the resource exists and does not have a policy
         /// set.
         /// </summary>
-        /// <param name="resource">
-        /// REQUIRED: The resource for which the policy is being requested.
-        /// `resource` is usually specified as a path. For example, a Project
-        /// resource is specified as `projects/{project}`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2480,13 +2726,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<Policy> GetIamPolicyAsync(
-            string resource,
+            GetIamPolicyRequest request,
             CallSettings callSettings = null)
         {
-            GetIamPolicyRequest request = new GetIamPolicyRequest
-            {
-                Resource = resource,
-            };
             Modify_GetIamPolicyRequest(ref request, ref callSettings);
             return _callGetIamPolicy.Async(request, callSettings);
         }
@@ -2496,10 +2738,8 @@ namespace Google.Cloud.PubSub.V1
         /// Returns an empty policy if the resource exists and does not have a policy
         /// set.
         /// </summary>
-        /// <param name="resource">
-        /// REQUIRED: The resource for which the policy is being requested.
-        /// `resource` is usually specified as a path. For example, a Project
-        /// resource is specified as `projects/{project}`.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2508,13 +2748,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override Policy GetIamPolicy(
-            string resource,
+            GetIamPolicyRequest request,
             CallSettings callSettings = null)
         {
-            GetIamPolicyRequest request = new GetIamPolicyRequest
-            {
-                Resource = resource,
-            };
             Modify_GetIamPolicyRequest(ref request, ref callSettings);
             return _callGetIamPolicy.Sync(request, callSettings);
         }
@@ -2524,16 +2760,8 @@ namespace Google.Cloud.PubSub.V1
         /// If the resource does not exist, this will return an empty set of
         /// permissions, not a NOT_FOUND error.
         /// </summary>
-        /// <param name="resource">
-        /// REQUIRED: The resource for which the policy detail is being requested.
-        /// `resource` is usually specified as a path. For example, a Project
-        /// resource is specified as `projects/{project}`.
-        /// </param>
-        /// <param name="permissions">
-        /// The set of permissions to check for the `resource`. Permissions with
-        /// wildcards (such as '*' or 'storage.*') are not allowed. For more
-        /// information see
-        /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2542,15 +2770,9 @@ namespace Google.Cloud.PubSub.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<TestIamPermissionsResponse> TestIamPermissionsAsync(
-            string resource,
-            IEnumerable<string> permissions,
+            TestIamPermissionsRequest request,
             CallSettings callSettings = null)
         {
-            TestIamPermissionsRequest request = new TestIamPermissionsRequest
-            {
-                Resource = resource,
-                Permissions = { permissions },
-            };
             Modify_TestIamPermissionsRequest(ref request, ref callSettings);
             return _callTestIamPermissions.Async(request, callSettings);
         }
@@ -2560,16 +2782,8 @@ namespace Google.Cloud.PubSub.V1
         /// If the resource does not exist, this will return an empty set of
         /// permissions, not a NOT_FOUND error.
         /// </summary>
-        /// <param name="resource">
-        /// REQUIRED: The resource for which the policy detail is being requested.
-        /// `resource` is usually specified as a path. For example, a Project
-        /// resource is specified as `projects/{project}`.
-        /// </param>
-        /// <param name="permissions">
-        /// The set of permissions to check for the `resource`. Permissions with
-        /// wildcards (such as '*' or 'storage.*') are not allowed. For more
-        /// information see
-        /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -2578,15 +2792,9 @@ namespace Google.Cloud.PubSub.V1
         /// The RPC response.
         /// </returns>
         public override TestIamPermissionsResponse TestIamPermissions(
-            string resource,
-            IEnumerable<string> permissions,
+            TestIamPermissionsRequest request,
             CallSettings callSettings = null)
         {
-            TestIamPermissionsRequest request = new TestIamPermissionsRequest
-            {
-                Resource = resource,
-                Permissions = { permissions },
-            };
             Modify_TestIamPermissionsRequest(ref request, ref callSettings);
             return _callTestIamPermissions.Sync(request, callSettings);
         }

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.Snippets/SpeechClientSnippets.cs
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.Snippets/SpeechClientSnippets.cs
@@ -25,7 +25,7 @@ namespace Google.Cloud.Speech.V1Beta1.Snippets
         public void SyncRecognize()
         {
             var audio = LoadResourceAudio("speech.raw");
-            // Snippet: SyncRecognize
+            // Snippet: SyncRecognize(*,*,*)
             SpeechClient client = SpeechClient.Create();
             RecognitionConfig config = new RecognitionConfig { Encoding = AudioEncoding.Linear16, SampleRate = 16000 };
             SyncRecognizeResponse response = client.SyncRecognize(config, audio);

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.Snippets/SpeechClientSnippets.g.cs
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.Snippets/SpeechClientSnippets.g.cs
@@ -60,6 +60,38 @@ namespace Google.Cloud.Speech.V1Beta1.Snippets
             // End snippet
         }
 
+        public async Task SyncRecognizeAsync_RequestObject()
+        {
+            // Snippet: SyncRecognizeAsync(SyncRecognizeRequest,CallSettings)
+            // Create client
+            SpeechClient speechClient = SpeechClient.Create();
+            // Initialize request argument(s)
+            SyncRecognizeRequest request = new SyncRecognizeRequest
+            {
+                Config = new RecognitionConfig(),
+                Audio = new RecognitionAudio(),
+            };
+            // Make the request
+            SyncRecognizeResponse response = await speechClient.SyncRecognizeAsync(request);
+            // End snippet
+        }
+
+        public void SyncRecognize_RequestObject()
+        {
+            // Snippet: SyncRecognize(SyncRecognizeRequest,CallSettings)
+            // Create client
+            SpeechClient speechClient = SpeechClient.Create();
+            // Initialize request argument(s)
+            SyncRecognizeRequest request = new SyncRecognizeRequest
+            {
+                Config = new RecognitionConfig(),
+                Audio = new RecognitionAudio(),
+            };
+            // Make the request
+            SyncRecognizeResponse response = speechClient.SyncRecognize(request);
+            // End snippet
+        }
+
         public async Task AsyncRecognizeAsync()
         {
             // Snippet: AsyncRecognizeAsync(RecognitionConfig,RecognitionAudio,CallSettings)
@@ -84,6 +116,38 @@ namespace Google.Cloud.Speech.V1Beta1.Snippets
             RecognitionAudio audio = new RecognitionAudio();
             // Make the request
             Operation response = speechClient.AsyncRecognize(config, audio);
+            // End snippet
+        }
+
+        public async Task AsyncRecognizeAsync_RequestObject()
+        {
+            // Snippet: AsyncRecognizeAsync(AsyncRecognizeRequest,CallSettings)
+            // Create client
+            SpeechClient speechClient = SpeechClient.Create();
+            // Initialize request argument(s)
+            AsyncRecognizeRequest request = new AsyncRecognizeRequest
+            {
+                Config = new RecognitionConfig(),
+                Audio = new RecognitionAudio(),
+            };
+            // Make the request
+            Operation response = await speechClient.AsyncRecognizeAsync(request);
+            // End snippet
+        }
+
+        public void AsyncRecognize_RequestObject()
+        {
+            // Snippet: AsyncRecognize(AsyncRecognizeRequest,CallSettings)
+            // Create client
+            SpeechClient speechClient = SpeechClient.Create();
+            // Initialize request argument(s)
+            AsyncRecognizeRequest request = new AsyncRecognizeRequest
+            {
+                Config = new RecognitionConfig(),
+                Audio = new RecognitionAudio(),
+            };
+            // Make the request
+            Operation response = speechClient.AsyncRecognize(request);
             // End snippet
         }
 

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/SpeechClient.cs
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/SpeechClient.cs
@@ -296,10 +296,13 @@ namespace Google.Cloud.Speech.V1Beta1
         public virtual Task<SyncRecognizeResponse> SyncRecognizeAsync(
             RecognitionConfig config,
             RecognitionAudio audio,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => SyncRecognizeAsync(
+                new SyncRecognizeRequest
+                {
+                    Config = config,
+                    Audio = audio,
+                },
+                callSettings);
 
         /// <summary>
         /// Perform synchronous speech-recognition: receive results after all audio
@@ -346,6 +349,49 @@ namespace Google.Cloud.Speech.V1Beta1
         public virtual SyncRecognizeResponse SyncRecognize(
             RecognitionConfig config,
             RecognitionAudio audio,
+            CallSettings callSettings = null) => SyncRecognize(
+                new SyncRecognizeRequest
+                {
+                    Config = config,
+                    Audio = audio,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Perform synchronous speech-recognition: receive results after all audio
+        /// has been sent and processed.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<SyncRecognizeResponse> SyncRecognizeAsync(
+            SyncRecognizeRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Perform synchronous speech-recognition: receive results after all audio
+        /// has been sent and processed.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual SyncRecognizeResponse SyncRecognize(
+            SyncRecognizeRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -373,10 +419,13 @@ namespace Google.Cloud.Speech.V1Beta1
         public virtual Task<Operation> AsyncRecognizeAsync(
             RecognitionConfig config,
             RecognitionAudio audio,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => AsyncRecognizeAsync(
+                new AsyncRecognizeRequest
+                {
+                    Config = config,
+                    Audio = audio,
+                },
+                callSettings);
 
         /// <summary>
         /// Perform asynchronous speech-recognition: receive results via the
@@ -427,6 +476,53 @@ namespace Google.Cloud.Speech.V1Beta1
         public virtual Operation AsyncRecognize(
             RecognitionConfig config,
             RecognitionAudio audio,
+            CallSettings callSettings = null) => AsyncRecognize(
+                new AsyncRecognizeRequest
+                {
+                    Config = config,
+                    Audio = audio,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Perform asynchronous speech-recognition: receive results via the
+        /// google.longrunning.Operations interface. Returns either an
+        /// `Operation.error` or an `Operation.response` which contains
+        /// an `AsyncRecognizeResponse` message.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Operation> AsyncRecognizeAsync(
+            AsyncRecognizeRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Perform asynchronous speech-recognition: receive results via the
+        /// google.longrunning.Operations interface. Returns either an
+        /// `Operation.error` or an `Operation.response` which contains
+        /// an `AsyncRecognizeResponse` message.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Operation AsyncRecognize(
+            AsyncRecognizeRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -472,12 +568,8 @@ namespace Google.Cloud.Speech.V1Beta1
         /// Perform synchronous speech-recognition: receive results after all audio
         /// has been sent and processed.
         /// </summary>
-        /// <param name="config">
-        /// [Required] The `config` message provides information to the recognizer
-        /// that specifies how to process the request.
-        /// </param>
-        /// <param name="audio">
-        /// [Required] The audio data to be recognized.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -486,15 +578,9 @@ namespace Google.Cloud.Speech.V1Beta1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<SyncRecognizeResponse> SyncRecognizeAsync(
-            RecognitionConfig config,
-            RecognitionAudio audio,
+            SyncRecognizeRequest request,
             CallSettings callSettings = null)
         {
-            SyncRecognizeRequest request = new SyncRecognizeRequest
-            {
-                Config = config,
-                Audio = audio,
-            };
             Modify_SyncRecognizeRequest(ref request, ref callSettings);
             return _callSyncRecognize.Async(request, callSettings);
         }
@@ -503,12 +589,8 @@ namespace Google.Cloud.Speech.V1Beta1
         /// Perform synchronous speech-recognition: receive results after all audio
         /// has been sent and processed.
         /// </summary>
-        /// <param name="config">
-        /// [Required] The `config` message provides information to the recognizer
-        /// that specifies how to process the request.
-        /// </param>
-        /// <param name="audio">
-        /// [Required] The audio data to be recognized.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -517,15 +599,9 @@ namespace Google.Cloud.Speech.V1Beta1
         /// The RPC response.
         /// </returns>
         public override SyncRecognizeResponse SyncRecognize(
-            RecognitionConfig config,
-            RecognitionAudio audio,
+            SyncRecognizeRequest request,
             CallSettings callSettings = null)
         {
-            SyncRecognizeRequest request = new SyncRecognizeRequest
-            {
-                Config = config,
-                Audio = audio,
-            };
             Modify_SyncRecognizeRequest(ref request, ref callSettings);
             return _callSyncRecognize.Sync(request, callSettings);
         }
@@ -536,12 +612,8 @@ namespace Google.Cloud.Speech.V1Beta1
         /// `Operation.error` or an `Operation.response` which contains
         /// an `AsyncRecognizeResponse` message.
         /// </summary>
-        /// <param name="config">
-        /// [Required] The `config` message provides information to the recognizer
-        /// that specifies how to process the request.
-        /// </param>
-        /// <param name="audio">
-        /// [Required] The audio data to be recognized.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -550,15 +622,9 @@ namespace Google.Cloud.Speech.V1Beta1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<Operation> AsyncRecognizeAsync(
-            RecognitionConfig config,
-            RecognitionAudio audio,
+            AsyncRecognizeRequest request,
             CallSettings callSettings = null)
         {
-            AsyncRecognizeRequest request = new AsyncRecognizeRequest
-            {
-                Config = config,
-                Audio = audio,
-            };
             Modify_AsyncRecognizeRequest(ref request, ref callSettings);
             return _callAsyncRecognize.Async(request, callSettings);
         }
@@ -569,12 +635,8 @@ namespace Google.Cloud.Speech.V1Beta1
         /// `Operation.error` or an `Operation.response` which contains
         /// an `AsyncRecognizeResponse` message.
         /// </summary>
-        /// <param name="config">
-        /// [Required] The `config` message provides information to the recognizer
-        /// that specifies how to process the request.
-        /// </param>
-        /// <param name="audio">
-        /// [Required] The audio data to be recognized.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -583,15 +645,9 @@ namespace Google.Cloud.Speech.V1Beta1
         /// The RPC response.
         /// </returns>
         public override Operation AsyncRecognize(
-            RecognitionConfig config,
-            RecognitionAudio audio,
+            AsyncRecognizeRequest request,
             CallSettings callSettings = null)
         {
-            AsyncRecognizeRequest request = new AsyncRecognizeRequest
-            {
-                Config = config,
-                Audio = audio,
-            };
             Modify_AsyncRecognizeRequest(ref request, ref callSettings);
             return _callAsyncRecognize.Sync(request, callSettings);
         }

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/TraceServiceClientSnippets.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/TraceServiceClientSnippets.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Trace.V1.Snippets
         public void ListTraces()
         {
             string projectId = _fixture.ProjectId;
-            // Snippet: ListTraces
+            // Snippet: ListTraces(*,*,*,*)
             TraceServiceClient client = TraceServiceClient.Create();
             PagedEnumerable<ListTracesResponse, Trace> traces = client.ListTraces(projectId);
             foreach (Trace trace in traces.Take(10))

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/TraceServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/TraceServiceClientSnippets.g.cs
@@ -59,6 +59,38 @@ namespace Google.Cloud.Trace.V1.Snippets
             // End snippet
         }
 
+        public async Task PatchTracesAsync_RequestObject()
+        {
+            // Snippet: PatchTracesAsync(PatchTracesRequest,CallSettings)
+            // Create client
+            TraceServiceClient traceServiceClient = TraceServiceClient.Create();
+            // Initialize request argument(s)
+            PatchTracesRequest request = new PatchTracesRequest
+            {
+                ProjectId = "",
+                Traces = new Traces(),
+            };
+            // Make the request
+            await traceServiceClient.PatchTracesAsync(request);
+            // End snippet
+        }
+
+        public void PatchTraces_RequestObject()
+        {
+            // Snippet: PatchTraces(PatchTracesRequest,CallSettings)
+            // Create client
+            TraceServiceClient traceServiceClient = TraceServiceClient.Create();
+            // Initialize request argument(s)
+            PatchTracesRequest request = new PatchTracesRequest
+            {
+                ProjectId = "",
+                Traces = new Traces(),
+            };
+            // Make the request
+            traceServiceClient.PatchTraces(request);
+            // End snippet
+        }
+
         public async Task GetTraceAsync()
         {
             // Snippet: GetTraceAsync(string,string,CallSettings)
@@ -83,6 +115,38 @@ namespace Google.Cloud.Trace.V1.Snippets
             string traceId = "";
             // Make the request
             Trace response = traceServiceClient.GetTrace(projectId, traceId);
+            // End snippet
+        }
+
+        public async Task GetTraceAsync_RequestObject()
+        {
+            // Snippet: GetTraceAsync(GetTraceRequest,CallSettings)
+            // Create client
+            TraceServiceClient traceServiceClient = TraceServiceClient.Create();
+            // Initialize request argument(s)
+            GetTraceRequest request = new GetTraceRequest
+            {
+                ProjectId = "",
+                TraceId = "",
+            };
+            // Make the request
+            Trace response = await traceServiceClient.GetTraceAsync(request);
+            // End snippet
+        }
+
+        public void GetTrace_RequestObject()
+        {
+            // Snippet: GetTrace(GetTraceRequest,CallSettings)
+            // Create client
+            TraceServiceClient traceServiceClient = TraceServiceClient.Create();
+            // Initialize request argument(s)
+            GetTraceRequest request = new GetTraceRequest
+            {
+                ProjectId = "",
+                TraceId = "",
+            };
+            // Make the request
+            Trace response = traceServiceClient.GetTrace(request);
             // End snippet
         }
 
@@ -139,6 +203,98 @@ namespace Google.Cloud.Trace.V1.Snippets
             // Make the request
             PagedEnumerable<ListTracesResponse,Trace> response =
                 traceServiceClient.ListTraces(projectId);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (Trace item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListTracesResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Trace item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Trace> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Trace item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public async Task ListTracesAsync_RequestObject()
+        {
+            // Snippet: ListTracesAsync(ListTracesRequest,CallSettings)
+            // Create client
+            TraceServiceClient traceServiceClient = TraceServiceClient.Create();
+            // Initialize request argument(s)
+            ListTracesRequest request = new ListTracesRequest
+            {
+                ProjectId = "",
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListTracesResponse,Trace> response =
+                traceServiceClient.ListTracesAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((Trace item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListTracesResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Trace item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Trace> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Trace item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListTraces_RequestObject()
+        {
+            // Snippet: ListTraces(ListTracesRequest,CallSettings)
+            // Create client
+            TraceServiceClient traceServiceClient = TraceServiceClient.Create();
+            // Initialize request argument(s)
+            ListTracesRequest request = new ListTracesRequest
+            {
+                ProjectId = "",
+            };
+            // Make the request
+            PagedEnumerable<ListTracesResponse,Trace> response =
+                traceServiceClient.ListTraces(request);
 
             // Iterate over all response items, lazily performing RPCs as required
             foreach (Trace item in response)

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Trace.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Trace.cs
@@ -62,9 +62,11 @@ namespace Google.Cloud.Trace.V1 {
             "cHJvamVjdF9pZH0vdHJhY2VzL3t0cmFjZV9pZH0SigEKC1BhdGNoVHJhY2Vz",
             "EjEuZ29vZ2xlLmRldnRvb2xzLmNsb3VkdHJhY2UudjEuUGF0Y2hUcmFjZXNS",
             "ZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5IjCC0+STAioyIC92MS9w",
-            "cm9qZWN0cy97cHJvamVjdF9pZH0vdHJhY2VzOgZ0cmFjZXNCSQohY29tLmdv",
-            "b2dsZS5kZXZ0b29scy5jbG91ZHRyYWNlLnYxQgpUcmFjZVByb3RvUAGqAhVH",
-            "b29nbGUuQ2xvdWQuVHJhY2UuVjFiBnByb3RvMw=="));
+            "cm9qZWN0cy97cHJvamVjdF9pZH0vdHJhY2VzOgZ0cmFjZXNCkgEKIWNvbS5n",
+            "b29nbGUuZGV2dG9vbHMuY2xvdWR0cmFjZS52MUIKVHJhY2VQcm90b1ABWkdn",
+            "b29nbGUuZ29sYW5nLm9yZy9nZW5wcm90by9nb29nbGVhcGlzL2RldnRvb2xz",
+            "L2Nsb3VkdHJhY2UvdjE7Y2xvdWR0cmFjZaoCFUdvb2dsZS5DbG91ZC5UcmFj",
+            "ZS5WMWIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Api.AnnotationsReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.EmptyReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/TraceServiceClient.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/TraceServiceClient.cs
@@ -332,10 +332,13 @@ namespace Google.Cloud.Trace.V1
         public virtual Task PatchTracesAsync(
             string projectId,
             Traces traces,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => PatchTracesAsync(
+                new PatchTracesRequest
+                {
+                    ProjectId = projectId,
+                    Traces = traces,
+                },
+                callSettings);
 
         /// <summary>
         /// Sends new traces to Stackdriver Trace or updates existing traces. If the ID
@@ -386,6 +389,55 @@ namespace Google.Cloud.Trace.V1
         public virtual void PatchTraces(
             string projectId,
             Traces traces,
+            CallSettings callSettings = null) => PatchTraces(
+                new PatchTracesRequest
+                {
+                    ProjectId = projectId,
+                    Traces = traces,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Sends new traces to Stackdriver Trace or updates existing traces. If the ID
+        /// of a trace that you send matches that of an existing trace, any fields
+        /// in the existing trace and its spans are overwritten by the provided values,
+        /// and any new fields provided are merged with the existing trace data. If the
+        /// ID does not match, a new trace is created.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task PatchTracesAsync(
+            PatchTracesRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Sends new traces to Stackdriver Trace or updates existing traces. If the ID
+        /// of a trace that you send matches that of an existing trace, any fields
+        /// in the existing trace and its spans are overwritten by the provided values,
+        /// and any new fields provided are merged with the existing trace data. If the
+        /// ID does not match, a new trace is created.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual void PatchTraces(
+            PatchTracesRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -409,10 +461,13 @@ namespace Google.Cloud.Trace.V1
         public virtual Task<Trace> GetTraceAsync(
             string projectId,
             string traceId,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => GetTraceAsync(
+                new GetTraceRequest
+                {
+                    ProjectId = projectId,
+                    TraceId = traceId,
+                },
+                callSettings);
 
         /// <summary>
         /// Gets a single trace by its ID.
@@ -455,6 +510,47 @@ namespace Google.Cloud.Trace.V1
         public virtual Trace GetTrace(
             string projectId,
             string traceId,
+            CallSettings callSettings = null) => GetTrace(
+                new GetTraceRequest
+                {
+                    ProjectId = projectId,
+                    TraceId = traceId,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a single trace by its ID.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Trace> GetTraceAsync(
+            GetTraceRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets a single trace by its ID.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Trace GetTrace(
+            GetTraceRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -484,10 +580,14 @@ namespace Google.Cloud.Trace.V1
             string projectId,
             string pageToken = null,
             int? pageSize = null,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ListTracesAsync(
+                new ListTracesRequest
+                {
+                    ProjectId = projectId,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
 
         /// <summary>
         /// Returns of a list of traces that match the specified filter conditions.
@@ -513,6 +613,48 @@ namespace Google.Cloud.Trace.V1
             string projectId,
             string pageToken = null,
             int? pageSize = null,
+            CallSettings callSettings = null) => ListTraces(
+                new ListTracesRequest
+                {
+                    ProjectId = projectId,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Returns of a list of traces that match the specified filter conditions.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="Trace"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListTracesResponse, Trace> ListTracesAsync(
+            ListTracesRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns of a list of traces that match the specified filter conditions.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="Trace"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListTracesResponse, Trace> ListTraces(
+            ListTracesRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -565,11 +707,8 @@ namespace Google.Cloud.Trace.V1
         /// and any new fields provided are merged with the existing trace data. If the
         /// ID does not match, a new trace is created.
         /// </summary>
-        /// <param name="projectId">
-        /// ID of the Cloud project where the trace data is stored.
-        /// </param>
-        /// <param name="traces">
-        /// The body of the message.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -578,15 +717,9 @@ namespace Google.Cloud.Trace.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task PatchTracesAsync(
-            string projectId,
-            Traces traces,
+            PatchTracesRequest request,
             CallSettings callSettings = null)
         {
-            PatchTracesRequest request = new PatchTracesRequest
-            {
-                ProjectId = projectId,
-                Traces = traces,
-            };
             Modify_PatchTracesRequest(ref request, ref callSettings);
             return _callPatchTraces.Async(request, callSettings);
         }
@@ -598,11 +731,8 @@ namespace Google.Cloud.Trace.V1
         /// and any new fields provided are merged with the existing trace data. If the
         /// ID does not match, a new trace is created.
         /// </summary>
-        /// <param name="projectId">
-        /// ID of the Cloud project where the trace data is stored.
-        /// </param>
-        /// <param name="traces">
-        /// The body of the message.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -611,15 +741,9 @@ namespace Google.Cloud.Trace.V1
         /// The RPC response.
         /// </returns>
         public override void PatchTraces(
-            string projectId,
-            Traces traces,
+            PatchTracesRequest request,
             CallSettings callSettings = null)
         {
-            PatchTracesRequest request = new PatchTracesRequest
-            {
-                ProjectId = projectId,
-                Traces = traces,
-            };
             Modify_PatchTracesRequest(ref request, ref callSettings);
             _callPatchTraces.Sync(request, callSettings);
         }
@@ -627,11 +751,8 @@ namespace Google.Cloud.Trace.V1
         /// <summary>
         /// Gets a single trace by its ID.
         /// </summary>
-        /// <param name="projectId">
-        /// ID of the Cloud project where the trace data is stored.
-        /// </param>
-        /// <param name="traceId">
-        /// ID of the trace to return.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -640,15 +761,9 @@ namespace Google.Cloud.Trace.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<Trace> GetTraceAsync(
-            string projectId,
-            string traceId,
+            GetTraceRequest request,
             CallSettings callSettings = null)
         {
-            GetTraceRequest request = new GetTraceRequest
-            {
-                ProjectId = projectId,
-                TraceId = traceId,
-            };
             Modify_GetTraceRequest(ref request, ref callSettings);
             return _callGetTrace.Async(request, callSettings);
         }
@@ -656,11 +771,8 @@ namespace Google.Cloud.Trace.V1
         /// <summary>
         /// Gets a single trace by its ID.
         /// </summary>
-        /// <param name="projectId">
-        /// ID of the Cloud project where the trace data is stored.
-        /// </param>
-        /// <param name="traceId">
-        /// ID of the trace to return.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -669,15 +781,9 @@ namespace Google.Cloud.Trace.V1
         /// The RPC response.
         /// </returns>
         public override Trace GetTrace(
-            string projectId,
-            string traceId,
+            GetTraceRequest request,
             CallSettings callSettings = null)
         {
-            GetTraceRequest request = new GetTraceRequest
-            {
-                ProjectId = projectId,
-                TraceId = traceId,
-            };
             Modify_GetTraceRequest(ref request, ref callSettings);
             return _callGetTrace.Sync(request, callSettings);
         }
@@ -685,16 +791,8 @@ namespace Google.Cloud.Trace.V1
         /// <summary>
         /// Returns of a list of traces that match the specified filter conditions.
         /// </summary>
-        /// <param name="projectId">
-        /// ID of the Cloud project where the trace data is stored.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -703,17 +801,9 @@ namespace Google.Cloud.Trace.V1
         /// A pageable asynchronous sequence of <see cref="Trace"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListTracesResponse, Trace> ListTracesAsync(
-            string projectId,
-            string pageToken = null,
-            int? pageSize = null,
+            ListTracesRequest request,
             CallSettings callSettings = null)
         {
-            ListTracesRequest request = new ListTracesRequest
-            {
-                ProjectId = projectId,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListTracesRequest(ref request, ref callSettings);
             return new GrpcPagedAsyncEnumerable<ListTracesRequest, ListTracesResponse, Trace>(_callListTraces, request, callSettings);
         }
@@ -721,16 +811,8 @@ namespace Google.Cloud.Trace.V1
         /// <summary>
         /// Returns of a list of traces that match the specified filter conditions.
         /// </summary>
-        /// <param name="projectId">
-        /// ID of the Cloud project where the trace data is stored.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -739,17 +821,9 @@ namespace Google.Cloud.Trace.V1
         /// A pageable sequence of <see cref="Trace"/> resources.
         /// </returns>
         public override PagedEnumerable<ListTracesResponse, Trace> ListTraces(
-            string projectId,
-            string pageToken = null,
-            int? pageSize = null,
+            ListTracesRequest request,
             CallSettings callSettings = null)
         {
-            ListTracesRequest request = new ListTracesRequest
-            {
-                ProjectId = projectId,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListTracesRequest(ref request, ref callSettings);
             return new GrpcPagedEnumerable<ListTracesRequest, ListTracesResponse, Trace>(_callListTraces, request, callSettings);
         }

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.cs
@@ -67,7 +67,7 @@ namespace Google.Cloud.Vision.V1.Snippets
         {
             Image image1 = LoadResourceImage("SchmidtBrinPage.jpg");
             Image image2 = LoadResourceImage("Chrome.png");
-            // Snippet: BatchAnnotateImages
+            // Snippet: BatchAnnotateImages(IEnumerable<AnnotateImageRequest>,*)
             ImageAnnotatorClient client = ImageAnnotatorClient.Create();
             // Perform face recognition on one image, and logo recognition on another.
             AnnotateImageRequest request1 = new AnnotateImageRequest

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.g.cs
@@ -57,5 +57,35 @@ namespace Google.Cloud.Vision.V1.Snippets
             // End snippet
         }
 
+        public async Task BatchAnnotateImagesAsync_RequestObject()
+        {
+            // Snippet: BatchAnnotateImagesAsync(BatchAnnotateImagesRequest,CallSettings)
+            // Create client
+            ImageAnnotatorClient imageAnnotatorClient = ImageAnnotatorClient.Create();
+            // Initialize request argument(s)
+            BatchAnnotateImagesRequest request = new BatchAnnotateImagesRequest
+            {
+                Requests = { },
+            };
+            // Make the request
+            BatchAnnotateImagesResponse response = await imageAnnotatorClient.BatchAnnotateImagesAsync(request);
+            // End snippet
+        }
+
+        public void BatchAnnotateImages_RequestObject()
+        {
+            // Snippet: BatchAnnotateImages(BatchAnnotateImagesRequest,CallSettings)
+            // Create client
+            ImageAnnotatorClient imageAnnotatorClient = ImageAnnotatorClient.Create();
+            // Initialize request argument(s)
+            BatchAnnotateImagesRequest request = new BatchAnnotateImagesRequest
+            {
+                Requests = { },
+            };
+            // Make the request
+            BatchAnnotateImagesResponse response = imageAnnotatorClient.BatchAnnotateImages(request);
+            // End snippet
+        }
+
     }
 }

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.cs
@@ -258,10 +258,12 @@ namespace Google.Cloud.Vision.V1
         /// </returns>
         public virtual Task<BatchAnnotateImagesResponse> BatchAnnotateImagesAsync(
             IEnumerable<AnnotateImageRequest> requests,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => BatchAnnotateImagesAsync(
+                new BatchAnnotateImagesRequest
+                {
+                    Requests = { requests },
+                },
+                callSettings);
 
         /// <summary>
         /// Run image detection and annotation for a batch of images.
@@ -295,6 +297,46 @@ namespace Google.Cloud.Vision.V1
         /// </returns>
         public virtual BatchAnnotateImagesResponse BatchAnnotateImages(
             IEnumerable<AnnotateImageRequest> requests,
+            CallSettings callSettings = null) => BatchAnnotateImages(
+                new BatchAnnotateImagesRequest
+                {
+                    Requests = { requests },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Run image detection and annotation for a batch of images.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<BatchAnnotateImagesResponse> BatchAnnotateImagesAsync(
+            BatchAnnotateImagesRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Run image detection and annotation for a batch of images.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual BatchAnnotateImagesResponse BatchAnnotateImages(
+            BatchAnnotateImagesRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -335,8 +377,8 @@ namespace Google.Cloud.Vision.V1
         /// <summary>
         /// Run image detection and annotation for a batch of images.
         /// </summary>
-        /// <param name="requests">
-        /// Individual image annotation requests for this batch.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -345,13 +387,9 @@ namespace Google.Cloud.Vision.V1
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<BatchAnnotateImagesResponse> BatchAnnotateImagesAsync(
-            IEnumerable<AnnotateImageRequest> requests,
+            BatchAnnotateImagesRequest request,
             CallSettings callSettings = null)
         {
-            BatchAnnotateImagesRequest request = new BatchAnnotateImagesRequest
-            {
-                Requests = { requests },
-            };
             Modify_BatchAnnotateImagesRequest(ref request, ref callSettings);
             return _callBatchAnnotateImages.Async(request, callSettings);
         }
@@ -359,8 +397,8 @@ namespace Google.Cloud.Vision.V1
         /// <summary>
         /// Run image detection and annotation for a batch of images.
         /// </summary>
-        /// <param name="requests">
-        /// Individual image annotation requests for this batch.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -369,13 +407,9 @@ namespace Google.Cloud.Vision.V1
         /// The RPC response.
         /// </returns>
         public override BatchAnnotateImagesResponse BatchAnnotateImages(
-            IEnumerable<AnnotateImageRequest> requests,
+            BatchAnnotateImagesRequest request,
             CallSettings callSettings = null)
         {
-            BatchAnnotateImagesRequest request = new BatchAnnotateImagesRequest
-            {
-                Requests = { requests },
-            };
             Modify_BatchAnnotateImagesRequest(ref request, ref callSettings);
             return _callBatchAnnotateImages.Sync(request, callSettings);
         }

--- a/apis/Google.LongRunning/Google.LongRunning.Snippets/OperationsClientSnippets.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.Snippets/OperationsClientSnippets.g.cs
@@ -57,6 +57,36 @@ namespace Google.LongRunning.Snippets
             // End snippet
         }
 
+        public async Task GetOperationAsync_RequestObject()
+        {
+            // Snippet: GetOperationAsync(GetOperationRequest,CallSettings)
+            // Create client
+            OperationsClient operationsClient = OperationsClient.Create();
+            // Initialize request argument(s)
+            GetOperationRequest request = new GetOperationRequest
+            {
+                Name = "",
+            };
+            // Make the request
+            Operation response = await operationsClient.GetOperationAsync(request);
+            // End snippet
+        }
+
+        public void GetOperation_RequestObject()
+        {
+            // Snippet: GetOperation(GetOperationRequest,CallSettings)
+            // Create client
+            OperationsClient operationsClient = OperationsClient.Create();
+            // Initialize request argument(s)
+            GetOperationRequest request = new GetOperationRequest
+            {
+                Name = "",
+            };
+            // Make the request
+            Operation response = operationsClient.GetOperation(request);
+            // End snippet
+        }
+
         public async Task ListOperationsAsync()
         {
             // Snippet: ListOperationsAsync(string,string,string,int?,CallSettings)
@@ -145,6 +175,100 @@ namespace Google.LongRunning.Snippets
             // End snippet
         }
 
+        public async Task ListOperationsAsync_RequestObject()
+        {
+            // Snippet: ListOperationsAsync(ListOperationsRequest,CallSettings)
+            // Create client
+            OperationsClient operationsClient = OperationsClient.Create();
+            // Initialize request argument(s)
+            ListOperationsRequest request = new ListOperationsRequest
+            {
+                Name = "",
+                Filter = "",
+            };
+            // Make the request
+            PagedAsyncEnumerable<ListOperationsResponse,Operation> response =
+                operationsClient.ListOperationsAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((Operation item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ListOperationsResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Operation item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Operation> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Operation item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        public void ListOperations_RequestObject()
+        {
+            // Snippet: ListOperations(ListOperationsRequest,CallSettings)
+            // Create client
+            OperationsClient operationsClient = OperationsClient.Create();
+            // Initialize request argument(s)
+            ListOperationsRequest request = new ListOperationsRequest
+            {
+                Name = "",
+                Filter = "",
+            };
+            // Make the request
+            PagedEnumerable<ListOperationsResponse,Operation> response =
+                operationsClient.ListOperations(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (Operation item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ListOperationsResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Operation item in page)
+                {
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Operation> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Operation item in singlePage)
+            {
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
         public async Task CancelOperationAsync()
         {
             // Snippet: CancelOperationAsync(string,CallSettings)
@@ -170,6 +294,36 @@ namespace Google.LongRunning.Snippets
             // End snippet
         }
 
+        public async Task CancelOperationAsync_RequestObject()
+        {
+            // Snippet: CancelOperationAsync(CancelOperationRequest,CallSettings)
+            // Create client
+            OperationsClient operationsClient = OperationsClient.Create();
+            // Initialize request argument(s)
+            CancelOperationRequest request = new CancelOperationRequest
+            {
+                Name = "",
+            };
+            // Make the request
+            await operationsClient.CancelOperationAsync(request);
+            // End snippet
+        }
+
+        public void CancelOperation_RequestObject()
+        {
+            // Snippet: CancelOperation(CancelOperationRequest,CallSettings)
+            // Create client
+            OperationsClient operationsClient = OperationsClient.Create();
+            // Initialize request argument(s)
+            CancelOperationRequest request = new CancelOperationRequest
+            {
+                Name = "",
+            };
+            // Make the request
+            operationsClient.CancelOperation(request);
+            // End snippet
+        }
+
         public async Task DeleteOperationAsync()
         {
             // Snippet: DeleteOperationAsync(string,CallSettings)
@@ -192,6 +346,36 @@ namespace Google.LongRunning.Snippets
             string name = "";
             // Make the request
             operationsClient.DeleteOperation(name);
+            // End snippet
+        }
+
+        public async Task DeleteOperationAsync_RequestObject()
+        {
+            // Snippet: DeleteOperationAsync(DeleteOperationRequest,CallSettings)
+            // Create client
+            OperationsClient operationsClient = OperationsClient.Create();
+            // Initialize request argument(s)
+            DeleteOperationRequest request = new DeleteOperationRequest
+            {
+                Name = "",
+            };
+            // Make the request
+            await operationsClient.DeleteOperationAsync(request);
+            // End snippet
+        }
+
+        public void DeleteOperation_RequestObject()
+        {
+            // Snippet: DeleteOperation(DeleteOperationRequest,CallSettings)
+            // Create client
+            OperationsClient operationsClient = OperationsClient.Create();
+            // Initialize request argument(s)
+            DeleteOperationRequest request = new DeleteOperationRequest
+            {
+                Name = "",
+            };
+            // Make the request
+            operationsClient.DeleteOperation(request);
             // End snippet
         }
 

--- a/apis/Google.LongRunning/Google.LongRunning/OperationsClient.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/OperationsClient.cs
@@ -351,10 +351,12 @@ namespace Google.LongRunning
         /// </returns>
         public virtual Task<Operation> GetOperationAsync(
             string name,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => GetOperationAsync(
+                new GetOperationRequest
+                {
+                    Name = name,
+                },
+                callSettings);
 
         /// <summary>
         /// Gets the latest state of a long-running operation.  Clients can use this
@@ -392,6 +394,50 @@ namespace Google.LongRunning
         /// </returns>
         public virtual Operation GetOperation(
             string name,
+            CallSettings callSettings = null) => GetOperation(
+                new GetOperationRequest
+                {
+                    Name = name,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets the latest state of a long-running operation.  Clients can use this
+        /// method to poll the operation result at intervals as recommended by the API
+        /// service.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Operation> GetOperationAsync(
+            GetOperationRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets the latest state of a long-running operation.  Clients can use this
+        /// method to poll the operation result at intervals as recommended by the API
+        /// service.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Operation GetOperation(
+            GetOperationRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -429,10 +475,15 @@ namespace Google.LongRunning
             string filter,
             string pageToken = null,
             int? pageSize = null,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => ListOperationsAsync(
+                new ListOperationsRequest
+                {
+                    Name = name,
+                    Filter = filter,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
 
         /// <summary>
         /// Lists operations that match the specified filter in the request. If the
@@ -466,6 +517,57 @@ namespace Google.LongRunning
             string filter,
             string pageToken = null,
             int? pageSize = null,
+            CallSettings callSettings = null) => ListOperations(
+                new ListOperationsRequest
+                {
+                    Name = name,
+                    Filter = filter,
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists operations that match the specified filter in the request. If the
+        /// server doesn't support this method, it returns `UNIMPLEMENTED`.
+        ///
+        /// NOTE: the `name` binding below allows API services to override the binding
+        /// to use different resource name schemes, such as `users/*/operations`.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="Operation"/> resources.
+        /// </returns>
+        public virtual PagedAsyncEnumerable<ListOperationsResponse, Operation> ListOperationsAsync(
+            ListOperationsRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists operations that match the specified filter in the request. If the
+        /// server doesn't support this method, it returns `UNIMPLEMENTED`.
+        ///
+        /// NOTE: the `name` binding below allows API services to override the binding
+        /// to use different resource name schemes, such as `users/*/operations`.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="Operation"/> resources.
+        /// </returns>
+        public virtual PagedEnumerable<ListOperationsResponse, Operation> ListOperations(
+            ListOperationsRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -494,10 +596,12 @@ namespace Google.LongRunning
         /// </returns>
         public virtual Task CancelOperationAsync(
             string name,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => CancelOperationAsync(
+                new CancelOperationRequest
+                {
+                    Name = name,
+                },
+                callSettings);
 
         /// <summary>
         /// Starts asynchronous cancellation on a long-running operation.  The server
@@ -549,6 +653,64 @@ namespace Google.LongRunning
         /// </returns>
         public virtual void CancelOperation(
             string name,
+            CallSettings callSettings = null) => CancelOperation(
+                new CancelOperationRequest
+                {
+                    Name = name,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Starts asynchronous cancellation on a long-running operation.  The server
+        /// makes a best effort to cancel the operation, but success is not
+        /// guaranteed.  If the server doesn't support this method, it returns
+        /// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+        /// [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+        /// other methods to check whether the cancellation succeeded or whether the
+        /// operation completed despite cancellation. On successful cancellation,
+        /// the operation is not deleted; instead, it becomes an operation with
+        /// an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+        /// corresponding to `Code.CANCELLED`.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task CancelOperationAsync(
+            CancelOperationRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Starts asynchronous cancellation on a long-running operation.  The server
+        /// makes a best effort to cancel the operation, but success is not
+        /// guaranteed.  If the server doesn't support this method, it returns
+        /// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+        /// [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+        /// other methods to check whether the cancellation succeeded or whether the
+        /// operation completed despite cancellation. On successful cancellation,
+        /// the operation is not deleted; instead, it becomes an operation with
+        /// an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+        /// corresponding to `Code.CANCELLED`.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual void CancelOperation(
+            CancelOperationRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -571,10 +733,12 @@ namespace Google.LongRunning
         /// </returns>
         public virtual Task DeleteOperationAsync(
             string name,
-            CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
+            CallSettings callSettings = null) => DeleteOperationAsync(
+                new DeleteOperationRequest
+                {
+                    Name = name,
+                },
+                callSettings);
 
         /// <summary>
         /// Deletes a long-running operation. This method indicates that the client is
@@ -614,6 +778,52 @@ namespace Google.LongRunning
         /// </returns>
         public virtual void DeleteOperation(
             string name,
+            CallSettings callSettings = null) => DeleteOperation(
+                new DeleteOperationRequest
+                {
+                    Name = name,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes a long-running operation. This method indicates that the client is
+        /// no longer interested in the operation result. It does not cancel the
+        /// operation. If the server doesn't support this method, it returns
+        /// `google.rpc.Code.UNIMPLEMENTED`.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task DeleteOperationAsync(
+            DeleteOperationRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Deletes a long-running operation. This method indicates that the client is
+        /// no longer interested in the operation result. It does not cancel the
+        /// operation. If the server doesn't support this method, it returns
+        /// `google.rpc.Code.UNIMPLEMENTED`.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual void DeleteOperation(
+            DeleteOperationRequest request,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -668,8 +878,8 @@ namespace Google.LongRunning
         /// method to poll the operation result at intervals as recommended by the API
         /// service.
         /// </summary>
-        /// <param name="name">
-        /// The name of the operation resource.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -678,13 +888,9 @@ namespace Google.LongRunning
         /// A Task containing the RPC response.
         /// </returns>
         public override Task<Operation> GetOperationAsync(
-            string name,
+            GetOperationRequest request,
             CallSettings callSettings = null)
         {
-            GetOperationRequest request = new GetOperationRequest
-            {
-                Name = name,
-            };
             Modify_GetOperationRequest(ref request, ref callSettings);
             return _callGetOperation.Async(request, callSettings);
         }
@@ -694,8 +900,8 @@ namespace Google.LongRunning
         /// method to poll the operation result at intervals as recommended by the API
         /// service.
         /// </summary>
-        /// <param name="name">
-        /// The name of the operation resource.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -704,13 +910,9 @@ namespace Google.LongRunning
         /// The RPC response.
         /// </returns>
         public override Operation GetOperation(
-            string name,
+            GetOperationRequest request,
             CallSettings callSettings = null)
         {
-            GetOperationRequest request = new GetOperationRequest
-            {
-                Name = name,
-            };
             Modify_GetOperationRequest(ref request, ref callSettings);
             return _callGetOperation.Sync(request, callSettings);
         }
@@ -722,19 +924,8 @@ namespace Google.LongRunning
         /// NOTE: the `name` binding below allows API services to override the binding
         /// to use different resource name schemes, such as `users/*/operations`.
         /// </summary>
-        /// <param name="name">
-        /// The name of the operation collection.
-        /// </param>
-        /// <param name="filter">
-        /// The standard list filter.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -743,19 +934,9 @@ namespace Google.LongRunning
         /// A pageable asynchronous sequence of <see cref="Operation"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListOperationsResponse, Operation> ListOperationsAsync(
-            string name,
-            string filter,
-            string pageToken = null,
-            int? pageSize = null,
+            ListOperationsRequest request,
             CallSettings callSettings = null)
         {
-            ListOperationsRequest request = new ListOperationsRequest
-            {
-                Name = name,
-                Filter = filter,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListOperationsRequest(ref request, ref callSettings);
             return new GrpcPagedAsyncEnumerable<ListOperationsRequest, ListOperationsResponse, Operation>(_callListOperations, request, callSettings);
         }
@@ -767,19 +948,8 @@ namespace Google.LongRunning
         /// NOTE: the `name` binding below allows API services to override the binding
         /// to use different resource name schemes, such as `users/*/operations`.
         /// </summary>
-        /// <param name="name">
-        /// The name of the operation collection.
-        /// </param>
-        /// <param name="filter">
-        /// The standard list filter.
-        /// </param>
-        /// <param name="pageToken">
-        /// The token returned from the previous request.
-        /// A value of <c>null</c> or an empty string retrieves the first page.
-        /// </param>
-        /// <param name="pageSize">
-        /// The size of page to request. The response will not be larger than this, but may be smaller.
-        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -788,19 +958,9 @@ namespace Google.LongRunning
         /// A pageable sequence of <see cref="Operation"/> resources.
         /// </returns>
         public override PagedEnumerable<ListOperationsResponse, Operation> ListOperations(
-            string name,
-            string filter,
-            string pageToken = null,
-            int? pageSize = null,
+            ListOperationsRequest request,
             CallSettings callSettings = null)
         {
-            ListOperationsRequest request = new ListOperationsRequest
-            {
-                Name = name,
-                Filter = filter,
-                PageToken = pageToken ?? "",
-                PageSize = pageSize ?? 0,
-            };
             Modify_ListOperationsRequest(ref request, ref callSettings);
             return new GrpcPagedEnumerable<ListOperationsRequest, ListOperationsResponse, Operation>(_callListOperations, request, callSettings);
         }
@@ -817,8 +977,8 @@ namespace Google.LongRunning
         /// an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
         /// corresponding to `Code.CANCELLED`.
         /// </summary>
-        /// <param name="name">
-        /// The name of the operation resource to be cancelled.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -827,13 +987,9 @@ namespace Google.LongRunning
         /// A Task containing the RPC response.
         /// </returns>
         public override Task CancelOperationAsync(
-            string name,
+            CancelOperationRequest request,
             CallSettings callSettings = null)
         {
-            CancelOperationRequest request = new CancelOperationRequest
-            {
-                Name = name,
-            };
             Modify_CancelOperationRequest(ref request, ref callSettings);
             return _callCancelOperation.Async(request, callSettings);
         }
@@ -850,8 +1006,8 @@ namespace Google.LongRunning
         /// an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
         /// corresponding to `Code.CANCELLED`.
         /// </summary>
-        /// <param name="name">
-        /// The name of the operation resource to be cancelled.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -860,13 +1016,9 @@ namespace Google.LongRunning
         /// The RPC response.
         /// </returns>
         public override void CancelOperation(
-            string name,
+            CancelOperationRequest request,
             CallSettings callSettings = null)
         {
-            CancelOperationRequest request = new CancelOperationRequest
-            {
-                Name = name,
-            };
             Modify_CancelOperationRequest(ref request, ref callSettings);
             _callCancelOperation.Sync(request, callSettings);
         }
@@ -877,8 +1029,8 @@ namespace Google.LongRunning
         /// operation. If the server doesn't support this method, it returns
         /// `google.rpc.Code.UNIMPLEMENTED`.
         /// </summary>
-        /// <param name="name">
-        /// The name of the operation resource to be deleted.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -887,13 +1039,9 @@ namespace Google.LongRunning
         /// A Task containing the RPC response.
         /// </returns>
         public override Task DeleteOperationAsync(
-            string name,
+            DeleteOperationRequest request,
             CallSettings callSettings = null)
         {
-            DeleteOperationRequest request = new DeleteOperationRequest
-            {
-                Name = name,
-            };
             Modify_DeleteOperationRequest(ref request, ref callSettings);
             return _callDeleteOperation.Async(request, callSettings);
         }
@@ -904,8 +1052,8 @@ namespace Google.LongRunning
         /// operation. If the server doesn't support this method, it returns
         /// `google.rpc.Code.UNIMPLEMENTED`.
         /// </summary>
-        /// <param name="name">
-        /// The name of the operation resource to be deleted.
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
         /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -914,13 +1062,9 @@ namespace Google.LongRunning
         /// The RPC response.
         /// </returns>
         public override void DeleteOperation(
-            string name,
+            DeleteOperationRequest request,
             CallSettings callSettings = null)
         {
-            DeleteOperationRequest request = new DeleteOperationRequest
-            {
-                Name = name,
-            };
             Modify_DeleteOperationRequest(ref request, ref callSettings);
             _callDeleteOperation.Sync(request, callSettings);
         }


### PR DESCRIPTION
Logging now has fuller resource name support, which has revealed a few interesting issues, but is nearly there.

The first commit is purely auto-generated. The second just fixes log4net to work with resource names; it's not *quite* ideal yet, as we'd like to not specify a LogName parameter in the request, but that's tricky right now (other than by creating the request directly). See https://github.com/googleapis/toolkit/issues/834.