### PR TITLE
Increase wait time between polling for traces 

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/TraceTest.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         private readonly TimeSpan _timeout = TimeSpan.FromSeconds(10);
 
         /// <summary>Time to sleep between checks for a trace.</summary>
-        private readonly TimeSpan _sleepInterval = TimeSpan.FromSeconds(1);
+        private readonly TimeSpan _sleepInterval = TimeSpan.FromSeconds(2);
 
         /// <summary>Project id to run the test on.</summary>
         private readonly string _projectId;
@@ -89,13 +89,16 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         /// <summary>
         /// Gets a trace that contains a span with the given name.
         /// </summary>
-        private async Task<TraceProto> GetTrace(string spanName)
+        /// <param name="expectTrace">True if the trace is expected to exist.  This is used
+        ///     to minimize RPC calls.</param>
+        private async Task<TraceProto> GetTrace(string spanName, bool expectTrace = true)
         {
-            double sleepTime = 0;
-            while (sleepTime < _timeout.TotalMilliseconds)
+            double totalSleepTime = 0;
+            while (totalSleepTime <= _timeout.TotalMilliseconds)
             {
-                sleepTime += _sleepInterval.TotalMilliseconds;
-                Thread.Sleep(Convert.ToInt32(_sleepInterval.TotalMilliseconds));
+                double sleepTime = expectTrace ? _sleepInterval.TotalMilliseconds : _timeout.TotalMilliseconds;
+                totalSleepTime += sleepTime;
+                Thread.Sleep(Convert.ToInt32(sleepTime));
 
                 ListTracesRequest request = new ListTracesRequest
                 {
@@ -170,7 +173,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
             BlockUntilClockTick();
             tracer.EndSpan();
 
-            TraceProto trace = await GetTrace(rootSpanName);
+            TraceProto trace = await GetTrace(rootSpanName, false);
             Assert.Null(trace);
         }
 
@@ -291,7 +294,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
             tracer.EndSpan();
             tracer.EndSpan();
 
-            TraceProto trace = await GetTrace(rootSpanName);
+            TraceProto trace = await GetTrace(rootSpanName, false);
             Assert.Null(trace);
         }
     }

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/TraceTest.cs
@@ -93,12 +93,12 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         ///     to minimize RPC calls.</param>
         private async Task<TraceProto> GetTrace(string spanName, bool expectTrace = true)
         {
-            double totalSleepTime = 0;
-            while (totalSleepTime <= _timeout.TotalMilliseconds)
+            TimeSpan totalSleepTime = TimeSpan.Zero;
+            while (totalSleepTime <= _timeout)
             {
-                double sleepTime = expectTrace ? _sleepInterval.TotalMilliseconds : _timeout.TotalMilliseconds;
+                TimeSpan sleepTime = expectTrace ? _sleepInterval : _timeout;
                 totalSleepTime += sleepTime;
-                Thread.Sleep(Convert.ToInt32(sleepTime));
+                Thread.Sleep(sleepTime);
 
                 ListTracesRequest request = new ListTracesRequest
                 {


### PR DESCRIPTION
Increase wait time between polling for traces and wait the full amount of timeout time when waiting for a trace that shouldn't exists.

This will help reduce RPC calls and avoid hitting API quotas