### PR TITLE
Cleaned up duplicate code from Google.Apis.Auth

### DIFF
--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/MetadataClient.cs
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/MetadataClient.cs
@@ -254,11 +254,11 @@ namespace Google.Cloud.Metadata.V1
         /// </para>
         /// </remarks>
         /// <param name="key">The metadata key of the value(s) to get, such as "instance/scheduling/automatic-restart"</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <exception cref="ArgumentException">
         /// <paramref name="key"/> does not have the proper format for a metadata key, which is a relative URL.
         /// </exception>
         /// <returns>A task containing the <see cref="MetadataResult"/> with the current value(s) for an endpoint or a JSON object with the contents of the directory.</returns>
-        /// <returns>
         /// <seealso cref="WaitForChangeAsync"/>
         public virtual Task<MetadataResult> GetMetadataAsync(string key, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/project.json
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/project.json
@@ -19,8 +19,9 @@
   },
 
   "dependencies": {
-    "Google.Apis": "1.18.0",
-    "Google.Apis.Compute.v1": "1.18.0.650"
+    "Google.Apis": "1.20.0",
+    "Google.Apis.Auth": "1.20.0",
+    "Google.Apis.Compute.v1": "1.19.0.692"
   },
 
   "frameworks": {


### PR DESCRIPTION
(also cleaned up some warnings I noticed)

Note: in the code I removed, I was using `UtcNow` (as suggested during the initial [PR review](https://github.com/GoogleCloudPlatform/google-cloud-dotnet/pull/412)), but the code is it using now from Google.Apis.Auth is using `Now`. This can't just be changed since other code getting/setting `TokenResponse.Issued` uses `Now`. So I wonder if all places should be updated.