### PR TITLE
Fixed issue where (Instance|Project)MetadataChanged always fired initially

### DIFF
--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/MetadataClientTest.cs
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/MetadataClientTest.cs
@@ -136,6 +136,7 @@ namespace Google.Cloud.Metadata.V1.IntegrationTests
                 waitHandle.Set();
             };
 
+            await Task.Delay(TimeSpan.FromSeconds(1));
             await _fixture.UpdateMetadataAsync($"instance/attributes/{key}", newValue);
             waitHandle.Wait(TimeSpan.FromSeconds(10));
             Assert.Equal(1, eventCount);
@@ -228,6 +229,7 @@ namespace Google.Cloud.Metadata.V1.IntegrationTests
                 waitHandle.Set();
             };
 
+            await Task.Delay(TimeSpan.FromSeconds(1));
             await _fixture.UpdateMetadataAsync($"project/attributes/{key}", newValue);
             waitHandle.Wait(TimeSpan.FromSeconds(10));
             Assert.Equal(1, eventCount);

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/MetadataClientImpl.cs
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/MetadataClientImpl.cs
@@ -556,7 +556,9 @@ namespace Google.Cloud.Metadata.V1
 
             private async Task WaitForChange()
             {
-                var response = await client.RequestMetadataAsync(path, cancellationTokenSource.Token).ConfigureAwait(false);
+                // Always add recursive. It is ignored for values and required for directories when waiting for changes and ETags differ between
+                // recursive and non-recursive requests for directories.
+                var response = await client.RequestMetadataAsync(path + "?recursive=true", cancellationTokenSource.Token).ConfigureAwait(false);
                 var lastETag = GetETag(response);
                 ready.Set();
 


### PR DESCRIPTION
The tests were only passing most of the time due to a race condition. I've added delays so they'll fail consistently if this issue is ever reintroduced.