### PR TITLE
Tests for HashValidatingDownloader

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/FakeBigqueryService.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/FakeBigqueryService.cs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 using Google.Apis.Bigquery.v2;
-using Google.Apis.Http;
 using Google.Apis.Requests;
+using Google.Cloud.ClientTesting;
 
 namespace Google.Cloud.BigQuery.V2.Tests
 {
@@ -33,7 +33,6 @@ namespace Google.Cloud.BigQuery.V2.Tests
         })
         {
             handler = (ReplayingMessageHandler) HttpClient.MessageHandler;
-            var client = new ConfigurableHttpClient(handler);
         }
 
         public void ExpectRequest<TResponse>(ClientServiceRequest<TResponse> request, TResponse response)
@@ -42,23 +41,6 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var httpRequest = request.CreateRequest();
             string responseContent = SerializeObject(response);            
             handler.ExpectRequest(httpRequest.RequestUri, httpRequest.Content?.ReadAsStringAsync()?.Result, responseContent);
-        }
-
-        /// <summary>
-        /// HTTP client factory which gets a specific message handler (for mocking) and use for creating the HTTP
-        /// client.
-        /// </summary>
-        private class FakeHttpClientFactory : IHttpClientFactory
-        {
-            private readonly ConfigurableMessageHandler _handler;
-
-            public FakeHttpClientFactory(ConfigurableMessageHandler handler)
-            {
-                _handler = handler;
-            }
-
-            public ConfigurableHttpClient CreateHttpClient(CreateHttpClientArgs args) =>
-                new ConfigurableHttpClient(_handler);
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/HashValidatingDownloaderTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/HashValidatingDownloaderTest.cs
@@ -1,0 +1,109 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using Google.Apis.Download;
+using Google.Apis.Http;
+using Google.Apis.Services;
+using Google.Cloud.ClientTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using Xunit;
+
+namespace Google.Cloud.Storage.V1.Tests
+{
+    public class HashValidatingDownloaderTest
+    {
+        private static readonly byte[] s_data = Enumerable.Range(0, 200000).Select(i => (byte) i).ToArray();
+        private const string Md5Value = "md5=PL4+tNeevS58x7PmIPW6YA==";
+        private const string Crc32Value = "crc32c=WfO2Ug==";
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(Md5Value)]
+        [InlineData(Md5Value + "," + Crc32Value)]
+        [InlineData(Crc32Value + "," + Md5Value)]
+        [InlineData(Crc32Value)]
+        public void Valid(string headerValue)
+        {
+            HashValidatingDownloader downloader = CreateDownloader(request => CreateResponse(headerValue));
+            for (int chunks = 1; chunks < 5; chunks++)
+            {
+                // Make sure it definitely fits...
+                downloader.ChunkSize = (s_data.Length + 100) / chunks;
+                var stream = new MemoryStream();
+                var status = downloader.Download("http://pretend.google.com/", stream);
+                if (status.Exception != null)
+                {
+                    throw status.Exception;
+                }
+                Assert.Equal(DownloadStatus.Completed, status.Status);
+                Assert.Equal(s_data, stream.ToArray());                
+            }
+        }
+
+        [Fact]
+        public void Invalid()
+        {
+            HashValidatingDownloader downloader = CreateDownloader(request => CreateResponse("crc32c=Bogus1=="));
+            for (int chunks = 1; chunks < 5; chunks++)
+            {
+                // Make sure it definitely fits...
+                downloader.ChunkSize = (s_data.Length + 100) / chunks;
+                var stream = new MemoryStream();
+                var status = downloader.Download("http://pretend.google.com/", stream);
+                Assert.Equal(DownloadStatus.Failed, status.Status);
+                Assert.Contains("Incorrect hash", status.Exception.Message);
+            }
+        }
+
+        private static HashValidatingDownloader CreateDownloader(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            var service = new MockableService(handler);
+            return new HashValidatingDownloader(service);
+        }
+
+        class MockableService : BaseClientService
+        {
+            internal MockableService(Func<HttpRequestMessage, HttpResponseMessage> handler)
+                : base(GetInitializer(handler))
+            {
+            }
+
+            public override string BasePath => "";
+            public override string BaseUri => "";
+            public override IList<string> Features => new List<string>();
+            public override string Name => "Mockable";
+
+            private static Initializer GetInitializer(Func<HttpRequestMessage, HttpResponseMessage> handler)
+            {
+                var httpMessageHandler = new MockableMessageHandler(handler);
+                var configurableHandler = new ConfigurableMessageHandler(httpMessageHandler);
+                var clientFactory = new FakeHttpClientFactory(configurableHandler);
+                return new Initializer { HttpClientFactory = clientFactory };
+            }
+        }
+
+        private static HttpResponseMessage CreateResponse(string headerValue)
+        {
+            HttpResponseMessage response = new HttpResponseMessage { Content = new ByteArrayContent(s_data) };
+            if (headerValue != null)
+            {
+                response.Headers.Add(Crc32c.HashHeaderName, headerValue);
+            }
+            return response;
+        }
+    }
+}

--- a/tools/Google.Cloud.ClientTesting/FakeHttpClientFactory.cs
+++ b/tools/Google.Cloud.ClientTesting/FakeHttpClientFactory.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Http;
+
+namespace Google.Cloud.ClientTesting
+{
+    /// <summary>
+    /// HTTP client factory which gets a specific message handler (for mocking) and use for creating the HTTP
+    /// client.
+    /// </summary>
+    public class FakeHttpClientFactory : IHttpClientFactory
+    {
+        private readonly ConfigurableMessageHandler _handler;
+
+        public FakeHttpClientFactory(ConfigurableMessageHandler handler)
+        {
+            _handler = handler;
+        }
+
+        public ConfigurableHttpClient CreateHttpClient(CreateHttpClientArgs args) => new ConfigurableHttpClient(_handler);
+    }
+}

--- a/tools/Google.Cloud.ClientTesting/MockableMessageHandler.cs
+++ b/tools/Google.Cloud.ClientTesting/MockableMessageHandler.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.ClientTesting
+{
+    /// <summary>
+    /// HttpMessageHandler which simply calls a delegate provided in the constructor.
+    /// This makes it easy to control for tests.
+    /// </summary>
+    public class MockableMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
+
+        public MockableMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = (req, token) => Task.FromResult(handler(req));
+        }
+
+        public MockableMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+        {
+            _handler = (req, token) => handler(req);
+        }
+
+        public MockableMessageHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> handler)
+        {
+            _handler = (req, token) => Task.FromResult(handler(req, token));
+        }
+
+        public MockableMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => _handler(request, cancellationToken);
+    }
+}

--- a/tools/Google.Cloud.ClientTesting/ReplayingMessageHandler.cs
+++ b/tools/Google.Cloud.ClientTesting/ReplayingMessageHandler.cs
@@ -21,7 +21,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Google.Cloud.BigQuery.V2.Tests
+namespace Google.Cloud.ClientTesting
 {
     /// <summary>
     /// Test helper class effectively acting as an HTTP mock.

--- a/tools/Google.Cloud.ClientTesting/project.json
+++ b/tools/Google.Cloud.ClientTesting/project.json
@@ -5,7 +5,8 @@
 
   "dependencies": {
     "NETStandard.Library": "1.6.0",
-    "xunit": "2.2.0-beta2-build3300"
+    "xunit": "2.2.0-beta2-build3300",
+    "Google.Apis": "1.20.0"
   },
 
   "frameworks": {


### PR DESCRIPTION
This involves moving some testing infrastructure from BigQuery
into common code, so that we can control the responses we're given
back.

Fixes #650.