### PR TITLE
Fix snippet URL for error reporting

### DIFF
--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/docs/index.md
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/docs/index.md
@@ -45,7 +45,7 @@ optionally specifying a service endpoint and settings.
 Using [`Google.Cloud.Diagnostics.AspNet`'s ExceptionLogger](Google.Cloud.Diagnostics.AspNet/index.html)
 uncaught exceptions in ASP.NET applications can be automatically reported to the Stackdriver Error Reporting API.
 
-[!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNet.AspNet.txt#RegisterExceptionLogger)]
+[!code-cs[](../Google.Cloud.Diagnostics.AspNet/obj/snippets/Google.Cloud.Diagnostics.AspNet.AspNet.txt#RegisterExceptionLogger)]
 
 ## Report an error
 


### PR DESCRIPTION
This makes me slightly nervous as it means we depend on the build order,
but it's not obvious how we'd want to fix that right now.