### PR TITLE
Add a Trace Label for the Agent to all Traces.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Trace/LabelsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Trace/LabelsTest.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Moq;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
@@ -25,6 +24,16 @@ namespace Google.Cloud.Diagnostics.AspNet.Tests
 {
     public class LabelsTest
     {
+
+        [Fact]
+        public void AgentLabel()
+        {
+            var labels = Labels.AgentLabel();
+            Assert.Single(labels);
+            Assert.Contains(Labels.AgentName, labels[Labels.Agent]);
+            Assert.Contains(Labels.AgentVersion, labels[Labels.Agent]);
+        }
+
         [Fact]
         public void FromHttpRequestWrapper()
         {

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Trace/LabelsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Trace/LabelsTest.cs
@@ -28,7 +28,7 @@ namespace Google.Cloud.Diagnostics.AspNet.Tests
         [Fact]
         public void AgentLabel()
         {
-            var labels = Labels.AgentLabel();
+            var labels = Labels.AgentLabel;
             Assert.Single(labels);
             Assert.Contains(Labels.AgentName, labels[Labels.Agent]);
             Assert.Contains(Labels.AgentVersion, labels[Labels.Agent]);

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
@@ -133,7 +133,7 @@ namespace Google.Cloud.Diagnostics.AspNet
             // Start the span and annotate it with information from the current request.
             tracer.StartSpan(HttpContext.Current.Request.Path);
             tracer.AnnotateSpan(Labels.FromHttpRequest(HttpContext.Current.Request));
-            tracer.AnnotateSpan(Labels.AgentLabel());
+            tracer.AnnotateSpan(Labels.AgentLabel);
         }
 
         private void EndRequest(object sender, EventArgs e)

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
@@ -133,6 +133,7 @@ namespace Google.Cloud.Diagnostics.AspNet
             // Start the span and annotate it with information from the current request.
             tracer.StartSpan(HttpContext.Current.Request.Path);
             tracer.AnnotateSpan(Labels.FromHttpRequest(HttpContext.Current.Request));
+            tracer.AnnotateSpan(Labels.AgentLabel());
         }
 
         private void EndRequest(object sender, EventArgs e)

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/Labels.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/Labels.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using System.Web;
 
@@ -27,6 +28,16 @@ namespace Google.Cloud.Diagnostics.AspNet
     /// </summary>
     internal static class Labels
     {
+        /// <summary>The version of the trace agent.</summary>
+        internal static readonly string AgentVersion = typeof(Labels)
+            .GetTypeInfo()
+            .Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            .InformationalVersion;
+
+        /// <summary>The name of the trace agent.</summary>
+        internal const string AgentName = "google-cloud-c-sharp-trace";
+
         ///<summary>The label to denote the size of a request.</summary> 
         internal const string HttpRequestSize = "trace.cloud.google.com/http/request/size";
 
@@ -41,6 +52,20 @@ namespace Google.Cloud.Diagnostics.AspNet
 
         ///<summary>The label to denote a stack trace.</summary> 
         internal const string StackTrace = "trace.cloud.google.com/stacktrace";
+
+        ///<summary>The label to denote an agent.</summary> 
+        internal const string Agent = " /agent";
+
+        /// <summary>
+        /// Gets a map with the label for the agent which contains the agent's name and version.
+        /// </summary>
+        internal static Dictionary<string, string> AgentLabel()
+        {
+            return new Dictionary<string, string>()
+            {
+                { Agent, $"{AgentName} {AgentVersion}"}
+            };
+        }
 
         /// <summary>
         /// Gets a map of labels for a span from an <see cref="HttpRequest"/>, such as request size, method, ect.

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/Labels.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/Labels.cs
@@ -35,8 +35,10 @@ namespace Google.Cloud.Diagnostics.AspNet
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             .InformationalVersion;
 
-        /// <summary>A dictionary with the agent label populated.</summary>
-        internal static readonly Dictionary<string, string> AgentLabelDictionary =
+        /// <summary>
+        /// Gets a map with the label for the agent which contains the agent's name and version.
+        /// </summary>
+        internal static Dictionary<string, string> AgentLabel { get; } =
             new Dictionary<string, string> { { Agent, $"{AgentName} {AgentVersion}" } };
 
         /// <summary>The name of the trace agent.</summary>
@@ -59,11 +61,6 @@ namespace Google.Cloud.Diagnostics.AspNet
 
         ///<summary>The label to denote an agent.</summary> 
         internal const string Agent = "/agent";
-
-        /// <summary>
-        /// Gets a map with the label for the agent which contains the agent's name and version.
-        /// </summary>
-        internal static Dictionary<string, string> AgentLabel() => AgentLabelDictionary;
 
         /// <summary>
         /// Gets a map of labels for a span from an <see cref="HttpRequest"/>, such as request size, method, ect.

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/Labels.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/Labels.cs
@@ -35,8 +35,12 @@ namespace Google.Cloud.Diagnostics.AspNet
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             .InformationalVersion;
 
+        /// <summary>A dictionary with the agent label populated.</summary>
+        internal static readonly Dictionary<string, string> AgentLabelDictionary =
+            new Dictionary<string, string> { { Agent, $"{AgentName} {AgentVersion}" } };
+
         /// <summary>The name of the trace agent.</summary>
-        internal const string AgentName = "google-cloud-c-sharp-trace";
+        internal const string AgentName = "google-cloud-csharp-trace";
 
         ///<summary>The label to denote the size of a request.</summary> 
         internal const string HttpRequestSize = "trace.cloud.google.com/http/request/size";
@@ -54,18 +58,12 @@ namespace Google.Cloud.Diagnostics.AspNet
         internal const string StackTrace = "trace.cloud.google.com/stacktrace";
 
         ///<summary>The label to denote an agent.</summary> 
-        internal const string Agent = " /agent";
+        internal const string Agent = "/agent";
 
         /// <summary>
         /// Gets a map with the label for the agent which contains the agent's name and version.
         /// </summary>
-        internal static Dictionary<string, string> AgentLabel()
-        {
-            return new Dictionary<string, string>()
-            {
-                { Agent, $"{AgentName} {AgentVersion}"}
-            };
-        }
+        internal static Dictionary<string, string> AgentLabel() => AgentLabelDictionary;
 
         /// <summary>
         /// Gets a map of labels for a span from an <see cref="HttpRequest"/>, such as request size, method, ect.


### PR DESCRIPTION
Adds a trace label for the name and version of the agent to all traces.

This will help with usage metrics.