### PR TITLE
Add a DelegatingHandler to for tracing outgoing http requests in ASP.NET applications.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/TraceTest.cs
@@ -16,7 +16,6 @@ using Google.Cloud.Trace.V1;
 using Google.Cloud.Diagnostics.AspNet.Tests;
 using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Diagnostics.Common.Tests;
-using Google.Protobuf.Collections;
 using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Collections.Generic;

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/AspNetSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/AspNetSnippets.cs
@@ -40,6 +40,7 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
         {
             public override void Init()
             {
+                base.Init();
                 string projectId = "[Google Cloud Platform project ID]";
                 // Trace a sampling of incoming Http requests.
                 CloudTrace.Initialize(projectId, this);
@@ -51,20 +52,20 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
         {
             // Sample: UseTracer
             // Manually trace a specific operation.
-            CloudTrace.GetCurrentTracer().StartSpan("hello-world");
+            CloudTrace.CurrentTracer.StartSpan("hello-world");
             Console.Out.WriteLine("Hello, World!");
-            CloudTrace.GetCurrentTracer().EndSpan();
+            CloudTrace.CurrentTracer.EndSpan();
             // End sample
         }
 
         public async Task<HttpResponseMessage> TraceOutgoing()
         {
             // Sample: TraceOutgoing
-            // Add a handler to trace outgoing requests and to propigate the trace header.
+            // Add a handler to trace outgoing requests and to propagate the trace header.
             var traceHeaderHandler = TraceHeaderPropagatingHandler.Create();
             using (var httpClient = HttpClientFactory.Create(traceHeaderHandler))
             {
-                return await httpClient.GetAsync("https://cloud.google.com/trace/");
+                return await httpClient.GetAsync("https://weather.com/");
             }
             // End sample
         }

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/AspNetSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/AspNetSnippets.cs
@@ -57,9 +57,9 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
             // End sample
         }
 
-        public async Task<HttpResponseMessage> AddTraceHeader()
+        public async Task<HttpResponseMessage> TraceOutgoing()
         {
-            // Sample: AddTraceHeader
+            // Sample: TraceOutgoing
             // Add a handler to trace outgoing requests and to propigate the trace header.
             var traceHeaderHandler = TraceHeaderPropagatingHandler.Create();
             using (var httpClient = HttpClientFactory.Create(traceHeaderHandler))

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/AspNetSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/AspNetSnippets.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Net.Http;
+using System.Threading.Tasks;
 using System.Web;
 using System.Web.Http;
 using System.Web.Http.ExceptionHandling;
@@ -36,7 +38,7 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
         // Sample: InitializeTrace
         public class Global : HttpApplication
         {
-            void Application_Start(object sender, EventArgs e)
+            public override void Init()
             {
                 string projectId = "[Google Cloud Platform project ID]";
                 // Trace a sampling of incoming Http requests.
@@ -52,6 +54,18 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
             CloudTrace.GetCurrentTracer().StartSpan("hello-world");
             Console.Out.WriteLine("Hello, World!");
             CloudTrace.GetCurrentTracer().EndSpan();
+            // End sample
+        }
+
+        public async Task<HttpResponseMessage> AddTraceHeader()
+        {
+            // Sample: AddTraceHeader
+            // Add a handler to trace outgoing requests and to propigate the trace header.
+            var traceHeaderHandler = TraceHeaderPropagatingHandler.Create();
+            using (var httpClient = HttpClientFactory.Create(traceHeaderHandler))
+            {
+                return await httpClient.GetAsync("https://cloud.google.com/trace/");
+            }
             // End sample
         }
 

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Trace/LabelsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Trace/LabelsTest.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Moq;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Trace/SimpleManagedTracerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Trace/SimpleManagedTracerTest.cs
@@ -220,5 +220,28 @@ namespace Google.Cloud.Diagnostics.AspNet.Tests
             var tracer = SimpleManagedTracer.Create(UnusedConsumer, CreateTrace());
             Assert.Equal(tracer.GetCurrentTraceId(), TraceId);
         }
+
+        [Fact]
+        public void GetCurrentSpanId_NoSpan()
+        {
+            var tracer = SimpleManagedTracer.Create(UnusedConsumer, CreateTrace());
+            Assert.Null(tracer.GetCurrentSpanId());
+        }
+
+        [Fact]
+        public void GetCurrentSpanId_Span()
+        {
+            var tracer = SimpleManagedTracer.Create(UnusedConsumer, CreateTrace());
+            tracer.StartSpan("span-name");
+            Assert.NotNull(tracer.GetCurrentSpanId());
+        }
+
+        [Fact]
+        public void GetCurrentSpanId_ParentSpan()
+        {
+            ulong parentSpanId = 54321;
+            var tracer = SimpleManagedTracer.Create(UnusedConsumer, CreateTrace(), parentSpanId);
+            Assert.Equal(tracer.GetCurrentSpanId(), parentSpanId);
+        }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Trace/TraceHeaderContextTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Trace/TraceHeaderContextTest.cs
@@ -108,5 +108,26 @@ namespace Google.Cloud.Diagnostics.AspNet.Tests
             Assert.True(context.ShouldTrace);
         }
 
+        [Fact]
+        public void Create()
+        {
+            var context = TraceHeaderContext.Create(TraceId, SpanId, true);
+            Assert.True(SpanId == context.SpanId);
+            Assert.Equal(TraceId, context.TraceId);
+            Assert.True(context.ShouldTrace);
+        }
+
+        [Fact]
+        public void ToStringTest()
+        {
+            var context = TraceHeaderContext.Create(TraceId, SpanId, true);
+            Assert.Equal($"{TraceId}/{SpanId};o=1", context.ToString());
+
+            context = TraceHeaderContext.Create(TraceId, SpanId, false);
+            Assert.Equal($"{TraceId}/{SpanId};o=0", context.ToString());
+
+            context = TraceHeaderContext.Create(null, null, false);
+            Assert.Equal("/;o=0", context.ToString());
+        }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Trace/TraceHeaderContextTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Trace/TraceHeaderContextTest.cs
@@ -112,7 +112,7 @@ namespace Google.Cloud.Diagnostics.AspNet.Tests
         public void Create()
         {
             var context = TraceHeaderContext.Create(TraceId, SpanId, true);
-            Assert.True(SpanId == context.SpanId);
+            Assert.Equal(SpanId, context.SpanId);
             Assert.Equal(TraceId, context.TraceId);
             Assert.True(context.ShouldTrace);
         }

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.xproj
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.xproj
@@ -8,7 +8,7 @@
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>d85333c3-f612-4d92-8ecd-e674a73aec8f</ProjectGuid>
-    <RootNamespace>Google.Devtools.AspNet</RootNamespace>
+    <RootNamespace>Google.Cloud.Diagnostics.AspNet</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
@@ -31,11 +31,24 @@ namespace Google.Cloud.Diagnostics.AspNet
     /// <code>
     ///  public class Global : HttpApplication
     ///  { 
-    ///       void Application_Start(object sender, EventArgs e)
+    ///       public override void Init()
     ///       {
     ///           CloudTrace.Initialize("some-project-id", this);
     ///       }
     ///  }
+    /// </code>
+    /// </example>
+    /// 
+    /// <example>
+    /// <code>
+    /// public void DoSomething()
+    /// {
+    ///     var traceHeaderHandler = TraceHeaderPropagatingHandler.Create();
+    ///     using (var httpClient = HttpClientFactory.Create(traceHeaderHandler))
+    ///     {
+    ///         ...
+    ///     }
+    /// }
     /// </code>
     /// </example>
     /// 
@@ -104,6 +117,14 @@ namespace Google.Cloud.Diagnostics.AspNet
         public static IManagedTracer GetCurrentTracer()
         {
             return TracerManager.GetCurrentTracer() ?? DoNothingTracer.Instance;
+        }
+
+        /// <summary>
+        /// True if tracing should occur for the current request.
+        /// </summary>
+        public static bool ShouldTrace()
+        {
+            return TracerManager.GetCurrentTracer() != null;
         }
 
         private void BeginRequest(object sender, EventArgs e)

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/DoNothingTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/DoNothingTracer.cs
@@ -29,5 +29,6 @@ namespace Google.Cloud.Diagnostics.AspNet
         public void AnnotateSpan(Dictionary<string, string> labels) { }
         public void SetStackTrace(StackTrace stackTrace) { }
         public string GetCurrentTraceId() => null;
+        public ulong? GetCurrentSpanId() => null;
     }
 }

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/IManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/IManagedTracer.cs
@@ -48,5 +48,10 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// Gets the current trace id or null if none exists.
         /// </summary>
         string GetCurrentTraceId();
+
+        /// <summary>
+        /// Gets the current span id or null if none exists.
+        /// </summary>
+        ulong? GetCurrentSpanId();
     }
 }

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/SimpleManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/SimpleManagedTracer.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Diagnostics.AspNet
     internal sealed class SimpleManagedTracer : IManagedTracer
     {
         /// <summary>A mutex to protect the rate limiter instance.</summary>
-        private static object _stackMutex = new object();
+        private static object _stackLock = new object();
 
         /// <summary>The trace consumer to push the trace to when completed.</summary>
         private readonly IConsumer<TraceProto> _consumer;
@@ -59,7 +59,7 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// <summary>
         /// Creates a <see cref="SimpleManagedTracer"/>>
         /// </summary>
-        /// <param name="consumer">The consumer to push finised traces to.</param>
+        /// <param name="consumer">The consumer to push finished traces to.</param>
         /// <param name="trace">The current trace.</param>
         /// <param name="rootSpanParentId">Optional, the parent span id of the root span of the passed in trace.</param>
         public static SimpleManagedTracer Create(IConsumer<TraceProto> consumer, TraceProto trace, ulong? rootSpanParentId = null)
@@ -79,7 +79,7 @@ namespace Google.Cloud.Diagnostics.AspNet
             span.Name = name;
             span.StartTime = Timestamp.FromDateTime(DateTime.Now.ToUniversalTime());
 
-            lock (_stackMutex)
+            lock (_stackLock)
             {
                 if (_traceStack.Count != 0)
                 {
@@ -97,7 +97,7 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// <inheritdoc />
         public void EndSpan()
         {
-            lock (_stackMutex)
+            lock (_stackLock)
             {
                 CheckStackNotEmpty();
 
@@ -118,7 +118,7 @@ namespace Google.Cloud.Diagnostics.AspNet
         {
             GaxPreconditions.CheckNotNull(labels, nameof(labels));
 
-            lock (_stackMutex)
+            lock (_stackLock)
             {
                 CheckStackNotEmpty();
 
@@ -148,7 +148,7 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// <inheritdoc />
         public ulong? GetCurrentSpanId()
         {
-            lock (_stackMutex)
+            lock (_stackLock)
             {
                 if (_traceStack.Count != 0)
                 {

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/SimpleManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/SimpleManagedTracer.cs
@@ -145,6 +145,23 @@ namespace Google.Cloud.Diagnostics.AspNet
             return _trace.TraceId;
         }
 
+        /// <inheritdoc />
+        public ulong? GetCurrentSpanId()
+        {
+            lock (_stackMutex)
+            {
+                if (_traceStack.Count != 0)
+                {
+                    return _traceStack.Peek().SpanId;
+                }
+                else if (_rootSpanParentId != null)
+                {
+                    return _rootSpanParentId;
+                }
+                return null;
+            }
+        }
+
         private void CheckStackNotEmpty()
         {
             GaxPreconditions.CheckState(_traceStack.Count != 0, "No available span.");

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/TraceHeaderContext.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/TraceHeaderContext.cs
@@ -56,14 +56,14 @@ namespace Google.Cloud.Diagnostics.AspNet
         public bool ShouldTrace { get; }
 
         /// <summary>
-        /// Create a <see cref="TraceHeaderContext"/> from a trace and span id.
+        /// Creates a <see cref="TraceHeaderContext"/> from a trace and span id.
         /// </summary>
         public static TraceHeaderContext Create(string traceId, ulong? spanId, bool shouldTrace) =>
             new TraceHeaderContext(traceId, spanId, shouldTrace);
         
 
         /// <summary>
-        /// Create a <see cref="TraceHeaderContext"/> from an <see cref="HttpRequest"/>. 
+        /// Creates a <see cref="TraceHeaderContext"/> from an <see cref="HttpRequest"/>. 
         /// </summary>
         public static TraceHeaderContext FromRequest(HttpRequest request)
         {

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/TraceHeaderContext.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/TraceHeaderContext.cs
@@ -108,8 +108,8 @@ namespace Google.Cloud.Diagnostics.AspNet
 
         /// <summary>
         /// Gets the <see cref="TraceHeaderContext"/> as a string.
-        /// Formated as "[trace-id]/[span-id];o=[should-trace]" with not brackets and
-        /// where should-trace is 1 to trace and 0 to not.
+        /// Formatted as "[trace-id]/[span-id];o=[should-trace]"
+        /// where "should-trace" is 1 to trace and 0 otherwise.
         /// </summary>
         public override string ToString()
         {

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/TraceHeaderContext.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/TraceHeaderContext.cs
@@ -56,6 +56,13 @@ namespace Google.Cloud.Diagnostics.AspNet
         public bool ShouldTrace { get; }
 
         /// <summary>
+        /// Create a <see cref="TraceHeaderContext"/> from a trace and span id.
+        /// </summary>
+        public static TraceHeaderContext Create(string traceId, ulong? spanId, bool shouldTrace) =>
+            new TraceHeaderContext(traceId, spanId, shouldTrace);
+        
+
+        /// <summary>
         /// Create a <see cref="TraceHeaderContext"/> from an <see cref="HttpRequest"/>. 
         /// </summary>
         public static TraceHeaderContext FromRequest(HttpRequest request)
@@ -97,6 +104,17 @@ namespace Google.Cloud.Diagnostics.AspNet
             TraceId = traceId;
             SpanId = spanId;
             ShouldTrace = shouldTrace;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="TraceHeaderContext"/> as a string.
+        /// Formated as "[trace-id]/[span-id];o=[should-trace]" with not brackets and
+        /// where should-trace is 1 to trace and 0 to not.
+        /// </summary>
+        public override string ToString()
+        {
+            var traceMask = ShouldTrace ? 1 : 0;
+            return $"{TraceId}/{SpanId};o={traceMask}";
         }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/TraceHeaderPropagatingHandler.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/TraceHeaderPropagatingHandler.cs
@@ -19,7 +19,7 @@ using System.Threading.Tasks;
 namespace Google.Cloud.Diagnostics.AspNet
 {
     /// <summary>
-    /// Traces outgoing http requests and propigates the trace header.
+    /// Traces outgoing http requests and propagates the trace header.
     /// </summary>
     ///
     /// <example>
@@ -35,15 +35,10 @@ namespace Google.Cloud.Diagnostics.AspNet
     /// </code>
     /// </example>
     /// <remarks>
-    /// Ensures the tracer header is propagated along in the http headers for outgoing http requests and 
+    /// Ensures the trace header is propagated in the headers for outgoing http requests and 
     /// traces the total time of the outgoing http request.  This is only done if tracing is initialized
     /// (See <see cref="CloudTrace.Initialize"/>) and tracing is enabled for the request current request
     /// (See <see cref="CloudTrace.ShouldTrace"/>).
-    /// 
-    /// By default when initialized a small sampling of http requests will automatically be traced.  Additional
-    /// trace data can be collected manually.
-    /// 
-    /// Docs: https://cloud.google.com/trace/docs/
     /// </remarks>
     public class TraceHeaderPropagatingHandler : DelegatingHandler
     {

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/TraceHeaderPropagatingHandler.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/TraceHeaderPropagatingHandler.cs
@@ -19,7 +19,7 @@ using System.Threading.Tasks;
 namespace Google.Cloud.Diagnostics.AspNet
 {
     /// <summary>
-    /// Traces outgoing http requests and propagates the trace header.
+    /// Traces outgoing HTTP requests and propagates the trace header.
     /// </summary>
     ///
     /// <example>
@@ -35,8 +35,8 @@ namespace Google.Cloud.Diagnostics.AspNet
     /// </code>
     /// </example>
     /// <remarks>
-    /// Ensures the trace header is propagated in the headers for outgoing http requests and 
-    /// traces the total time of the outgoing http request.  This is only done if tracing is initialized
+    /// Ensures the trace header is propagated in the headers for outgoing HTTP requests and 
+    /// traces the total time of the outgoing HTTP request.  This is only done if tracing is initialized
     /// (See <see cref="CloudTrace.Initialize"/>) and tracing is enabled for the request current request
     /// (See <see cref="CloudTrace.ShouldTrace"/>).
     /// </remarks>
@@ -54,18 +54,18 @@ namespace Google.Cloud.Diagnostics.AspNet
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         { 
-            if (!CloudTrace.ShouldTrace())
+            if (!CloudTrace.ShouldTrace)
             {
                 return await base.SendAsync(request, cancellationToken);
             }
 
-            var tracer = CloudTrace.GetCurrentTracer();
+            var tracer = CloudTrace.CurrentTracer;
 
             var traceHeader = TraceHeaderContext.Create(
                 tracer.GetCurrentTraceId(), tracer.GetCurrentSpanId() ?? 0, true);
             request.Headers.Add(TraceHeaderContext.TraceHeader, traceHeader.ToString());
             
-            tracer.StartSpan(request.RequestUri.AbsoluteUri);
+            tracer.StartSpan(request.RequestUri.ToString());
             var tracedRequest = await base.SendAsync(request, cancellationToken);
             tracer.EndSpan();
 

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/TraceHeaderPropagatingHandler.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/TraceHeaderPropagatingHandler.cs
@@ -1,0 +1,80 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Diagnostics.AspNet
+{
+    /// <summary>
+    /// Traces outgoing http requests and propigates the trace header.
+    /// </summary>
+    ///
+    /// <example>
+    /// <code>
+    /// public void DoSomething()
+    /// {
+    ///     var traceHeaderHandler = TraceHeaderPropagatingHandler.Create();
+    ///     using (var httpClient = HttpClientFactory.Create(traceHeaderHandler))
+    ///     {
+    ///         ...
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    /// <remarks>
+    /// Ensures the tracer header is propagated along in the http headers for outgoing http requests and 
+    /// traces the total time of the outgoing http request.  This is only done if tracing is initialized
+    /// (See <see cref="CloudTrace.Initialize"/>) and tracing is enabled for the request current request
+    /// (See <see cref="CloudTrace.ShouldTrace"/>).
+    /// 
+    /// By default when initialized a small sampling of http requests will automatically be traced.  Additional
+    /// trace data can be collected manually.
+    /// 
+    /// Docs: https://cloud.google.com/trace/docs/
+    /// </remarks>
+    public class TraceHeaderPropagatingHandler : DelegatingHandler
+    {
+        private TraceHeaderPropagatingHandler() { }
+
+        /// <summary>Gets a <see cref="TraceHeaderPropagatingHandler"/>.</summary>
+        public static TraceHeaderPropagatingHandler Create() => new TraceHeaderPropagatingHandler();
+
+        /// <summary>
+        /// Sends the given request.  If tracing is initialized and enabled the outgoing request is
+        /// traced and the trace header is added to the request.
+        /// </summary>
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        { 
+            if (!CloudTrace.ShouldTrace())
+            {
+                return await base.SendAsync(request, cancellationToken);
+            }
+
+            var tracer = CloudTrace.GetCurrentTracer();
+
+            var traceHeader = TraceHeaderContext.Create(
+                tracer.GetCurrentTraceId(), tracer.GetCurrentSpanId() ?? 0, true);
+            request.Headers.Add(TraceHeaderContext.TraceHeader, traceHeader.ToString());
+            
+            tracer.StartSpan(request.RequestUri.AbsoluteUri);
+            var tracedRequest = await base.SendAsync(request, cancellationToken);
+            tracer.EndSpan();
+
+            return tracedRequest;
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNet/docs/index.md
+++ b/apis/Google.Cloud.Diagnostics.AspNet/docs/index.md
@@ -42,6 +42,10 @@ installed, run the following command in a Google Cloud SDK Shell:
 
 [!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNet.AspNet.txt#InitializeTrace)]
 
+## Trace Outgoing Http Requests
+
+[!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNet.AspNet.txt#TraceOutgoing)]
+
 ## Manual Tracing
 
 [!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNet.AspNet.txt#UseTracer)]

--- a/apis/Google.Cloud.Diagnostics.AspNet/docs/index.md
+++ b/apis/Google.Cloud.Diagnostics.AspNet/docs/index.md
@@ -42,7 +42,7 @@ installed, run the following command in a Google Cloud SDK Shell:
 
 [!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNet.AspNet.txt#InitializeTrace)]
 
-## Trace Outgoing Http Requests
+## Trace Outgoing HTTP Requests
 
 [!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNet.AspNet.txt#TraceOutgoing)]
 


### PR DESCRIPTION
Add a DelegatingHandler to for tracing outgoing http requests in ASP.NET applications and propagating trace headers.  These will only be done when trace has been initialized and is enabled for the given request.