### PR TITLE
Rename ASP.NET Core Error Reporting Entry Funciton to Match Style

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
@@ -210,7 +210,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTest
 
         public void Configure(IApplicationBuilder app)
         {
-            app.ReportExceptionsToGoogle(_projectId, Service, Version);
+            app.UseGoogleExceptionLogging(_projectId, Service, Version);
 
             app.UseMvc(routes =>
             {

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/AspNetCoreSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/AspNetCoreSnippets.cs
@@ -29,7 +29,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             string projectId = "[Google Cloud Platform project ID]";
             string serviceName = "[Name of service]";
             string version = "[Version of service]";
-            app.ReportExceptionsToGoogle(projectId, serviceName, version);
+            app.UseGoogleExceptionLogging(projectId, serviceName, version);
         }
         // End sample
         

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLogger.cs
@@ -34,7 +34,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
     ///     string projectId = "[Google Cloud Platform project ID]";
     ///     string serviceName = "[Name of service]";
     ///     string version = "[Version of service]";
-    ///     app.ReportExceptionsToGoogle(projectId, serviceName, version);
+    ///     app.UseGoogleExceptionLogging(projectId, serviceName, version);
     ///     ...
     /// }
     /// </code>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerExtension.cs
@@ -49,7 +49,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <param name="projectId">The Google Cloud Platform project ID.</param>
         /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.</param>
         /// <param name="version">Represents the source code version that the developer provided.</param> 
-        public static void ReportExceptionsToGoogle(
+        public static void UseGoogleExceptionLogging(
             this IApplicationBuilder app, string projectId, string serviceName, string version)
         {
             var logger = ErrorReportingExceptionLogger.Create(projectId, serviceName, version);

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerExtension.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
     ///     string projectId = "[Google Cloud Platform project ID]";
     ///     string serviceName = "[Name of service]";
     ///     string version = "[Version of service]";
-    ///     app.ReportExceptionsToGoogle(projectId, serviceName, version);
+    ///     app.UseGoogleExceptionLogging(projectId, serviceName, version);
     ///     ...
     /// }
     /// </code>


### PR DESCRIPTION
The general style for adding to IApplicationBuilder is Use*.