### PR TITLE
Rename FromUri to FetchFromUri to clarify that data is fetched locally

### DIFF
--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.Snippets/RecognitionAudioSnippets.cs
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.Snippets/RecognitionAudioSnippets.cs
@@ -23,7 +23,7 @@ namespace Google.Cloud.Speech.V1Beta1.Snippets
         {
             // Sample: FactoryMethods
             RecognitionAudio audio1 = RecognitionAudio.FromFile("Sound/SpeechSample.flac");
-            RecognitionAudio audio2 = RecognitionAudio.FromUri("https://.../HostedSpeech.flac");
+            RecognitionAudio audio2 = RecognitionAudio.FetchFromUri("https://.../HostedSpeech.flac");
             RecognitionAudio audio3 = RecognitionAudio.FromStorageUri("gs://my-bucket/my-file");
 
             byte[] bytes = ReadAudioData(); // For example, from a database

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/RecognitionAudioPartial.cs
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/RecognitionAudioPartial.cs
@@ -23,6 +23,8 @@ namespace Google.Cloud.Speech.V1Beta1
 {
     public partial class RecognitionAudio
     {
+        private static readonly HttpClient s_defaultHttpClient = new HttpClient();
+
         /// <summary>
         /// Constructs a <see cref="RecognitionAudio"/> with a <see cref="Uri"/> property referring to a Google Cloud
         /// Storage URI.
@@ -40,30 +42,30 @@ namespace Google.Cloud.Speech.V1Beta1
         /// Asynchronously constructs a <see cref="RecognitionAudio"/> by downloading data from the given URI.
         /// </summary>
         /// <param name="uri">The URI to fetch. Must not be null.</param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> to use to fetch the image, or
+        /// <c>null</c> to use a default client.</param>
         /// <returns>A task representing the asynchronous operation. The result will be the newly created RecognitionAudio.</returns>
-        public async static Task<RecognitionAudio> FromUriAsync(Uri uri)
+        public async static Task<RecognitionAudio> FetchFromUriAsync(Uri uri, HttpClient httpClient = null)
         {
             GaxPreconditions.CheckNotNull(uri, nameof(uri));
-            using (var client = new HttpClient())
-            {
-                var bytes = await client.GetByteArrayAsync(uri).ConfigureAwait(false);
-                return FromBytes(bytes);
-            }
+            httpClient = httpClient ?? s_defaultHttpClient;
+            var bytes = await httpClient.GetByteArrayAsync(uri).ConfigureAwait(false);
+            return FromBytes(bytes);
         }
 
         /// <summary>
         /// Asynchronously constructs a <see cref="RecognitionAudio"/> by downloading data from the given URI.
         /// </summary>
         /// <param name="uri">The URI to fetch. Must not be null.</param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> to use to fetch the image, or
+        /// <c>null</c> to use a default client.</param>
         /// <returns>A task representing the asynchronous operation. The result will be the newly created RecognitionAudio.</returns>
-        public async static Task<RecognitionAudio> FromUriAsync(string uri)
+        public async static Task<RecognitionAudio> FetchFromUriAsync(string uri, HttpClient httpClient = null)
         {
             GaxPreconditions.CheckNotNull(uri, nameof(uri));
-            using (var client = new HttpClient())
-            {
-                var bytes = await client.GetByteArrayAsync(uri).ConfigureAwait(false);
-                return FromBytes(bytes);
-            }
+            httpClient = httpClient ?? s_defaultHttpClient;
+            var bytes = await httpClient.GetByteArrayAsync(uri).ConfigureAwait(false);
+            return FromBytes(bytes);
         }
 
         // TODO: Find better synchronous HTTP fetching?
@@ -72,22 +74,28 @@ namespace Google.Cloud.Speech.V1Beta1
         /// Constructs a <see cref="RecognitionAudio"/> by downloading data from the given URI.
         /// </summary>
         /// <param name="uri">The URI to fetch. Must not be null.</param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> to use to fetch the image, or
+        /// <c>null</c> to use a default client.</param>
         /// <returns>The newly created RecognitionAudio.</returns>
-        public static RecognitionAudio FromUri(string uri)
+        public static RecognitionAudio FetchFromUri(string uri, HttpClient httpClient = null)
         {
             GaxPreconditions.CheckNotNull(uri, nameof(uri));
-            return Task.Run(() => FromUriAsync(uri)).Result;
+            // TODO: Use ResultWithUnwrappedExceptions when it's public in GAX.
+            return Task.Run(() => FetchFromUriAsync(uri, httpClient)).Result;
         }
 
         /// <summary>
         /// Constructs a <see cref="RecognitionAudio"/> by downloading data from the given URI.
         /// </summary>
         /// <param name="uri">The URI to fetch. Must not be null.</param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> to use to fetch the image, or
+        /// <c>null</c> to use a default client.</param>
         /// <returns>The newly created RecognitionAudio.</returns>
-        public static RecognitionAudio FromUri(Uri uri)
+        public static RecognitionAudio FetchFromUri(Uri uri, HttpClient httpClient = null)
         {
             GaxPreconditions.CheckNotNull(uri, nameof(uri));
-            return Task.Run(() => FromUriAsync(uri)).Result;
+            // TODO: Use ResultWithUnwrappedExceptions when it's public in GAX.
+            return Task.Run(() => FetchFromUriAsync(uri, httpClient)).Result;
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageSnippets.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageSnippets.cs
@@ -23,7 +23,7 @@ namespace Google.Cloud.Vision.V1.Snippets
         {
             // Sample: FactoryMethods
             Image image1 = Image.FromFile("Pictures/LocalImage.jpg");
-            Image image2 = Image.FromUri("https://cloud.google.com/images/devtools-icon-64x64.png");
+            Image image2 = Image.FetchFromUri("https://cloud.google.com/images/devtools-icon-64x64.png");
             Image image3 = Image.FromStorageUri("gs://my-bucket/my-file");
 
             byte[] bytes = ReadImageData(); // For example, from a database

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImagePartial.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImagePartial.cs
@@ -23,6 +23,8 @@ namespace Google.Cloud.Vision.V1
 {
     public partial class Image
     {
+        private static readonly HttpClient s_defaultHttpClient = new HttpClient();
+
         /// <summary>
         /// Constructs an <see cref="Image"/> with a <see cref="Image.Source"/> property referring to a Google Cloud
         /// Storage URI.
@@ -40,30 +42,30 @@ namespace Google.Cloud.Vision.V1
         /// Asynchronously constructs an <see cref="Image"/> by downloading data from the given URI.
         /// </summary>
         /// <param name="uri">The URI to fetch. Must not be null.</param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> to use to fetch the image, or
+        /// <c>null</c> to use a default client.</param>
         /// <returns>A task representing the asynchronous operation. The result will be the newly created image.</returns>
-        public async static Task<Image> FromUriAsync(Uri uri)
+        public async static Task<Image> FetchFromUriAsync(Uri uri, HttpClient httpClient = null)
         {
             GaxPreconditions.CheckNotNull(uri, nameof(uri));
-            using (var client = new HttpClient())
-            {
-                var bytes = await client.GetByteArrayAsync(uri).ConfigureAwait(false);
-                return FromBytes(bytes);
-            }
+            httpClient = httpClient ?? s_defaultHttpClient;
+            var bytes = await httpClient.GetByteArrayAsync(uri).ConfigureAwait(false);
+            return FromBytes(bytes);
         }
 
         /// <summary>
         /// Asynchronously constructs an <see cref="Image"/> by downloading data from the given URI.
         /// </summary>
         /// <param name="uri">The URI to fetch. Must not be null.</param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> to use to fetch the image, or
+        /// <c>null</c> to use a default client.</param>
         /// <returns>A task representing the asynchronous operation. The result will be the newly created image.</returns>
-        public async static Task<Image> FromUriAsync(string uri)
+        public async static Task<Image> FetchFromUriAsync(string uri, HttpClient httpClient = null)
         {
             GaxPreconditions.CheckNotNull(uri, nameof(uri));
-            using (var client = new HttpClient())
-            {
-                var bytes = await client.GetByteArrayAsync(uri).ConfigureAwait(false);
-                return FromBytes(bytes);
-            }
+            httpClient = httpClient ?? s_defaultHttpClient;
+            var bytes = await httpClient.GetByteArrayAsync(uri).ConfigureAwait(false);
+            return FromBytes(bytes);
         }
 
         // TODO: Find better synchronous HTTP fetching?
@@ -72,22 +74,28 @@ namespace Google.Cloud.Vision.V1
         /// Constructs an <see cref="Image"/> by downloading data from the given URI.
         /// </summary>
         /// <param name="uri">The URI to fetch. Must not be null.</param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> to use to fetch the image, or
+        /// <c>null</c> to use a default client.</param>
         /// <returns>The newly created image.</returns>
-        public static Image FromUri(string uri)
+        public static Image FetchFromUri(string uri, HttpClient httpClient = null)
         {
             GaxPreconditions.CheckNotNull(uri, nameof(uri));
-            return Task.Run(() => FromUriAsync(uri)).Result;
+            // TODO: Use ResultWithUnwrappedExceptions when it's public in GAX.
+            return Task.Run(() => FetchFromUriAsync(uri, httpClient)).Result;
         }
 
         /// <summary>
         /// Constructs an <see cref="Image"/> by downloading data from the given URI.
         /// </summary>
         /// <param name="uri">The URI to fetch. Must not be null.</param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> to use to fetch the image, or
+        /// <c>null</c> to use a default client.</param>
         /// <returns>The newly created image.</returns>
-        public static Image FromUri(Uri uri)
+        public static Image FetchFromUri(Uri uri, HttpClient httpClient = null)
         {
             GaxPreconditions.CheckNotNull(uri, nameof(uri));
-            return Task.Run(() => FromUriAsync(uri)).Result;
+            // TODO: Use ResultWithUnwrappedExceptions when it's public in GAX.
+            return Task.Run(() => FetchFromUriAsync(uri, httpClient)).Result;
         }
 
         /// <summary>


### PR DESCRIPTION
At the same time, add an optional HttpClient parameter, defaulting to a singleton.
This fixes #407.