### PR TITLE
Use ResultWithUnwrappedExceptions when fetching synchronously

### DIFF
--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/RecognitionAudioPartial.cs
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/RecognitionAudioPartial.cs
@@ -80,8 +80,7 @@ namespace Google.Cloud.Speech.V1Beta1
         public static RecognitionAudio FetchFromUri(string uri, HttpClient httpClient = null)
         {
             GaxPreconditions.CheckNotNull(uri, nameof(uri));
-            // TODO: Use ResultWithUnwrappedExceptions when it's public in GAX.
-            return Task.Run(() => FetchFromUriAsync(uri, httpClient)).Result;
+            return Task.Run(() => FetchFromUriAsync(uri, httpClient)).ResultWithUnwrappedExceptions();
         }
 
         /// <summary>
@@ -94,8 +93,7 @@ namespace Google.Cloud.Speech.V1Beta1
         public static RecognitionAudio FetchFromUri(Uri uri, HttpClient httpClient = null)
         {
             GaxPreconditions.CheckNotNull(uri, nameof(uri));
-            // TODO: Use ResultWithUnwrappedExceptions when it's public in GAX.
-            return Task.Run(() => FetchFromUriAsync(uri, httpClient)).Result;
+            return Task.Run(() => FetchFromUriAsync(uri, httpClient)).ResultWithUnwrappedExceptions();
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImagePartial.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImagePartial.cs
@@ -80,8 +80,7 @@ namespace Google.Cloud.Vision.V1
         public static Image FetchFromUri(string uri, HttpClient httpClient = null)
         {
             GaxPreconditions.CheckNotNull(uri, nameof(uri));
-            // TODO: Use ResultWithUnwrappedExceptions when it's public in GAX.
-            return Task.Run(() => FetchFromUriAsync(uri, httpClient)).Result;
+            return Task.Run(() => FetchFromUriAsync(uri, httpClient)).ResultWithUnwrappedExceptions();
         }
 
         /// <summary>
@@ -95,7 +94,7 @@ namespace Google.Cloud.Vision.V1
         {
             GaxPreconditions.CheckNotNull(uri, nameof(uri));
             // TODO: Use ResultWithUnwrappedExceptions when it's public in GAX.
-            return Task.Run(() => FetchFromUriAsync(uri, httpClient)).Result;
+            return Task.Run(() => FetchFromUriAsync(uri, httpClient)).ResultWithUnwrappedExceptions();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #707.