### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The following libraries are available at a [beta](#versioning) quality level:
 
 The following libraries are available at an [alpha](#versioning) quality level:
 
+* Google Cloud Diagnostics for ASP.NET Core - [API docs](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Diagnostics.AspNetCore/) (alpha)
 * Google Cloud Metadata - [API docs](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Metadata.V1) (alpha)
 * [Google Cloud Vision](https://cloud.google.com/vision/) - [API docs](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Vision.V1/) (alpha)
 * [Google Cloud Speech](https://cloud.google.com/speech/) - [API docs](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Speech.V1Beta1/) (alpha)

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/docs/index.md
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/docs/index.md
@@ -45,7 +45,13 @@ optionally specifying a service endpoint and settings.
 Using [`Google.Cloud.Diagnostics.AspNet`'s ExceptionLogger](Google.Cloud.Diagnostics.AspNet/index.html)
 uncaught exceptions in ASP.NET applications can be automatically reported to the Stackdriver Error Reporting API.
 
-[!code-cs[](../Google.Cloud.Diagnostics.AspNet/obj/snippets/Google.Cloud.Diagnostics.AspNet.AspNet.txt#RegisterExceptionLogger)]
+In ASP.NET MVC:
+
+[!code-cs[](../Google.Cloud.Diagnostics.AspNet/obj/snippets/Google.Cloud.Diagnostics.AspNet.AspNet.txt#RegisterExceptionLoggerMvc)]
+
+In Web API:
+
+[!code-cs[](../Google.Cloud.Diagnostics.AspNet/obj/snippets/Google.Cloud.Diagnostics.AspNet.AspNet.txt#RegisterExceptionLoggerWebApi)]
 
 ## Report an error
 

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -32,6 +32,7 @@ Beta:
 
 Alpha:
 
+- [Google.Cloud.Diagnostics.AspNetCore](Google.Cloud.Diagnostics.AspNetCore/index.html)
 - [Google.Cloud.Metadata.V1](Google.Cloud.Metadata.V1/index.html)
 - [Google.Cloud.Speech.V1Beta1](Google.Cloud.Speech.V1Beta1/index.html)
 - [Google.Cloud.Vision.V1](Google.Cloud.Vision.V1/index.html)


### PR DESCRIPTION
- Fix an old snippet reference (would have been spotted by AppVeyor,
  but that's backlogged at the moment)
- Add ASP.NET Core to the Alpha list