### PR TITLE
Use the right deadline and cancellation token when polling

### DIFF
--- a/apis/Google.LongRunning/Google.LongRunning/Operation.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/Operation.cs
@@ -137,12 +137,13 @@ namespace Google.LongRunning
             {
                 return this;
             }
-            // TODO: Use the deadline and get a cancellation token from the effective call settings.
-            Func<DateTime?, Operation<T>> pollAction = deadline => PollOnce(callSettings);
+            callSettings = Client.GetEffectiveCallSettingsForGetOperation(callSettings);
+
+            Func<DateTime?, Operation<T>> pollAction = deadline => PollOnce(callSettings.WithEarlierDeadline(deadline, Client.Clock));
             return Polling.PollRepeatedly(
                 pollAction, o => o.IsCompleted,
                 Client.Clock, Client.Scheduler, pollSettings ?? s_defaultPollSettings,
-                CancellationToken.None);
+                callSettings?.CancellationToken ?? CancellationToken.None);
         }
 
         /// <summary>
@@ -162,12 +163,12 @@ namespace Google.LongRunning
             {
                 return Task.FromResult(this);
             }
-            // TODO: Use the deadline and get a cancellation token from the effective call settings.
-            Func<DateTime?, Task<Operation<T>>> pollAction = deadline => PollOnceAsync(callSettings);
+            callSettings = Client.GetEffectiveCallSettingsForGetOperation(callSettings);
+            Func<DateTime?, Task<Operation<T>>> pollAction = deadline => PollOnceAsync(callSettings.WithEarlierDeadline(deadline, Client.Clock));
             return Polling.PollRepeatedlyAsync(
                 pollAction, o => o.IsCompleted,
                 Client.Clock, Client.Scheduler, pollSettings ?? s_defaultPollSettings,
-                CancellationToken.None);
+                callSettings?.CancellationToken ?? CancellationToken.None);
         }
 
         /// <summary>

--- a/apis/Google.LongRunning/Google.LongRunning/OperationsClientPartial.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/OperationsClientPartial.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
 using System;
 
 namespace Google.LongRunning
@@ -34,6 +35,22 @@ namespace Google.LongRunning
         {
             get { throw new NotImplementedException(); }
         }
+
+        /// <summary>
+        /// Return the <see cref="CallSettings"/> that would be used by a call to
+        /// <see cref="GetOperation(GetOperationRequest, CallSettings)"/>, using the base
+        /// settings of this client and the specified per-call overrides.
+        /// </summary>
+        /// <remarks>
+        /// This method is used when polling, to determine the appropriate timeout and cancellation
+        /// token to use for each call.
+        /// </remarks>
+        /// <param name="callSettings">The per-call override, if any.</param>
+        /// <returns>The effective call settings for a GetOperation RPC.</returns>
+        protected internal virtual CallSettings GetEffectiveCallSettingsForGetOperation(CallSettings callSettings)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public partial class OperationsClientImpl
@@ -43,5 +60,12 @@ namespace Google.LongRunning
 
         /// <inheritdoc />
         public override IScheduler Scheduler => _clientHelper.Scheduler;
+
+        // Note: if we ever have a partial Modify_GetOperationRequest call body,
+        // we'd want to call it here, but cope with not providing a request.
+
+        /// <inheritdoc />
+        protected internal override CallSettings GetEffectiveCallSettingsForGetOperation(CallSettings callSettings) =>
+            _callGetOperation.BaseCallSettings.MergedWith(callSettings);
     }
 }

--- a/apis/Google.LongRunning/Google.LongRunning/project.json
+++ b/apis/Google.LongRunning/Google.LongRunning/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta07"
+    "Google.Api.Gax.Grpc": "1.0.0-beta08"
   },
 
   "frameworks": {


### PR DESCRIPTION
Needs tests, along with a new GAX release, but should give context to the GAX changes