### PR TITLE
Make MetadataResult constructor public

### DIFF
--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/MetadataResult.cs
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/MetadataResult.cs
@@ -33,10 +33,15 @@ namespace Google.Cloud.Metadata.V1
         /// </summary>
         public string Content { get; }
 
-        internal MetadataResult(string content, string etag)
+        /// <summary>
+        /// Construct a result.
+        /// </summary>
+        /// <param name="content">The content of the server response.</param>
+        /// <param name="eTag">The ETag header from the server response.</param>
+        public MetadataResult(string content, string eTag)
         {
             Content = content;
-            ETag = etag;
+            ETag = eTag;
         }
     }
 }


### PR DESCRIPTION
To allow faking/mocking of the API calls that return a MetadataResult.