### PR TITLE
Make the PollSettings client-specific, configurable by settings

### DIFF
--- a/apis/Google.LongRunning/Google.LongRunning.Tests/OperationTest.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.Tests/OperationTest.cs
@@ -237,6 +237,7 @@ namespace Google.LongRunning.Tests
             private readonly CallSettings _baseCallSettings;
             public override IClock Clock => FakeScheduler.Clock;
             public override IScheduler Scheduler => FakeScheduler;
+            public override PollSettings DefaultPollSettings => null;
             public FakeClock FakeClock => FakeScheduler.Clock;
             public FakeScheduler FakeScheduler { get; }
             public int RequestCount { get; private set; }

--- a/apis/Google.LongRunning/Google.LongRunning/Operation.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/Operation.cs
@@ -31,6 +31,9 @@ namespace Google.LongRunning
     /// <typeparam name="T">The response message type.</typeparam>
     public class Operation<T> where T : IMessage<T>, new()
     {
+        /// <summary>
+        /// The poll settings to use if the neither the OperationsClient nor the caller provides anything.
+        /// </summary>
         private static readonly PollSettings s_defaultPollSettings = new PollSettings(Expiration.None, TimeSpan.FromSeconds(10));
 
         /// <summary>
@@ -142,7 +145,7 @@ namespace Google.LongRunning
             Func<DateTime?, Operation<T>> pollAction = deadline => PollOnce(callSettings.WithEarlierDeadline(deadline, Client.Clock));
             return Polling.PollRepeatedly(
                 pollAction, o => o.IsCompleted,
-                Client.Clock, Client.Scheduler, pollSettings ?? s_defaultPollSettings,
+                Client.Clock, Client.Scheduler, pollSettings ?? Client.DefaultPollSettings ?? s_defaultPollSettings,
                 callSettings?.CancellationToken ?? CancellationToken.None);
         }
 
@@ -167,7 +170,7 @@ namespace Google.LongRunning
             Func<DateTime?, Task<Operation<T>>> pollAction = deadline => PollOnceAsync(callSettings.WithEarlierDeadline(deadline, Client.Clock));
             return Polling.PollRepeatedlyAsync(
                 pollAction, o => o.IsCompleted,
-                Client.Clock, Client.Scheduler, pollSettings ?? s_defaultPollSettings,
+                Client.Clock, Client.Scheduler, pollSettings ?? Client.DefaultPollSettings ?? s_defaultPollSettings,
                 callSettings?.CancellationToken ?? CancellationToken.None);
         }
 

--- a/apis/Google.LongRunning/Google.LongRunning/OperationsClientPartial.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/OperationsClientPartial.cs
@@ -18,6 +18,19 @@ using System;
 
 namespace Google.LongRunning
 {
+    public partial class OperationsSettings
+    {
+        /// <summary>
+        /// The poll settings used by default for repeated polling operations.
+        /// </summary>
+        public PollSettings DefaultPollSettings { get; private set; }
+
+        partial void OnCopy(OperationsSettings existing)
+        {
+            DefaultPollSettings = existing.DefaultPollSettings;
+        }
+    }
+
     public partial class OperationsClient
     {
         /// <summary>
@@ -32,6 +45,15 @@ namespace Google.LongRunning
         /// The scheduler used for timeouts, retries and polling.
         /// </summary>
         public virtual IScheduler Scheduler
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        /// <summary>
+        /// The poll settings used by default for repeated polling operations.
+        /// May be null if no defaults have been set.
+        /// </summary>
+        public virtual PollSettings DefaultPollSettings
         {
             get { throw new NotImplementedException(); }
         }
@@ -57,12 +79,16 @@ namespace Google.LongRunning
     {
         private IClock _clock;
         private IScheduler _scheduler;
+        private PollSettings _defaultPollSettings;
 
         /// <inheritdoc />
         public override IClock Clock => _clock;
 
         /// <inheritdoc />
         public override IScheduler Scheduler => _scheduler;
+
+        /// <inheritdoc />
+        public override PollSettings DefaultPollSettings => _defaultPollSettings;
 
         // Note: if we ever have a partial Modify_GetOperationRequest call body,
         // we'd want to call it here, but cope with not providing a request.
@@ -75,6 +101,7 @@ namespace Google.LongRunning
         {
             _clock = clientHelper.Clock;
             _scheduler = clientHelper.Scheduler;
+            _defaultPollSettings = effectiveSettings?.DefaultPollSettings;
         }
     }
 }


### PR DESCRIPTION
This PR includes generated code - we'd need to change the codegen
to include these partial methods.

(We can decide whether to submit as-is and update codegen before we next generate LRO, or hold of on this change. The codegen would need to change to generate the right OperationsSettings too.)