### PR TITLE
[WIP] log4net sourceLocation and platform detection

### DIFF
--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/LruCacheTest.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/LruCacheTest.cs
@@ -1,0 +1,102 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Logging.Log4Net.Tests
+{
+    public class LruCacheTest
+    {
+        [Fact]
+        public void TestWithCapacity1()
+        {
+            var lru = new LruCache<int, object>(1);
+            Assert.Equal(0, lru.Count);
+            var one = new object();
+            var two = new object();
+            Assert.Same(one, lru.GetOrAdd(1, () => one));
+            Assert.Equal(1, lru.Count);
+            Assert.Same(one, lru.GetOrAdd(1, () => null));
+            Assert.Equal(1, lru.Count);
+            Assert.Same(two, lru.GetOrAdd(2, () => two));
+            Assert.Equal(1, lru.Count);
+            Assert.Same(two, lru.GetOrAdd(2, () => null));
+            Assert.Equal(1, lru.Count);
+        }
+
+        [Fact]
+        public void TestWithCapacity100()
+        {
+            var lru = new LruCache<int, string>(100);
+            var values = new string[50];
+            // Add 50 known value, check they are returned
+            for (int i = 0; i < 50; i++)
+            {
+                values[i] = $"value:{i}";
+                Assert.Same(values[i], lru.GetOrAdd(i, () => values[i]));
+            }
+            Assert.Equal(50, lru.Count);
+            // Check original 50 values still there
+            for (int i = 0; i < 50; i++)
+            {
+                Assert.Same(values[i], lru.GetOrAdd(i, () => null));
+            }
+            Assert.Equal(50, lru.Count);
+            // Add 50 more values
+            for (int i = 50; i < 100; i++)
+            {
+                Assert.Null(lru.GetOrAdd(i, () => null));
+            }
+            Assert.Equal(100, lru.Count);
+            // Check original 50 values still there
+            for (int i = 0; i < 50; i++)
+            {
+                Assert.Same(values[i], lru.GetOrAdd(i, () => null));
+            }
+            Assert.Equal(100, lru.Count);
+            // Add 50 more values
+            for (int i = 100; i < 125; i++)
+            {
+                Assert.Null(lru.GetOrAdd(i, () => null));
+            }
+            Assert.Equal(100, lru.Count);
+            // Check original 50 are still there
+            for (int i = 0; i < 50; i++)
+            {
+                Assert.Same(values[i], lru.GetOrAdd(i, () => null));
+            }
+            Assert.Equal(100, lru.Count);
+            // Add 75 more values, to wipe out 25 of the original 50
+            for (int i = 125; i < 200; i++)
+            {
+                Assert.Null(lru.GetOrAdd(i, () => null));
+            }
+            Assert.Equal(100, lru.Count);
+            // check 25-49 are still there, and 0-24 are gone
+            for (int i = 25; i < 50; i++)
+            {
+                Assert.Same(values[i], lru.GetOrAdd(i, () => null));
+            }
+            for (int i = 0; i < 25; i++)
+            {
+                Assert.Equal("gone", lru.GetOrAdd(i, () => "gone"));
+            }
+            Assert.Equal(100, lru.Count);
+        }
+    }
+}

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/project.json
@@ -10,7 +10,9 @@
     "Google.Api.Gax.Testing": "1.0.0-beta07",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "Moq": "4.6.36-alpha"
+    "Moq": "4.6.36-alpha",
+    "System.Text.RegularExpressions": "4.0.0",
+    "Google.Api.Gax": "1.0.0-beta08-CI00126" // Temp
   },
   "testRunner": "xunit",
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/project.json
@@ -7,13 +7,13 @@
 
   "dependencies": {
     "Google.Cloud.Logging.Log4Net": { "target": "project" },
-    "Google.Api.Gax.Testing": "1.0.0-beta07",
+    "Google.Api.Gax.Testing": "1.0.0-beta09",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Moq": "4.6.36-alpha",
-    "System.Text.RegularExpressions": "4.0.0",
-    "Google.Api.Gax": "1.0.0-beta08-CI00126" // Temp
+    "System.Text.RegularExpressions": "4.0.0"
   },
+
   "testRunner": "xunit",
 
   "frameworks": {

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender.cs
@@ -114,9 +114,23 @@ namespace Google.Cloud.Logging.Log4Net
         private Task<long?> _initIdTask;
         private long _currentId = -1; // Initialised here, in case Flush() is called before any log entries written.
 
+        private List<Label> _resourceLabels = new List<Label>();
         private List<Label> _customLabels = new List<Label>();
         private HashSet<MetaDataType> _withMetaData = new HashSet<MetaDataType>();
 
+        class PlatformDetails
+        {
+            public PlatformDetails(MonitoredResource resource, string logName, LogEntry logsLostWarningEntry)
+            {
+                Resource = resource;
+                LogName = logName;
+                LogsLostWarningEntry = logsLostWarningEntry;
+            }
+
+            public MonitoredResource Resource { get; }
+            public string LogName { get; }
+            public LogEntry LogsLostWarningEntry { get; }
+        }
         /// <inheritdoc/>
         public override void ActivateOptions()
         {
@@ -127,10 +141,16 @@ namespace Google.Cloud.Logging.Log4Net
             _scheduler = _scheduler ?? SystemScheduler.Instance;
             _clock = _clock ?? SystemClock.Instance;
 
+            // Normalize string configuration
+            ResourceType = string.IsNullOrWhiteSpace(ResourceType) ? null : ResourceType;
+            ProjectId = string.IsNullOrWhiteSpace(ProjectId) ? null : ProjectId;
+            LogId = string.IsNullOrWhiteSpace(LogId) ? null : LogId;
+            File = string.IsNullOrWhiteSpace(File) ? null : File;
+
             // Validate configuration
-            GaxPreconditions.CheckState(!string.IsNullOrEmpty(ResourceType), $"{nameof(ResourceType)} must be set.");
-            GaxPreconditions.CheckState(!string.IsNullOrEmpty(ProjectId), $"{nameof(ProjectId)} must be set.");
-            GaxPreconditions.CheckState(!string.IsNullOrEmpty(LogId), $"{nameof(LogId)} must be set.");
+            GaxPreconditions.CheckState(ResourceType != null || _resourceLabels.Count == 0,
+                $"Resource labels must be empty if {nameof(ResourceType)} is set.");
+            GaxPreconditions.CheckState(LogId != null, $"{nameof(LogId)} must be set.");
             GaxPreconditions.CheckState(MaxUploadBatchSize > 0, $"{nameof(MaxUploadBatchSize)} must be > 0");
             GaxPreconditions.CheckEnumValue<LocalQueueType>(LocalQueueType, nameof(LocalQueueType));
             switch (LocalQueueType)
@@ -140,7 +160,7 @@ namespace Google.Cloud.Logging.Log4Net
                         $"Either {nameof(MaxMemoryCount)} or {nameof(MaxFileSize)} must be configured to be > 0");
                     break;
                 case LocalQueueType.Disk:
-                    GaxPreconditions.CheckState(!string.IsNullOrEmpty(File), $"{nameof(File)} must be set.");
+                    GaxPreconditions.CheckState(File != null, $"{nameof(File)} must be set.");
                     GaxPreconditions.CheckState(MaxFileSize > 0, $"{nameof(MaxFileSize)} must be > 0");
                     GaxPreconditions.CheckState(MaxSizeRollBackups > 0, $"{nameof(MaxSizeRollBackups)} must be > 0");
                     break;
@@ -155,11 +175,75 @@ namespace Google.Cloud.Logging.Log4Net
                 $"{nameof(ServerErrorBackoffMaxDelaySeconds)} must be >= 20 seconds.");
 
             // Configure the logger from the given configuration
-            _logName = new LogName(ProjectId, LogId).ToString();
-            _resource = new MonitoredResource
+            if (ResourceType != null && ProjectId != null && !PreferPlatformResourceTypeDetection)
             {
-                Type = ResourceType
-            };
+                // If ResourceType and ProjectId explicitly set in configuration,
+                // and platform detected is not prefered, then just use the manual configuration.
+                _logName = new LogName(ProjectId, LogId).ToString();
+                _resource = new MonitoredResource
+                {
+                    Type = ResourceType,
+                    Labels = { _resourceLabels.ToDictionary(x => x.Key, x => x.Value) }
+                };
+            }
+            else
+            {
+                // Use auto-detected platform information.
+                string platformProjectId;
+                MonitoredResource platformResource;
+                var platform = Platform.Instance();
+                switch (platform.Type)
+                {
+                    case PlatformType.Gae:
+                        var gae = platform.GaeDetails;
+                        platformProjectId = gae.ProjectId;
+                        platformResource = new MonitoredResource
+                        {
+                            Type = "gae_app",
+                            Labels =
+                            {
+                                { "project_id", gae.ProjectId },
+                                { "module_id", gae.ServiceId },
+                                { "version_id", gae.VersionId }
+                            }
+                        };
+                        break;
+                    case PlatformType.Gce:
+                        var gce = platform.GceDetails;
+                        platformProjectId = gce.ProjectId;
+                        platformResource = new MonitoredResource
+                        {
+                            Type = "gce_instance",
+                            Labels =
+                            {
+                                { "project_id", gce.ProjectId },
+                                { "instance_id", gce.InstanceId },
+                                { "zone", gce.ZoneName }
+                            }
+                        };
+                        break;
+                    case PlatformType.Unknown:
+                        GaxPreconditions.CheckState(!string.IsNullOrEmpty(ProjectId), $"{nameof(ProjectId)} must be set on this platform.");
+                        platformProjectId = ProjectId;
+                        platformResource = new MonitoredResource
+                        {
+                            Type = "global",
+                            Labels =
+                            {
+                                {"project_id", ProjectId }
+                            }
+                        };
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unrecognized platform detected: '{platform.Type}'");
+                }
+                _logName = new LogName(PreferPlatformResourceTypeDetection ? platformProjectId : (ProjectId ?? platformProjectId), LogId).ToString();
+                _resource = PreferPlatformResourceTypeDetection ? platformResource : (ResourceType != null ? new MonitoredResource
+                {
+                    Type = ResourceType,
+                    Labels = { _resourceLabels.ToDictionary(x => x.Key, x => x.Value) }
+                } : platformResource);
+            }
             switch (LocalQueueType)
             {
                 case LocalQueueType.Memory:
@@ -182,7 +266,7 @@ namespace Google.Cloud.Logging.Log4Net
                 Severity = LogSeverity.Warning,
                 LogName = _logName,
                 Resource = _resource,
-                Labels = { labels },
+                Labels = { _customLabels.ToDictionary(x => x.Key, x => x.Value) },
             };
             var serverErrorBackoffSettings = new BackoffSettings(
                 delay: TimeSpan.FromSeconds(ServerErrorBackoffDelaySeconds),
@@ -195,15 +279,69 @@ namespace Google.Cloud.Logging.Log4Net
                 serverErrorBackoffSettings);
         }
 
+        private LruCache<string, System.Type> _typeCache = new LruCache<string, System.Type>(1000);
+
         private LogEntry BuildLogEntry(LoggingEvent loggingEvent)
         {
             const string unknown = "[unknown]";
             var labels = new Dictionary<string, string>();
+            LogEntrySourceLocation sourceLocation = null;
             if (_withMetaData.Contains(MetaDataType.Location))
             {
-                labels.Add(nameof(MetaDataType.Location) + ".FileName", loggingEvent.LocationInformation?.FileName ?? unknown);
-                labels.Add(nameof(MetaDataType.Location) + ".ClassName", loggingEvent.LocationInformation?.ClassName ?? unknown);
-                labels.Add(nameof(MetaDataType.Location) + ".LineNumber", loggingEvent.LocationInformation?.LineNumber ?? unknown);
+                string file = null;
+                long? line = null;
+                string function = null;
+                if (loggingEvent.LocationInformation?.FileName != null)
+                {
+                    file = loggingEvent.LocationInformation?.FileName;
+                }
+                long lineNumber;
+                if (long.TryParse(loggingEvent.LocationInformation?.LineNumber, out lineNumber))
+                {
+                    line = lineNumber;
+                }
+                string function0 = null;
+                string typeName = loggingEvent.LocationInformation?.ClassName;
+                if (typeName != null)
+                {
+                    try
+                    {
+                        var type = _typeCache.GetOrAdd(typeName, () =>
+                            AppDomain.CurrentDomain.GetAssemblies()
+                                .SelectMany(a => a.GetTypes())
+                                .FirstOrDefault(t => t.FullName == typeName)
+                        );
+                        function0 = type.AssemblyQualifiedName;
+                    }
+                    catch
+                    {
+                        // Ignore exceptions. This is best-effort only, and expected to fail in some situations.
+                    }
+                }
+                string function1 = loggingEvent.LocationInformation?.MethodName;
+                if (function0 != null || function1 != null)
+                {
+                    function = $"[{function0 ?? ""}].{function1 ?? ""}";
+                }
+                if (file != null || line != null || function != null)
+                {
+                    sourceLocation = new LogEntrySourceLocation();
+                    if (file != null)
+                    {
+                        sourceLocation.File = file;
+                    }
+                    if (line != null)
+                    {
+                        sourceLocation.Line = line.Value;
+                    }
+                    if (function != null)
+                    {
+                        // Format of "function" is:
+                        // "[<assembly-qualified type name>].<method name>"
+                        // E.g. "[Google.Cloud.Logging.Log4Net.Tests.Log4NetTest, Google.Cloud.Logging.Log4Net.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0].LogInfo"
+                        sourceLocation.Function = function;
+                    }
+                }
             }
             if (_withMetaData.Contains(MetaDataType.Identity))
             {
@@ -233,7 +371,7 @@ namespace Google.Cloud.Logging.Log4Net
             {
                 labels.Add(customLabel.Key, customLabel.Value);
             }
-            return new LogEntry
+            var logEntry = new LogEntry
             {
                 TextPayload = RenderLoggingEvent(loggingEvent),
                 Severity = s_levelMap[loggingEvent.Level],
@@ -242,6 +380,11 @@ namespace Google.Cloud.Logging.Log4Net
                 Resource = _resource,
                 Labels = { labels },
             };
+            if (sourceLocation != null)
+            {
+                logEntry.SourceLocation = sourceLocation;
+            }
+            return logEntry;
         }
 
         private void Write(IEnumerable<LogEntry> logEntries)

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender_Configuration.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender_Configuration.cs
@@ -106,13 +106,46 @@ namespace Google.Cloud.Logging.Log4Net
         }
 
         /// <summary>
-        /// The resource type of log entries.
-        /// Default value is "global".
+        /// Whether to prefer platform detection for setting resource type
+        /// over the manual configuration; if the platform is not unknown.
         /// </summary>
-        public string ResourceType { get; set; } = "global";
+        public bool PreferPlatformResourceTypeDetection { get; set; } = false;
 
         /// <summary>
-        /// The project ID for all log entries. Must be configured.
+        /// The resource type of log entries.
+        /// Default value depends on the detected platform. See the remarks section for details.
+        /// </summary>
+        /// <remarks>
+        /// If this is not set, then Resource type is set depending on the detected execution platform:
+        /// <list type="bullet">
+        /// <item><description>
+        /// Google App Engine: ResourceType "gae_app", with project_id, module_id, and version_id set approprately.
+        /// </description></item>
+        /// <item><description>
+        /// Google Compute Engine: ResourceType "gce_instance", with project_id, instance_id, and zone set approprately.
+        /// </description></item>
+        /// <item><description>
+        /// Unknown: ResourceType "global", with project_id set from this configuration.
+        /// </description></item>
+        /// </list>
+        /// If <see cref="PreferPlatformResourceTypeDetection"/> is <c>true</c>, then this detected
+        /// resource-type is always used, unless the platform is unknown.
+        /// </remarks>
+        public string ResourceType { get; set; } = null;
+
+        /// <summary>
+        /// Specify labels for the resource type.
+        /// </summary>
+        /// <param name="label">The resource type label.</param>
+        public void AddResourceLabel(Label label)
+        {
+            _resourceLabels.Add(label);
+        }
+
+        /// <summary>
+        /// The project ID for all log entries.
+        /// Must be configured in not executing on Google Compute Engine or Google App Engine.
+        /// If running on GCE or GAE, the ProjectId will be automatically detected if not set.
         /// </summary>
         public string ProjectId { get; set; }
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender_Configuration.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender_Configuration.cs
@@ -106,10 +106,10 @@ namespace Google.Cloud.Logging.Log4Net
         }
 
         /// <summary>
-        /// Whether to prefer platform detection for setting resource type
-        /// over the manual configuration; if the platform is not unknown.
+        /// If set, disables resource-type detection based on platform,
+        /// so ResourceType will default to "global" if not manually set. 
         /// </summary>
-        public bool PreferPlatformResourceTypeDetection { get; set; } = false;
+        public bool DisableResourceTypeDetection { get; set; } = false;
 
         /// <summary>
         /// The resource type of log entries.
@@ -128,13 +128,14 @@ namespace Google.Cloud.Logging.Log4Net
         /// Unknown: ResourceType "global", with project_id set from this configuration.
         /// </description></item>
         /// </list>
-        /// If <see cref="PreferPlatformResourceTypeDetection"/> is <c>true</c>, then this detected
-        /// resource-type is always used, unless the platform is unknown.
+        /// If <see cref="DisableResourceTypeDetection"/> is <c>true</c>, then this platform detection
+        /// is not performed, and this ResourceType defaults to "global" if not set.
         /// </remarks>
         public string ResourceType { get; set; } = null;
 
         /// <summary>
-        /// Specify labels for the resource type.
+        /// Specify labels for the resource type;
+        /// only used if platform detection is disabled or detects an unknown platform.
         /// </summary>
         /// <param name="label">The resource type label.</param>
         public void AddResourceLabel(Label label)

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/LruCache.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/LruCache.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Logging.Log4Net
+{
+    class LruCache<K, V>
+    {
+        struct Item
+        {
+            public Item(LinkedListNode<K> node, V value)
+            {
+                Node = node;
+                Value = value;
+            }
+
+            public LinkedListNode<K> Node { get; }
+            public V Value { get; }
+        }
+
+        public LruCache(int capacity)
+        {
+            _capacity = capacity;
+            _dict = new Dictionary<K, Item>(capacity);
+            _order = new LinkedList<K>();
+        }
+
+        private readonly object _lock = new object();
+        private readonly int _capacity;
+        private readonly Dictionary<K, Item> _dict;
+        private readonly LinkedList<K> _order;
+
+        public V GetOrAdd(K key, Func<V> valueFn)
+        {
+            lock (_lock)
+            {
+                Item item;
+                if (_dict.TryGetValue(key, out item))
+                {
+                    _order.Remove(item.Node);
+                }
+                else
+                {
+                    if (_dict.Count >= _capacity)
+                    {
+                        LinkedListNode<K> last = _order.Last;
+                        _order.RemoveLast();
+                        _dict.Remove(last.Value);
+                    }
+                    item = new Item(new LinkedListNode<K>(key), valueFn());
+                    _dict.Add(key, item);
+                }
+                _order.AddFirst(item.Node);
+                return item.Value;
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                lock(_lock)
+                {
+                    return _dict.Count;
+                }
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/LruCache.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/LruCache.cs
@@ -1,8 +1,19 @@
-﻿using System;
-using System.Collections;
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Google.Cloud.Logging.Log4Net
 {

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/project.json
@@ -20,8 +20,7 @@
 
   "dependencies": {
     "Google.Cloud.Logging.V2": { "target": "project" },
-    "log4net": "2.0.5",
-    "Google.Api.Gax": "1.0.0-beta08-CI00126" // Temp
+    "log4net": "2.0.5"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/project.json
@@ -20,7 +20,8 @@
 
   "dependencies": {
     "Google.Cloud.Logging.V2": { "target": "project" },
-    "log4net": "2.0.5"
+    "log4net": "2.0.5",
+    "Google.Api.Gax": "1.0.0-beta08-CI00126" // Temp
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/project.json
@@ -19,7 +19,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Grpc": "1.0.0-beta07",
+    "Google.Api.Gax.Grpc": "1.0.0-beta09",
     "Google.Cloud.Logging.Type": { "target": "project" }
   },
 


### PR DESCRIPTION
If location is enabled, puts source location data in the source_location field of the LogEntry proto.

Detects platform (GCE, GAE, & Unknown) and uses the correct ResourceType and resource labels.