### PR TITLE
Support customer-supplied encryption keys for storage

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/EncryptionTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/EncryptionTest.cs
@@ -1,0 +1,135 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+using Xunit;
+
+using static Google.Cloud.Storage.V1.IntegrationTests.TestHelpers;
+
+namespace Google.Cloud.Storage.V1.IntegrationTests
+{
+    [Collection(nameof(StorageFixture))]
+    public class EncryptionTest
+    {
+        private readonly StorageFixture _fixture;
+
+        public EncryptionTest(StorageFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public void DownloadWithKey()
+        {
+            var bucket = _fixture.SingleVersionBucket;
+            var data = GenerateData(100);
+            var key = EncryptionKey.Generate();
+            var contentType = "application/octet-stream";
+            var client = StorageClient.Create(encryptionKey: key);
+
+            var name = GenerateName();
+            client.UploadObject(bucket, name, contentType, data);
+            // Client default key
+            ValidateData(bucket, name, data, client);
+
+            // Overridden
+            ValidateData(bucket, name, data, null, new DownloadObjectOptions { EncryptionKey = key });
+        }
+
+        [Fact]
+        public void DownloadWithoutKey()
+        {
+            var bucket = _fixture.SingleVersionBucket;
+            var data = GenerateData(100);
+            var key = EncryptionKey.Generate();
+            var contentType = "application/octet-stream";
+            var client = StorageClient.Create();
+
+            var name = GenerateName();
+            client.UploadObject(bucket, name, contentType, data, new UploadObjectOptions { EncryptionKey = key });
+            Assert.Throws<GoogleApiException>(() => client.DownloadObject(bucket, name, new MemoryStream()));
+        }
+
+        [Fact]
+        public void RotateKeys()
+        {
+            var bucket = _fixture.SingleVersionBucket;
+            var data = GenerateData(100);
+            var key1 = EncryptionKey.Generate();
+            var key2 = EncryptionKey.Generate();
+            var contentType = "application/octet-stream";
+
+            var name = GenerateName();
+
+            var client1 = StorageClient.Create(encryptionKey: key1);
+            client1.UploadObject(_fixture.SingleVersionBucket, name, contentType, data);
+
+            var client2 = StorageClient.Create(encryptionKey: key2);
+
+            // We're copying over the top of the original object. We don't have to, but that's
+            // probably typical for key rotation.
+            client2.CopyObject(bucket, name, bucket, name, new CopyObjectOptions { SourceEncryptionKey = key1 });
+            ValidateData(bucket, name, data, client2);
+        }
+
+        [Fact]
+        public void GetMetadata()
+        {
+            var bucket = _fixture.SingleVersionBucket;
+            var data = GenerateData(100);
+            var key = EncryptionKey.Generate();
+            var contentType = "application/octet-stream";
+            var client = StorageClient.Create();
+            var name = GenerateName();
+
+            var uploaded = client.UploadObject(bucket, name, contentType, data, new UploadObjectOptions { EncryptionKey = key });
+            var fetchedWithoutKey = client.GetObject(bucket, name);
+            Assert.Null(fetchedWithoutKey.Md5Hash);
+            var fetchedWithKey = client.GetObject(bucket, name, new GetObjectOptions { EncryptionKey = key });
+            Assert.NotNull(fetchedWithKey.Md5Hash);
+            Assert.Equal(uploaded.Md5Hash, fetchedWithKey.Md5Hash);
+        }
+
+        [Fact]
+        public void NoneEquality()
+        {
+            var key = EncryptionKey.None;
+            Assert.True(EncryptionKey.None.Equals(key));
+            Assert.True(EncryptionKey.None.Equals((object) key));
+            Assert.Equal(0, key.GetHashCode());
+
+            Assert.False(key.Equals(null));
+            Assert.False(key.Equals((object) null));
+        }
+
+        [Fact]
+        public void NotNoneEquality()
+        {
+            var key1a = EncryptionKey.Generate();
+            var key1b = EncryptionKey.Create(Convert.FromBase64String(key1a.Base64Key));
+            var key2 = EncryptionKey.Generate();
+            Assert.True(key1a.Equals(key1b));
+            Assert.True(key1a.Equals((object) key1b));
+            Assert.Equal(key1a.GetHashCode(), key1b.GetHashCode());
+
+            Assert.False(key1a.Equals(key2));
+            Assert.False(key1a.Equals((object) key2));
+            Assert.NotEqual(key1a.GetHashCode(), key2.GetHashCode());
+
+            Assert.False(key1a.Equals(null));
+            Assert.False(key1a.Equals((object) null));
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/TestHelpers.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/TestHelpers.cs
@@ -40,12 +40,18 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             return new MemoryStream(data);
         }
 
-        internal static void ValidateData(string bucketName, string objectName, byte[] expectedData)
+        internal static void ValidateData(string bucketName, string objectName, byte[] expectedData,
+            StorageClient client = null, DownloadObjectOptions options = null)
         {
-            var client = StorageClient.Create();
+            client = client ?? StorageClient.Create();
             var downloaded = new MemoryStream();
-            client.DownloadObject(bucketName, objectName, downloaded);
+            client.DownloadObject(bucketName, objectName, downloaded, options);
             Assert.Equal(expectedData, downloaded.ToArray());
         }
+
+
+        internal static void ValidateData(string bucketName, string objectName, MemoryStream expectedData,
+            StorageClient client = null, DownloadObjectOptions options = null) =>
+            ValidateData(bucketName, objectName, expectedData.ToArray(), client, options);
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UploadObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UploadObjectTest.cs
@@ -46,7 +46,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             Assert.Equal(_fixture.MultiVersionBucket, result.Bucket);
             Assert.Equal(name, result.Name);
             Assert.Equal(contentType, result.ContentType);
-            ValidateData(source, name);            
+            ValidateData(_fixture.MultiVersionBucket, name, source);
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             Assert.Equal(destination.ContentType, result.ContentType);
             Assert.Equal(destination.ContentDisposition, result.ContentDisposition);
             Assert.Equal(destination.Metadata, result.Metadata);
-            ValidateData(source, destination.Name);
+            ValidateData(_fixture.MultiVersionBucket, destination.Name, source);
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
                 CancellationToken.None, progress);
             Assert.Equal(chunks + 1, progressCount); // Should start with a 0 progress
             Assert.Equal(name, result.Name); // Assume the rest of the properties are okay...
-            ValidateData(source, name);
+            ValidateData(_fixture.MultiVersionBucket, name, source);
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             var contentType = "application/octet-stream";
             var source1 = GenerateData(100);
             var firstVersion = client.UploadObject(bucket, name, contentType, source1);
-            ValidateData(source1, name);
+            ValidateData(_fixture.MultiVersionBucket, name, source1);
             var source2 = GenerateData(50);
             firstVersion.ContentType = "application/x-replaced";
 
@@ -106,7 +106,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             firstVersion.ETag = null;
             firstVersion.Md5Hash = null;
             var secondVersion = client.UploadObject(firstVersion, source2);
-            ValidateData(source2, name);
+            ValidateData(_fixture.MultiVersionBucket, name, source2);
             Assert.NotEqual(firstVersion.Generation, secondVersion.Generation);
             Assert.Equal(firstVersion.ContentType, secondVersion.ContentType); // The modified content type should stick
 
@@ -232,13 +232,6 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             obj.ETag = null;
             obj.Md5Hash = null;
             return obj;
-        }
-
-        private void ValidateData(MemoryStream original, string objectName)
-        {
-            var downloaded = new MemoryStream();
-            _fixture.Client.DownloadObject(_fixture.MultiVersionBucket, objectName, downloaded);
-            Assert.Equal(original.ToArray(), downloaded.ToArray());
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/StorageClientSnippets.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/StorageClientSnippets.cs
@@ -75,6 +75,30 @@ namespace Google.Cloud.Storage.V1.Snippets
         }
 
         [Fact]
+        public void CustomerSuppliedEncryptionKeys()
+        {
+            var bucketName = _fixture.BucketName;
+
+            // Sample: CustomerSuppliedEncryptionKeys
+            // Use EncryptionKey.Create if you already have a key.
+            EncryptionKey key = EncryptionKey.Generate();
+            
+            // This will affect all object-based operations by default.
+            var client = StorageClient.Create(encryptionKey: key);
+            var content = Encoding.UTF8.GetBytes("hello, world");
+            client.UploadObject(bucketName, "encrypted.txt", "text/plain", new MemoryStream(content));
+
+            // When downloading, either use a client with the same key...
+            client.DownloadObject(bucketName, "encrypted.txt", new MemoryStream());
+
+            // Or specify a key just for that operation.
+            var client2 = StorageClient.Create();
+            client2.DownloadObject(bucketName, "encrypted.txt", new MemoryStream(),
+                new DownloadObjectOptions { EncryptionKey = key });
+            // End sample
+        }
+
+        [Fact]
         public void ListBuckets()
         {
             var projectId = _fixture.ProjectId;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/EncryptionKeyTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/EncryptionKeyTest.cs
@@ -1,0 +1,128 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Xunit;
+
+namespace Google.Cloud.Storage.V1.Tests
+{
+    public class EncryptionKeyTest
+    {
+        [Fact]
+        public void Generate()
+        {
+            EncryptionKey key1 = EncryptionKey.Generate();
+            EncryptionKey key2 = EncryptionKey.Generate();
+
+            Assert.NotNull(key1.Base64Key);
+            Assert.NotNull(key1.Base64Hash);
+
+            Assert.NotEqual(key1.Base64Key, key2.Base64Key);
+            Assert.NotEqual(key1.Base64Hash, key2.Base64Hash);
+        }
+
+        [Fact]
+        public void Create()
+        {
+            EncryptionKey key = EncryptionKey.Create(new byte[32]);
+            Assert.Equal("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", key.Base64Key);
+            Assert.Equal("Zmh6rfhivXdsj8GLjp+OIAiXFIVu4jOzkCpZHQ1fKSU=", key.Base64Hash);
+        }
+
+        [Fact]
+        public void Create_Invalid()
+        {
+            Assert.Throws<ArgumentNullException>(() => EncryptionKey.Create(null));
+            Assert.Throws<ArgumentException>(() => EncryptionKey.Create(new byte[33]));
+            Assert.Throws<ArgumentException>(() => EncryptionKey.Create(new byte[31]));
+        }
+
+        [Fact]
+        public void None()
+        {
+            Assert.Null(EncryptionKey.None.Base64Key);
+            Assert.Null(EncryptionKey.None.Base64Hash);
+        }
+
+        [Fact]
+        public void ModifyRequest_None()
+        {
+            var request = new HttpRequestMessage();
+            EncryptionKey.None.ModifyRequest(request);
+            IEnumerable<string> values;
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.AlgorithmHeader, out values));
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.KeyHeader, out values));
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.KeyHashHeader, out values));
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.CopySourceAlgorithmHeader, out values));
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.CopySourceKeyHeader, out values));
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.CopySourceKeyHashHeader, out values));
+        }
+
+        [Fact]
+        public void ModifyRequest_NotNone()
+        {
+            EncryptionKey key = EncryptionKey.Create(new byte[32]);
+            var request = new HttpRequestMessage();
+            key.ModifyRequest(request);
+            IEnumerable<string> values;
+            Assert.True(request.Headers.TryGetValues(EncryptionKey.AlgorithmHeader, out values));
+            Assert.Equal(new[] { EncryptionKey.AlgorithmValue }, values);
+            Assert.True(request.Headers.TryGetValues(EncryptionKey.KeyHeader, out values));
+            Assert.Equal(new[] { "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" }, values);
+            Assert.True(request.Headers.TryGetValues(EncryptionKey.KeyHashHeader, out values));
+            Assert.Equal(new[] { "Zmh6rfhivXdsj8GLjp+OIAiXFIVu4jOzkCpZHQ1fKSU=" }, values);
+
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.CopySourceAlgorithmHeader, out values));
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.CopySourceKeyHeader, out values));
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.CopySourceKeyHashHeader, out values));
+        }
+
+        [Fact]
+        public void ModifyRequestForRewriteSource_None()
+        {
+            var request = new HttpRequestMessage();
+            EncryptionKey.None.ModifyRequestForRewriteSource(request);
+            IEnumerable<string> values;
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.CopySourceAlgorithmHeader, out values));
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.CopySourceKeyHeader, out values));
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.CopySourceKeyHashHeader, out values));
+
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.AlgorithmHeader, out values));
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.KeyHeader, out values));
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.KeyHashHeader, out values));
+        }
+
+
+        [Fact]
+        public void ModifyRequestForRewriteSource_NotNone()
+        {
+            EncryptionKey key = EncryptionKey.Create(new byte[32]);
+            var request = new HttpRequestMessage();
+            key.ModifyRequestForRewriteSource(request);
+            IEnumerable<string> values;
+            Assert.True(request.Headers.TryGetValues(EncryptionKey.CopySourceAlgorithmHeader, out values));
+            Assert.Equal(new[] { EncryptionKey.AlgorithmValue }, values);
+            Assert.True(request.Headers.TryGetValues(EncryptionKey.CopySourceKeyHeader, out values));
+            Assert.Equal(new[] { "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" }, values);
+            Assert.True(request.Headers.TryGetValues(EncryptionKey.CopySourceKeyHashHeader, out values));
+            Assert.Equal(new[] { "Zmh6rfhivXdsj8GLjp+OIAiXFIVu4jOzkCpZHQ1fKSU=" }, values);
+
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.AlgorithmHeader, out values));
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.KeyHeader, out values));
+            Assert.False(request.Headers.TryGetValues(EncryptionKey.KeyHashHeader, out values));
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/CopyObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/CopyObjectOptions.cs
@@ -98,6 +98,18 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public Object ExtraMetadata { get; set; }
 
+        /// <summary>
+        /// The encryption key to use for this operation. If this property is null, the <see cref="StorageClient.EncryptionKey"/>
+        /// will be used instead. Use <see cref="EncryptionKey.None"/> to remove encryption headers from this request.
+        /// </summary>
+        public EncryptionKey EncryptionKey { get; set; }
+
+        /// <summary>
+        /// The encryption key to use for the source of the copy. If this property is null, the <see cref="StorageClient.EncryptionKey"/>
+        /// will be used instead. Use <see cref="EncryptionKey.None"/> if the source is not encrypted.
+        /// </summary>
+        public EncryptionKey SourceEncryptionKey { get; set; }
+
         internal void ModifyRequest(RewriteRequest request)
         {
             // Note the use of ArgumentException here, as this will basically be the result of invalid

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/CustomMediaUpload.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/CustomMediaUpload.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Services;
+using System;
+using System.IO;
+using System.Net.Http;
+using static Google.Apis.Storage.v1.ObjectsResource;
+using Google.Apis.Upload;
+
+namespace Google.Cloud.Storage.V1
+{
+    /// <summary>
+    /// Upload subclass which allows us to modify headers, for customer-supplied encryption keys.
+    /// </summary>
+    internal sealed class CustomMediaUpload : InsertMediaUpload
+    {
+        public CustomMediaUpload(IClientService service, Apis.Storage.v1.Data.Object body, string bucket,
+            Stream stream, string contentType)
+            : base(service, body, bucket, stream, contentType)
+        {
+        }
+
+        internal new ResumableUploadOptions Options => base.Options;
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DownloadObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DownloadObjectOptions.cs
@@ -61,6 +61,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public RangeHeaderValue Range { get; set; }
 
+        /// <summary>
+        /// The encryption key to use for this operation. If this property is null, the <see cref="StorageClient.EncryptionKey"/>
+        /// will be used instead. Use <see cref="EncryptionKey.None"/> to remove encryption headers from this request.
+        /// </summary>
+        public EncryptionKey EncryptionKey { get; set; }
+
         internal void ModifyDownloader(MediaDownloader downloader)
         {
             if (ChunkSize != null)

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/EncryptionKey.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/EncryptionKey.cs
@@ -1,0 +1,130 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Apis.Requests;
+using System;
+using System.Net.Http;
+using System.Security.Cryptography;
+
+namespace Google.Cloud.Storage.V1
+{
+    /// <summary>
+    /// An AES-256 key passed to the Google Cloud Storage servers via headers to allow objects to be encrypted at
+    /// rest using a client-supplied key rather than a server-supplied default key.
+    /// </summary>
+    public sealed class EncryptionKey : IEquatable<EncryptionKey>
+    {
+        internal const string AlgorithmHeader = "x-goog-encryption-algorithm";
+        internal const string KeyHeader = "x-goog-encryption-key";
+        internal const string KeyHashHeader = "x-goog-encryption-key-sha256";
+        internal const string AlgorithmValue = "AES256";
+        internal const string CopySourceAlgorithmHeader = "x-goog-copy-source-encryption-algorithm";
+        internal const string CopySourceKeyHeader = "x-goog-copy-source-encryption-key";
+        internal const string CopySourceKeyHashHeader = "x-goog-copy-source-encryption-key-sha256";
+
+        /// <summary>
+        /// A "don't encrypt" key, used in call-specific options to indicate that a particular request should
+        /// not use encryption even if the client has a default encryption key.
+        /// </summary>
+        public static EncryptionKey None { get; } = new EncryptionKey();
+
+        /// <summary>
+        /// The base64 representation of the key. This will always be 45 characters long,
+        /// or <c>null</c> for <see cref="None"/>.
+        /// </summary>
+        public string Base64Key { get; }
+
+        /// <summary>
+        /// The base64 representation of the SHA-256 hash of the key. This will always be 45 characters long,
+        /// or <c>null</c> for <see cref="None"/>.
+        /// </summary>
+        public string Base64Hash { get; }
+
+        // Only used for "None" - leaves properties null
+        private EncryptionKey()
+        {
+        }
+
+        private EncryptionKey(byte[] key)
+        {
+            using (var hasher = SHA256.Create())
+            {
+                Base64Key = Convert.ToBase64String(key);
+                Base64Hash = Convert.ToBase64String(hasher.ComputeHash(key));
+            }
+        }
+
+        /// <summary>
+        /// Creates an encryption key from the specified raw bytes.
+        /// </summary>
+        /// <param name="key">The raw key data; must be non-null and 32 bytes long.</param>
+        /// <returns>An <see cref="EncryptionKey"/> based on <paramref name="key"/>.</returns>
+        public static EncryptionKey Create(byte[] key)
+        {
+            GaxPreconditions.CheckNotNull(key, nameof(key));
+            GaxPreconditions.CheckArgument(key.Length == 32, nameof(key), "Key must be 32 bytes long");
+            return new EncryptionKey(key);
+        }
+
+        /// <summary>
+        /// Generates a random encryption key using <see cref="RandomNumberGenerator"/>.
+        /// </summary>
+        /// <returns>A generated encryption key.</returns>
+        public static EncryptionKey Generate()
+        {
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                byte[] key = new byte[32];
+                rng.GetBytes(key);
+                return Create(key);
+            }
+        }
+
+        /// <inheritdoc />
+        public bool Equals(EncryptionKey other) => other != null && other.Base64Key == Base64Key;
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as EncryptionKey);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => Base64Key?.GetHashCode() ?? 0;
+
+        /// <summary>
+        /// Adds encryption headers to the specified request, unless this key is <see cref="EncryptionKey.None"/>, 
+        /// </summary>
+        /// <param name="request">The request to modify. Must not be null.</param>
+        public void ModifyRequest(HttpRequestMessage request)
+        {
+            GaxPreconditions.CheckNotNull(request, nameof(request));
+            if (Base64Key != null)
+            {
+                request.Headers.Add(AlgorithmHeader, AlgorithmValue);
+                request.Headers.Add(KeyHeader, Base64Key);
+                request.Headers.Add(KeyHashHeader, Base64Hash);
+            }
+        }
+
+        internal void ModifyRequestForRewriteSource(HttpRequestMessage request)
+        {
+            GaxPreconditions.CheckNotNull(request, nameof(request));
+            if (Base64Key != null)
+            {
+                request.Headers.Add(CopySourceAlgorithmHeader, AlgorithmValue);
+                request.Headers.Add(CopySourceKeyHeader, Base64Key);
+                request.Headers.Add(CopySourceKeyHashHeader, Base64Hash);
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/GetObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/GetObjectOptions.cs
@@ -59,6 +59,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public long? IfMetagenerationNotMatch { get; set; }
 
+        /// <summary>
+        /// The encryption key to use for this operation. If this property is null, the <see cref="StorageClient.EncryptionKey"/>
+        /// will be used instead. Use <see cref="EncryptionKey.None"/> to remove encryption headers from this request.
+        /// </summary>
+        public EncryptionKey EncryptionKey { get; set; }
+
         internal void ModifyRequest(GetRequest request)
         {
             // Note the use of ArgumentException here, as this will basically be the result of invalid

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListObjectsOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListObjectsOptions.cs
@@ -52,6 +52,12 @@ namespace Google.Cloud.Storage.V1
         public Projection? Projection { get; set; }
 
         /// <summary>
+        /// The encryption key to use for this operation. If this property is null, the <see cref="StorageClient.EncryptionKey"/>
+        /// will be used instead. Use <see cref="EncryptionKey.None"/> to remove encryption headers from this request.
+        /// </summary>
+        public EncryptionKey EncryptionKey { get; set; }
+
+        /// <summary>
         /// Modifies the specified request for all non-null properties of this options object.
         /// </summary>
         /// <param name="request">The request to modify</param>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/PatchObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/PatchObjectOptions.cs
@@ -63,6 +63,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public PredefinedObjectAcl? PredefinedAcl { get; set; }
 
+        /// <summary>
+        /// The encryption key to use for this operation. If this property is null, the <see cref="StorageClient.EncryptionKey"/>
+        /// will be used instead. Use <see cref="EncryptionKey.None"/> to remove encryption headers from this request.
+        /// </summary>
+        public EncryptionKey EncryptionKey { get; set; }
+
         internal void ModifyRequest(PatchRequest request)
         {
             // Note the use of ArgumentException here, as this will basically be the result of invalid

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.cs
@@ -28,8 +28,8 @@ namespace Google.Cloud.Storage.V1
     /// <remarks>
     /// <para>
     /// This abstract class is provided to enable testability while permitting
-    /// additional operations to be added in the future. See <see cref="Create(GoogleCredential)"/>
-    /// and <see cref="CreateAsync(GoogleCredential)"/> to construct instances; alternatively, you can
+    /// additional operations to be added in the future. See <see cref="Create(GoogleCredential, EncryptionKey)"/>
+    /// and <see cref="CreateAsync(GoogleCredential, EncryptionKey)"/> to construct instances; alternatively, you can
     /// construct a <see cref="StorageClientImpl"/> directly from a <see cref="StorageService"/>.
     /// </para>
     /// <para>
@@ -54,6 +54,13 @@ namespace Google.Cloud.Storage.V1
         public virtual StorageService Service { get { throw new NotImplementedException(); } }
 
         /// <summary>
+        /// The encryption key used by default for all object-based operations. This can be overridden in call-specific options.
+        /// This will never return null in the built-in implementation; if no encryption key is specified,
+        /// <see cref="EncryptionKey.None"/> is returned.
+        /// </summary>
+        public virtual EncryptionKey EncryptionKey { get { throw new NotImplementedException(); } }
+
+        /// <summary>
         /// Asynchronously creates a <see cref="StorageClient"/>, using application default credentials if
         /// no credentials are specified.
         /// </summary>
@@ -61,11 +68,12 @@ namespace Google.Cloud.Storage.V1
         /// The credentials are scoped as necessary.
         /// </remarks>
         /// <param name="credential">Optional <see cref="GoogleCredential"/>.</param>
+        /// <param name="encryptionKey">Optional <see cref="EncryptionKey"/> to use for all object-based operations by default. May be null.</param>
         /// <returns>The task representing the created <see cref="StorageClient"/>.</returns>
-        public static async Task<StorageClient> CreateAsync(GoogleCredential credential = null)
+        public static async Task<StorageClient> CreateAsync(GoogleCredential credential = null, EncryptionKey encryptionKey = null)
         {
             var scopedCredentials = await _credentialProvider.GetCredentialsAsync(credential);
-            return CreateImpl(scopedCredentials);
+            return CreateImpl(scopedCredentials, encryptionKey);
         }
 
         /// <summary>
@@ -76,15 +84,16 @@ namespace Google.Cloud.Storage.V1
         /// The credentials are scoped as necessary.
         /// </remarks>
         /// <param name="credential">Optional <see cref="GoogleCredential"/>.</param>
+        /// <param name="encryptionKey">Optional <see cref="EncryptionKey"/> to use for all object-based operations by default. May be null.</param>
         /// <returns>The created <see cref="StorageClient"/>.</returns>
-        public static StorageClient Create(GoogleCredential credential = null)
+        public static StorageClient Create(GoogleCredential credential = null, EncryptionKey encryptionKey = null)
         {
             var scopedCredentials = _credentialProvider.GetCredentials(credential);
-            return CreateImpl(scopedCredentials);
+            return CreateImpl(scopedCredentials, encryptionKey);
         }
 
 
-        private static StorageClient CreateImpl(GoogleCredential scopedCredentials)
+        private static StorageClient CreateImpl(GoogleCredential scopedCredentials, EncryptionKey encryptionKey)
         {
             var service = new StorageService(new BaseClientService.Initializer
             {
@@ -92,7 +101,7 @@ namespace Google.Cloud.Storage.V1
                 ApplicationName = StorageClientImpl.ApplicationName,
             });
 
-            return new StorageClientImpl(service);
+            return new StorageClientImpl(service, encryptionKey);
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.CopyObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.CopyObject.cs
@@ -74,6 +74,8 @@ namespace Google.Cloud.Storage.V1
             Object obj = options?.ExtraMetadata ?? new Object();
             var request = Service.Objects.Rewrite(obj, sourceBucket, sourceObjectName, destinationBucket, destinationObjectName);
             options?.ModifyRequest(request);
+            ApplyEncryptionKey(options?.EncryptionKey, request);
+            request.ModifyRequest += (options?.SourceEncryptionKey ?? EncryptionKey).ModifyRequestForRewriteSource;
             return request;
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.DownloadObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.DownloadObject.cs
@@ -105,6 +105,7 @@ namespace Google.Cloud.Storage.V1
             GaxPreconditions.CheckNotNull(destination, nameof(destination));
             var downloader = new HashValidatingDownloader(Service);
             options?.ModifyDownloader(downloader);
+            ApplyEncryptionKey(options?.EncryptionKey, downloader);
             string uri = options == null ? baseUri : options.GetUri(baseUri);
             if (progress != null)
             {
@@ -128,6 +129,7 @@ namespace Google.Cloud.Storage.V1
             GaxPreconditions.CheckNotNull(destination, nameof(destination));
             var downloader = new HashValidatingDownloader(Service);
             options?.ModifyDownloader(downloader);
+            ApplyEncryptionKey(options?.EncryptionKey, downloader);
             string uri = options == null ? baseUri : options.GetUri(baseUri);
             if (progress != null)
             {

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.GetObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.GetObject.cs
@@ -45,6 +45,7 @@ namespace Google.Cloud.Storage.V1
         private ObjectsResource.GetRequest CreateGetObjectRequest(string bucket, string objectName, GetObjectOptions options)
         {
             var request = Service.Objects.Get(bucket, objectName);
+            ApplyEncryptionKey(options?.EncryptionKey, request);
             options?.ModifyRequest(request);
             return request;
         }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.ListObjects.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.ListObjects.cs
@@ -60,6 +60,7 @@ namespace Google.Cloud.Storage.V1
             var request = Service.Objects.List(bucket);
             request.Prefix = prefix;
             options?.ModifyRequest(request);
+            ApplyEncryptionKey(options?.EncryptionKey, request);
             return request;
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.PatchObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.PatchObject.cs
@@ -42,6 +42,7 @@ namespace Google.Cloud.Storage.V1
             GaxPreconditions.CheckArgument(obj.Name != null, nameof(obj), "The Name property of the object to update is null");
             var request = Service.Objects.Patch(obj, obj.Bucket, obj.Name);
             options?.ModifyRequest(request);
+            ApplyEncryptionKey(options?.EncryptionKey, request);
             return request;
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.UpdateObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.UpdateObject.cs
@@ -42,6 +42,7 @@ namespace Google.Cloud.Storage.V1
             GaxPreconditions.CheckArgument(obj.Name != null, nameof(obj), "The Name property of the object to update is null");
             var request = Service.Objects.Update(obj, obj.Bucket, obj.Name);
             options?.ModifyRequest(request, obj);
+            ApplyEncryptionKey(options?.EncryptionKey, request);
             return request;
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.UploadObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.UploadObject.cs
@@ -65,8 +65,9 @@ namespace Google.Cloud.Storage.V1
         {
             ValidateObject(destination, nameof(destination));
             GaxPreconditions.CheckNotNull(source, nameof(source));
-            var mediaUpload = Service.Objects.Insert(destination, destination.Bucket, source, destination.ContentType);
+            var mediaUpload = new CustomMediaUpload(Service, destination, destination.Bucket, source, destination.ContentType);
             options?.ModifyMediaUpload(mediaUpload);
+            ApplyEncryptionKey(options?.EncryptionKey, mediaUpload);
             if (progress != null)
             {
                 mediaUpload.ProgressChanged += progress.Report;
@@ -76,6 +77,7 @@ namespace Google.Cloud.Storage.V1
             {
                 throw finalProgress.Exception;
             }
+            
             return mediaUpload.ResponseBody;
         }
 
@@ -89,8 +91,9 @@ namespace Google.Cloud.Storage.V1
         {
             ValidateObject(destination, nameof(destination));
             GaxPreconditions.CheckNotNull(source, nameof(source));
-            var mediaUpload = Service.Objects.Insert(destination, destination.Bucket, source, destination.ContentType);
+            var mediaUpload = new CustomMediaUpload(Service, destination, destination.Bucket, source, destination.ContentType);
             options?.ModifyMediaUpload(mediaUpload);
+            ApplyEncryptionKey(options?.EncryptionKey, mediaUpload);
             if (progress != null)
             {
                 mediaUpload.ProgressChanged += progress.Report;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UpdateObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UpdateObjectOptions.cs
@@ -71,6 +71,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public bool? ForceNoPreconditions { get; set; }
 
+        /// <summary>
+        /// The encryption key to use for this operation. If this property is null, the <see cref="StorageClient.EncryptionKey"/>
+        /// will be used instead. Use <see cref="EncryptionKey.None"/> to remove encryption headers from this request.
+        /// </summary>
+        public EncryptionKey EncryptionKey { get; set; }
+
         private bool AnyExplicitPreconditions =>
             IfGenerationMatch != null || IfGenerationNotMatch != null || IfMetagenerationMatch != null || IfMetagenerationNotMatch != null;
 

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UploadObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UploadObjectOptions.cs
@@ -85,6 +85,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public Projection? Projection { get; set; }
 
+        /// <summary>
+        /// The encryption key to use for this operation. If this property is null, the <see cref="StorageClient.EncryptionKey"/>
+        /// will be used instead. Use <see cref="EncryptionKey.None"/> to remove encryption headers from this request.
+        /// </summary>
+        public EncryptionKey EncryptionKey { get; set; }
+
         internal void ModifyMediaUpload(InsertMediaUpload upload)
         {
             // Note the use of ArgumentException here, as this will basically be the result of invalid

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.cs
@@ -39,8 +39,6 @@ namespace Google.Cloud.Storage.V1
     public sealed class UrlSigner
     {
         private const string GoogHeaderPrefix = "x-goog-";
-        private const string GoogEncryptionKeyHeader = "x-goog-encryption-key";
-        private const string GoogEncryptionKeySHA256Header = "x-goog-encryption-key-sha256";
         private const string StorageHost = "https://storage.googleapis.com";
         private static readonly DateTimeOffset UnixEpoch = new DateTimeOffset(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc), TimeSpan.Zero);
 
@@ -359,8 +357,8 @@ namespace Google.Cloud.Storage.V1
             {
                 var key = header.Key.ToLowerInvariant();
                 if (!key.StartsWith(GoogHeaderPrefix) ||
-                    key == GoogEncryptionKeyHeader ||
-                    key == GoogEncryptionKeySHA256Header)
+                    key == EncryptionKey.KeyHeader ||
+                    key == EncryptionKey.KeyHashHeader)
                 {
                     continue;
                 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/project.json
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.Gax.Rest": "1.0.0-beta07",
-    "Google.Apis.Storage.v1": "1.20.0.692"
+    "Google.Apis.Storage.v1": "1.21.0.753"
   },
   "frameworks": {
     "net45": {

--- a/apis/Google.Cloud.Storage.V1/docs/index.md
+++ b/apis/Google.Cloud.Storage.V1/docs/index.md
@@ -47,3 +47,12 @@ existing objects:
 Or write-only access to put specific object content into a bucket:
 
 [!code-cs[](obj/snippets/Google.Cloud.Storage.V1.UrlSigner.txt#SignedURLPut)]
+
+## Customer-supplied encryption keys
+
+Storage objects are always stored encrypted, but if you wish to
+specify your own encryption key instead of using the server-supplied
+one, you can do so either for all operations with a particular
+`StorageClient` or on individual ones.
+
+[!code-cs[](obj/snippets/Google.Cloud.Storage.V1.StorageClient.txt#CustomerSuppliedEncryptionKeys)]


### PR DESCRIPTION
Draft of the changes to support customer-suppied encryption keys.
I haven't performed *any* testing yet, and this relies a change in the REST support libraries