### PR TITLE
Pass a label with the agent and version to all log entries

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/TraceTest.cs
@@ -24,7 +24,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-using LabelsCommon = Google.Cloud.Diagnostics.Common.Labels;
+using LabelsCommon = Google.Cloud.Diagnostics.Common.TraceLabels;
 using TraceProto = Google.Cloud.Trace.V1.Trace;
 
 namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Trace/LabelsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Trace/LabelsTest.cs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Diagnostics.Common;
 using Moq;
 using System.IO;
 using System.Web;
 using Xunit;
 
-using LabelsCommon = Google.Cloud.Diagnostics.Common.Labels;
+using LabelsCommon = Google.Cloud.Diagnostics.Common.TraceLabels;
 
 namespace Google.Cloud.Diagnostics.AspNet.Tests
 {
@@ -29,8 +30,8 @@ namespace Google.Cloud.Diagnostics.AspNet.Tests
         {
             var labels = Labels.AgentLabel;
             Assert.Single(labels);
-            Assert.Contains(LabelsCommon.AgentName, labels[LabelsCommon.Agent]);
-            Assert.Contains(LabelsCommon.GetAgentVersion(typeof(Labels)), labels[LabelsCommon.Agent]);
+            Assert.Contains(CommonUtils.AgentName, labels[LabelsCommon.Agent]);
+            Assert.Contains(CommonUtils.GetVersion(typeof(CommonUtils)), labels[LabelsCommon.Agent]);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/Labels.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/Labels.cs
@@ -17,7 +17,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Web;
 
-using LabelsCommon = Google.Cloud.Diagnostics.Common.Labels;
+using LabelsCommon = Google.Cloud.Diagnostics.Common.TraceLabels;
 
 namespace Google.Cloud.Diagnostics.AspNet
 {
@@ -29,8 +29,7 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// <summary>
         /// Gets a map with the label for the agent which contains the agent's name and version.
         /// </summary>
-        internal static Dictionary<string, string> AgentLabel { get; } =
-            LabelsCommon.GetAgentLabel(typeof(Labels));
+        internal static Dictionary<string, string> AgentLabel { get; } = LabelsCommon.GetAgentLabel();
         
         /// <summary>
         /// Gets a map of labels for a span from an <see cref="HttpRequest"/>, such as request size, method, ect.

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
@@ -103,8 +103,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTest
             Assert.Equal(2, trace.Spans.Count);
             var span = trace.Spans.First(s => s.Name.StartsWith("/Trace/Trace/"));
             Assert.NotEmpty(span.Labels);
-            Assert.Equal(span.Labels[Common.Labels.HttpMethod], "GET");
-            Assert.Equal(span.Labels[Common.Labels.HttpStatusCode], "200");
+            Assert.Equal(span.Labels[Common.TraceLabels.HttpMethod], "GET");
+            Assert.Equal(span.Labels[Common.TraceLabels.HttpStatusCode], "200");
         }
 
         [Fact]
@@ -150,8 +150,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTest
             Assert.Equal(2, trace.Spans.Count);
             var span = trace.Spans.First(s => s.Name.StartsWith("Trace"));
             Assert.Single(span.Labels);
-            Assert.Contains(nameof(TraceController), span.Labels[Common.Labels.StackTrace]);
-            Assert.Contains(nameof(TraceController.CreateStackTrace), span.Labels[Common.Labels.StackTrace]);   
+            Assert.Contains(nameof(TraceController), span.Labels[Common.TraceLabels.StackTrace]);
+            Assert.Contains(nameof(TraceController.CreateStackTrace), span.Labels[Common.TraceLabels.StackTrace]);   
         }
 
         [Fact]
@@ -259,8 +259,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTest
             Assert.NotNull(trace);
             var span = trace.Spans.First(s => s.Name.StartsWith("/Trace/ThrowException"));
             Assert.NotEmpty(span.Labels);
-            Assert.Contains(nameof(TraceController), span.Labels[Common.Labels.StackTrace]);
-            Assert.Contains(nameof(TraceController.ThrowException), span.Labels[Common.Labels.StackTrace]);
+            Assert.Contains(nameof(TraceController), span.Labels[Common.TraceLabels.StackTrace]);
+            Assert.Contains(nameof(TraceController.ThrowException), span.Labels[Common.TraceLabels.StackTrace]);
         }
     }
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/LabelsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/LabelsTest.cs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Diagnostics.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 using Xunit;
 
-using LabelsCommon = Google.Cloud.Diagnostics.Common.Labels;
+using LabelsCommon = Google.Cloud.Diagnostics.Common.TraceLabels;
 
 namespace Google.Cloud.Diagnostics.AspNetCore.Tests
 {
@@ -27,8 +28,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
         {
             var labels = Labels.AgentLabel;
             Assert.Single(labels);
-            Assert.Contains(LabelsCommon.AgentName, labels[LabelsCommon.Agent]);
-            Assert.Contains(LabelsCommon.GetAgentVersion(typeof(Labels)), labels[LabelsCommon.Agent]);
+            Assert.Contains(CommonUtils.AgentName, labels[LabelsCommon.Agent]);
+            Assert.Contains(CommonUtils.GetVersion(typeof(CommonUtils)), labels[LabelsCommon.Agent]);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/Labels.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/Labels.cs
@@ -18,7 +18,7 @@ using Microsoft.AspNetCore.Http.Internal;
 using System.Collections.Generic;
 using System.Linq;
 
-using LabelsCommon = Google.Cloud.Diagnostics.Common.Labels;
+using LabelsCommon = Google.Cloud.Diagnostics.Common.TraceLabels;
 
 namespace Google.Cloud.Diagnostics.AspNetCore
 {
@@ -30,8 +30,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <summary>
         /// Gets a map with the label for the agent which contains the agent's name and version.
         /// </summary>
-        internal static Dictionary<string, string> AgentLabel { get; } =
-            LabelsCommon.GetAgentLabel(typeof(Labels));
+        internal static Dictionary<string, string> AgentLabel { get; } = LabelsCommon.GetAgentLabel();
 
         /// <summary>
         /// Gets a map of labels for a span from an <see cref="HttpContext"/>, such as request size,

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/CommonUtilsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/CommonUtilsTest.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Google.Cloud.Diagnostics.Common.Tests
+{
+    public class CommonUtilsTest
+    {
+        [Fact]
+        public void AgentNameAndVersion()
+        {
+            Assert.Contains(CommonUtils.AgentName, CommonUtils.AgentNameAndVersion);
+            Assert.Contains(CommonUtils.GetVersion(typeof(CommonUtils)), CommonUtils.AgentNameAndVersion);
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Logging/GrpcLogConsumerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Logging/GrpcLogConsumerTest.cs
@@ -28,8 +28,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         {
             var logs = new[] { new LogEntry(), new LogEntry() };
             var mockClient = new Mock<LoggingServiceV2Client>();
-            mockClient.Setup(c => c.WriteLogEntries(
-                null, null, It.IsAny<IDictionary<string, string>>(), logs, null));
+            mockClient.Setup(c => c.WriteLogEntries(null, null, LogLabels.AgentLabel, logs, null));
             var consumer = new GrpcLogConsumer(mockClient.Object);
 
             consumer.Receive(logs);
@@ -43,8 +42,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             var consumer = new GrpcLogConsumer(mockClient.Object);
 
             consumer.Receive(new LogEntry[] { });
-            mockClient.Verify(c => c.WriteLogEntries(
-                null, null, It.IsAny<IDictionary<string, string>>(),
+            mockClient.Verify(c => c.WriteLogEntries(null, null, LogLabels.AgentLabel,
                 It.IsAny<IEnumerable<LogEntry>>(), null), Times.Never());
         }
 
@@ -55,7 +53,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             var mockClient = new Mock<LoggingServiceV2Client>();
             var task = Task.FromResult(new WriteLogEntriesRequest());
             mockClient.Setup(c => c.WriteLogEntriesAsync(
-                null, null, It.IsAny<IDictionary<string, string>>(), logs, CancellationToken.None))
+                null, null, LogLabels.AgentLabel, logs, CancellationToken.None))
                 .Returns(Task.FromResult(new WriteLogEntriesResponse()));
             var consumer = new GrpcLogConsumer(mockClient.Object);
 
@@ -70,8 +68,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             var consumer = new GrpcLogConsumer(mockClient.Object);
 
             await consumer.ReceiveAsync(new LogEntry[] { }, CancellationToken.None);
-            mockClient.Verify(c => c.WriteLogEntriesAsync(
-                null, null, It.IsAny<IDictionary<string, string>>(),
+            mockClient.Verify(c => c.WriteLogEntriesAsync(null, null, LogLabels.AgentLabel,
                 It.IsAny<IEnumerable<LogEntry>>(), CancellationToken.None), Times.Never());
         }
     }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Logging/LogLabelsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Logging/LogLabelsTest.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Google.Cloud.Diagnostics.Common.Tests
+{
+    public class LogLabelsTest
+    {
+        [Fact]
+        public void AgentLabel()
+        {
+            var labels = LogLabels.AgentLabel;
+            Assert.Single(labels);
+            Assert.Contains(CommonUtils.AgentName, labels[LogLabels.Agent]);
+            Assert.Contains(CommonUtils.GetVersion(typeof(CommonUtils)), labels[LogLabels.Agent]);
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
@@ -144,7 +144,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             mockConsumer.Setup(c => c.Receive(
                 Match.Create<IEnumerable<TraceProto>>(
                     t => IsValidSpan(t.Single().Spans.Single(), "span-name") &&
-                        !string.IsNullOrWhiteSpace(t.ElementAt(0).Spans[0].Labels[Labels.StackTrace]))));
+                        !string.IsNullOrWhiteSpace(t.ElementAt(0).Spans[0].Labels[TraceLabels.StackTrace]))));
 
             tracer.StartSpan("span-name");
             tracer.SetStackTrace(FilledStackTrace);
@@ -170,7 +170,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
                     IsValidSpan(spans[2], "grandchild-two", spans[3].SpanId) &&
                     TraceUtils.IsValidAnnotation(spans[2], annotation) &&
                     IsValidSpan(spans[3], "child-two", spans[4].SpanId) &&
-                    !string.IsNullOrWhiteSpace(spans[0].Labels[Labels.StackTrace]) &&
+                    !string.IsNullOrWhiteSpace(spans[0].Labels[TraceLabels.StackTrace]) &&
                     IsValidSpan(spans[4], "root");
             };
             mockConsumer.Setup(c => c.Receive(Match.Create(matcher)));

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/TraceLabelsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/TraceLabelsTest.cs
@@ -20,7 +20,7 @@ using Xunit;
 
 namespace Google.Cloud.Diagnostics.Common.Tests
 {
-    public class LabelsTest
+    public class TraceLabelsTest
     {
         [Fact]
         public void FromStackTrace()
@@ -41,9 +41,9 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             stackTraceMock.Setup(t => t.GetFrames()).Returns(new StackFrame[] {
                 frameRequest.Object, frameResponse.Object, frameStack.Object });
 
-            var labels = Labels.FromStackTrace(stackTraceMock.Object);
+            var labels = TraceLabels.FromStackTrace(stackTraceMock.Object);
             Assert.Equal(1, labels.Count);
-            string jsonTrace = labels[Labels.StackTrace];
+            string jsonTrace = labels[TraceLabels.StackTrace];
 
             Assert.Equal(Regex.Matches(jsonTrace, "stack_frame").Count, 1);
             Assert.Equal(Regex.Matches(jsonTrace, "class_name").Count, 3);
@@ -66,9 +66,9 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             var stackTraceMock = new Mock<StackTrace>();
             stackTraceMock.Setup(t => t.GetFrames()).Returns(new StackFrame[] { });
 
-            var labels = Labels.FromStackTrace(stackTraceMock.Object);
+            var labels = TraceLabels.FromStackTrace(stackTraceMock.Object);
             Assert.Equal(1, labels.Count);
-            Assert.Equal(string.Empty, labels[Labels.StackTrace]);
+            Assert.Equal(string.Empty, labels[TraceLabels.StackTrace]);
         }
 
         [Fact]
@@ -77,9 +77,9 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             var stackTraceMock = new Mock<StackTrace>();
             stackTraceMock.Setup(t => t.GetFrames()).Returns((StackFrame[]) null);
 
-            var labels = Labels.FromStackTrace(stackTraceMock.Object);
+            var labels = TraceLabels.FromStackTrace(stackTraceMock.Object);
             Assert.Equal(1, labels.Count);
-            Assert.Equal(string.Empty, labels[Labels.StackTrace]);
+            Assert.Equal(string.Empty, labels[TraceLabels.StackTrace]);
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/CommonUtils.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/CommonUtils.cs
@@ -19,17 +19,17 @@ namespace Google.Cloud.Diagnostics.Common
 {
     internal static class CommonUtils
     {
-        /// <summary>A completed <see cref="Task"/>.</summary>
-        internal readonly static Task CompletedTask = Task.FromResult(false);
-
         /// <summary>The name of the this agent.</summary>
         internal const string AgentName = "google-cloud-csharp-diagnostics";
+
+        /// <summary>A completed <see cref="Task"/>.</summary>
+        internal readonly static Task CompletedTask = Task.FromResult(false);
 
         /// <summary>
         /// The agent name <see cref="AgentName"/> and version of the agent in the
         /// format "[agent-name] [agent-version]".
         /// </summary>
-        internal static string AgentNameAndVersion = $"{AgentName} {GetVersion(typeof(CommonUtils))}";
+        internal readonly static string AgentNameAndVersion = $"{AgentName} {GetVersion(typeof(CommonUtils))}";
 
         /// <summary>Gets the version of the current library using reflection.</summary>
         internal static string GetVersion(System.Type type) =>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/CommonUtils.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/CommonUtils.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Google.Cloud.Diagnostics.Common
@@ -20,5 +21,14 @@ namespace Google.Cloud.Diagnostics.Common
     {
         /// <summary>A completed <see cref="Task"/>.</summary>
         internal readonly static Task CompletedTask = Task.FromResult(false);
+
+        /// <summary>Gets the version of the current library using reflection.</summary>
+        internal static string GetVersion(System.Type type)
+        {
+            return type.GetTypeInfo()
+                .Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                .InformationalVersion;
+        }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/CommonUtils.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/CommonUtils.cs
@@ -22,13 +22,21 @@ namespace Google.Cloud.Diagnostics.Common
         /// <summary>A completed <see cref="Task"/>.</summary>
         internal readonly static Task CompletedTask = Task.FromResult(false);
 
+        /// <summary>The name of the this agent.</summary>
+        internal const string AgentName = "google-cloud-csharp-diagnostics";
+
+        /// <summary>
+        /// The agent name <see cref="AgentName"/> and version of the agent in the
+        /// format "[agent-name] [agent-version]".
+        /// </summary>
+        internal static string AgentNameAndVersion = $"{AgentName} {GetVersion(typeof(CommonUtils))}";
+
         /// <summary>Gets the version of the current library using reflection.</summary>
-        internal static string GetVersion(System.Type type)
-        {
-            return type.GetTypeInfo()
+        internal static string GetVersion(System.Type type) =>
+            type.GetTypeInfo()
                 .Assembly
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                 .InformationalVersion;
-        }
+        
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Logging/GrpcLogConsumer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Logging/GrpcLogConsumer.cs
@@ -26,9 +26,6 @@ namespace Google.Cloud.Diagnostics.Common
     /// </summary>
     internal sealed class GrpcLogConsumer : IConsumer<LogEntry>
     {
-        /// <summary>An empty dictionary used for labels.</summary>
-        private static readonly IDictionary<string, string> EmptyDictionary = new Dictionary<string, string>();
-
         private LoggingServiceV2Client _client;
 
         /// <param name="client">The logging client that will push logs to the Stackdriver Logging API.</param>
@@ -45,7 +42,7 @@ namespace Google.Cloud.Diagnostics.Common
             {
                 return;
             }
-            _client.WriteLogEntries(null, null, EmptyDictionary, logs);
+            _client.WriteLogEntries(null, null, LogLabels.AgentLabel, logs);
         }
 
         /// <inheritdoc />
@@ -57,7 +54,7 @@ namespace Google.Cloud.Diagnostics.Common
             {
                 return CommonUtils.CompletedTask;
             }
-            return _client.WriteLogEntriesAsync(null, null, EmptyDictionary, logs, cancellationToken);
+            return _client.WriteLogEntriesAsync(null, null, LogLabels.AgentLabel, logs, cancellationToken);
         }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Logging/LogLabels.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Logging/LogLabels.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace Google.Cloud.Diagnostics.Common
+{
+    internal static class LogLabels
+    {
+        ///<summary>The label key to denote this agent.</summary> 
+        public const string Agent = "agent";
+
+        /// <summary>
+        /// Gets a map with the label for the agent which contains the agent's name and version.
+        /// </summary>
+        public static Dictionary<string, string> AgentLabel { get; } =
+            new Dictionary<string, string> { { Agent, CommonUtils.AgentNameAndVersion } };
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/Labels.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/Labels.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using System.Text;
 
 namespace Google.Cloud.Diagnostics.Common
 {
@@ -64,16 +63,8 @@ namespace Google.Cloud.Diagnostics.Common
         /// Gets a map with the label for the agent which contains the agent's name and version.
         /// </summary>
         internal static Dictionary<string, string> GetAgentLabel(System.Type type) =>
-            new Dictionary<string, string> { { Agent, $"{AgentName} {GetAgentVersion(type)}" } };
+            new Dictionary<string, string> { { Agent, $"{AgentName} {CommonUtils.GetVersion(type)}" } };
 
-        /// <summary>Gets the version of the current library using reflection.</summary>
-        internal static string GetAgentVersion(System.Type type)
-        {
-            return type.GetTypeInfo()
-                .Assembly
-                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-                .InformationalVersion;
-        }
 
         /// <summary>
         /// Creates a string JSON representation of a stack trace or the empty string

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
@@ -135,7 +135,7 @@ namespace Google.Cloud.Diagnostics.Common
             GaxPreconditions.CheckNotNull(stackTrace, nameof(stackTrace));
             CheckStackNotEmpty();
 
-            AnnotateSpan(Labels.FromStackTrace(stackTrace));
+            AnnotateSpan(TraceLabels.FromStackTrace(stackTrace));
         }
 
         /// <inheritdoc />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceLabels.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceLabels.cs
@@ -17,18 +17,14 @@ using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
 
 namespace Google.Cloud.Diagnostics.Common
 {
     /// <summary>
     /// A helper class to handle span labels.
     /// </summary>
-    internal static class Labels
+    internal static class TraceLabels
     {
-        /// <summary>The name of the trace agent.</summary>
-        internal const string AgentName = "google-cloud-csharp-trace";
-
         ///<summary>The label to denote the size of a request.</summary> 
         internal const string HttpRequestSize = "trace.cloud.google.com/http/request/size";
 
@@ -62,8 +58,8 @@ namespace Google.Cloud.Diagnostics.Common
         /// <summary>
         /// Gets a map with the label for the agent which contains the agent's name and version.
         /// </summary>
-        internal static Dictionary<string, string> GetAgentLabel(System.Type type) =>
-            new Dictionary<string, string> { { Agent, $"{AgentName} {CommonUtils.GetVersion(type)}" } };
+        internal static Dictionary<string, string> GetAgentLabel() =>
+            new Dictionary<string, string> { { Agent, CommonUtils.AgentNameAndVersion } };
 
 
         /// <summary>


### PR DESCRIPTION
This will allow the agent that is sending logs to be recorded.