### PR TITLE
More exhaustive checking of types for BigQuery

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryFixture.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryFixture.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.Bigquery.v2.Data;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -41,6 +42,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
         public string HighScoreTableId { get; } = "highscores";
         public string PeopleTableId { get; } = "people";
         public string ComplexTypesTableId { get; } = "complex";
+        public string ExhaustiveTypesTableId { get; } = "exhaustive";
 
         public BigQueryFixture()
         {
@@ -63,6 +65,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             CreateHighScoreTable(dataset);
             CreatePeopleTable(dataset);
             CreateComplexTypesTable(dataset);
+            CreateExhaustiveTypesTable(dataset);
         }
 
         private void CreateHighScoreTable(BigQueryDataset dataset)
@@ -163,6 +166,51 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
                     BigQueryFieldMode.Repeated
                 }
             }.Build());
+        }
+
+        private void CreateExhaustiveTypesTable(BigQueryDataset dataset)
+        {
+            // Record containing a single string, a repeated string and a nested record
+            TableSchema recordSchema = new TableSchemaBuilder
+            {
+                { "single_string", BigQueryDbType.String },
+                { "repeated_string", BigQueryDbType.String, BigQueryFieldMode.Repeated },
+                { "nested_record",
+                    new TableSchemaBuilder {    
+                        { "a", BigQueryDbType.Int64 },
+                        { "b", BigQueryDbType.Int64 },
+                    }
+                }
+            }.Build();
+
+            var table = dataset.CreateTable(ExhaustiveTypesTableId, new TableSchemaBuilder
+            {
+                // Single fields
+                { "single_string", BigQueryDbType.String },
+                { "single_bool", BigQueryDbType.Bool },
+                { "single_bytes", BigQueryDbType.Bytes },
+                { "single_date", BigQueryDbType.Date },
+                { "single_datetime", BigQueryDbType.DateTime },
+                { "single_time", BigQueryDbType.Time },
+                { "single_timestamp", BigQueryDbType.Timestamp },
+                { "single_int64", BigQueryDbType.Int64 },
+                { "single_float64", BigQueryDbType.Float64 },
+                { "single_record", recordSchema },
+                
+                // Repeated fields
+                { "array_string", BigQueryDbType.String, BigQueryFieldMode.Repeated },
+                { "array_bool", BigQueryDbType.Bool, BigQueryFieldMode.Repeated },
+                { "array_bytes", BigQueryDbType.Bytes, BigQueryFieldMode.Repeated },
+                { "array_date", BigQueryDbType.Date, BigQueryFieldMode.Repeated },
+                { "array_datetime", BigQueryDbType.DateTime, BigQueryFieldMode.Repeated },
+                { "array_time", BigQueryDbType.Time, BigQueryFieldMode.Repeated },
+                { "array_timestamp", BigQueryDbType.Timestamp, BigQueryFieldMode.Repeated },
+                { "array_int64", BigQueryDbType.Int64, BigQueryFieldMode.Repeated },
+                { "array_float64", BigQueryDbType.Float64, BigQueryFieldMode.Repeated },
+                { "array_record", recordSchema, BigQueryFieldMode.Repeated },                
+            }.Build());
+
+            table.Insert(ExhaustiveTypesTest.GetSampleRow());
         }
 
         internal List<string> LoadTextResource(string relativeName)

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/ExhaustiveTypesTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/ExhaustiveTypesTest.cs
@@ -1,0 +1,221 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Google.Cloud.BigQuery.V2.IntegrationTests
+{
+    /// <summary>
+    /// Check that we can handle every type, for all operations.
+    /// </summary>
+    [Collection(nameof(BigQueryFixture))]
+    public class ExhaustiveTypesTest
+    {
+        private readonly BigQueryFixture _fixture;
+
+        public ExhaustiveTypesTest(BigQueryFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        // No explicit tests for InsertRow or CreateTable - they are implicitly tested
+        // by us being able to create and populate the table in the fixture setup.
+
+        [Fact]
+        public void StandardQuery()
+        {
+            var table = GetTable();
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var rows = client.ExecuteQuery($"SELECT * FROM {table}").GetRows().ToList();
+            ValidateRows(rows);
+        }
+
+        [Fact]
+        public void ListRows()
+        {
+            var rows = GetTable().ListRows().ToList();
+            ValidateRows(rows);
+        }
+
+        private void ValidateRows(List<BigQueryRow> rows)
+        {
+            Assert.Equal(1, rows.Count);
+            var row = rows[0];
+            Assert.Equal("single string value", (string) row["single_string"]);
+            Assert.Equal(true, (bool) row["single_bool"]);
+            Assert.Equal(Encoding.UTF8.GetBytes("some bytes"), (byte[]) row["single_bytes"]);
+            AssertDateTimeEqual(new DateTime(2017, 2, 14, 0, 0, 0, DateTimeKind.Unspecified), (DateTime) row["single_date"]);
+            AssertDateTimeEqual(new DateTime(2017, 2, 14, 10, 11, 12, DateTimeKind.Unspecified), (DateTime) row["single_datetime"]);
+            Assert.Equal(new TimeSpan(12, 15, 22) + TimeSpan.FromTicks(1234560), (TimeSpan) row["single_time"]);
+            AssertDateTimeEqual(new DateTime(2017, 1, 20, 5, 6, 37, DateTimeKind.Utc) + TimeSpan.FromTicks(6543210), (DateTime) row["single_timestamp"]);
+            Assert.Equal(123456789012L, (long) row["single_int64"]);
+            Assert.Equal(1.25, (double) row["single_float64"]);
+
+            var singleRecord = (Dictionary<string, object>) row["single_record"];
+            Assert.Equal("nested string", (string) singleRecord["single_string"]);
+            Assert.Equal(new[] { "nested string 1", "nested string 2" }, (string[]) singleRecord["repeated_string"]);
+            var nestedRecord = (Dictionary<string, object>) singleRecord["nested_record"];
+            Assert.Equal(-10L, (long) nestedRecord["a"]);
+            Assert.Equal(20L, (long) nestedRecord["b"]);
+
+            Assert.Equal(new[] { "array string value 1", "array string value 2" }, (string[]) row["array_string"]);
+            Assert.Equal(new[] { true, false }, (bool[]) row["array_bool"]);
+            Assert.Equal(new[] { Encoding.UTF8.GetBytes("bytes1"), Encoding.UTF8.GetBytes("bytes2") }, (byte[][]) row["array_bytes"]);
+            AssertDateTimesEqual(
+                new[] { new DateTime(2017, 2, 15), new DateTime(2017, 2, 16) },
+                (DateTime[]) row["array_date"]);
+            AssertDateTimesEqual(
+                new[] { new DateTime(2017, 2, 15, 10, 11, 12, DateTimeKind.Unspecified), new DateTime(2017, 2, 16, 10, 11, 12, DateTimeKind.Unspecified) },
+                (DateTime[]) row["array_datetime"]);
+            Assert.Equal(new[] { new TimeSpan(12, 15, 22), new TimeSpan(10, 53, 10) }, (TimeSpan[]) row["array_time"]);
+            AssertDateTimesEqual(
+                new[] { new DateTime(2017, 3, 20, 5, 6, 37, DateTimeKind.Utc), new DateTime(2017, 4, 20, 5, 6, 37, DateTimeKind.Utc) },
+                (DateTime[]) row["array_timestamp"]);
+            Assert.Equal(new [] { 1234567890123L, 12345678901234L }, (long[]) row["array_int64"]);
+            Assert.Equal(new[] { -1.25, 2.5 }, (double[]) row["array_float64"]);
+
+            var arrayRecords = (Dictionary<string, object>[]) row["array_record"];
+
+            Assert.Equal("array record string 1", (string) arrayRecords[0]["single_string"]);
+            Assert.Equal(new[] { "array record string 1.1", "array record string 1.2" }, (string[]) arrayRecords[0]["repeated_string"]);
+            nestedRecord = (Dictionary<string, object>) arrayRecords[0]["nested_record"];
+            Assert.Equal(-100L, (long) nestedRecord["a"]);
+            Assert.Equal(200L, (long) nestedRecord["b"]);
+
+            Assert.Equal("array record string 2", (string) arrayRecords[1]["single_string"]);
+            Assert.Equal(new[] { "array record string 2.1", "array record string 2.2" }, (string[]) arrayRecords[1]["repeated_string"]);
+            nestedRecord = (Dictionary<string, object>) arrayRecords[1]["nested_record"];
+            Assert.Equal(-1000L, (long) nestedRecord["a"]);
+            Assert.Equal(2000L, (long) nestedRecord["b"]);
+        }
+
+        [Fact]
+        public void QueryParameters()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.String, "foo"));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Bool, true));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Int64, 123456L));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Float64, 123.75));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Bytes, new byte[] { 1, 2, 3, 4 }));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Date, new DateTime(2017, 2, 14)));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.DateTime, new DateTime(2017, 2, 14, 17, 25, 30, DateTimeKind.Unspecified)));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Timestamp, new DateTime(2017, 2, 14, 17, 25, 30, DateTimeKind.Utc)));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Time, new TimeSpan(0, 1, 2, 3, 456)));
+
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array, new[] { "foo", "bar" }));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array, new[] { true, false }));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array, new[] { 123456L, -1234L }));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array, new[] { 123.75, 10.5 }));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array, new[] { new byte[] { 1, 2, 3, 4 }, new byte[] { 255, 254, 253, 252 } }));
+            // Date/DateTime/Timestamp arrays need to be given the types explicitly.
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array,
+                new[] { new DateTime(2017, 2, 14), new DateTime(2017, 2, 15) })
+                { ArrayType = BigQueryDbType.Date });
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array,
+                new[] { new DateTime(2017, 2, 14, 17, 25, 30, DateTimeKind.Unspecified), new DateTime(2017, 2, 15, 17, 25, 30, DateTimeKind.Unspecified) })
+                { ArrayType = BigQueryDbType.DateTime });
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array,
+                new[] { new DateTime(2017, 2, 14, 17, 25, 30, DateTimeKind.Utc), new DateTime(2017, 2, 15, 17, 25, 30, DateTimeKind.Utc) })
+                { ArrayType = BigQueryDbType.Timestamp });
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array,
+                new[] { new TimeSpan(0, 1, 2, 3, 456), new TimeSpan(0, 23, 59, 59, 987) }));
+        }
+
+        private void AssertParameterRoundTrip(BigQueryClient client, BigQueryParameter parameter)
+        {
+            var command = new BigQueryCommand($"SELECT ? AS value")
+            {
+                Parameters = { parameter },
+                ParameterMode = BigQueryParameterMode.Positional
+            };
+            var results = client.ExecuteQuery(command).GetRows().ToList();
+            Assert.Equal(1, results.Count);
+            Assert.Equal(parameter.Value, results[0]["value"]);
+            if (parameter.Value is DateTime)
+            {
+                AssertDateTimeEqual((DateTime) parameter.Value, (DateTime) results[0]["value"]);
+            }
+        }
+
+        // Assertion for DateTime, including the Kind.
+        private void AssertDateTimeEqual(DateTime expected, DateTime actual)
+        {
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.Kind, actual.Kind);
+        }
+
+        private void AssertDateTimesEqual(DateTime[] expected, DateTime[] actual)
+        {
+            foreach (var pair in expected.Zip(actual, (e, a) => new { e, a }))
+            {
+                AssertDateTimeEqual(pair.e, pair.a);
+            }
+        }
+
+        private BigQueryTable GetTable()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            return client.GetTable(_fixture.DatasetId, _fixture.ExhaustiveTypesTableId);
+        }
+
+        // Here rather than in the fixture (where it's used) for ease of writing/checking the tests above.
+        internal static BigQueryInsertRow GetSampleRow() => new BigQueryInsertRow
+        {
+            ["single_string"] = "single string value",
+            ["single_bool"] = true,
+            ["single_bytes"] = Encoding.UTF8.GetBytes("some bytes"),
+            ["single_date"] = new DateTime(2017, 2, 14).AsBigQueryDate(),
+            ["single_datetime"] = new DateTime(2017, 2, 14, 10, 11, 12, DateTimeKind.Unspecified),
+            ["single_time"] = new TimeSpan(12, 15, 22) + TimeSpan.FromTicks(1234560), // 10 ticks per microsecond
+            ["single_timestamp"] = new DateTime(2017, 1, 20, 5, 6, 37, DateTimeKind.Utc) + TimeSpan.FromTicks(6543210),
+            ["single_int64"] = 123456789012L, // Larger than an int32
+            ["single_float64"] = 1.25,
+            ["single_record"] = new BigQueryInsertRow
+            {
+                ["single_string"] = "nested string",
+                ["repeated_string"] = new[] { "nested string 1", "nested string 2" },
+                ["nested_record"] = new BigQueryInsertRow { ["a"] = -10, ["b"] = 20 }
+            },
+
+            ["array_string"] = new[] { "array string value 1", "array string value 2" },
+            ["array_bool"] = new[] { true, false },
+            ["array_bytes"] = new[] { Encoding.UTF8.GetBytes("bytes1"), Encoding.UTF8.GetBytes("bytes2") },
+            ["array_date"] = new[] { new DateTime(2017, 2, 15).AsBigQueryDate(), new DateTime(2017, 2, 16).AsBigQueryDate() },
+            ["array_datetime"] = new[] { new DateTime(2017, 2, 15, 10, 11, 12, DateTimeKind.Unspecified), new DateTime(2017, 2, 16, 10, 11, 12, DateTimeKind.Unspecified) },
+            ["array_time"] = new[] { new TimeSpan(12, 15, 22), new TimeSpan(10, 53, 10) },
+            ["array_timestamp"] = new[] { new DateTime(2017, 3, 20, 5, 6, 37, DateTimeKind.Utc), new DateTime(2017, 4, 20, 5, 6, 37, DateTimeKind.Utc) },
+            ["array_int64"] = new[] { 1234567890123L, 12345678901234L },
+            ["array_float64"] = new[] { -1.25, 2.5 },
+            ["array_record"] = new[] {
+                    new BigQueryInsertRow
+                    {
+                        ["single_string"] = "array record string 1",
+                        ["repeated_string"] = new[] { "array record string 1.1", "array record string 1.2" },
+                        ["nested_record"] = new BigQueryInsertRow { ["a"] = -100, ["b"] = 200 }
+                    },
+                    new BigQueryInsertRow
+                    {
+                        ["single_string"] = "array record string 2",
+                        ["repeated_string"] = new[] { "array record string 2.1", "array record string 2.2" },
+                        ["nested_record"] = new BigQueryInsertRow { ["a"] = -1000, ["b"] = 2000 }
+                    },
+                }
+        };
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryInsertRowTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryInsertRowTest.cs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using Xunit;
 
 namespace Google.Cloud.BigQuery.V2.Tests
 {
-    public class InsertRowTest
+    public class BigQueryInsertRowTest
     {
         [Fact]
         public void InsertId()
@@ -103,18 +102,42 @@ namespace Google.Cloud.BigQuery.V2.Tests
                 { "field", new DateTimeOffset(2000, 1, 1, 5, 0, 0, TimeSpan.FromHours(2)) },
             };
             var rowData = row.ToRowsData();
-            Assert.Equal("2000-01-01 03:00:00Z", rowData.Json["field"]);
+            Assert.Equal("2000-01-01T03:00:00Z", rowData.Json["field"]);
         }
 
         [Fact]
-        public void DateTimeFormatting()
+        public void TimeSpan_Invalid()
+        {
+            AssertInvalid("field", TimeSpan.FromTicks(-1L));
+            AssertInvalid("field", TimeSpan.FromDays(1));
+        }
+
+        [Fact]
+        public void LocalDateTimeRejection()
+        {
+            AssertInvalid("field", new DateTime(2000, 1, 1, 5, 0, 0, DateTimeKind.Local));
+        }
+
+        [Fact]
+        public void UnspecifiedDateTimeFormatting()
+        {
+            var row = new BigQueryInsertRow
+            {
+                { "field", new DateTime(2000, 1, 1, 5, 0, 0, DateTimeKind.Unspecified) },
+            };
+            var rowData = row.ToRowsData();
+            Assert.Equal("2000-01-01T05:00:00", rowData.Json["field"]);
+        }
+
+        [Fact]
+        public void UtcDateTimeFormatting()
         {
             var row = new BigQueryInsertRow
             {
                 { "field", new DateTime(2000, 1, 1, 5, 0, 0, DateTimeKind.Utc) },
             };
             var rowData = row.ToRowsData();
-            Assert.Equal("2000-01-01 05:00:00Z", rowData.Json["field"]);
+            Assert.Equal("2000-01-01T05:00:00Z", rowData.Json["field"]);
         }
 
         [Fact]

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryParameterTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryParameterTest.cs
@@ -119,7 +119,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             // Timestamp
             ScalarTest("Timestamp parameter, DateTime value (UTC)", BigQueryDbType.Timestamp,
                 new DateTime(2016, 10, 31, 1, 2, 3, 123, DateTimeKind.Utc).AddTicks(4567),
-                "2016-10-31 01:02:03.123456"), // UTC is implicit
+                "2016-10-31 01:02:03.123456+00"),
             ScalarTest("Timestamp parameter, DateTimeOffset value positive offset", BigQueryDbType.Timestamp,
                 new DateTimeOffset(2016, 10, 31, 0, 0, 0, TimeSpan.FromHours(2)), "2016-10-31 00:00:00+02:00"),
             ScalarTest("Timestamp parameter, DateTimeOffset value negative offset", BigQueryDbType.Timestamp,
@@ -209,7 +209,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var parameter = new BigQueryParameter();
             parameter.Value = value;
             var queryParameter = parameter.ToQueryParameter(BigQueryParameterMode.Positional);
-            Assert.Equal(EnumMap.ToApiValue(BigQueryDbType.Array), queryParameter.ParameterType.Type);
+            Assert.Equal(BigQueryDbType.Array.ToParameterApiType(), queryParameter.ParameterType.Type);
             var actualArrayType = EnumMap<BigQueryDbType>.ToValue(queryParameter.ParameterType.ArrayType.Type);
             Assert.Equal(expectedArrayType, actualArrayType);
         }
@@ -255,8 +255,8 @@ namespace Google.Cloud.BigQuery.V2.Tests
             {
                 ParameterType = new QueryParameterType
                 {
-                    Type = EnumMap.ToApiValue(BigQueryDbType.Array),
-                    ArrayType = new QueryParameterType { Type = EnumMap.ToApiValue(BigQueryDbType.DateTime) }
+                    Type = BigQueryDbType.Array.ToParameterApiType(),
+                    ArrayType = new QueryParameterType { Type = BigQueryDbType.DateTime.ToParameterApiType() }
                 },
                 ParameterValue = new QueryParameterValue
                 {
@@ -296,7 +296,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
         private static QueryParameter ScalarParameter(BigQueryDbType type, string value) =>
             new QueryParameter
             {
-                ParameterType = new QueryParameterType { Type = EnumMap.ToApiValue(type) },
+                ParameterType = new QueryParameterType { Type = type.ToParameterApiType() },
                 ParameterValue = new QueryParameterValue { Value = value }
             };
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDateTimeExtensions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDateTimeExtensions.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Globalization;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// Extension methods for <c>System.DateTime</c> and <c>System.DateTimeOffset</c> for use with BigQuery.
+    /// </summary>
+    public static class BigQueryDateTimeExtensions
+    {
+        /// <summary>
+        /// Returns the given date and time formatted as BigQuery expects date values to be formatted.
+        /// </summary>
+        /// <param name="value">The date/time value to extract the date from.</param>
+        /// <returns>The date in yyyy-MM-dd format.</returns>
+        public static string AsBigQueryDate(this DateTime value) =>
+            value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        /// <summary>
+        /// Returns the given date and time formatted as BigQuery expects date values to be formatted.
+        /// The "local" value of the <c>DateTimeOffset</c> is used; it is not converted to UTC.
+        /// </summary>
+        /// <param name="value">The date/time offset value to extract the date from.</param>
+        /// <returns>The date in yyyy-MM-dd format.</returns>
+        public static string AsBigQueryDate(this DateTimeOffset value) =>
+            value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDbType.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDbType.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Generic;
+
 namespace Google.Cloud.BigQuery.V2
 {
     /// <summary>
@@ -75,5 +77,28 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         [ApiValue("RECORD")]
         Struct
+    }
+
+    internal static class BigQueryDbTypeExtensions
+    {
+        // The names given in query parameters aren't always the same as the names in the rest of the API.
+        // (BOOL is BOOLEAN elsewhere, for example.) We could use another attribute, but a dictionary
+        // is a bit simpler.
+        private static Dictionary<BigQueryDbType, string> s_typeToNameMapping = new Dictionary<BigQueryDbType, string>
+        {
+            { BigQueryDbType.Int64, "INTEGER" },
+            { BigQueryDbType.Float64, "FLOAT" },
+            { BigQueryDbType.Bool, "BOOL" },
+            { BigQueryDbType.String, "STRING" },
+            { BigQueryDbType.Bytes, "BYTES" },
+            { BigQueryDbType.Date, "DATE" },
+            { BigQueryDbType.DateTime, "DATETIME" },
+            { BigQueryDbType.Time, "TIME" },
+            { BigQueryDbType.Timestamp, "TIMESTAMP" },
+            { BigQueryDbType.Array, "ARRAY" },
+            { BigQueryDbType.Struct, "STRUCT" }
+        };
+
+        internal static string ToParameterApiType(this BigQueryDbType type) => s_typeToNameMapping[type];
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameter.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameter.cs
@@ -227,7 +227,7 @@ namespace Google.Cloud.BigQuery.V2
             var parameter = new QueryParameter
             {
                 Name = Name,
-                ParameterType = new QueryParameterType { Type = EnumMap.ToApiValue(type) },
+                ParameterType = new QueryParameterType { Type = type.ToParameterApiType() },
             };
             switch (type)
             {
@@ -242,8 +242,8 @@ namespace Google.Cloud.BigQuery.V2
                         ?? parameter.PopulateScalar<string>(value, x => x)
                         ?? parameter.UseNullScalarOrThrow(value);
                 case BigQueryDbType.Date:
-                    return parameter.PopulateScalar<DateTime>(value, x => x.ToString("yyyy-MM-dd", InvariantCulture))
-                        ?? parameter.PopulateScalar<DateTimeOffset>(value, x => x.ToString("yyyy-MM-dd", InvariantCulture))
+                    return parameter.PopulateScalar<DateTime>(value, x => x.AsBigQueryDate())
+                        ?? parameter.PopulateScalar<DateTimeOffset>(value, x => x.AsBigQueryDate())
                         ?? parameter.PopulateScalar<string>(value, x => x)
                         ?? parameter.UseNullScalarOrThrow(value);
                 case BigQueryDbType.DateTime:
@@ -277,7 +277,7 @@ namespace Google.Cloud.BigQuery.V2
                             {
                                 throw new InvalidOperationException($"A DateTime with a Kind of {x.Kind} cannot be used for a Timestamp parameter");
                             }
-                            return x.ToString("yyyy-MM-dd HH:mm:ss.FFFFFF");
+                            return x.ToString("yyyy-MM-dd HH:mm:ss.FFFFFF+00", InvariantCulture);
                         })
                         ?? parameter.PopulateScalar<DateTimeOffset>(value, x => x.ToString("yyyy-MM-dd HH:mm:ss.FFFFFFzzz", InvariantCulture))
                         ?? parameter.PopulateScalar<string>(value, x => x)
@@ -329,8 +329,8 @@ namespace Google.Cloud.BigQuery.V2
             BigQueryDbType actualArrayType = arrayType ?? s_typeMapping[GetArrayElementType(value)];
             parameter.ParameterType = new QueryParameterType
             {
-                Type = EnumMap.ToApiValue(BigQueryDbType.Array),
-                ArrayType = new QueryParameterType { Type = EnumMap.ToApiValue(actualArrayType) }
+                Type = BigQueryDbType.Array.ToParameterApiType(),
+                ArrayType = new QueryParameterType { Type = actualArrayType.ToParameterApiType() }
             };
             var parameterValues = values
                 .Select(p => new BigQueryParameter(actualArrayType, p).ToQueryParameter(BigQueryParameterMode.Positional).ParameterValue)


### PR DESCRIPTION
- Check that all types can be inserted
- Check that all types can be queried
- Check that all types can round-trip as parameters

Fixes are needed for some of these:

- Support for DateTime, Date and Time parameters
- Change how DateTime values are handled in general - no implicit
  conversion to UTC.
- Change the type used in JSON for Boolean parameters

Fixes #771.