### PR TITLE
Change Google.Cloud.ErrorReporting.V1Beta1 target to be project

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/project.json
@@ -18,7 +18,7 @@
     "Microsoft.Owin.Host.HttpListener": "3.0.1",
     "Microsoft.Owin.Hosting": "3.0.1",
     "Microsoft.Owin.Testing": "3.0.1",
-    "xunit": "2.2.0-beta3-build3402"
+    "xunit": "2.2.0-rc2-build3523"
   },
   "testRunner": "xunit",
 

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/project.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Google.Cloud.Diagnostics.AspNet": { "target": "project" },
-    "xunit": "2.2.0-beta3-build3402"
+    "xunit": "2.2.0-rc2-build3523"
   },
   "testRunner": "xunit",
 

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/project.json
@@ -6,13 +6,13 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Testing": "1.0.0-beta07",
+    "Google.Api.Gax.Testing": "1.0.0-beta09",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Google.Cloud.Diagnostics.AspNet": { "target": "project" },
     "Google.Cloud.Diagnostics.Common": { "target": "project" },
     "Google.Cloud.Diagnostics.Common.Tests": { "target": "project" },
-    "xunit": "2.2.0-beta3-build3402",
-    "Moq": "4.6.36-alpha"
+    "xunit": "2.2.0-rc2-build3523",
+    "Moq": "4.6.38-alpha"
   },
   "testRunner": "xunit",
 

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax": "1.0.0-beta07",
+    "Google.Api.Gax": "1.0.0-beta09",
     "Google.Cloud.ErrorReporting.V1Beta1": { "target": "project" },
     "Google.Cloud.Trace.V1": { "target": "project" },
     "Google.Cloud.Diagnostics.Common": { "target": "project" },

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "description": "Integration tests for the Google Stackdriver Instrumentation Core Libraries.",
 
   "buildOptions": {
@@ -9,7 +9,7 @@
     "Google.Cloud.Diagnostics.AspNetCore": { "target": "project" },
     "Google.Cloud.Diagnostics.Common.Tests": { "target": "project" },
     "Google.Cloud.Diagnostics.Common.IntegrationTests": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc2-build3523",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Microsoft.AspNetCore.TestHost": "1.1.0",
     "Microsoft.AspNetCore.Mvc.Core": "1.0.1",

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/project.json
@@ -6,13 +6,13 @@
   },
 
   "dependencies": {
-    "xunit": "2.2.0-beta3-build3402",
+    "xunit": "2.2.0-rc2-build3523",
     "Moq": "4.6.38-alpha",
     "Microsoft.Extensions.Logging": "1.0.0",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Google.Cloud.Diagnostics.AspNetCore": { "target": "project" },
     "Google.Cloud.Diagnostics.Common.Tests": { "target": "project" },
-    "Google.Api.Gax.Testing": "1.0.0-beta07",
+    "Google.Api.Gax.Testing": "1.0.0-beta09",
     "Microsoft.AspNetCore.Http": "1.1.0"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/project.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "Google.Api.Gax": "1.0.0-beta07",
     "Google.Cloud.Diagnostics.Common": { "target": "project" },
-    "Google.Cloud.ErrorReporting.V1Beta1": "1.0.0-beta01",
+    "Google.Cloud.ErrorReporting.V1Beta1": { "target": "project" },
     "Google.Cloud.Logging.Type": { "target": "project" },
     "Google.Cloud.Logging.V2": { "target": "project" },
     "Google.Cloud.Trace.V1": { "target": "project" },

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "1.0.0-alpha01",
   "description": "Integration tests for the  Google Stackdriver Instrumentation Libraries Common Components.",
   "authors": [ "Google Inc." ],
@@ -9,11 +9,11 @@
 
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "xunit": "2.2.0-beta3-build3402",
+    "xunit": "2.2.0-rc2-build3523",
     "Google.Cloud.Logging.Type": { "target": "project" },
     "Google.Cloud.Logging.V2": { "target": "project" },
     "Google.Cloud.Trace.V1": { "target": "project" },
-    "Google.Cloud.ErrorReporting.V1Beta1": "1.0.0-beta01",
+    "Google.Cloud.ErrorReporting.V1Beta1": { "target": "project" },
     "Google.Cloud.Diagnostics.Common.Tests": { "target": "project" }
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/project.json
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "1.0.0-alpha01",
   "description": "Unit tests for the  Google Stackdriver Instrumentation Libraries Common Components.",
   "authors": [ "Google Inc." ],
@@ -9,10 +9,10 @@
 
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "Google.Api.Gax.Testing": "1.0.0-beta07",
+    "Google.Api.Gax.Testing": "1.0.0-beta09",
     "Google.Cloud.Diagnostics.Common": { "target": "project" },
     "Moq": "4.6.38-alpha",
-    "xunit": "2.2.0-beta3-build3402"
+    "xunit": "2.2.0-rc2-build3523"
   },
   "testRunner": "xunit",
 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/project.json
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/project.json
@@ -24,7 +24,7 @@
     "Google.Cloud.Logging.Type": { "target": "project" },
     "Google.Cloud.Logging.V2": { "target": "project" },
     "Google.Cloud.Trace.V1": { "target": "project" },
-    "Google.Cloud.ErrorReporting.V1Beta1": "1.0.0-beta01",
+    "Google.Cloud.ErrorReporting.V1Beta1": { "target": "project" },
     "System.Net.Http": "4.3.0"
   },
 


### PR DESCRIPTION
 Change Google.Cloud.ErrorReporting.V1Beta1 target to be project (as are the other Google.Cloud.* libs) and update other packages.