### PR TITLE
Update the timed buffer to automatically flush buffers after the given wait time.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LoggerOptions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LoggerOptions.cs
@@ -49,12 +49,12 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <param name="logLevel">Optional, the minimum log level.  Defaults to <see cref="LogLevel.Information"/></param>
         /// <param name="monitoredResource">Optional, the monitored resource.  Defaults to the global resource.
         ///     See: https://cloud.google.com/logging/docs/api/v2/resource-list </param>
-        /// <param name="bufferOptions">Optional, the buffer options.  Defaults to a <see cref="BufferType.Sized"/></param>
+        /// <param name="bufferOptions">Optional, the buffer options.  Defaults to a <see cref="BufferType.Timed"/></param>
         public static LoggerOptions Create(LogLevel logLevel = LogLevel.Information,
             MonitoredResource monitoredResource = null, BufferOptions bufferOptions = null)
         {
             monitoredResource = monitoredResource ?? GlobalResource;
-            bufferOptions = bufferOptions ?? BufferOptions.SizedBuffer();
+            bufferOptions = bufferOptions ?? BufferOptions.TimedBuffer();
             return new LoggerOptions(logLevel, monitoredResource, bufferOptions);
         }
     }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/FakeThreadingTimer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/FakeThreadingTimer.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+
+namespace Google.Cloud.Diagnostics.Common.Tests
+{
+    /// <summary>
+    /// An <see cref="IThreadingTimer"/> for testing that does not automatically call the
+    /// callback.
+    /// </summary>
+    internal class FakeThreadingTimer : IThreadingTimer
+    {
+        private TimerCallback _callback;
+
+        /// <summary>Does not start a timer.</summary>
+        public void Initialize(TimerCallback callback, TimeSpan waitTime) => _callback = callback;
+
+        /// <summary>
+        /// Calls the passed in callback from <see cref="Initialize(TimerCallback, TimeSpan)"/> once.
+        /// </summary>
+        public void FullTick() => _callback(null);
+
+        /// <summary>Does nothing.</summary>
+        public void Dispose() { }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/IThreadingTimer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/IThreadingTimer.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+
+namespace Google.Cloud.Diagnostics.Common
+{
+    /// <summary>
+    /// A timer that will automatically call a callback every after every wait time interval.
+    /// </summary>
+    interface IThreadingTimer : IDisposable
+    {
+        /// <summary>
+        /// Initialize the timer.
+        /// </summary>
+        /// <param name="callback">The callback to be called when after every wait time interval.</param>
+        /// <param name="waitTime">The amount of time between calls to the callback.</param>
+        void Initialize(TimerCallback callback, TimeSpan waitTime);
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/IThreadingTimer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/IThreadingTimer.cs
@@ -18,14 +18,14 @@ using System.Threading;
 namespace Google.Cloud.Diagnostics.Common
 {
     /// <summary>
-    /// A timer that will automatically call a callback every after every wait time interval.
+    /// A timer that will automatically call a callback after every wait time interval.
     /// </summary>
     interface IThreadingTimer : IDisposable
     {
         /// <summary>
         /// Initialize the timer.
         /// </summary>
-        /// <param name="callback">The callback to be called when after every wait time interval.</param>
+        /// <param name="callback">The callback to be called after every wait time interval.</param>
         /// <param name="waitTime">The amount of time between calls to the callback.</param>
         void Initialize(TimerCallback callback, TimeSpan waitTime);
     }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/SimpleThreadingTimer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/SimpleThreadingTimer.cs
@@ -23,7 +23,7 @@ namespace Google.Cloud.Diagnostics.Common
     internal class SimpleThreadingTimer : IThreadingTimer
     {
         /// <summary>The underlying timer.</summary>
-        Timer _timer;
+        private Timer _timer;
 
         /// <inheritdoc />
         void IThreadingTimer.Initialize(TimerCallback callback, TimeSpan waitTime)

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/SimpleThreadingTimer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/SimpleThreadingTimer.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+
+namespace Google.Cloud.Diagnostics.Common
+{
+    /// <summary>
+    /// A simple <see cref="IThreadingTimer"/> based on a <see cref="Timer"/>.
+    /// </summary>
+    internal class SimpleThreadingTimer : IThreadingTimer
+    {
+        /// <summary>The underlying timer.</summary>
+        Timer _timer;
+
+        /// <inheritdoc />
+        void IThreadingTimer.Initialize(TimerCallback callback, TimeSpan waitTime)
+            => _timer = new Timer(callback, null, waitTime, waitTime);
+        
+        /// <inheritdoc />
+        public void Dispose() => _timer.Dispose();
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/TimedBufferingConsumer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/TimedBufferingConsumer.cs
@@ -22,7 +22,7 @@ namespace Google.Cloud.Diagnostics.Common
 {
     /// <summary>
     /// A <see cref="IFlushableConsumer{T}"/> that will automatically flush the buffer after a 
-    /// given amoutn of time.
+    /// given amount of time.
     /// </summary>
     internal class TimedBufferingConsumer<T> : FlushableConsumerBase<T>
     {

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceConfiguration.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceConfiguration.cs
@@ -44,11 +44,11 @@ namespace Google.Cloud.Diagnostics.Common
         /// <param name="qpsSampleRate">Optional, the qps sample rate.  The sample rate determines
         ///     how often requests are automatically traced. Defaults to <see cref="DefaultQpsSampleRate"/>
         /// </param>
-        /// <param name="bufferOptions">Optional, the buffer options.  Defaults to a <see cref="BufferType.Sized"/></param>
+        /// <param name="bufferOptions">Optional, the buffer options.  Defaults to a <see cref="BufferType.Timed"/></param>
         public static TraceConfiguration Create(
             double qpsSampleRate = DefaultQpsSampleRate, BufferOptions bufferOptions = null)
         {
-            return new TraceConfiguration(qpsSampleRate, bufferOptions ?? BufferOptions.SizedBuffer());
+            return new TraceConfiguration(qpsSampleRate, bufferOptions ?? BufferOptions.TimedBuffer());
         }
     }
 }


### PR DESCRIPTION
1. Update the timed buffer to automatically flush buffers after the given wait time
2. The timed buffer does not wait for a receive call to flush.
3. Use the timed buffer as the default buffer.

These changes will give users an over all better experience. Previously entries could possibly never shown up with the sized buffer (it never filled) or the timed buffer (if another receive never occurred).