### PR TITLE
Simplify project files

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/project.json
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/project.json
@@ -8,7 +8,7 @@
 
   "dependencies": {
     "Google.Cloud.BigQuery.V2": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/project.json
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Integration tests for the Google BigQuery library.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk",
     "embed": {

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/project.json
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Snippets for the Google.Cloud.BigQuery.V2 package (written as tests).",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/project.json
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Google.Cloud.BigQuery.V2": { "target": "project" },
     "Google.Cloud.Storage.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/project.json
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Google.Cloud.BigQuery.V2": { "target": "project" },
     "Google.Cloud.ClientTesting": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "Moq": "4.6.36-alpha",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/project.json
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Unit tests for the BigQuery client wrapper library.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/project.json
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/project.json
@@ -19,7 +19,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Rest": "1.0.0-beta07",
+    "Google.Api.Gax.Rest": "1.0.0-beta11",
     "Google.Apis.Bigquery.v2": "1.20.0.667"
   },
   "frameworks": {

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.Datastore.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Integration tests for Google.Cloud.Datastore.V1.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Snippets for the Google.Cloud.Datastore.V1 package (written as tests).",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.Datastore.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/project.json
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/project.json
@@ -6,7 +6,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Grpc.Testing": "1.0.0-beta07",
+    "Google.Api.Gax.Grpc.Testing": "1.0.0-beta11",
     "Google.Cloud.ClientTesting": { "target": "project" },
     "Google.Cloud.Datastore.V1": { "target": "project" },
     "xunit": "2.2.0-beta2-build3300",

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/project.json
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/project.json
@@ -7,7 +7,7 @@
     "Google.Api.Gax.Grpc.Testing": "1.0.0-beta11",
     "Google.Cloud.ClientTesting": { "target": "project" },
     "Google.Cloud.Datastore.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/project.json
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Unit tests for the Google Cloud Datastore library.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/project.json
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/project.json
@@ -19,7 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta05",
     "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/project.json
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta07"
+    "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/project.json
@@ -16,7 +16,7 @@
     "Microsoft.Owin.Host.HttpListener": "3.0.1",
     "Microsoft.Owin.Hosting": "3.0.1",
     "Microsoft.Owin.Testing": "3.0.1",
-    "xunit": "2.2.0-rc2-build3523"
+    "xunit": "2.2.0-rc3-build3528"
   },
   "testRunner": "xunit",
 

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/project.json
@@ -1,6 +1,4 @@
 {
-  "description": "Integration tests for the Google Stackdriver Insturmnetation Libraries.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Google.Cloud.Diagnostics.AspNet": { "target": "project" },
-    "xunit": "2.2.0-rc2-build3523"
+    "xunit": "2.2.0-rc3-build3528"
   },
   "testRunner": "xunit",
 

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/project.json
@@ -1,6 +1,4 @@
 {
-  "description": "Snippets for the ASP.NET instrumentation library.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/project.json
@@ -9,7 +9,7 @@
     "Google.Cloud.Diagnostics.AspNet": { "target": "project" },
     "Google.Cloud.Diagnostics.Common": { "target": "project" },
     "Google.Cloud.Diagnostics.Common.Tests": { "target": "project" },
-    "xunit": "2.2.0-rc2-build3523",
+    "xunit": "2.2.0-rc3-build3528",
     "Moq": "4.6.38-alpha"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/project.json
@@ -1,6 +1,4 @@
 {
-  "description": "Unit tests for the Google Stackdriver Instrumentation Libraries",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/project.json
@@ -6,7 +6,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Testing": "1.0.0-beta09",
+    "Google.Api.Gax.Testing": "1.0.0-beta11",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Google.Cloud.Diagnostics.AspNet": { "target": "project" },
     "Google.Cloud.Diagnostics.Common": { "target": "project" },

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/project.json
@@ -19,10 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax": "1.0.0-beta11",
-    "Google.Cloud.ErrorReporting.V1Beta1": { "target": "project" },
-    "Google.Cloud.Trace.V1": { "target": "project" },
     "Google.Cloud.Diagnostics.Common": { "target": "project" },
     "Microsoft.AspNet.WebApi.Core": "5.2.3",
     "Microsoft.AspNet.WebPages": "3.2.3",

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax": "1.0.0-beta09",
+    "Google.Api.Gax": "1.0.0-beta11",
     "Google.Cloud.ErrorReporting.V1Beta1": { "target": "project" },
     "Google.Cloud.Trace.V1": { "target": "project" },
     "Google.Cloud.Diagnostics.Common": { "target": "project" },

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/project.json
@@ -7,7 +7,7 @@
     "Google.Cloud.Diagnostics.AspNetCore": { "target": "project" },
     "Google.Cloud.Diagnostics.Common.Tests": { "target": "project" },
     "Google.Cloud.Diagnostics.Common.IntegrationTests": { "target": "project" },
-    "xunit": "2.2.0-rc2-build3523",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Microsoft.AspNetCore.TestHost": "1.1.0",
     "Microsoft.AspNetCore.Mvc.Core": "1.0.1",

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/project.json
@@ -1,6 +1,4 @@
 {
-  "description": "Integration tests for the Google Stackdriver Instrumentation Core Libraries.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Snippets for the ASP.NET Core instrumentation library.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/project.json
@@ -4,7 +4,7 @@
   },
 
   "dependencies": {
-    "xunit": "2.2.0-rc2-build3523",
+    "xunit": "2.2.0-rc3-build3528",
     "Moq": "4.6.38-alpha",
     "Microsoft.Extensions.Logging": "1.0.0",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/project.json
@@ -12,7 +12,7 @@
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Google.Cloud.Diagnostics.AspNetCore": { "target": "project" },
     "Google.Cloud.Diagnostics.Common.Tests": { "target": "project" },
-    "Google.Api.Gax.Testing": "1.0.0-beta09",
+    "Google.Api.Gax.Testing": "1.0.0-beta11",
     "Microsoft.AspNetCore.Http": "1.1.0"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/project.json
@@ -1,6 +1,4 @@
 {
-  "description": "Unit tests for the Google Stackdriver ASP.NET Core Instrumentation Libraries",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/project.json
@@ -19,12 +19,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax": "1.0.0-beta11",
     "Google.Cloud.Diagnostics.Common": { "target": "project" },
-    "Google.Cloud.ErrorReporting.V1Beta1": { "target": "project" },
-    "Google.Cloud.Logging.Type": { "target": "project" },
-    "Google.Cloud.Logging.V2": { "target": "project" },
-    "Google.Cloud.Trace.V1": { "target": "project" },
     "Microsoft.AspNetCore.Diagnostics.Abstractions": "1.0.0",
     "Microsoft.AspNetCore.Http": "1.1.0",
     "Microsoft.AspNetCore.Http.Abstractions": "1.1.0",

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/project.json
@@ -19,7 +19,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax": "1.0.0-beta10",
+    "Google.Api.Gax": "1.0.0-beta11",
     "Google.Cloud.Diagnostics.Common": { "target": "project" },
     "Google.Cloud.ErrorReporting.V1Beta1": { "target": "project" },
     "Google.Cloud.Logging.Type": { "target": "project" },

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/project.json
@@ -1,8 +1,4 @@
 {
-  "version": "1.0.0-alpha01",
-  "description": "Integration tests for the  Google Stackdriver Instrumentation Libraries Common Components.",
-  "authors": [ "Google Inc." ],
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "xunit": "2.2.0-rc2-build3523",
+    "xunit": "2.2.0-rc3-build3528",
     "Google.Cloud.Logging.Type": { "target": "project" },
     "Google.Cloud.Logging.V2": { "target": "project" },
     "Google.Cloud.Trace.V1": { "target": "project" },

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/project.json
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/project.json
@@ -1,8 +1,4 @@
 {
-  "version": "1.0.0-alpha01",
-  "description": "Unit tests for the  Google Stackdriver Instrumentation Libraries Common Components.",
-  "authors": [ "Google Inc." ],
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/project.json
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/project.json
@@ -8,7 +8,7 @@
     "Google.Api.Gax.Testing": "1.0.0-beta11",
     "Google.Cloud.Diagnostics.Common": { "target": "project" },
     "Moq": "4.6.38-alpha",
-    "xunit": "2.2.0-rc2-build3523"
+    "xunit": "2.2.0-rc3-build3528"
   },
   "testRunner": "xunit",
 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/project.json
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/project.json
@@ -9,7 +9,7 @@
 
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "Google.Api.Gax.Testing": "1.0.0-beta10",
+    "Google.Api.Gax.Testing": "1.0.0-beta11",
     "Google.Cloud.Diagnostics.Common": { "target": "project" },
     "Moq": "4.6.38-alpha",
     "xunit": "2.2.0-rc2-build3523"

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/project.json
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax": "1.0.0-beta10",
+    "Google.Api.Gax": "1.0.0-beta11",
     "Google.Cloud.Logging.Type": { "target": "project" },
     "Google.Cloud.Logging.V2": { "target": "project" },
     "Google.Cloud.Trace.V1": { "target": "project" },

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/project.json
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/project.json
@@ -19,8 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax": "1.0.0-beta11",
     "Google.Cloud.Logging.Type": { "target": "project" },
     "Google.Cloud.Logging.V2": { "target": "project" },
     "Google.Cloud.Trace.V1": { "target": "project" },

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/project.json
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Snippets for the Google.Cloud.ErrorReporting.V1Beta1 package (written as tests).",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/project.json
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.ErrorReporting.V1Beta1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/project.json
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/project.json
@@ -19,7 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta05",
     "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/project.json
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta07"
+    "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/project.json
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/project.json
@@ -19,7 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta05",
     "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/project.json
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta07"
+    "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.Language.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Snippets for the Google.Cloud.Language.V1 package (written as tests).",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Tests/project.json
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Tests/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.Language.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Tests/project.json
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Tests/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Unit tests for the Google Cloud Natural Language library.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/project.json
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/project.json
@@ -19,7 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta05",
     "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/project.json
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta07"
+    "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Snippets/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Snippets/project.json
@@ -8,7 +8,7 @@
 
   "dependencies": {
     "Google.Cloud.Logging.Log4Net": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Snippets/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Snippets/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Google.Cloud.Logging.Log4Net.Snippets Class Library",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk",
     "embed": {

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Unit tests for the Google StackDriver log4net appender library.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Google.Cloud.Logging.Log4Net": { "target": "project" },
     "Google.Api.Gax.Testing": "1.0.0-beta11",
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Moq": "4.6.36-alpha",
     "System.Text.RegularExpressions": "4.0.0"

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net.Tests/project.json
@@ -7,7 +7,7 @@
 
   "dependencies": {
     "Google.Cloud.Logging.Log4Net": { "target": "project" },
-    "Google.Api.Gax.Testing": "1.0.0-beta09",
+    "Google.Api.Gax.Testing": "1.0.0-beta11",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Moq": "4.6.36-alpha",

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.Logging.V2": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Snippets for the Google.Cloud.Logging.V2 package",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/project.json
@@ -19,7 +19,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Grpc": "1.0.0-beta10",
+    "Google.Api.Gax.Grpc": "1.0.0-beta11",
     "Google.Cloud.Logging.Type": { "target": "project" }
   },
 

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/project.json
@@ -12,7 +12,7 @@
 
   "dependencies": {
     "Google.Cloud.Metadata.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Integration tests for Google.Cloud.Metadata.V1.",
-
   "buildOptions": {
     "embed": {
       "include": [

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Snippets/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Google.Cloud.Metadata.V1": { "target": "project" },
     "Google.Cloud.Metadata.V1.IntegrationTests": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Snippets/project.json
@@ -1,6 +1,4 @@
 {
-  "description": "Snippets for the Google.Cloud.Metadata.V1 package (written as tests).",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Tests/project.json
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Tests/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Unit tests for Google.Cloud.Metadata.V1.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Tests/project.json
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Tests/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.Metadata.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/project.json
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.Monitoring.V3": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/project.json
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Snippets for the Google.Cloud.Monitoring.V3 package (written as tests).",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/project.json
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/project.json
@@ -19,7 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta05",
     "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/project.json
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta07"
+    "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/project.json
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Snippets for the Google.Cloud.Pubsub.V1 package",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/project.json
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.PubSub.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/project.json
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/project.json
@@ -19,7 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta05",
     "Google.Api.Gax.Grpc": "1.0.0-beta11",
     "Google.Cloud.Iam.V1": { "target": "project" }
   },

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/project.json
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta07",
+    "Google.Api.Gax.Grpc": "1.0.0-beta11",
     "Google.Cloud.Iam.V1": { "target": "project" }
   },
 

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.Spanner.Admin.Database.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/project.json
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta09",
+    "Google.Api.Gax.Grpc": "1.0.0-beta11",
     "Google.Cloud.Iam.V1": { "target": "project" },
     "Google.LongRunning": { "target": "project" }
   },

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/project.json
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/project.json
@@ -19,8 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta11",
     "Google.Cloud.Iam.V1": { "target": "project" },
     "Google.LongRunning": { "target": "project" }
   },

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.Spanner.Admin.Instance.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/project.json
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta09",
+    "Google.Api.Gax.Grpc": "1.0.0-beta11",
     "Google.Cloud.Iam.V1": { "target": "project" },
     "Google.LongRunning": { "target": "project" }
   },

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/project.json
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/project.json
@@ -19,8 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta11",
     "Google.Cloud.Iam.V1": { "target": "project" },
     "Google.LongRunning": { "target": "project" }
   },

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.Spanner.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/project.json
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/project.json
@@ -19,7 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta05",
     "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/project.json
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta09"
+    "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.Snippets/project.json
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.Snippets/project.json
@@ -8,7 +8,7 @@
 
   "dependencies": {
     "Google.Cloud.Speech.V1Beta1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.Snippets/project.json
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1.Snippets/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Snippets for the Google.Cloud.Speech.V1Beta1 package (written as tests).",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk",
     "embed": {

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
@@ -19,7 +19,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Grpc": "1.0.0-beta07",
+    "Google.Api.Gax.Grpc": "1.0.0-beta11",
     "Google.LongRunning": { "target": "project" }
   },
 

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/project.json
@@ -1,6 +1,4 @@
 {
-  "description": "Integration tests for the Cloud Storage client wrapper library",
-
   "dependencies": {
     "Google.Cloud.Storage.V1": { "target": "project" },
     "xunit": "2.2.0-beta2-build3300",

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Google.Cloud.Storage.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/project.json
@@ -1,6 +1,4 @@
 {
-  "description": "Snippets for the Google.Cloud.Storage.V1 package (written as tests).",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.Storage.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/project.json
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/project.json
@@ -1,6 +1,4 @@
 {
-  "description": "Unit tests for the Cloud Storage client wrapper library.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/project.json
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Google.Cloud.ClientTesting": { "target": "project" },
     "Google.Cloud.Storage.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/project.json
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/project.json
@@ -19,7 +19,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Rest": "1.0.0-beta09",
+    "Google.Api.Gax.Rest": "1.0.0-beta11",
     "Google.Apis.Storage.v1": "1.21.0.753"
   },
   "frameworks": {

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.Trace.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Snippets for the Google.Cloud.Trace.V1 package (written as tests).",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/project.json
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/project.json
@@ -19,7 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta05",
     "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/project.json
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta07"
+    "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.IntegrationTests/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.Vision.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.IntegrationTests/project.json
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.IntegrationTests/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Integration tests for Google.Cloud.Vision.V1.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/project.json
@@ -8,7 +8,7 @@
 
   "dependencies": {
     "Google.Cloud.Vision.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/project.json
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Snippets for the Google.Cloud.Vision.V1 package (written as tests).",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk",
     "embed": {

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Tests/project.json
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Tests/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.Cloud.Vision.V1": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Tests/project.json
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Tests/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Unit tests for the Google Cloud Vision library.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
@@ -19,7 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta05",
     "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta07"
+    "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 
   "frameworks": {

--- a/apis/Google.LongRunning/Google.LongRunning.Snippets/project.json
+++ b/apis/Google.LongRunning/Google.LongRunning.Snippets/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Snippets for the Google.LongRunning package",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.LongRunning/Google.LongRunning.Snippets/project.json
+++ b/apis/Google.LongRunning/Google.LongRunning.Snippets/project.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "Google.LongRunning": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.LongRunning/Google.LongRunning.Tests/project.json
+++ b/apis/Google.LongRunning/Google.LongRunning.Tests/project.json
@@ -6,7 +6,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Testing": "1.0.0-beta07",
+    "Google.Api.Gax.Testing": "1.0.0-beta11",
     "Google.Cloud.ClientTesting": { "target": "project" },
     "Google.LongRunning": { "target": "project" },
     "xunit": "2.2.0-beta2-build3300",

--- a/apis/Google.LongRunning/Google.LongRunning.Tests/project.json
+++ b/apis/Google.LongRunning/Google.LongRunning.Tests/project.json
@@ -1,6 +1,4 @@
 ﻿{
-  "description": "Unit tests for the Google Cloud Datastore library.",
-
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },

--- a/apis/Google.LongRunning/Google.LongRunning.Tests/project.json
+++ b/apis/Google.LongRunning/Google.LongRunning.Tests/project.json
@@ -7,7 +7,7 @@
     "Google.Api.Gax.Testing": "1.0.0-beta11",
     "Google.Cloud.ClientTesting": { "target": "project" },
     "Google.LongRunning": { "target": "project" },
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-rc3-build3528",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",

--- a/apis/Google.LongRunning/Google.LongRunning/project.json
+++ b/apis/Google.LongRunning/Google.LongRunning/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.CommonProtos": "1.0.0-beta05",
-    "Google.Api.Gax.Grpc": "1.0.0-beta08"
+    "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 
   "frameworks": {

--- a/apis/Google.LongRunning/Google.LongRunning/project.json
+++ b/apis/Google.LongRunning/Google.LongRunning/project.json
@@ -19,7 +19,6 @@
   },
 
   "dependencies": {
-    "Google.Api.CommonProtos": "1.0.0-beta05",
     "Google.Api.Gax.Grpc": "1.0.0-beta11"
   },
 


### PR DESCRIPTION
Three goals:

- Update dependencies (primarily GAX and xunit)
- Remove unnecessary aspects of project files (e.g. descriptions in non-nuget packages)
- Remove unnecessary dependencies 

These will all help reduce maintenance costs when introducing new packages or updating dependency versions. I'm open to discussion as to whether to squash the 6 commits together or keep them separate - I think I'm leaning towards keeping them separate.