### PR TITLE
Dispose of ASP.NET Core bits

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/AspNetSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/AspNetSnippets.cs
@@ -51,20 +51,12 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
         // Sample: InitializeTrace
         public class Global : HttpApplication
         {
-            private CloudTrace _cloudTrace;
-
             public override void Init()
             {
                 base.Init();
                 string projectId = "[Google Cloud Platform project ID]";
                 // Trace a sampling of incoming Http requests.
-                _cloudTrace = CloudTrace.Initialize(projectId, this);
-            }
-
-            public override void Dispose()
-            {
-                base.Dispose();
-                _cloudTrace.Dispose();
+                CloudTrace.Initialize(projectId, this);
             }
         }
         // End sample

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/AspNetSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/AspNetSnippets.cs
@@ -51,12 +51,20 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
         // Sample: InitializeTrace
         public class Global : HttpApplication
         {
+            private CloudTrace _cloudTrace;
+
             public override void Init()
             {
                 base.Init();
                 string projectId = "[Google Cloud Platform project ID]";
                 // Trace a sampling of incoming Http requests.
-                CloudTrace.Initialize(projectId, this);
+                _cloudTrace = CloudTrace.Initialize(projectId, this);
+            }
+
+            public override void Dispose()
+            {
+                base.Dispose();
+                _cloudTrace.Dispose();
             }
         }
         // End sample

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/ErrorReportingExceptionFilter.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/ErrorReportingExceptionFilter.cs
@@ -49,7 +49,7 @@ namespace Google.Cloud.Diagnostics.AspNet
     /// https://msdn.microsoft.com/en-us/library/system.web.mvc.iexceptionfilter.onexception(v=vs.118).aspx
     /// Docs: https://cloud.google.com/error-reporting/docs/
     /// </remarks>
-    public class ErrorReportingExceptionFilter : IExceptionFilter
+    public class ErrorReportingExceptionFilter : IExceptionFilter, IDisposable
     {
         // The service context in which this error has occurred.
         // See: https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events#ServiceContext
@@ -96,6 +96,9 @@ namespace Google.Cloud.Diagnostics.AspNet
             var errorEvent = CreateReportRequest(context);
             _consumer.Receive(new[] { errorEvent });
         }
+
+        /// <inheritdoc />
+        public void Dispose() => _consumer.Dispose();
 
         /// <summary>
         /// Gets information about the HTTP request and response when the exception occured 

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/ErrorReportingExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/ErrorReportingExceptionLogger.cs
@@ -48,7 +48,7 @@ namespace Google.Cloud.Diagnostics.AspNet
     /// Reports unhandled exceptions to Google Cloud Error Reporting.
     /// Docs: https://cloud.google.com/error-reporting/docs/
     /// </remarks>
-    public sealed class ErrorReportingExceptionLogger : ExceptionLogger
+    public sealed class ErrorReportingExceptionLogger : ExceptionLogger, IDisposable
     {
         // The service context in which this error has occurred.
         // See: https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events#ServiceContext
@@ -106,6 +106,9 @@ namespace Google.Cloud.Diagnostics.AspNet
         {
             return context?.Exception != null;
         }
+
+        /// <inheritdoc />
+        public void Dispose() => _consumer.Dispose();
 
         /// <summary>
         /// Gets information about the HTTP request and response when the exception occured 

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
@@ -105,7 +105,7 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// <param name="config">Optional trace configuration, if unset the default will be used.</param>
         /// <param name="client">Optional trace client, if unset the default will be used.</param>
         /// <returns>The initialized instance of <see cref="CloudTrace"/> the caller is responsible for disposal.</returns>
-        public static CloudTrace Initialize(string projectId, HttpApplication application, TraceConfiguration config = null, Task<TraceServiceClient> client = null)
+        public static void Initialize(string projectId, HttpApplication application, TraceConfiguration config = null, Task<TraceServiceClient> client = null)
         {
             GaxPreconditions.CheckNotNull(application, nameof(application));
             CloudTrace trace = new CloudTrace(projectId, config, client);
@@ -113,11 +113,13 @@ namespace Google.Cloud.Diagnostics.AspNet
             // Add event handlers to the application.
             application.BeginRequest += trace.BeginRequest;
             application.EndRequest += trace.EndRequest;
-            return trace;
+            application.Disposed += trace.Disposed;
         }
 
         /// <inheritdoc />
         public void Dispose() => _consumer.Dispose();
+
+        private void Disposed(object sender, EventArgs e) => Dispose();
 
         private void BeginRequest(object sender, EventArgs e)
         {

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
@@ -112,13 +112,11 @@ namespace Google.Cloud.Diagnostics.AspNet
             // Add event handlers to the application.
             application.BeginRequest += trace.BeginRequest;
             application.EndRequest += trace.EndRequest;
-            application.Disposed += trace.Disposed;
+            application.Disposed += (object sender, EventArgs e) => { trace.Dispose(); };
         }
 
         /// <inheritdoc />
         public void Dispose() => _consumer.Dispose();
-
-        private void Disposed(object sender, EventArgs e) => Dispose();
 
         private void BeginRequest(object sender, EventArgs e)
         {

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
@@ -104,7 +104,6 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// <param name="application">The Http application.</param>
         /// <param name="config">Optional trace configuration, if unset the default will be used.</param>
         /// <param name="client">Optional trace client, if unset the default will be used.</param>
-        /// <returns>The initialized instance of <see cref="CloudTrace"/> the caller is responsible for disposal.</returns>
         public static void Initialize(string projectId, HttpApplication application, TraceConfiguration config = null, Task<TraceServiceClient> client = null)
         {
             GaxPreconditions.CheckNotNull(application, nameof(application));


### PR DESCRIPTION
Properly dispose of ASP.NET Core bits.

1. Services registered with HttpConfiguration that implement IDisposable are cleaned up automatically.
2. We dispose of CloudTrace via Event Handlers that are called during dispose.
3. #803 To track proper disposal for ErrorReportingExceptionFilter.
4. #802 To track proper disposal for ASP.NET Core Middleware.