### PR TITLE
Make StartSpan return an IDisposable.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/AspNetSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/AspNetSnippets.cs
@@ -65,9 +65,18 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
         {
             // Sample: UseTracer
             // Manually trace a specific operation.
-            CloudTrace.CurrentTracer.StartSpan("hello-world");
-            Console.Out.WriteLine("Hello, World!");
-            CloudTrace.CurrentTracer.EndSpan();
+            using (CloudTrace.CurrentTracer.StartSpan("hello-world"))
+            {
+                Console.Out.WriteLine("Hello, World!");
+            }
+            // End sample
+
+
+            // Sample: UseTracerRunIn
+            // Manually trace a specific Action or Func<T>.
+            CloudTrace.CurrentTracer.RunInSpan(
+                () => Console.Out.WriteLine("Hello, World!"),
+                "hello-world");
             // End sample
         }
         

--- a/apis/Google.Cloud.Diagnostics.AspNet/docs/index.md
+++ b/apis/Google.Cloud.Diagnostics.AspNet/docs/index.md
@@ -43,3 +43,5 @@ installed, run the following command in a Google Cloud SDK Shell:
 ## Manual Tracing
 
 [!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNet.AspNet.txt#UseTracer)]
+
+[!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNet.AspNet.txt#UseTracerRunIn)]

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
@@ -326,11 +326,12 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         public string TraceLabels(string id, [FromServices] IManagedTracer tracer)
         {
             string message = GetMessage(nameof(TraceLabels), id);
-            tracer.StartSpan(message);
-            Thread.Sleep(10);
-            tracer.AnnotateSpan(new Dictionary<string, string> { { Label, LabelValue } });
-            tracer.EndSpan();
-            return message;
+            using (tracer.StartSpan(message))
+            {
+                Thread.Sleep(10);
+                tracer.AnnotateSpan(new Dictionary<string, string> { { Label, LabelValue } });
+                return message;
+            }
         }
 
         /// <summary>Traces a 10ms sleep and adds a stacktrace.</summary>
@@ -349,10 +350,11 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         {
             // Add a span with the test id to allow for the trace to be found.
             string message = GetMessage(nameof(ThrowException), id);
-            tracer.StartSpan(message);
-            Thread.Sleep(10);
-            tracer.EndSpan();
-            throw new DivideByZeroException();
+            using (tracer.StartSpan(message))
+            {
+                Thread.Sleep(10);
+                throw new DivideByZeroException();
+            }
         }
 
         /// <summary>Creates a stack trace.</summary>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/AspNetCoreSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/AspNetCoreSnippets.cs
@@ -75,9 +75,23 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             public void TraceHelloWorld(IManagedTracer tracer)
             {
                 // Manually trace a specific operation.
-                tracer.StartSpan(nameof(TraceHelloWorld));
-                Console.Out.WriteLine("Hello, World!");
-                tracer.EndSpan();
+                using (tracer.StartSpan(nameof(TraceHelloWorld)))
+                {
+                    Console.Out.WriteLine("Hello, World!");
+                }
+            }
+            // End sample
+
+            // Sample: UseTracerRunIn
+            /// <summary>
+            /// The <see cref="IManagedTracer"/> is populated by dependency injection.
+            /// </summary>
+            public void TraceHelloWorldRunIn(IManagedTracer tracer)
+            {
+                // Manually trace a specific Action or Func<T>.
+                tracer.RunInSpan(
+                    () => Console.Out.WriteLine("Hello, World!"),
+                    nameof(TraceHelloWorldRunIn));
             }
             // End sample
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
@@ -45,6 +45,8 @@ installed, run the following command in a Google Cloud SDK Shell:
 
 [!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNetCore.AspNetCore.txt#UseTracer)]
 
+[!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNetCore.AspNetCore.txt#UseTracerRunIn)]
+
 ## Trace Outgoing HTTP Requests
 
 [!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNetCore.AspNetCore.txt#TraceOutgoing)]

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
@@ -82,6 +82,20 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         }
 
         [Fact]
+        public void SingleSpan_Dispose()
+        {
+            var mockConsumer = new Mock<IConsumer<TraceProto>>();
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+
+            mockConsumer.Setup(c => c.Receive(
+                Match.Create<IEnumerable<TraceProto>>(
+                    t => IsValidSpan(t.Single().Spans.Single(), "span-name"))));
+
+            using (tracer.StartSpan("span-name")) { }
+            mockConsumer.VerifyAll();
+        }
+
+        [Fact]
         public void SingleSpan_ParentId()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
@@ -102,11 +116,15 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
             var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
 
+            var annotation = new Dictionary<string, string>();
+            annotation.Add("annotation-key", "annotation-value");
+
             mockConsumer.Setup(c => c.Receive(
                 Match.Create<IEnumerable<TraceProto>>(
-                    t => IsValidSpan(t.Single().Spans.Single(), "span-name", 0, SpanKind.RpcClient))));
+                    t => IsValidSpan(t.Single().Spans.Single(), "span-name", 0, SpanKind.RpcClient)
+                        && TraceUtils.IsValidAnnotation(t.ElementAt(0).Spans[0], annotation))));
 
-            var options = StartSpanOptions.Create(SpanKind.RpcClient);
+            var options = StartSpanOptions.Create(SpanKind.RpcClient, annotation);
             tracer.StartSpan("span-name", options);
             tracer.EndSpan();
             mockConsumer.VerifyAll();
@@ -153,6 +171,36 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         }
 
         [Fact]
+        public void RunInSpan_Action()
+        {
+            var mockConsumer = new Mock<IConsumer<TraceProto>>();
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+
+            mockConsumer.Setup(c => c.Receive(
+                Match.Create<IEnumerable<TraceProto>>(
+                    t => IsValidSpan(t.Single().Spans.Single(), "span-name"))));
+
+            bool hasActionRan = false;
+            tracer.RunInSpan(() => { hasActionRan = true; }, "span-name");
+            Assert.True(hasActionRan);
+            mockConsumer.VerifyAll();
+        }
+
+        [Fact]
+        public void RunInSpan_Func()
+        {
+            var mockConsumer = new Mock<IConsumer<TraceProto>>();
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+
+            mockConsumer.Setup(c => c.Receive(
+                Match.Create<IEnumerable<TraceProto>>(
+                    t => IsValidSpan(t.Single().Spans.Single(), "span-name"))));
+
+            Assert.Equal(11, tracer.RunInSpan(() => { return 11; }, "span-name"));
+            mockConsumer.VerifyAll();
+        }
+
+        [Fact]
         public void MultipleSpans()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
@@ -187,6 +235,37 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             tracer.EndSpan();
             tracer.EndSpan();
             tracer.EndSpan();
+            mockConsumer.VerifyAll();
+        }
+
+        [Fact]
+        public void MultipleSpans_Dispose()
+        {
+            var mockConsumer = new Mock<IConsumer<TraceProto>>();
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+
+            var annotation = new Dictionary<string, string>();
+            annotation.Add("annotation-key", "annotation-value");
+
+            Predicate<IEnumerable<TraceProto>> matcher = (IEnumerable<TraceProto> t) =>
+            {
+                var spans = t.Single().Spans;
+                return spans.Count == 4 &&
+                    IsValidSpan(spans[0], "child-one", spans[3].SpanId) &&
+                    IsValidSpan(spans[1], "grandchild-one", spans[2].SpanId) &&
+                    IsValidSpan(spans[2], "child-two", spans[3].SpanId) &&
+                    IsValidSpan(spans[3], "root");
+            };
+            mockConsumer.Setup(c => c.Receive(Match.Create(matcher)));
+
+            using (tracer.StartSpan("root"))
+            {
+                using (tracer.StartSpan("child-one")) { }
+                using (tracer.StartSpan("child-two"))
+                {
+                    using (tracer.StartSpan("grandchild-one")) { } ;
+                }
+            }
             mockConsumer.VerifyAll();
         }
 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/DoNothingTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/DoNothingTracer.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -22,10 +23,16 @@ namespace Google.Cloud.Diagnostics.Common
     /// </summary>
     internal sealed class DoNothingTracer : IManagedTracer
     {
-        public static DoNothingTracer Instance = new DoNothingTracer();
+        public static readonly DoNothingTracer Instance = new DoNothingTracer();
+
+        private class DoNothingDisposable : IDisposable { public void Dispose() { } }
+        private static readonly DoNothingDisposable _doNothingDisposableInstnace = new DoNothingDisposable();
+
         private DoNothingTracer() { }
-        public void StartSpan(string name, StartSpanOptions options = null) { }
+        public IDisposable StartSpan(string name, StartSpanOptions options = null) => _doNothingDisposableInstnace;
         public void EndSpan() { }
+        public void RunInSpan(Action action, string name, StartSpanOptions options = null) => action();
+        public T RunInSpan<T>(Func<T> func, string name, StartSpanOptions options = null) => func();
         public void AnnotateSpan(Dictionary<string, string> labels) { }
         public void SetStackTrace(StackTrace stackTrace) { }
         public string GetCurrentTraceId() => null;

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/IManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/IManagedTracer.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -27,12 +28,37 @@ namespace Google.Cloud.Diagnostics.Common
         /// </summary>
         /// <param name="name">The name of the span, cannot be null.</param>
         /// <param name="options">The span options to override default values.</param>
-        void StartSpan(string name, StartSpanOptions options = null);
+        /// <returns>
+        /// An <see cref="IDisposable"/> that will end the current span.  If the span cannot
+        /// end in the current scope, disposal can be skipped and <see cref="EndSpan"/> can
+        /// be called at a later time (this is not recommended and should be avoided if possible).
+        /// </returns>
+        IDisposable StartSpan(string name, StartSpanOptions options = null);
 
         /// <summary>
-        /// Ends the current span.
+        /// Ends the current span if not ended by the <see cref="IDisposable"/> from
+        /// <see cref="StartSpan(string, StartSpanOptions)"/>.
         /// </summary>
         void EndSpan();
+
+        /// <summary>
+        /// Runs the function in a span and will add a stacktrace from a thrown
+        /// exception (the exception will be re-thrown) to the span.
+        /// </summary>
+        /// <param name="action">The action to run in a span.</param>
+        /// <param name="name">The name of the span, cannot be null.</param>
+        /// <param name="options">The span options to override default values.</param>
+        void RunInSpan(Action action, string name, StartSpanOptions options = null);
+
+        /// <summary>
+        /// Runs the function in a span and will add a stacktrace from a thrown
+        /// exception (the exception will be re-thrown) to the span.
+        /// </summary>
+        /// <param name="func">The function to run in a span.</param>
+        /// <param name="name">The name of the span, cannot be null.</param>
+        /// <param name="options">The span options to override default values.</param>
+        /// <returns>The result from the call to <paramref name="func"/></returns>
+        T RunInSpan<T>(Func<T> func, string name, StartSpanOptions options = null);
 
         /// <summary>
         /// Annotates the current span with the given labels. 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/IManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/IManagedTracer.cs
@@ -29,8 +29,8 @@ namespace Google.Cloud.Diagnostics.Common
         /// <param name="name">The name of the span, cannot be null.</param>
         /// <param name="options">The span options to override default values.</param>
         /// <returns>
-        /// An <see cref="IDisposable"/> that will end the current span.  If the span cannot
-        /// end in the current scope, disposal can be skipped and <see cref="EndSpan"/> can
+        /// An <see cref="IDisposable"/> that will end the current span when disposed.  If the span
+        /// cannot end in the current scope, disposal can be skipped and <see cref="EndSpan"/> can
         /// be called at a later time (this is not recommended and should be avoided if possible).
         /// </returns>
         IDisposable StartSpan(string name, StartSpanOptions options = null);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
@@ -208,8 +208,8 @@ namespace Google.Cloud.Diagnostics.Common
 
         /// <summary>
         /// Sets a <see cref="StackTrace"/> on the current span for the given exception and
-        /// returns false.  This is used for exception handling to ensure proper timing for
-        /// recording the stacktrace.
+        /// returns false.  This is used for exception handling to ensure no data is lost
+        /// in the stacktrace.
         /// </summary>
         private bool SetStackTraceAndReturnFalse(Exception e)
         {

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/StartSpanOptions.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/StartSpanOptions.cs
@@ -25,7 +25,7 @@ namespace Google.Cloud.Diagnostics.Common
         /// <summary>Gets the span kind.</summary>
         public SpanKind SpanKind { get; }
 
-        /// <summary>Gets the lables to be added to the span.</summary>
+        /// <summary>Gets the labels to be added to the span.</summary>
         public Dictionary<string, string> Labels { get; }
 
         private StartSpanOptions(SpanKind spanKind, Dictionary<string, string> labels)

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/StartSpanOptions.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/StartSpanOptions.cs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax;
+using System.Collections.Generic;
+
 namespace Google.Cloud.Diagnostics.Common
 {
     /// <summary>
@@ -22,16 +25,22 @@ namespace Google.Cloud.Diagnostics.Common
         /// <summary>Gets the span kind.</summary>
         public SpanKind SpanKind { get; }
 
-        private StartSpanOptions(SpanKind spanKind)
+        /// <summary>Gets the lables to be added to the span.</summary>
+        public Dictionary<string, string> Labels { get; }
+
+        private StartSpanOptions(SpanKind spanKind, Dictionary<string, string> labels)
         {
-            SpanKind = spanKind;
+            SpanKind = GaxPreconditions.CheckEnumValue(spanKind, nameof(spanKind));
+            Labels = GaxPreconditions.CheckNotNull(labels, nameof(labels));
         }
 
         /// <summary>
         /// Creates a <see cref="StartSpanOptions"/>.
         /// </summary>
         /// <param name="spanKind">Optional, the span kind.  Defaults to <see cref="SpanKind.Unspecified"/></param>
-        public static StartSpanOptions Create(SpanKind spanKind = SpanKind.Unspecified)
-            => new StartSpanOptions(spanKind);
+        /// <param name="labels">Optional, labels to add to the span.<param>
+        public static StartSpanOptions Create(
+            SpanKind spanKind = SpanKind.Unspecified, Dictionary<string, string> labels = null)
+                => new StartSpanOptions(spanKind, labels ?? new Dictionary<string, string>());
     }
 }


### PR DESCRIPTION
This will greatly simplify ending spans especially if an exception is thrown.

Also adds RunInSpan which runs a function in a span and captures a stacktrace if one occurs. The RunInSpan changes includes a change to span options so users can easily pass in labels.

Also fixes an old issue where the simple managed tracer mutex was static and should have been readonly instead.



Fixes #791