### PR TITLE
Use a TraceServiceClient in place of the Task<TraceServiceClient>

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
@@ -101,12 +101,12 @@ namespace Google.Cloud.Diagnostics.AspNet
         public static TraceHeaderPropagatingHandler CreateTracingHttpMessageHandler() =>
             new TraceHeaderPropagatingHandler(() => CurrentTracer);
 
-        private CloudTrace(string projectId, TraceConfiguration config = null, Task<TraceServiceClient> client = null)
+        private CloudTrace(string projectId, TraceConfiguration config = null, TraceServiceClient client = null)
         {
             GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
 
             // Create the default values if not set.
-            client = client ?? TraceServiceClient.CreateAsync();
+            client = client ?? TraceServiceClient.Create();
             config = config ?? TraceConfiguration.Create();
 
             _consumer = ConsumerFactory<TraceProto>.GetConsumer(
@@ -123,7 +123,7 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// <param name="application">The Http application.</param>
         /// <param name="config">Optional trace configuration, if unset the default will be used.</param>
         /// <param name="client">Optional trace client, if unset the default will be used.</param>
-        public static void Initialize(string projectId, HttpApplication application, TraceConfiguration config = null, Task<TraceServiceClient> client = null)
+        public static void Initialize(string projectId, HttpApplication application, TraceConfiguration config = null, TraceServiceClient client = null)
         {
             GaxPreconditions.CheckNotNull(application, nameof(application));
             CloudTrace trace = new CloudTrace(projectId, config, client);

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
@@ -91,20 +91,19 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <param name="services">The service collection. Cannot be null.</param>
         /// <param name="projectId">The Google Cloud Platform project ID. Cannot be null.</param>
         /// <param name="config">Optional trace configuration, if unset the default will be used.</param>
-        /// <param name="clientTask">Optional task which produces the Trace client, if 
-        ///     unset the default will be used.</param>
+        /// <param name="client">Optional Trace client, if unset the default will be used.</param>
         public static void AddGoogleTrace(
             this IServiceCollection services, string projectId,
-            TraceConfiguration config = null, Task<TraceServiceClient> clientTask = null)
+            TraceConfiguration config = null, TraceServiceClient client = null)
         {
             GaxPreconditions.CheckNotNull(services, nameof(services));
             GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
 
-            clientTask = clientTask ?? TraceServiceClient.CreateAsync();
+            client = client ?? TraceServiceClient.Create();
             config = config ?? TraceConfiguration.Create();
 
             IConsumer<TraceProto> consumer = ConsumerFactory<TraceProto>.GetConsumer(
-                 new GrpcTraceConsumer(clientTask), MessageSizer<TraceProto>.GetSize, config.BufferOptions);
+                 new GrpcTraceConsumer(client), MessageSizer<TraceProto>.GetSize, config.BufferOptions);
 
             var tracerFactory = new ManagedTracerFactory(projectId, consumer,
                 RateLimitingTraceOptionsFactory.Create(config), TraceIdFactory.Create());

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/SimpleManagedTracerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/SimpleManagedTracerTest.cs
@@ -45,7 +45,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         private IConsumer<TraceProto> CreateGrpcTraceConsumer()
         {
             TraceServiceClient client = TraceServiceClient.Create();
-            return new GrpcTraceConsumer(Task.FromResult(client));
+            return new GrpcTraceConsumer(client);
         }
 
         private SimpleManagedTracer CreateSimpleManagedTracer(IConsumer<TraceProto> consumer)

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceHeaderPropagatingHandlerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceHeaderPropagatingHandlerTest.cs
@@ -87,7 +87,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         {
             string traceId = _traceIdFactory.NextId();
             var traceProto = new TraceProto { ProjectId = _projectId, TraceId = traceId };
-            var consumer = new GrpcTraceConsumer(TraceServiceClient.CreateAsync());
+            var consumer = new GrpcTraceConsumer(TraceServiceClient.Create());
             return SimpleManagedTracer.Create(consumer, traceProto, null);
         }
 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/GrpcTraceConsumerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/GrpcTraceConsumerTest.cs
@@ -38,8 +38,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
 
             var mockClient = new Mock<TraceServiceClient>();
             mockClient.Setup(c => c.PatchTraces(ProjectId, traces, null));
-            var taskClient = Task.FromResult(mockClient.Object);
-            var consumer = new GrpcTraceConsumer(taskClient);
+            var consumer = new GrpcTraceConsumer(mockClient.Object);
 
             consumer.Receive(traces.Traces_);
             mockClient.VerifyAll();
@@ -49,8 +48,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void Receive_EmptyTracesIgnored()
         {
             var mockClient = new Mock<TraceServiceClient>();
-            var taskClient = Task.FromResult(mockClient.Object);
-            var consumer = new GrpcTraceConsumer(taskClient);
+            var consumer = new GrpcTraceConsumer(mockClient.Object);
 
             consumer.Receive(new List<TraceProto>());
             mockClient.Verify(c => c.PatchTraces(It.IsAny<string>(), It.IsAny<Traces>(), null), Times.Never());
@@ -64,8 +62,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             var mockClient = new Mock<TraceServiceClient>();
             mockClient.Setup(c => c.PatchTracesAsync(
                 ProjectId, traces, CancellationToken.None)).Returns(CommonUtils.CompletedTask);
-            var taskClient = Task.FromResult(mockClient.Object);
-            var consumer = new GrpcTraceConsumer(taskClient);
+            var consumer = new GrpcTraceConsumer(mockClient.Object);
 
             await consumer.ReceiveAsync(traces.Traces_, CancellationToken.None);
             mockClient.VerifyAll();
@@ -75,8 +72,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public async Task ReceiveAsync_EmptyTracesIgnored()
         {
             var mockClient = new Mock<TraceServiceClient>();
-            var taskClient = Task.FromResult(mockClient.Object);
-            var consumer = new GrpcTraceConsumer(taskClient);
+            var consumer = new GrpcTraceConsumer(mockClient.Object);
 
             await consumer.ReceiveAsync(new List<TraceProto>());
             mockClient.Verify(c => c.PatchTracesAsync(It.IsAny<string>(), It.IsAny<Traces>(), null), Times.Never());

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/GrpcTraceConsumer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/GrpcTraceConsumer.cs
@@ -28,12 +28,12 @@ namespace Google.Cloud.Diagnostics.Common
     /// </summary>
     internal sealed class GrpcTraceConsumer : IConsumer<TraceProto>
     {
-        private readonly Task<TraceServiceClient> _clientTask;
+        private readonly TraceServiceClient _client;
 
         /// <param name="client">The trace client that will push traces to the Stackdriver Trace API.</param>
-        internal GrpcTraceConsumer(Task<TraceServiceClient> client)
+        internal GrpcTraceConsumer(TraceServiceClient client)
         {
-            _clientTask = GaxPreconditions.CheckNotNull(client, nameof(client));
+            _client = GaxPreconditions.CheckNotNull(client, nameof(client));
         }
 
         /// <inheritdoc />
@@ -50,7 +50,7 @@ namespace Google.Cloud.Diagnostics.Common
 
             Traces tracesObj = new Traces { Traces_ = { traces } };
             // If the client task has faulted this will throw when accessing 'Result'
-            _clientTask.Result.PatchTraces(trace.ProjectId, tracesObj);
+            _client.PatchTraces(trace.ProjectId, tracesObj);
         }
 
         /// <inheritdoc />
@@ -67,7 +67,7 @@ namespace Google.Cloud.Diagnostics.Common
 
             Traces tracesObj = new Traces { Traces_ = { traces } };
             // If the client task has faulted this will throw when accessing 'Result'
-            return _clientTask.Result.PatchTracesAsync(trace.ProjectId, tracesObj, cancellationToken);
+            return _client.PatchTracesAsync(trace.ProjectId, tracesObj, cancellationToken);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This is to be consistent with the other diagnostic bits.  We do not need to make this an async operation as creation of clients is not costly.

This fixed #813 