### PR TITLE
Add a RunInSpanAsync and fix namespaces

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceHeaderPropagatingHandlerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceHeaderPropagatingHandlerTest.cs
@@ -25,7 +25,7 @@ using Xunit;
 
 using TraceProto = Google.Cloud.Trace.V1.Trace;
 
-namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
+namespace Google.Cloud.Diagnostics.Common.IntegrationTests
 {
     public class TraceHeaderPropagatingHandlerTest
     {

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/TraceHeaderPropagatingHandlerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/TraceHeaderPropagatingHandlerTest.cs
@@ -57,7 +57,6 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         [Fact]
         public async Task SendAsync_Trace()
         {
-
             var mockTracer = GetSetUpTracer();
             var fakeHandler = new FakeDelegatingHandler(headerContext);
             var traceHandler = new TraceHeaderPropagatingHandler(() => mockTracer.Object, fakeHandler);
@@ -65,7 +64,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             var requestUri = new Uri("https://www.google.com");
             var requestUriString = requestUri.ToString();
 
-            mockTracer.Setup(t => t.RunInSpan(
+            mockTracer.Setup(t => t.RunInSpanAsync(
                 It.IsAny<Func<Task<HttpResponseMessage>>>(), requestUri.ToString(), null))
                 .Returns(Task.FromResult(new HttpResponseMessage()));
 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/IManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/IManagedTracer.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace Google.Cloud.Diagnostics.Common
 {
@@ -59,6 +60,17 @@ namespace Google.Cloud.Diagnostics.Common
         /// <param name="options">The span options to override default values.</param>
         /// <returns>The result from the call to <paramref name="func"/></returns>
         T RunInSpan<T>(Func<T> func, string name, StartSpanOptions options = null);
+
+        /// <summary>
+        /// Runs the function asynchronously in a span and will add a stacktrace
+        /// from a thrown exception (the exception will be re-thrown) to the span.
+        /// </summary>
+        /// <param name="func">The function to run in a span.</param>
+        /// <param name="name">The name of the span, cannot be null.</param>
+        /// <param name="options">The span options to override default values.</param>
+        /// <returns>The result from the call to <paramref name="func"/></returns>
+        Task<T> RunInSpanAsync<T>(Func<Task<T>> func, string name, StartSpanOptions options = null);
+
 
         /// <summary>
         /// Annotates the current span with the given labels. 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/NullManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/NullManagedTracer.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace Google.Cloud.Diagnostics.Common
 {
@@ -56,6 +57,11 @@ namespace Google.Cloud.Diagnostics.Common
         /// Calls <paramref name="func"/> and returns the result.
         /// </summary>
         public T RunInSpan<T>(Func<T> func, string name, StartSpanOptions options = null) => func();
+
+        /// <summary>
+        /// Calls <paramref name="func"/> asynchronously and returns the result.
+        /// </summary>
+        public async Task<T> RunInSpanAsync<T>(Func<Task<T>> func, string name, StartSpanOptions options = null) => await func();
 
         /// <summary>
         /// Does nothing.

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
@@ -145,7 +145,7 @@ namespace Google.Cloud.Diagnostics.Common
             {
                 try
                 {
-                    return await func();
+                    return await func().ConfigureAwait(false);
                 }
                 catch (Exception e) when (SetStackTraceAndReturnFalse(e))
                 {

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
@@ -18,7 +18,7 @@ using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-
+using System.Threading.Tasks;
 using TraceProto = Google.Cloud.Trace.V1.Trace;
 
 namespace Google.Cloud.Diagnostics.Common
@@ -134,6 +134,23 @@ namespace Google.Cloud.Diagnostics.Common
                 {
                     // This will never return as the condition above will always be false.
                     return default(T);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<T> RunInSpanAsync<T>(Func<Task<T>> func, string name, StartSpanOptions options = null)
+        {
+            using (StartSpan(name, options))
+            {
+                try
+                {
+                    return await func();
+                }
+                catch (Exception e) when (SetStackTraceAndReturnFalse(e))
+                {
+                    // This will never return as the condition above will always be false.
+                    return await Task.FromResult(default(T));
                 }
             }
         }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceHeaderPropagatingHandler.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceHeaderPropagatingHandler.cs
@@ -66,21 +66,21 @@ namespace Google.Cloud.Diagnostics.Common
         /// Sends the given request.  If tracing is initialized and enabled the outgoing request is
         /// traced and the trace header is added to the request.
         /// </summary>
-        protected override async Task<HttpResponseMessage> SendAsync(
+        protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var tracer = _managedTracerFactory();
             if (tracer.GetCurrentTraceId() == null)
             {
-                return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                return base.SendAsync(request, cancellationToken);
             }
 
             var traceHeader = TraceHeaderContext.Create(
                 tracer.GetCurrentTraceId(), tracer.GetCurrentSpanId() ?? 0, true);
             request.Headers.Add(TraceHeaderContext.TraceHeader, traceHeader.ToString());
 
-            return await tracer.RunInSpan(
-                async () => { return await base.SendAsync(request, cancellationToken).ConfigureAwait(false); }, 
+            return tracer.RunInSpanAsync(
+                () => { return base.SendAsync(request, cancellationToken); }, 
                 request.RequestUri.ToString());
         }
     }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceHeaderPropagatingHandler.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceHeaderPropagatingHandler.cs
@@ -80,7 +80,7 @@ namespace Google.Cloud.Diagnostics.Common
             request.Headers.Add(TraceHeaderContext.TraceHeader, traceHeader.ToString());
 
             return tracer.RunInSpanAsync(
-                () => { return base.SendAsync(request, cancellationToken); }, 
+                () => base.SendAsync(request, cancellationToken), 
                 request.RequestUri.ToString());
         }
     }


### PR DESCRIPTION
The RunInSpanAsync fixes a bug around proper exception handling.

The namespace fix was due to a bad move in a previous PR