### PR TITLE
Fix Logging_SizedBufferNoLogs test failure and ensure others dont fail in the same way

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/ErrorReporting/ExceptionLoggerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/ErrorReporting/ExceptionLoggerTest.cs
@@ -62,10 +62,10 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
             using (TestServer server = TestServer.Create<T>())
             {
                 await server.HttpClient.GetAsync("");
-            }
 
-            var errorEvent = _polling.GetEvents(startTime, _testId, 1).Single();
-            Assert.Contains(_testId, errorEvent.Message);
+                var errorEvent = _polling.GetEvents(startTime, _testId, 1).Single();
+                Assert.Contains(_testId, errorEvent.Message);
+            }
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
@@ -74,10 +74,10 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             {
                 var client = server.CreateClient();
                 await client.GetAsync($"/ErrorReporting/Index/{testId}");
-            }
 
-            var errorEvents = _polling.GetEvents(startTime, testId, 0);
-            Assert.Empty(errorEvents);
+                var errorEvents = _polling.GetEvents(startTime, testId, 0);
+                Assert.Empty(errorEvents);
+            }
         }
 
         /// <summary>
@@ -97,11 +97,11 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 var client = server.CreateClient();
                 await Assert.ThrowsAsync<Exception>(() =>
                     client.GetAsync($"/ErrorReporting/ThrowsException/{testId}"));
-            }
 
-            var errorEvents = _polling.GetEvents(startTime, testId, 1);
-            Assert.Single(errorEvents);
-            VerifyErrorEvent(errorEvents.First(), testId, "ThrowsException");
+                var errorEvents = _polling.GetEvents(startTime, testId, 1);
+                Assert.Single(errorEvents);
+                VerifyErrorEvent(errorEvents.First(), testId, "ThrowsException");
+            }
         }
 
         /// <summary>
@@ -127,21 +127,21 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                     client.GetAsync($"/ErrorReporting/ThrowsException/{testId}"));
                 await Assert.ThrowsAsync<Exception>(() =>
                     client.GetAsync($"/ErrorReporting/ThrowsException/{testId}"));
+
+                var errorEvents = _polling.GetEvents(startTime, testId, 4);
+                Assert.Equal(4, errorEvents.Count());
+
+                var exceptionEvents = errorEvents.Where(e => e.Message.Contains("ThrowsException"));
+                Assert.Equal(3, exceptionEvents.Count());
+                foreach (var errorEvent in exceptionEvents)
+                {
+                    VerifyErrorEvent(errorEvent, testId, "ThrowsException");
+                }
+
+                var argumentExceptionEvents = errorEvents.Where(e => e.Message.Contains("ThrowsArgumentException"));
+                Assert.Single(argumentExceptionEvents);
+                VerifyErrorEvent(argumentExceptionEvents.First(), testId, "ThrowsArgumentException");
             }
-
-            var errorEvents = _polling.GetEvents(startTime, testId, 4);
-            Assert.Equal(4, errorEvents.Count());
-
-            var exceptionEvents = errorEvents.Where(e => e.Message.Contains("ThrowsException"));
-            Assert.Equal(3, exceptionEvents.Count());
-            foreach (var errorEvent in exceptionEvents)
-            {
-                VerifyErrorEvent(errorEvent, testId, "ThrowsException");
-            }
-
-            var argumentExceptionEvents = errorEvents.Where(e => e.Message.Contains("ThrowsArgumentException"));
-            Assert.Single(argumentExceptionEvents);
-            VerifyErrorEvent(argumentExceptionEvents.First(), testId, "ThrowsArgumentException");
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -48,11 +48,34 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 await client.GetAsync($"/Main/Warning/{testId}");
                 await client.GetAsync($"/Main/Error/{testId}");
                 await client.GetAsync($"/Main/Critical/{testId}");
+
+                // No entries should be found as not enough entries were created to
+                // flush the buffer.
+                Assert.Empty(_polling.GetEntries(startTime, testId, 0));
+            }
+        }
+
+        [Fact]
+        public async Task Logging_DisposeFlush()
+        {
+            string testId = Utils.GetTestId();
+            DateTime startTime = DateTime.UtcNow;
+
+            var builder = new WebHostBuilder().UseStartup<SizedBufferErrorLoggerTestApplication>();
+            using (TestServer server = new TestServer(builder))
+            {
+                var client = server.CreateClient();
+                await client.GetAsync($"/Main/Warning/{testId}");
+                await client.GetAsync($"/Main/Error/{testId}");
+                await client.GetAsync($"/Main/Critical/{testId}");
             }
 
-            // No entries should be found as not enough entries were created to
-            // flush the buffer.
-            Assert.Empty(_polling.GetEntries(startTime, testId, 0));
+            // While we normally should not have entries we disposed of the server
+            // which should flush the buffer.
+            var results = _polling.GetEntries(startTime, testId, 2);
+            Assert.Equal(2, results.Count());
+            Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Error));
+            Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Critical));
         }
 
         [Fact]
@@ -70,14 +93,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 await client.GetAsync($"/Main/Warning/{testId}");
                 await client.GetAsync($"/Main/Error/{testId}");
                 await client.GetAsync($"/Main/Critical/{testId}");
-            }
 
-            // NoBufferLoggerTestApplication does not support debug or info logs.
-            var results = _polling.GetEntries(startTime, testId, 3);
-            Assert.Equal(3, results.Count());
-            Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Warning));
-            Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Error));
-            Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Critical));
+                // NoBufferLoggerTestApplication does not support debug or info logs.
+                var results = _polling.GetEntries(startTime, testId, 3);
+                Assert.Equal(3, results.Count());
+                Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Warning));
+                Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Error));
+                Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Critical));
+            }
         }
 
         [Fact]
@@ -99,17 +122,17 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                     await client.GetAsync($"/Main/Critical/{testId}");
                     await client.GetAsync($"/Main/Exception/{testId}");
                 }
-            }
 
-            // Just check that a large portion of logs entires were pushed.  Not all
-            // will be pushed as some may be in the buffer.
-            var results = _polling.GetEntries(startTime, testId, 500);
-            Assert.True(results.Count() >= 500);
-            Assert.Null(results.FirstOrDefault(l => l.Severity == LogSeverity.Debug));
-            Assert.Null(results.FirstOrDefault(l => l.Severity == LogSeverity.Info));
-            Assert.Null(results.FirstOrDefault(l => l.Severity == LogSeverity.Warning));
-            Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Error));
-            Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Critical));
+                // Just check that a large portion of logs entires were pushed.  Not all
+                // will be pushed as some may be in the buffer.
+                var results = _polling.GetEntries(startTime, testId, 500);
+                Assert.True(results.Count() >= 500);
+                Assert.Null(results.FirstOrDefault(l => l.Severity == LogSeverity.Debug));
+                Assert.Null(results.FirstOrDefault(l => l.Severity == LogSeverity.Info));
+                Assert.Null(results.FirstOrDefault(l => l.Severity == LogSeverity.Warning));
+                Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Error));
+                Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Critical));
+            }
         }
 
 
@@ -133,13 +156,13 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 await client.GetAsync($"/Main/Error/{testId}");
                 await client.GetAsync($"/Main/Critical/{testId}");
                 Thread.Sleep(TimeSpan.FromSeconds(10));
-            }
 
-            var results = _polling.GetEntries(startTime, testId, 4);
-            Assert.Equal(4, results.Count());
-            Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Warning));
-            Assert.Equal(2, results.Count(l => l.Severity == LogSeverity.Error));
-            Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Critical));
+                var results = _polling.GetEntries(startTime, testId, 4);
+                Assert.Equal(4, results.Count());
+                Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Warning));
+                Assert.Equal(2, results.Count(l => l.Severity == LogSeverity.Error));
+                Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Critical));
+            }
         }
 
         [Fact]
@@ -155,13 +178,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 await client.GetAsync($"/Main/Warning/{testId}");
                 await client.GetAsync($"/Main/Error/{testId}");
                 await client.GetAsync($"/Main/Critical/{testId}");
-            }
 
-            var results = _polling.GetEntries(startTime, testId, 3);
-            Assert.Equal(3, results.Count());
-            var resourceType = NoBufferResourceLoggerTestApplication.Resource.Type;
-            var buildResources = results.Where(e => e.Resource.Type.Equals(resourceType));
-            Assert.Equal(3, buildResources.Count());
+                var results = _polling.GetEntries(startTime, testId, 3);
+                Assert.Equal(3, results.Count());
+                var resourceType = NoBufferResourceLoggerTestApplication.Resource.Type;
+                var buildResources = results.Where(e => e.Resource.Type.Equals(resourceType));
+                Assert.Equal(3, buildResources.Count());
+
+            }
         }
     }
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
@@ -46,17 +46,17 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             {
                 var client = server.CreateClient();
                 await client.GetAsync($"/Trace/Trace/{testId}");
+
+                var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);
+                var trace = _polling.GetTrace(spanName, startTime);
+
+                Assert.NotNull(trace);
+                Assert.Equal(2, trace.Spans.Count);
+                var span = trace.Spans.First(s => s.Name.StartsWith("/Trace/Trace/"));
+                Assert.NotEmpty(span.Labels);
+                Assert.Equal(span.Labels[TraceLabels.HttpMethod], "GET");
+                Assert.Equal(span.Labels[TraceLabels.HttpStatusCode], "200");
             }
-
-            var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);
-            var trace = _polling.GetTrace(spanName, startTime);
-
-            Assert.NotNull(trace);
-            Assert.Equal(2, trace.Spans.Count);
-            var span = trace.Spans.First(s => s.Name.StartsWith("/Trace/Trace/"));
-            Assert.NotEmpty(span.Labels);
-            Assert.Equal(span.Labels[TraceLabels.HttpMethod], "GET");
-            Assert.Equal(span.Labels[TraceLabels.HttpStatusCode], "200");
         }
 
         [Fact]
@@ -70,16 +70,16 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             {
                 var client = server.CreateClient();
                 await client.GetAsync($"/Trace/TraceLabels/{testId}");
-            }
 
-            var spanName = TraceController.GetMessage(nameof(TraceController.TraceLabels), testId);
-            var trace = _polling.GetTrace(spanName, startTime);
+                var spanName = TraceController.GetMessage(nameof(TraceController.TraceLabels), testId);
+                var trace = _polling.GetTrace(spanName, startTime);
 
-            Assert.NotNull(trace);
-            Assert.Equal(2, trace.Spans.Count);
-            var span = trace.Spans.First(s => s.Name.StartsWith("Trace"));
-            Assert.Single(span.Labels);
-            Assert.Equal(span.Labels[TraceController.Label], TraceController.LabelValue);
+                Assert.NotNull(trace);
+                Assert.Equal(2, trace.Spans.Count);
+                var span = trace.Spans.First(s => s.Name.StartsWith("Trace"));
+                Assert.Single(span.Labels);
+                Assert.Equal(span.Labels[TraceController.Label], TraceController.LabelValue);
+            }   
         }
 
         [Fact]
@@ -93,17 +93,17 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             {
                 var client = server.CreateClient();
                 await client.GetAsync($"/Trace/TraceStackTrace/{testId}");
-            }
 
-            var spanName = TraceController.GetMessage(nameof(TraceController.TraceStackTrace), testId);
-            var trace = _polling.GetTrace(spanName, startTime);
+                var spanName = TraceController.GetMessage(nameof(TraceController.TraceStackTrace), testId);
+                var trace = _polling.GetTrace(spanName, startTime);
 
-            Assert.NotNull(trace);
-            Assert.Equal(2, trace.Spans.Count);
-            var span = trace.Spans.First(s => s.Name.StartsWith("Trace"));
-            Assert.Single(span.Labels);
-            Assert.Contains(nameof(TraceController), span.Labels[TraceLabels.StackTrace]);
-            Assert.Contains(nameof(TraceController.CreateStackTrace), span.Labels[TraceLabels.StackTrace]);   
+                Assert.NotNull(trace);
+                Assert.Equal(2, trace.Spans.Count);
+                var span = trace.Spans.First(s => s.Name.StartsWith("Trace"));
+                Assert.Single(span.Labels);
+                Assert.Contains(nameof(TraceController), span.Labels[TraceLabels.StackTrace]);
+                Assert.Contains(nameof(TraceController.CreateStackTrace), span.Labels[TraceLabels.StackTrace]);
+            }   
         }
 
         [Fact]
@@ -122,16 +122,16 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 var header = TraceHeaderContext.Create(traceId, spanId, shouldTrace: true);
                 client.DefaultRequestHeaders.Add(TraceHeaderContext.TraceHeader, header.ToString());
                 await client.GetAsync($"/Trace/Trace/{testId}");
+
+                var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);
+                var trace = _polling.GetTrace(spanName, startTime);
+
+                Assert.NotNull(trace);
+                Assert.Equal(traceId, trace.TraceId);
+                Assert.Equal(2, trace.Spans.Count);
+                var span = trace.Spans.First(s => s.Name.StartsWith("/Trace"));
+                Assert.Equal(spanId, span.ParentSpanId);
             }
-
-            var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);
-            var trace = _polling.GetTrace(spanName, startTime);
-
-            Assert.NotNull(trace);
-            Assert.Equal(traceId, trace.TraceId);
-            Assert.Equal(2, trace.Spans.Count);
-            var span = trace.Spans.First(s => s.Name.StartsWith("/Trace"));
-            Assert.Equal(spanId, span.ParentSpanId);
         }
 
         [Fact]
@@ -150,13 +150,13 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 // request is traced.
                 await client.GetAsync($"/Trace/TraceLabels/{testId}");
                 Thread.Sleep(TimeSpan.FromSeconds(2));
-                await client.GetAsync($"/Trace/Trace/{testId}");                
-            }
+                await client.GetAsync($"/Trace/Trace/{testId}");
 
-            var spanNameTrace = TraceController.GetMessage(nameof(TraceController.Trace), testId);
-            var spanNameLabels = TraceController.GetMessage(nameof(TraceController.TraceLabels), testId);
-            Assert.Null(_polling.GetTrace(spanNameLabels, startTime, expectTrace: false));
-            Assert.NotNull(_polling.GetTrace(spanNameTrace, startTime));
+                var spanNameTrace = TraceController.GetMessage(nameof(TraceController.Trace), testId);
+                var spanNameLabels = TraceController.GetMessage(nameof(TraceController.TraceLabels), testId);
+                Assert.Null(_polling.GetTrace(spanNameLabels, startTime, expectTrace: false));
+                Assert.NotNull(_polling.GetTrace(spanNameTrace, startTime));
+            }
         }
 
         [Fact]
@@ -178,11 +178,11 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
                 // Make a large trace that will flush the buffer.
                 await client.GetAsync($"/Trace/TraceStackTrace/{testId}");
-            }
 
-            var spanNameStack = TraceController.GetMessage(nameof(TraceController.TraceStackTrace), testId);
-            Assert.NotNull(_polling.GetTrace(spanName, startTime));
-            Assert.NotNull(_polling.GetTrace(spanNameStack, startTime));
+                var spanNameStack = TraceController.GetMessage(nameof(TraceController.TraceStackTrace), testId);
+                Assert.NotNull(_polling.GetTrace(spanName, startTime));
+                Assert.NotNull(_polling.GetTrace(spanNameStack, startTime));
+            }
         }
 
         [Fact]
@@ -203,16 +203,16 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 {
                     // This will throw as the task faults.
                 }
+
+                var spanName = TraceController.GetMessage(nameof(TraceController.ThrowException), testId);
+                var trace = _polling.GetTrace(spanName, startTime);
+
+                Assert.NotNull(trace);
+                var span = trace.Spans.First(s => s.Name.StartsWith("/Trace/ThrowException"));
+                Assert.NotEmpty(span.Labels);
+                Assert.Contains(nameof(TraceController), span.Labels[Common.TraceLabels.StackTrace]);
+                Assert.Contains(nameof(TraceController.ThrowException), span.Labels[Common.TraceLabels.StackTrace]);
             }
-
-            var spanName = TraceController.GetMessage(nameof(TraceController.ThrowException), testId);
-            var trace = _polling.GetTrace(spanName, startTime);
-
-            Assert.NotNull(trace);
-            var span = trace.Spans.First(s => s.Name.StartsWith("/Trace/ThrowException"));
-            Assert.NotEmpty(span.Labels);
-            Assert.Contains(nameof(TraceController), span.Labels[Common.TraceLabels.StackTrace]);
-            Assert.Contains(nameof(TraceController.ThrowException), span.Labels[Common.TraceLabels.StackTrace]);
         }
     }
 


### PR DESCRIPTION
The test Logging_SizedBufferNoLogs was failing as we were checking for for the resources after the test server was disposed of.  This disposed of the buffered consumers and flushed results and we were not expecting them to exist.

I moved most test checks before disposal of the test server to prevent this.  The exception is when testing that disposal  flushes the buffers.