### PR TITLE
Use the IHttpContextAccessor to get the IManagedTracer.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/CloudTraceExtensionTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/CloudTraceExtensionTest.cs
@@ -48,16 +48,19 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
         [Fact]
         public void CreateManagedTracer()
         {
-
+            var accessor = new HttpContextAccessor();
+            accessor.HttpContext = new DefaultHttpContext();
             var context = TraceHeaderContext.Create(null, null, false);
             var tracerFactoryMock = new Mock<IManagedTracerFactory>();
             tracerFactoryMock.Setup(f => f.CreateTracer(context)).Returns(NullManagedTracer.Instance);
             var mockProvider = new Mock<IServiceProvider>();
             mockProvider.Setup(p => p.GetService(typeof(TraceHeaderContext))).Returns(context);
             mockProvider.Setup(p => p.GetService(typeof(IManagedTracerFactory))).Returns(tracerFactoryMock.Object);
+            mockProvider.Setup(p => p.GetService(typeof(IHttpContextAccessor))).Returns(accessor);
 
             var tracer = CloudTraceExtension.CreateManagedTracer(mockProvider.Object);
             Assert.IsType(typeof(NullManagedTracer), tracer);
+            Assert.Equal(tracer, accessor.HttpContext.Items[CloudTraceExtension.TraceKey]);
             tracerFactoryMock.VerifyAll();
             mockProvider.VerifyAll();
         }


### PR DESCRIPTION
We do this as the IHttpContextAccessor is a singleton and will always have the proper HttpContext while IServiceProvider does not.

Without this traces will be incorrectly reported.