### PR TITLE
Fix trace integration tests.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceLabels.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceLabels.cs
@@ -27,19 +27,19 @@ namespace Google.Cloud.Diagnostics.Common
     internal static class TraceLabels
     {
         ///<summary>The label to denote the size of a request.</summary> 
-        internal const string HttpRequestSize = "trace.cloud.google.com/http/request/size";
+        internal const string HttpRequestSize = "/http/request/size";
 
         ///<summary>The label to denote the host.</summary> 
-        internal const string HttpHost = "trace.cloud.google.com/http/host";
+        internal const string HttpHost = "/http/host";
 
         ///<summary>The label to denote the request method.</summary> 
-        internal const string HttpMethod = "trace.cloud.google.com/http/method";
+        internal const string HttpMethod = "/http/method";
 
         ///<summary>The label to denote the response status code.</summary> 
-        internal const string HttpStatusCode = "trace.cloud.google.com/http/status_code";
+        internal const string HttpStatusCode = "/http/status_code";
 
         ///<summary>The label to denote a stack trace.</summary> 
-        internal const string StackTrace = "trace.cloud.google.com/stacktrace";
+        internal const string StackTrace = "/stacktrace";
 
         ///<summary>The label to denote an agent.</summary> 
         internal const string Agent = "/agent";


### PR DESCRIPTION
The trace service made changes to how they handle and process labels that would be picked to show up in the Google Cloud Console UI.

Previously the labels needed to be prefixed with "trace.cloud.google.com"  such as "trace.cloud.google.com/stacktrace".  The prefix is now not required and stripped from the label.

This broke the integration tests as we were sending "trace.cloud.google.com/stacktrace" and expecting "trace.cloud.google.com/stacktrace" but received "/stacktrace".  However we can now send "/stacktrace" and reveive "/stacktrace"