### PR TITLE
Small updates to the Simple Managed Tracer

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/SimpleManagedTracerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/SimpleManagedTracerTest.cs
@@ -48,15 +48,8 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
             return new GrpcTraceConsumer(client);
         }
 
-        private SimpleManagedTracer CreateSimpleManagedTracer(IConsumer<TraceProto> consumer)
-        {
-            TraceProto trace = new TraceProto
-            {
-                ProjectId = _projectId,
-                TraceId = _traceIdFactory.NextId()
-            };
-            return SimpleManagedTracer.Create(consumer, trace, null);
-        }
+        private SimpleManagedTracer CreateSimpleManagedTracer(IConsumer<TraceProto> consumer) =>
+            SimpleManagedTracer.Create(consumer, _projectId, _traceIdFactory.NextId(), null);
 
         /// <summary>
         /// Block until the time has changed.

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceHeaderPropagatingHandlerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceHeaderPropagatingHandlerTest.cs
@@ -100,9 +100,8 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         private IManagedTracer CreateTracer()
         {
             string traceId = _traceIdFactory.NextId();
-            var traceProto = new TraceProto { ProjectId = _projectId, TraceId = traceId };
             var consumer = new GrpcTraceConsumer(TraceServiceClient.Create());
-            return SimpleManagedTracer.Create(consumer, traceProto, null);
+            return SimpleManagedTracer.Create(consumer, _projectId, traceId, null);
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
@@ -302,6 +302,33 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         }
 
         [Fact]
+        public void SpansClearedOnFlush()
+        {
+            var mockConsumer = new Mock<IConsumer<TraceProto>>();
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+
+            mockConsumer.Setup(c => c.Receive(
+                 Match.Create<IEnumerable<TraceProto>>(
+                     t => IsValidSpan(t.Single().Spans.Single(), "span-name-0"))));
+
+            tracer.StartSpan("span-name-0");
+            tracer.EndSpan();
+
+            mockConsumer.VerifyAll();
+
+            mockConsumer.Setup(c => c.Receive(
+                Match.Create<IEnumerable<TraceProto>>(
+                    t => IsValidSpan(t.Single().Spans.Single(), "span-name-1"))));
+
+            tracer.StartSpan("span-name-1");
+            tracer.EndSpan();
+
+            mockConsumer.VerifyAll();
+
+
+        }
+
+        [Fact]
         public void EndSpan_NoAvailableSpan()
         {
             var tracer = SimpleManagedTracer.Create(UnusedConsumer, CreateTrace());

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
@@ -324,8 +324,6 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             tracer.EndSpan();
 
             mockConsumer.VerifyAll();
-
-
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
@@ -34,9 +34,6 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         private static readonly StackTrace EmptyStackTrace = new StackTrace(new Exception(), false);
         private static readonly StackTrace FilledStackTrace = CreateStackTrace();
 
-        private static TraceProto CreateTrace(string projectId = ProjectId, string traceId = TraceId)
-            => new TraceProto { ProjectId = ProjectId, TraceId = TraceId };
-
         private static bool IsValidSpan(TraceSpan span, string name)
             => IsValidSpan(span, name, 0);
 
@@ -70,7 +67,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void SingleSpan()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
-            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, ProjectId, TraceId);
 
             mockConsumer.Setup(c => c.Receive(
                 Match.Create<IEnumerable<TraceProto>>(
@@ -85,7 +82,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void SingleSpan_Dispose()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
-            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, ProjectId, TraceId);
 
             mockConsumer.Setup(c => c.Receive(
                 Match.Create<IEnumerable<TraceProto>>(
@@ -99,7 +96,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void SingleSpan_ParentId()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
-            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace(), 123);
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, ProjectId, TraceId, 123);
 
             mockConsumer.Setup(c => c.Receive(
                 Match.Create<IEnumerable<TraceProto>>(
@@ -114,7 +111,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void SingleSpan_Options()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
-            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, ProjectId, TraceId);
 
             var annotation = new Dictionary<string, string>();
             annotation.Add("annotation-key", "annotation-value");
@@ -134,7 +131,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void SingleSpan_Annotation()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
-            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, ProjectId, TraceId);
 
             var annotation = new Dictionary<string, string>();
             annotation.Add("annotation-key", "annotation-value");
@@ -154,7 +151,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void SingleSpan_Stacktrace()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
-            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, ProjectId, TraceId);
 
             var annotation = new Dictionary<string, string>();
             annotation.Add("annotation-key", "annotation-value");
@@ -174,7 +171,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void RunInSpan_Action()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
-            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, ProjectId, TraceId);
 
             mockConsumer.Setup(c => c.Receive(
                 Match.Create<IEnumerable<TraceProto>>(
@@ -190,7 +187,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void RunInSpan_Action_Throws()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
-            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, ProjectId, TraceId);
 
             mockConsumer.Setup(c => c.Receive(
                 Match.Create<IEnumerable<TraceProto>>(
@@ -208,7 +205,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void RunInSpan_Func()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
-            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, ProjectId, TraceId);
 
             mockConsumer.Setup(c => c.Receive(
                 Match.Create<IEnumerable<TraceProto>>(
@@ -222,7 +219,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void MultipleSpans()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
-            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, ProjectId, TraceId);
 
             var annotation = new Dictionary<string, string>();
             annotation.Add("annotation-key", "annotation-value");
@@ -260,7 +257,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void MultipleSpans_Dispose()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
-            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, ProjectId, TraceId);
 
             var annotation = new Dictionary<string, string>();
             annotation.Add("annotation-key", "annotation-value");
@@ -291,7 +288,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void IncompleteSpans()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
-            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, ProjectId, TraceId);
 
             tracer.StartSpan("span-name-0");
             tracer.StartSpan("span-name-1");
@@ -305,7 +302,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void SpansClearedOnFlush()
         {
             var mockConsumer = new Mock<IConsumer<TraceProto>>();
-            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(mockConsumer.Object, ProjectId, TraceId);
 
             mockConsumer.Setup(c => c.Receive(
                  Match.Create<IEnumerable<TraceProto>>(
@@ -324,47 +321,49 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             tracer.EndSpan();
 
             mockConsumer.VerifyAll();
+
+
         }
 
         [Fact]
         public void EndSpan_NoAvailableSpan()
         {
-            var tracer = SimpleManagedTracer.Create(UnusedConsumer, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(UnusedConsumer, ProjectId, TraceId);
             Assert.Throws<InvalidOperationException>(() => tracer.EndSpan());
         }
 
         [Fact]
         public void AnnotateSpan_NoAvailableSpan()
         {
-            var tracer = SimpleManagedTracer.Create(UnusedConsumer, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(UnusedConsumer, ProjectId, TraceId);
             Assert.Throws<InvalidOperationException>(() => tracer.AnnotateSpan(EmptyDictionary));
         }
 
         [Fact]
         public void SetStackTrace_NoAvailableSpan()
         {
-            var tracer = SimpleManagedTracer.Create(UnusedConsumer, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(UnusedConsumer, ProjectId, TraceId);
             Assert.Throws<InvalidOperationException>(() => tracer.SetStackTrace(EmptyStackTrace));
         }
 
         [Fact]
         public void GetCurrentTraceId()
         {
-            var tracer = SimpleManagedTracer.Create(UnusedConsumer, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(UnusedConsumer, ProjectId, TraceId);
             Assert.Equal(tracer.GetCurrentTraceId(), TraceId);
         }
 
         [Fact]
         public void GetCurrentSpanId_NoSpan()
         {
-            var tracer = SimpleManagedTracer.Create(UnusedConsumer, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(UnusedConsumer, ProjectId, TraceId);
             Assert.Null(tracer.GetCurrentSpanId());
         }
 
         [Fact]
         public void GetCurrentSpanId_Span()
         {
-            var tracer = SimpleManagedTracer.Create(UnusedConsumer, CreateTrace());
+            var tracer = SimpleManagedTracer.Create(UnusedConsumer, ProjectId, TraceId);
             tracer.StartSpan("span-name");
             Assert.NotNull(tracer.GetCurrentSpanId());
         }
@@ -373,7 +372,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void GetCurrentSpanId_ParentSpan()
         {
             ulong parentSpanId = 54321;
-            var tracer = SimpleManagedTracer.Create(UnusedConsumer, CreateTrace(), parentSpanId);
+            var tracer = SimpleManagedTracer.Create(UnusedConsumer, ProjectId, TraceId, parentSpanId);
             Assert.Equal(tracer.GetCurrentSpanId(), parentSpanId);
         }
     }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
@@ -321,8 +321,6 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             tracer.EndSpan();
 
             mockConsumer.VerifyAll();
-
-
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ManagedTracerFactory.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ManagedTracerFactory.cs
@@ -60,13 +60,8 @@ namespace Google.Cloud.Diagnostics.Common
             {
                 return NullManagedTracer.Instance;
             }
-
-            TraceProto trace = new TraceProto
-            {
-                ProjectId = _projectId,
-                TraceId = headerContext.TraceId ?? _traceIdFactory.NextId(),
-            };
-            return SimpleManagedTracer.Create(_consumer, trace, headerContext.SpanId);
+            var traceId = headerContext.TraceId ?? _traceIdFactory.NextId();
+            return SimpleManagedTracer.Create(_consumer, _projectId, traceId,  headerContext.SpanId);
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
@@ -47,7 +47,7 @@ namespace Google.Cloud.Diagnostics.Common
         private readonly IConsumer<TraceProto> _consumer;
 
         /// <summary>The current trace.</summary>
-        private readonly TraceProto _trace;
+        private TraceProto _trace;
 
         /// <summary>A stack of trace spans.</summary>
         private readonly Stack<TraceSpan> _traceStack;
@@ -241,9 +241,9 @@ namespace Google.Cloud.Diagnostics.Common
 
         private void Flush()
         {
-            _consumer.Receive(new[] { _trace });
-            // Clear out the flushed spans.
-            _trace.Spans.Clear();
+            var old = _trace;
+            _trace = new TraceProto { TraceId = old.TraceId };
+            _consumer.Receive(new[] { old });
         }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
@@ -242,6 +242,8 @@ namespace Google.Cloud.Diagnostics.Common
         private void Flush()
         {
             _consumer.Receive(new[] { _trace });
+            // Clear out the flushed spans.
+            _trace.Spans.Clear();
         }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
@@ -80,7 +80,7 @@ namespace Google.Cloud.Diagnostics.Common
         /// </summary>
         /// <param name="consumer">The consumer to push finished traces to. Cannot be null.</param>
         /// <param name="projectId">The Google Cloud Platform project ID. Cannot be null.</param>
-        /// <param name="traceId">The id of the current trace.  Cannot be null.</param>
+        /// <param name="traceId">The id of the current trace. Cannot be null.</param>
         /// <param name="rootSpanParentId">Optional, the parent span id of the root span of the passed in trace.</param>
         public static SimpleManagedTracer Create(IConsumer<TraceProto> consumer, string projectId,
             string traceId, ulong? rootSpanParentId = null)


### PR DESCRIPTION
- Change constructor to take a trace id and project id instead of a trace proto
- Fix a bug where a flush does not remove the already reported spans.
