### PR TITLE
Make the common extensions internal and not public.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SpanKind.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SpanKind.cs
@@ -34,14 +34,12 @@ namespace Google.Cloud.Diagnostics.Common
     /// <summary>
     /// Common extensions.
     /// </summary>
-    public static class Extensions
+    internal static class Extensions
     {
         /// <summary>
         /// Converts a <see cref="SpanKind"/> to a <see cref="TraceSpan.Types.SpanKind"/>.
         /// </summary>
-        /// <param name="kind"></param>
-        /// <returns></returns>
-        public static TraceSpan.Types.SpanKind Convert(this SpanKind kind)
+        internal static TraceSpan.Types.SpanKind Convert(this SpanKind kind)
         {
             switch (kind)
             {


### PR DESCRIPTION
They are only used internally and we have no reason to expose them.