### PR TITLE
Update storage dependency to 1.22.

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/SignedUrlResumableUpload.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/SignedUrlResumableUpload.cs
@@ -59,7 +59,7 @@ namespace Google.Cloud.Storage.V1
         }
 
         /// <inheritdoc/>
-        protected override async Task<Uri> InitiateSessionAsync(CancellationToken cancellationToken)
+        public override async Task<Uri> InitiateSessionAsync(CancellationToken cancellationToken)
         {
             var httpClient = Options?.HttpClient ?? new HttpClient();
             var request = new HttpRequestMessage(HttpMethod.Post, SignedUrl);

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/project.json
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.Gax.Rest": "1.0.0-beta12",
-    "Google.Apis.Storage.v1": "1.21.0.753"
+    "Google.Apis.Storage.v1": "1.22.0.785"
   },
   "frameworks": {
     "net45": {


### PR DESCRIPTION
Fixes #824 (via the Google.Apis dependency getting updated)

Making InitiateSessionAsync public in https://github.com/google/google-api-dotnet-client/commit/5a33ddc141e717648ff26b5f757b4a5ce01cb8a9 was a breaking change after all - but
it's unlikely to have hit anyone, and it's too late now...