### PR TITLE
Skip an integration test for BigQuery

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/InsertTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/InsertTest.cs
@@ -120,7 +120,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Equal(expectedResults, resultRows);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/897")]
         public void Insert_RepeatedField()
         {
             var client = BigQueryClient.Create(_fixture.ProjectId);


### PR DESCRIPTION
This is due to #897: when we know what's going on there, we can modify the test accordingly.