### PR TITLE
Add simpler support for GqlQueryParameters

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/DatastoreTransactionTest.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/DatastoreTransactionTest.cs
@@ -41,7 +41,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
                 var gql = new GqlQuery
                 {
                     QueryString = "SELECT * FROM childKind WHERE __key__ HAS ANCESTOR @1",
-                    PositionalBindings = { new GqlQueryParameter { Value = parentKey } }
+                    PositionalBindings = { parentKey }
                 };
                 var lazyResults = transaction.RunQueryLazily(query);
                 Assert.Equal(1, lazyResults.Count());
@@ -66,7 +66,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
                 var gql = new GqlQuery
                 {
                     QueryString = "SELECT * FROM childKind WHERE __key__ HAS ANCESTOR @1",
-                    PositionalBindings = { new GqlQueryParameter { Value = parentKey } }
+                    PositionalBindings = { parentKey }
                 };
                 var lazyResults = transaction.RunQueryLazilyAsync(query);
                 Assert.Equal(1, await lazyResults.Count());

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreClientSnippets.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreClientSnippets.cs
@@ -88,7 +88,7 @@ namespace Google.Cloud.Datastore.V1.Snippets
             request.GqlQuery = new GqlQuery
             {
                 QueryString = "SELECT * FROM book WHERE author = @author",
-                NamedBindings = { { "author", new GqlQueryParameter { Value = "Jane Austen" } } },
+                NamedBindings = { { "author", "Jane Austen" } },
             };
             foreach (EntityResult result in response.Batch.EntityResults)
             {

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreDbSnippets.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreDbSnippets.cs
@@ -164,7 +164,7 @@ namespace Google.Cloud.Datastore.V1.Snippets
             GqlQuery gqlQuery = new GqlQuery
             {
                 QueryString = "SELECT * FROM book WHERE author = @author",
-                NamedBindings = { { "author", new GqlQueryParameter { Value = "Jane Austen" } } },
+                NamedBindings = { { "author", "Jane Austen" } },
             };
             LazyDatastoreQuery results = db.RunQueryLazily(gqlQuery);
             // LazyDatastoreQuery implements IEnumerable<Entity>, but you can
@@ -196,7 +196,7 @@ namespace Google.Cloud.Datastore.V1.Snippets
             GqlQuery gqlQuery = new GqlQuery
             {
                 QueryString = "SELECT * FROM book WHERE author = @author",
-                NamedBindings = { { "author", new GqlQueryParameter { Value = "Jane Austen" } } },
+                NamedBindings = { { "author", "Jane Austen" } },
             };
             AsyncLazyDatastoreQuery results = db.RunQueryLazilyAsync(gqlQuery);
             // AsyncLazyDatastoreQuery implements IAsyncEnumerable<Entity>, but you can
@@ -291,8 +291,8 @@ namespace Google.Cloud.Datastore.V1.Snippets
             {
                 QueryString = "SELECT * FROM book WHERE author = @author LIMIT @limit",
                 NamedBindings = {
-                    { "author", new GqlQueryParameter { Value = "Jane Austen" } },
-                    { "limit", new GqlQueryParameter { Value = 10 } }
+                    { "author", "Jane Austen" },
+                    { "limit", 10 }
                 }
             };
             DatastoreQueryResults results = db.RunQuery(gqlQuery);
@@ -324,7 +324,7 @@ namespace Google.Cloud.Datastore.V1.Snippets
             GqlQuery gqlQuery = new GqlQuery
             {
                 QueryString = "SELECT * FROM book WHERE author = @author",
-                NamedBindings = { { "author", new GqlQueryParameter { Value = "Jane Austen" } } },
+                NamedBindings = { { "author", "Jane Austen" } },
             };
             DatastoreQueryResults results = await db.RunQueryAsync(gqlQuery);
             // RunQuery fetches all the results into memory in a single call.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreTransactionSnippets.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreTransactionSnippets.cs
@@ -288,7 +288,7 @@ namespace Google.Cloud.Datastore.V1.Snippets
                 GqlQuery query = new GqlQuery
                 {
                     QueryString = "SELECT * FROM game WHERE __key__ HAS ANCESTOR @player",
-                    NamedBindings = { { "player", new GqlQueryParameter { Value = playerKey } } }
+                    NamedBindings = { { "player", playerKey } }
                 };
                 LazyDatastoreQuery results = db.RunQueryLazily(query);
                 // LazyDatastoreQuery implements IEnumerable<Entity>, but you can
@@ -347,8 +347,8 @@ namespace Google.Cloud.Datastore.V1.Snippets
                 {
                     QueryString = "SELECT * FROM game WHERE __key__ HAS ANCESTOR @player LIMIT @limit",
                     NamedBindings = {
-                        { "player", new GqlQueryParameter { Value = playerKey } },
-                        { "limit", new GqlQueryParameter { Value = 10 } }
+                        { "player", playerKey },
+                        { "limit", 10 }
                     }
                 };
                 DatastoreQueryResults results = db.RunQuery(query);

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/QueryExtensions.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/QueryExtensions.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using Google.Protobuf;
 using Google.Protobuf.Collections;
 using static Google.Cloud.Datastore.V1.PropertyOrder.Types;
 
@@ -74,6 +75,34 @@ namespace Google.Cloud.Datastore.V1
         {
             GaxPreconditions.CheckNotNull(orderings, nameof(orderings));
             orderings.Add(new PropertyOrder { Direction = Direction.Ascending, Property = new PropertyReference(propertyName) });
+        }
+
+        /// <summary>
+        /// Adds a GQL parameter with the specified value.
+        /// </summary>
+        /// <param name="parameters">The mapping of GQL query parameters to add to. Must not be null.</param>
+        /// <param name="parameterName">The name of the parameter. Must not be null.</param>
+        /// <param name="value">The value to add.  May be null, which indicates
+        /// a value with <see cref="Value.NullValue"/> set.</param>
+        public static void Add(this MapField<string, GqlQueryParameter> parameters, string parameterName, Value value)
+        {
+            GaxPreconditions.CheckNotNull(parameters, nameof(parameters));
+            GaxPreconditions.CheckNotNull(parameterName, nameof(parameterName));
+            GaxPreconditions.CheckNotNull(value, nameof(value));
+            parameters.Add(parameterName, new GqlQueryParameter { Value = value ?? Value.ForNull() });
+        }
+
+        /// <summary>
+        /// Adds a GQL parameter with the specified value.
+        /// </summary>
+        /// <param name="parameters">The list of positional GQL query parameters to add to. Must not be null.</param>
+        /// <param name="value">The value to add.  May be null, which indicates
+        /// a value with <see cref="Value.NullValue"/> set.</param>
+        public static void Add(this RepeatedField<GqlQueryParameter> parameters, Value value)
+        {
+            GaxPreconditions.CheckNotNull(parameters, nameof(parameters));
+            GaxPreconditions.CheckNotNull(value, nameof(value));
+            parameters.Add(new GqlQueryParameter { Value = value ?? Value.ForNull() });
         }
     }
 }


### PR DESCRIPTION
Note that this only populated a GqlQueryParameter with a Value, never a Cursor.
While we could add overloads for cursors, the parameter type would be ByteString...
which can also be converted to Value. So I'm basically betting that when you've got a
ByteString, you're more likely to want to use it as a Value parameter than as a Cursor
parameter.

Fixes #887