### PR TITLE
Decrease flakes in Diagnostic integration tests.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
@@ -24,6 +24,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -32,6 +33,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
     public class ErrorReportingTest
     {
         private readonly ErrorEventEntryPolling _polling = new ErrorEventEntryPolling();
+
+        private readonly bool _isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
         [Fact]
         public Task NoExceptions_ErrorReporting()
@@ -162,9 +165,12 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             Assert.False(string.IsNullOrWhiteSpace(errorEvent.Context.HttpRequest.Url));
             Assert.True(errorEvent.Context.HttpRequest.ResponseStatusCode >= 200);
 
-            Assert.False(string.IsNullOrWhiteSpace(errorEvent.Context.ReportLocation.FilePath));
+            if (_isWindows)
+            {
+                Assert.False(string.IsNullOrWhiteSpace(errorEvent.Context.ReportLocation.FilePath));
+                Assert.True(errorEvent.Context.ReportLocation.LineNumber > 0);
+            }
             Assert.Equal(functionName, errorEvent.Context.ReportLocation.FunctionName);
-            Assert.True(errorEvent.Context.ReportLocation.LineNumber > 0);
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
@@ -207,13 +207,13 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
     /// <summary>
     /// A web application to test <see cref="CloudTraceMiddleware"/> and associated classes.
-    /// This app uses a size buffer (1,000 bytes) and will sample 1000000 QPS.
+    /// This app uses a size buffer (500 bytes) and will sample 1000000 QPS.
     /// </summary>
     public class TraceTestBufferHighQpsApplication : AbstractTraceTestApplication
     {
         public override double GetSampleRate() => 1000000;
         public override BufferOptions GetBufferOptions() =>
-            BufferOptions.SizedBuffer(1000);
+            BufferOptions.SizedBuffer(500);
     }
 
     /// <summary>


### PR DESCRIPTION
- Use a smaller buffer for trace buffer tests as this depends the stacktrace created being large enough.
- Only check for filepath and line number on windows as we do in other tests