### PR TITLE
Document target platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,15 @@ Next, choose a method for authenticating API requests from within your project:
       Download the SDK if you haven't already, then login by running the following in the command line:
 
       ```
-      gcloud auth login
+      gcloud auth application-default login
       ```
+
+## Supported platforms
+
+See the [Supported Platforms
+documentation](https://googlecloudplatform.github.io/google-cloud-dotnet/docs/platforms.html)
+for details on where the Google Cloud Libraries for .NET are
+supported.
 
 ## Contributing
 

--- a/docs/root/platforms.md
+++ b/docs/root/platforms.md
@@ -1,0 +1,28 @@
+# Supported platforms
+
+We aim to make the Google Cloud Libraries for .NET run in as wide a
+set of environments as possible, where we have confidence that they
+will work correctly.
+
+## REST-based libraries
+
+These libraries target the **netstandard1.3** and **net45** [Target
+Framework
+Monikers](https://docs.microsoft.com/en-us/nuget/schema/target-frameworks).
+
+Unfortunately there are currently issues supporting Universal
+Windows Platform (UWP) applications, as discussed
+[here](https://github.com/google/google-api-dotnet-client/issues/787).
+When UWP is supported by the `google-api-dotnet-client` project, we
+hope a subsequent release of the REST-based Google Cloud Libraries
+for .NET will support UWP as well.
+
+## gRPC-based libraries
+
+These libraries target **netstandard1.5** and **net45**. They depend
+on the [Grpc.Core](https://www.nuget.org/packages/Grpc.Core)
+library, which has the same targets.
+
+An additional constraint is that `Grpc.Core` contains a
+platform-native component. This currently ships on x86 and x64 for
+Linux, Windows and OS X, but not other platforms such as ARM.


### PR DESCRIPTION
Fixes #695.

I had expected to have to refer to the Microsoft.NETCore.App package
for NuGet, but I've just tried building a new application and it all
just worked. We can add more wording if required.