### PR TITLE
Fix signed URL issues on CI server

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UrlSignerTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UrlSignerTest.cs
@@ -66,7 +66,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
 
                     // Verify that the URL works initially.
                     var response = await _fixture.HttpClient.DeleteAsync(url);
-                    Assert.True(response.IsSuccessStatusCode);
+                    await VerifyResponseAsync(response);
                     var obj = await _fixture.Client.ListObjectsAsync(bucket, name).FirstOrDefault(o => o.Name == name);
                     Assert.Null(obj);
 
@@ -159,7 +159,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
 
                     // Verify that the URL works initially.
                     var response = await _fixture.HttpClient.GetAsync(url);
-                    Assert.True(response.IsSuccessStatusCode);
+                    await VerifyResponseAsync(response);
                     var result = await response.Content.ReadAsByteArrayAsync();
                     Assert.Equal(content, result);
                 },
@@ -292,7 +292,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
 
                     // Verify that the URL works initially.
                     var response = await _fixture.HttpClient.SendAsync(createRequest());
-                    Assert.True(response.IsSuccessStatusCode);
+                    await VerifyResponseAsync(response);
                 },
                 afterDelay: async () =>
                 {
@@ -322,7 +322,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
 
                     // Verify that the URL works initially.
                     var response = await _fixture.HttpClient.SendAsync(createRequest());
-                    Assert.True(response.IsSuccessStatusCode);
+                    await VerifyResponseAsync(response);
                 },
                 afterDelay: async () =>
                 {
@@ -391,7 +391,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
 
             // Verify that the URL works initially.
             var response = await _fixture.HttpClient.PutAsync(url, content);
-            Assert.True(response.IsSuccessStatusCode);
+            await VerifyResponseAsync(response);
             var result = new MemoryStream();
             await _fixture.Client.DownloadObjectAsync(bucket, name, result);
             Assert.Equal(result.ToArray(), _fixture.SmallContent);
@@ -442,7 +442,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
                     // Verify that the URL works initially.
                     request.RequestUri = new Uri(url);
                     var response = await _fixture.HttpClient.SendAsync(request);
-                    Assert.True(response.IsSuccessStatusCode);
+                    await VerifyResponseAsync(response);
 
                     // Make sure the encryption succeeded.
                     var downloadedData = new MemoryStream();
@@ -495,7 +495,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
                         Headers = {
                             { "x-goog-foo", "xy\r\n z" },
                             { "x-goog-bar", "  12345   " },
-                            { "x-goog-foo", new [] { "A B  C", "def" } }
+                            { "x-goog-foo2", new [] { "A B  C", "def" } }
                         }
                     };
                 }
@@ -510,7 +510,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
 
                     // Verify that the URL works initially.
                     var response = await _fixture.HttpClient.SendAsync(request);
-                    Assert.True(response.IsSuccessStatusCode);
+                    await VerifyResponseAsync(response);
                     var result = new MemoryStream();
                     await _fixture.Client.DownloadObjectAsync(bucket, name, result);
                     Assert.Equal(result.ToArray(), _fixture.SmallContent);
@@ -663,6 +663,16 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
                     Assert.Equal(UploadStatus.Failed, progress.Status);
                     Assert.IsType(typeof(GoogleApiException), progress.Exception);
                 });
+        }
+
+        private static async Task VerifyResponseAsync(HttpResponseMessage response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                // This will automatically fail, but gives more information about the failure cause than
+                // simply asserting that IsSuccessStatusCode is true.
+                Assert.Null(await response.Content.ReadAsStringAsync());
+            }
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/SignedUrlResumableUpload.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/SignedUrlResumableUpload.cs
@@ -63,6 +63,12 @@ namespace Google.Cloud.Storage.V1
         {
             var httpClient = Options?.HttpClient ?? new HttpClient();
             var request = new HttpRequestMessage(HttpMethod.Post, SignedUrl);
+
+            // The request may auto-populate the Content-Type to be "application/x-www-form-urlencoded",
+            // so force it to be null so it is not auto-populated.
+            request.Content = new ByteArrayContent(new byte[0]);
+            request.Content.Headers.ContentType = null;
+
             request.Headers.Add("x-goog-resumable", "start");
             Options?.ModifySessionInitiationRequest?.Invoke(request);
             var result = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
There were two issues here:

1. The Content-Type header was getting auto-populated to be "application/x-www-form-urlencoded" when `SignedUrlResumableUpload.InitiateSessionAsync` was initiating sessions, so now we force it to not include the header.
2. When using the same header name between content and request headers, we assumed a consistent ordering between them in the HTTP request, but apparently the order doesn't matter and might be different on different platforms. I removed this part of the test since it doesn't seem likely to be needed in practice.

I also updated some tests so we can get more useful error messages in the event of failures in the future.