### PR TITLE
Add CreateExtractJob method for BigQuery.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryClientTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryClientTest.cs
@@ -13,21 +13,19 @@
 // limitations under the License.
 
 using Google.Api.Gax;
-using Google.Api.Gax.Rest;
 using Google.Apis.Bigquery.v2.Data;
 using Google.Cloud.ClientTesting;
 using Moq;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Xunit;
-using System.Collections;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace Google.Cloud.BigQuery.V2.Tests
 {
@@ -70,6 +68,10 @@ namespace Google.Cloud.BigQuery.V2.Tests
             if (parameter.ParameterType == typeof(BigQueryInsertRow))
             {
                 return new BigQueryInsertRow();
+            }
+            if (parameter.ParameterType == typeof(TableReference))
+            {
+                return new TableReference();
             }
             return base.GetArgument(parameter);
         }
@@ -448,6 +450,29 @@ namespace Google.Cloud.BigQuery.V2.Tests
         }
 
         [Fact]
+        public void CreateExtractJobEquivalents()
+        {
+            var datasetId = "dataset";
+            var tableId = "table";
+            var jobReference = GetJobReference("job");
+            var tableReference = GetTableReference(datasetId, tableId);
+            var uri = "gs://bucket/object";
+            var options = new CreateExtractJobOptions();
+
+            VerifyEquivalent(new BigQueryJob(new DerivedBigQueryClient(), new Job { JobReference = jobReference }),
+                client => client.CreateExtractJob(MatchesWhenSerialized(tableReference), new[] { uri }, options),
+                client => client.CreateExtractJob(ProjectId, datasetId, tableId, uri, options),
+                client => client.CreateExtractJob(datasetId, tableId, uri, options),
+                client => client.CreateExtractJob(tableReference, uri, options),
+                client => client.CreateExtractJob(ProjectId, datasetId, tableId, new[] { uri }, options),
+                client => client.CreateExtractJob(datasetId, tableId, uri, options),
+                client => client.CreateExtractJob(datasetId, tableId, uri, options),
+                client => client.CreateExtractJob(ProjectId, datasetId, tableId, uri, options),
+                client => new BigQueryTable(client, GetTable(tableReference)).CreateExtractJob(uri, options),
+                client => new BigQueryTable(client, GetTable(tableReference)).CreateExtractJob(new[] { uri }, options));
+        }
+
+        [Fact]
         public void CreateDatasetAsyncEquivalents()
         {
             var datasetId = "dataset";
@@ -780,6 +805,30 @@ namespace Google.Cloud.BigQuery.V2.Tests
                 client => client.InsertRowsAsync(datasetId, tableId, rows[0], rows[1]),
                 client => client.InsertRowsAsync(ProjectId, datasetId, tableId, rows[0], rows[1]),
                 client => new BigQueryTable(client, GetTable(reference)).InsertRowsAsync(rows[0], rows[1]));
+        }
+
+        [Fact]
+        public void CreateExtractJobAsyncEquivalents()
+        {
+            var datasetId = "dataset";
+            var tableId = "table";
+            var jobReference = GetJobReference("job");
+            var tableReference = GetTableReference(datasetId, tableId);
+            var uri = "gs://bucket/object";
+            var options = new CreateExtractJobOptions();
+            var token = new CancellationTokenSource().Token;
+
+            VerifyEquivalentAsync(new BigQueryJob(new DerivedBigQueryClient(), new Job { JobReference = jobReference }),
+                client => client.CreateExtractJobAsync(MatchesWhenSerialized(tableReference), new[] { uri }, options, token),
+                client => client.CreateExtractJobAsync(ProjectId, datasetId, tableId, uri, options, token),
+                client => client.CreateExtractJobAsync(datasetId, tableId, uri, options, token),
+                client => client.CreateExtractJobAsync(tableReference, uri, options, token),
+                client => client.CreateExtractJobAsync(ProjectId, datasetId, tableId, new[] { uri }, options, token),
+                client => client.CreateExtractJobAsync(datasetId, tableId, uri, options, token),
+                client => client.CreateExtractJobAsync(datasetId, tableId, uri, options, token),
+                client => client.CreateExtractJobAsync(ProjectId, datasetId, tableId, uri, options, token),
+                client => new BigQueryTable(client, GetTable(tableReference)).CreateExtractJobAsync(uri, options, token),
+                client => new BigQueryTable(client, GetTable(tableReference)).CreateExtractJobAsync(new[] { uri }, options, token));
         }
 
         private T MatchesWhenSerialized<T>(T expected)

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.JobCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.JobCrud.cs
@@ -15,6 +15,7 @@
 using Google.Api.Gax;
 using Google.Apis.Bigquery.v2.Data;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -150,6 +151,88 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <returns>The final state of the job.</returns>
         public virtual BigQueryJob CancelJob(JobReference jobReference, CancelJobOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Creates a job to extract data from the specified BigQuery table to Google Cloud Storage.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="CreateExtractJob(TableReference, string, CreateExtractJobOptions)"/>.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="destinationUri">The Google Cloud Storage URI (possibly including a wildcard) to extract the data to. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The job created for the extract operation.</returns>
+        public virtual BigQueryJob CreateExtractJob(string projectId, string datasetId, string tableId, string destinationUri, CreateExtractJobOptions options = null)
+            => CreateExtractJob(GetTableReference(projectId, datasetId, tableId), destinationUri, options);
+
+        /// <summary>
+        /// Creates a job to extract data from the specified BigQuery table within this client's project to Google Cloud Storage.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="CreateExtractJob(TableReference, string, CreateExtractJobOptions)"/>.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="destinationUri">The Google Cloud Storage URI (possibly including a wildcard) to extract the data to. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The job created for the extract operation.</returns>
+        public virtual BigQueryJob CreateExtractJob(string datasetId, string tableId, string destinationUri, CreateExtractJobOptions options = null)
+            => CreateExtractJob(GetTableReference(datasetId, tableId), destinationUri, options);
+
+        /// <summary>
+        /// Creates a job to extract data from the specified BigQuery table to Google Cloud Storage.
+        /// This method just creates a single-element array and delegates to <see cref="CreateExtractJob(TableReference, IEnumerable{String}, CreateExtractJobOptions)"/>.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
+        /// <param name="destinationUri">The Google Cloud Storage URI (possibly including a wildcard) to extract the data to. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The job created for the extract operation.</returns>
+        public virtual BigQueryJob CreateExtractJob(TableReference tableReference, string destinationUri, CreateExtractJobOptions options = null) =>
+            CreateExtractJob(
+                GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference)),
+                new[] { GaxPreconditions.CheckNotNull(destinationUri, nameof(destinationUri)) },
+                options);
+
+        /// <summary>
+        /// Creates a job to extract data from the specified BigQuery table to Google Cloud Storage.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="CreateExtractJob(TableReference, IEnumerable{String}, CreateExtractJobOptions)"/>.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="destinationUris">The Google Cloud Storage URIs (possibly including a wildcard) to extract the data to. Must not be null or empty.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The job created for the extract operation.</returns>
+        public virtual BigQueryJob CreateExtractJob(string projectId, string datasetId, string tableId, IEnumerable<string> destinationUris, CreateExtractJobOptions options = null)
+            => CreateExtractJob(GetTableReference(projectId, datasetId, tableId), destinationUris, options);
+
+        /// <summary>
+        /// Creates a job to extract data from the specified BigQuery table within this client's project to Google Cloud Storage.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="CreateExtractJob(TableReference, IEnumerable{String}, CreateExtractJobOptions)"/>.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="destinationUris">The Google Cloud Storage URIs (possibly including a wildcard) to extract the data to. Must not be null or empty.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The job created for the extract operation.</returns>
+        public virtual BigQueryJob CreateExtractJob(string datasetId, string tableId, IEnumerable<string> destinationUris, CreateExtractJobOptions options = null)
+            => CreateExtractJob(GetTableReference(datasetId, tableId), destinationUris, options);
+
+        /// <summary>
+        /// Creates a job to extract data from the specified BigQuery table within this client's project to Google Cloud Storage.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
+        /// <param name="destinationUris">The Google Cloud Storage URIs (possibly including a wildcard) to extract the data to. Must not be null or empty.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The job created for the extract operation.</returns>
+        public virtual BigQueryJob CreateExtractJob(TableReference tableReference, IEnumerable<string> destinationUris, CreateExtractJobOptions options = null)
         {
             throw new NotImplementedException();
         }
@@ -300,6 +383,94 @@ namespace Google.Cloud.BigQuery.V2
         /// <returns>A task representing the asynchronous operation. When complete, the result is
         /// the final state of job.</returns>
         public virtual Task<BigQueryJob> CancelJobAsync(JobReference jobReference, CancelJobOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Asynchronously creates a job to extract data from the specified BigQuery table to Google Cloud Storage.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="CreateExtractJobAsync(TableReference, string, CreateExtractJobOptions, CancellationToken)"/>.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="destinationUri">The Google Cloud Storage URI (possibly including a wildcard) to extract the data to. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is the job created for the extract operation.</returns>
+        public virtual Task<BigQueryJob> CreateExtractJobAsync(string projectId, string datasetId, string tableId, string destinationUri, CreateExtractJobOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+            => CreateExtractJobAsync(GetTableReference(projectId, datasetId, tableId), destinationUri, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously creates a job to extract data from the specified BigQuery table within this client's project to Google Cloud Storage.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="CreateExtractJobAsync(TableReference, string, CreateExtractJobOptions, CancellationToken)"/>.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="destinationUri">The Google Cloud Storage URI (possibly including a wildcard) to extract the data to. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is the job created for the extract operation.</returns>
+        public virtual Task<BigQueryJob> CreateExtractJobAsync(string datasetId, string tableId, string destinationUri, CreateExtractJobOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+            => CreateExtractJobAsync(GetTableReference(datasetId, tableId), destinationUri, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously creates a job to extract data from the specified BigQuery table to Google Cloud Storage.
+        /// This method just creates a single-element array and delegates to <see cref="CreateExtractJobAsync(TableReference, IEnumerable{String}, CreateExtractJobOptions, CancellationToken)"/>.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
+        /// <param name="destinationUri">The Google Cloud Storage URI (possibly including a wildcard) to extract the data to. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is the job created for the extract operation.</returns>
+        public virtual Task<BigQueryJob> CreateExtractJobAsync(TableReference tableReference, string destinationUri, CreateExtractJobOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            CreateExtractJobAsync(
+                GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference)),
+                new[] { GaxPreconditions.CheckNotNull(destinationUri, nameof(destinationUri)) },
+                options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously creates a job to extract data from the specified BigQuery table to Google Cloud Storage.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="CreateExtractJobAsync(TableReference, IEnumerable{String}, CreateExtractJobOptions, CancellationToken)"/>.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="destinationUris">The Google Cloud Storage URIs (possibly including a wildcard) to extract the data to. Must not be null or empty.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is the job created for the extract operation.</returns>
+        public virtual Task<BigQueryJob> CreateExtractJobAsync(string projectId, string datasetId, string tableId, IEnumerable<string> destinationUris, CreateExtractJobOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+            => CreateExtractJobAsync(GetTableReference(projectId, datasetId, tableId), destinationUris, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously creates a job to extract data from the specified BigQuery table within this client's project to Google Cloud Storage.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="CreateExtractJobAsync(TableReference, IEnumerable{String}, CreateExtractJobOptions, CancellationToken)"/>.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="destinationUris">The Google Cloud Storage URIs (possibly including a wildcard) to extract the data to. Must not be null or empty.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is the job created for the extract operation.</returns>
+        public virtual Task<BigQueryJob> CreateExtractJobAsync(string datasetId, string tableId, IEnumerable<string> destinationUris, CreateExtractJobOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+            => CreateExtractJobAsync(GetTableReference(datasetId, tableId), destinationUris, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously creates a job to extract data from the specified BigQuery table within this client's project to Google Cloud Storage.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
+        /// <param name="destinationUris">The Google Cloud Storage URIs (possibly including a wildcard) to extract the data to. Must not be null or empty.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is the job created for the extract operation.</returns>
+        public virtual Task<BigQueryJob> CreateExtractJobAsync(TableReference tableReference, IEnumerable<string> destinationUris, CreateExtractJobOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             throw new NotImplementedException();
         }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryTable.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryTable.cs
@@ -161,6 +161,28 @@ namespace Google.Cloud.BigQuery.V2
         public void Delete(DeleteTableOptions options = null) => _client.DeleteTable(Reference, options);
 
         /// <summary>
+        /// Creates a job to extract data from this table to Google Cloud Storage.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigQueryClient.CreateExtractJob(TableReference, String, CreateExtractJobOptions)"/>.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="destinationUri">The Google Cloud Storage URI (possibly including a wildcard) to extract the data to. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The job created for the extract operation.</returns>
+        public BigQueryJob CreateExtractJob(string destinationUri, CreateExtractJobOptions options = null) =>
+            _client.CreateExtractJob(Reference, destinationUri, options);
+
+        /// <summary>
+        /// Creates a job to extract data from this table to Google Cloud Storage.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigQueryClient.CreateExtractJob(TableReference, IEnumerable{String}, CreateExtractJobOptions)"/>.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="destinationUris">The Google Cloud Storage URIs (possibly including a wildcard) to extract the data to. Must not be null or empty.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The job created for the extract operation.</returns>
+        public BigQueryJob CreateExtractJob(IEnumerable<string> destinationUris, CreateExtractJobOptions options = null) =>
+            _client.CreateExtractJob(Reference, destinationUris, options);
+
+        /// <summary>
         /// Asynchronously uploads a stream of CSV data to this table.
         /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigQueryClient.UploadCsvAsync(TableReference, TableSchema, Stream, UploadCsvOptions, CancellationToken)"/>.
         /// </summary>
@@ -261,6 +283,30 @@ namespace Google.Cloud.BigQuery.V2
         /// <returns>A task representing the asynchronous operation.</returns>
         public Task DeleteAsync(DeleteTableOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
             _client.DeleteTableAsync(Reference, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously creates a job to extract data from this table to Google Cloud Storage.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigQueryClient.CreateExtractJobAsync(TableReference, String, CreateExtractJobOptions, CancellationToken)"/>.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="destinationUri">The Google Cloud Storage URI (possibly including a wildcard) to extract the data to. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is the job created for the extract operation.</returns>
+        public Task<BigQueryJob> CreateExtractJobAsync(string destinationUri, CreateExtractJobOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            _client.CreateExtractJobAsync(Reference, destinationUri, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously creates a job to extract data from this table to Google Cloud Storage.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigQueryClient.CreateExtractJobAsync(TableReference, IEnumerable{String}, CreateExtractJobOptions, CancellationToken)"/>.
+        /// See [the BigQuery documentation](https://cloud.google.com/bigquery/docs/exporting-data) for more information on extract jobs.
+        /// </summary>
+        /// <param name="destinationUris">The Google Cloud Storage URIs (possibly including a wildcard) to extract the data to. Must not be null or empty.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is the job created for the extract operation.</returns>
+        public Task<BigQueryJob> CreateExtractJobAsync(IEnumerable<string> destinationUris, CreateExtractJobOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            _client.CreateExtractJobAsync(Reference, destinationUris, options, cancellationToken);
 
         /// <summary>
         /// Returns the fully-qualified ID of the table in Legacy SQL format. The Legacy SQL

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CompressionType.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CompressionType.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// Options for compression.
+    /// </summary>
+    public enum CompressionType
+    {
+        /// <summary>
+        /// No compression is applied.
+        /// </summary>
+        None,
+        /// <summary>
+        /// Gzip compression is applied.
+        /// </summary>
+        Gzip
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateExtractJobOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateExtractJobOptions.cs
@@ -1,0 +1,72 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// Options for <c>CreateExtractJob</c> operations.
+    /// </summary>
+    public sealed class CreateExtractJobOptions
+    {
+        /// <summary>
+        /// The file format to use for output. If this is unspecified,
+        /// the default is to create CSV files.
+        /// </summary>
+        public FileFormat? DestinationFormat { get; set; }
+
+        /// <summary>
+        /// The compression to apply for output. If this is unspecified,
+        /// the default is not to compress the output.
+        /// </summary>
+        public CompressionType? Compression { get; set; }
+
+        /// <summary>
+        /// The delimiter to use between fields in the exported data.
+        /// If this is unspecified, the default is a comma.
+        /// </summary>
+        public string FieldDelimiter { get; set; }
+
+        /// <summary>
+        /// Whether to print out a header row in the results. If this
+        /// is unspecified, the default is true.
+        /// </summary>
+        public bool? PrintHeader { get; set; }
+
+        internal void ModifyRequest(JobConfigurationExtract extract)
+        {
+            if (DestinationFormat != null)
+            {
+                extract.DestinationFormat = EnumMap.ToApiValue(DestinationFormat.Value);
+            }
+            if (Compression != null)
+            {
+                extract.Compression = EnumMap.ToApiValue(Compression.Value);
+            }
+            if (FieldDelimiter != null)
+            {
+                extract.FieldDelimiter = FieldDelimiter;
+            }
+            if (PrintHeader != null)
+            {
+                extract.PrintHeader = PrintHeader;
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/FileFormat.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/FileFormat.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// A file format used for load/extract operations.
+    /// </summary>
+    public enum FileFormat
+    {
+        /// <summary>
+        /// A CSV file.
+        /// </summary>
+        [ApiValue("CSV")]
+        Csv,
+        /// <summary>
+        /// A file where each line is a JSON object.
+        /// </summary>
+        [ApiValue("NEWLINE_DELIMITED_JSON")]
+        NewlineDelimitedJson,
+
+        /// <summary>
+        /// A file in Avro format
+        /// </summary>
+        [ApiValue("AVRO")]
+        Avro
+    }
+}


### PR DESCRIPTION
First part of implementing #914.

The removed snippet tests are not currently used or run. This PR replaces ExportCsv, and the others will be covered by the other operations.