### PR TITLE
Add the Trace Teader to HTTP Response Headers.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
@@ -171,6 +171,12 @@ namespace Google.Cloud.Diagnostics.AspNet
 
             TracerManager.SetCurrentTracer(tracer);
 
+            // Set the updated trace header on the response.
+            var updatedHeaderContext = TraceHeaderContext.Create(
+                tracer.GetCurrentTraceId(), tracer.GetCurrentSpanId() ?? 0, true);
+            HttpContext.Current.Response.Headers.Set(
+                TraceHeaderContext.TraceHeader, updatedHeaderContext.ToString());
+
             // Start the span and annotate it with information from the current request.
             tracer.StartSpan(HttpContext.Current.Request.Path);
             tracer.AnnotateSpan(Labels.FromHttpRequest(HttpContext.Current.Request));

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
@@ -171,11 +171,14 @@ namespace Google.Cloud.Diagnostics.AspNet
 
             TracerManager.SetCurrentTracer(tracer);
 
-            // Set the updated trace header on the response.
-            var updatedHeaderContext = TraceHeaderContext.Create(
-                tracer.GetCurrentTraceId(), tracer.GetCurrentSpanId() ?? 0, true);
-            HttpContext.Current.Response.Headers.Set(
-                TraceHeaderContext.TraceHeader, updatedHeaderContext.ToString());
+            if (headerContext.TraceId != null)
+            {
+                // Set the updated trace header on the response.
+                var updatedHeaderContext = TraceHeaderContext.Create(
+                    tracer.GetCurrentTraceId(), tracer.GetCurrentSpanId() ?? 0, true);
+                HttpContext.Current.Response.Headers.Set(
+                    TraceHeaderContext.TraceHeader, updatedHeaderContext.ToString());
+            }
 
             // Start the span and annotate it with information from the current request.
             tracer.StartSpan(HttpContext.Current.Request.Path);

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
@@ -48,7 +48,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
             var client = _noBufferHighQps.CreateClient();
-            await client.GetAsync($"/Trace/Trace/{testId}");
+            var response = await client.GetAsync($"/Trace/Trace/{testId}");
 
             var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);
             var trace = _polling.GetTrace(spanName, startTime);
@@ -59,6 +59,13 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             Assert.NotEmpty(span.Labels);
             Assert.Equal(span.Labels[TraceLabels.HttpMethod], "GET");
             Assert.Equal(span.Labels[TraceLabels.HttpStatusCode], "200");
+
+            Assert.True(response.Headers.Contains(TraceHeaderContext.TraceHeader));
+            var returnedHeader = response.Headers.GetValues(TraceHeaderContext.TraceHeader).Single();
+            var headerContext = TraceHeaderContext.FromHeader(returnedHeader);
+            Assert.False(string.IsNullOrEmpty(headerContext.TraceId));
+            Assert.Equal((ulong)0, headerContext.SpanId);
+            Assert.True(headerContext.ShouldTrace);
         }
 
         [Fact]
@@ -113,7 +120,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 
             var header = TraceHeaderContext.Create(traceId, spanId, shouldTrace: true);
             client.DefaultRequestHeaders.Add(TraceHeaderContext.TraceHeader, header.ToString());
-            await client.GetAsync($"/Trace/Trace/{testId}");
+            var response = await client.GetAsync($"/Trace/Trace/{testId}");
 
             var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);
             var trace = _polling.GetTrace(spanName, startTime);
@@ -123,6 +130,13 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             Assert.Equal(2, trace.Spans.Count);
             var span = trace.Spans.First(s => s.Name.StartsWith("/Trace"));
             Assert.Equal(spanId, span.ParentSpanId);
+
+            Assert.True(response.Headers.Contains(TraceHeaderContext.TraceHeader));
+            var returnedHeader = response.Headers.GetValues(TraceHeaderContext.TraceHeader).Single();
+            var headerContext = TraceHeaderContext.FromHeader(returnedHeader);
+            Assert.Equal(traceId, headerContext.TraceId);
+            Assert.Equal(spanId, headerContext.SpanId);
+            Assert.True(headerContext.ShouldTrace);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
@@ -60,12 +60,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             Assert.Equal(span.Labels[TraceLabels.HttpMethod], "GET");
             Assert.Equal(span.Labels[TraceLabels.HttpStatusCode], "200");
 
-            Assert.True(response.Headers.Contains(TraceHeaderContext.TraceHeader));
-            var returnedHeader = response.Headers.GetValues(TraceHeaderContext.TraceHeader).Single();
-            var headerContext = TraceHeaderContext.FromHeader(returnedHeader);
-            Assert.False(string.IsNullOrEmpty(headerContext.TraceId));
-            Assert.Equal((ulong)0, headerContext.SpanId);
-            Assert.True(headerContext.ShouldTrace);
+            Assert.False(response.Headers.Contains(TraceHeaderContext.TraceHeader));
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceMiddleware.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceMiddleware.cs
@@ -72,7 +72,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
                 var updatedHeaderContext = TraceHeaderContext.Create(
                     tracer.GetCurrentTraceId(), tracer.GetCurrentSpanId() ?? 0, true);
                 httpContext.Response.Headers.Add(
-                        TraceHeaderContext.TraceHeader, updatedHeaderContext.ToString());
+                    TraceHeaderContext.TraceHeader, updatedHeaderContext.ToString());
 
                 // Trace the delegate and annotate it with information from the current
                 // http context.

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceMiddleware.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceMiddleware.cs
@@ -68,6 +68,12 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             }
             else
             {
+                // Set the trace updated trace header on the response.
+                var updatedHeaderContext = TraceHeaderContext.Create(
+                    tracer.GetCurrentTraceId(), tracer.GetCurrentSpanId() ?? 0, true);
+                httpContext.Response.Headers.Add(
+                        TraceHeaderContext.TraceHeader, updatedHeaderContext.ToString());
+
                 // Trace the delegate and annotate it with information from the current
                 // http context.
                 tracer.StartSpan(httpContext.Request.Path);

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceMiddleware.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceMiddleware.cs
@@ -68,11 +68,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             }
             else
             {
-                // Set the trace updated trace header on the response.
-                var updatedHeaderContext = TraceHeaderContext.Create(
-                    tracer.GetCurrentTraceId(), tracer.GetCurrentSpanId() ?? 0, true);
-                httpContext.Response.Headers.Add(
-                    TraceHeaderContext.TraceHeader, updatedHeaderContext.ToString());
+                if (traceHeaderContext.TraceId != null)
+                {
+                    // Set the trace updated trace header on the response.
+                    var updatedHeaderContext = TraceHeaderContext.Create(
+                        tracer.GetCurrentTraceId(), tracer.GetCurrentSpanId() ?? 0, true);
+                    httpContext.Response.Headers.Add(
+                        TraceHeaderContext.TraceHeader, updatedHeaderContext.ToString());
+                }
 
                 // Trace the delegate and annotate it with information from the current
                 // http context.


### PR DESCRIPTION
This is required to allow load balancers to make trace decisions properly.