### PR TITLE
Fix BigQuery integration tests

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryParameterTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryParameterTest.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
         public void IntegerParameter()
         {
             var client = BigQueryClient.Create(_fixture.ProjectId);
-            var command = new BigQueryCommand("SELECT value FROM UNNEST([0, 1, 2, 3, 4]) AS value WHERE value > @value")
+            var command = new BigQueryCommand("SELECT value FROM UNNEST([0, 1, 2, 3, 4]) AS value WHERE value > @value ORDER BY value")
             {
                 Parameters = { { "value", BigQueryDbType.Int64, 2 } }
             };
@@ -44,7 +44,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
         public void IntegerArrayParameter()
         {
             var client = BigQueryClient.Create(_fixture.ProjectId);
-            var command = new BigQueryCommand("SELECT value FROM UNNEST([0, 1, 2, 3, 4]) AS value WHERE value IN UNNEST(@p)")
+            var command = new BigQueryCommand("SELECT value FROM UNNEST([0, 1, 2, 3, 4]) AS value WHERE value IN UNNEST(@p) ORDER BY value")
             {
                 Parameters = { { "p", BigQueryDbType.Array, new[] { 1, 3, 5 } } }
             };


### PR DESCRIPTION
A server-side change has revealed test flakiness: we were assuming
the order of results. The fix is just to specify the ordering.