### PR TITLE
Add an example of using the IManagedTracer in AspNetCore with MVC

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/AspNetCoreSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/AspNetCoreSnippets.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
 {
@@ -105,6 +106,41 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
                 using (var httpClient = new HttpClient(traceHeaderHandler))
                 {
                     return await httpClient.GetAsync("https://weather.com/");
+                }
+            }
+            // End sample
+
+            // Sample: TraceMVCConstructor
+            public class SampleConstructorController : Controller
+            {
+                private readonly IManagedTracer _tracer;
+
+                public SampleConstructorController(IManagedTracer tracer)
+                {
+                    _tracer = tracer;
+                }
+
+                public ActionResult Hello()
+                {
+                    using (_tracer.StartSpan(nameof(Hello)))
+                    {
+                        ViewData["text"] = "Hello, World!";
+                        return View();
+                    }
+                }
+            }
+            // End sample
+
+            // Sample: TraceMVCMethod
+            public class SampleMethodController : Controller
+            {
+                public ActionResult Hello([FromServices] IManagedTracer tracer)
+                {
+                    using (tracer.StartSpan(nameof(Hello)))
+                    {
+                        ViewData["text"] = "Hello, World!";
+                        return View();
+                    }
                 }
             }
             // End sample

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/project.json
@@ -1,10 +1,11 @@
-﻿{
+{
   "buildOptions": {
     "keyFile": "../../GoogleApis.snk"
   },
 
   "dependencies": {
-    "Google.Cloud.Diagnostics.AspNetCore": { "target": "project" }
+    "Google.Cloud.Diagnostics.AspNetCore": { "target": "project" },
+    "Microsoft.AspNetCore.Mvc.ViewFeatures": "1.1.2"
   },
 
   "frameworks": {

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
@@ -44,7 +44,7 @@ installed, run the following command in a Google Cloud SDK Shell:
 ## Tracing in MVC Controllers
 
 To use the `IManagedTracer` in MVC controllers you can either inject the singleton instance of 
-`IManagedTracer`into the controller's constructor (see `SampleConstructorController`) or you
+`IManagedTracer` into the controller's constructor (see `SampleConstructorController`) or you
 can in inject the `IManagedTracer` into the action method using the `[FromServices]` attribute
 (see `SampleMethodController`).
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
@@ -41,6 +41,17 @@ installed, run the following command in a Google Cloud SDK Shell:
 
 [!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNetCore.AspNetCore.txt#RegisterGoogleTracer)]
 
+## Tracing in MVC Controllers
+
+To use the `IManagedTracer` in MVC controllers you can either inject the singleton instance of 
+`IManagedTracer`into the controller's constructor (see `SampleConstructorController`) or you
+can in inject the `IManagedTracer` into the action method using the `[FromServices]` attribute
+(see `SampleMethodController`).
+
+[!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNetCore.AspNetCore.txt#TraceMVCConstructor)]
+
+[!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNetCore.AspNetCore.txt#TraceMVCMethod)]
+
 ## Manual Tracing
 
 [!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNetCore.AspNetCore.txt#UseTracer)]


### PR DESCRIPTION
The usage is not straight forward as an extra attribute is required to inject the IManagedTracer into MVC action methods.

Fixes #948