### PR TITLE
Update version numbers for *all* packages

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/project.json
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta09-*",
+  "version": "1.0.0-beta10-*",
   "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/project.json
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta08-*",
+  "version": "1.0.0",
   "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta07-*",
+  "version": "1.0.0-beta08-*",
   "description": "Google Stackdriver Instrumentation Libraries for ASP.NET.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha07-*",
+  "version": "1.0.0-alpha08-*",
   "description": "Google Stackdriver Instrumentation Libraries for ASP.NET Core.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/project.json
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha06-*",
+  "version": "1.0.0-alpha07-*",
   "description": "Google Stackdriver Instrumentation Libraries Common Components.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/project.json
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta04-*",
+  "version": "1.0.0-beta05-*",
   "description": "Recommended Google client library to access the Stackdriver Error Reporting API, which groups and counts similar errors from cloud services. The Stackdriver Error Reporting API provides a way to report new errors and read access to error groups and their associated errors.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/project.json
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta08-*",
+  "version": "1.0.0-beta09-*",
   "description": "gRPC services for the Google Identity and Access Management API. This library is typically used as a dependency for other API client libraries.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/project.json
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta05-*",
+  "version": "1.0.0-beta06-*",
   "description": "Recommended Google client library to access the Google Cloud Natural Language API, which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Log4Net/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta09-*",
+  "version": "1.0.0-beta10-*",
   "description": "Log4Net client library for the Google Stackdriver Logging API.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Type/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Type/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta09-*",
+  "version": "1.0.0",
   "description": "Version-agnostic types for the Google Stackdriver Logging API.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/project.json
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta09-*",
+  "version": "1.0.0",
   "description": "Recommended Google client library to access the Google Stackdriver Logging API, which writes log entries and manages your logs, log sinks, and logs-based metrics.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/project.json
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha03-*",
+  "version": "1.0.0-alpha04-*",
   "description": "Google Compute Engine Metadata v1 client library",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/project.json
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta04-*",
+  "version": "1.0.0-beta05-*",
   "description": "Recommended Google client library to access the Stackdriver Monitoring API, which manages your Stackdriver Monitoring data and configurations. Most projects must be associated with a Stackdriver account, with a few exceptions as noted on the individual method pages.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/project.json
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta08-*",
+  "version": "1.0.0-beta09-*",
   "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
+++ b/apis/Google.Cloud.Speech.V1Beta1/Google.Cloud.Speech.V1Beta1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha06-*",
+  "version": "1.0.0-alpha07-*",
   "description": "Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/project.json
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta08-*",
+  "version": "1.0.0",
   "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/project.json
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta04-*",
+  "version": "1.0.0-beta05-*",
   "description": "Recommended Google client library to access the Google Cloud Trace API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/project.json
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0-*",
+  "version": "1.0.0-alpha01",
   "description": "Recommended Google client library to access the Translation API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta01-*",
+  "version": "1.0.0-beta02-*",
   "description": "Recommended Google client library to access the Google Cloud Vision API, which integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.LongRunning/Google.LongRunning/project.json
+++ b/apis/Google.LongRunning/Google.LongRunning/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta07-*",
+  "version": "1.0.0-beta08-*",
   "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",
   "authors": [ "Google Inc." ],
 


### PR DESCRIPTION
Most packages are just bumped up their existing alpha/beta level.
In addition:

- Google.Cloud.Storage.V1 goes to 1.0.0 (GA)
- Google.Cloud.Datastore.V1 goes to 1.0.0 (GA)
- Google.Cloud.Logging.V2 goes to 1.0.0 (GA)
- Google.Cloud.Logging.Type goes to 1.0.0 (GA)
- Google.Cloud.Translation.V2 goes to 1.0.0-alpha01