### PR TITLE
Support DryRun in BigQueryClient.CreateQueryJob

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/BigQueryClientSnippets.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/BigQueryClientSnippets.cs
@@ -1428,5 +1428,54 @@ namespace Google.Cloud.BigQuery.V2.Snippets
         // TODO:
         // Dataset update/patch
         // Table update/patch
+
+        [Fact]
+        public void DryRunValidQuery()
+        {
+            string projectId = _fixture.ProjectId;
+            string datasetId = _fixture.GameDatasetId;
+            string tableId = _fixture.HistoryTableId;
+
+            // Sample: DryRunValidQuery
+            BigQueryClient client = BigQueryClient.Create(projectId);
+            BigQueryTable table = client.GetTable(projectId, datasetId, tableId);
+            CreateQueryJobOptions options = new CreateQueryJobOptions { DryRun = true };
+            BigQueryJob job = client.CreateQueryJob($"SELECT player, game_started FROM {table}", options);
+            // There are no rows in the result, but we do have the schema as if we'd run the query.
+            TableSchema schema = job.Resource.Statistics.Query.Schema;
+            foreach (var field in schema.Fields)
+            {
+                Console.WriteLine($"{field.Name}: {field.Type}");
+            }
+            // End sample
+
+            // Although the JobReference itself isn't null, the job ID is, showing that this hasn't
+            // created a job.
+            Assert.Null(job.Reference.JobId);
+        }
+
+        [Fact]
+        public void DryRunInvalidQuery()
+        {
+            string projectId = _fixture.ProjectId;
+            string datasetId = _fixture.GameDatasetId;
+            string tableId = _fixture.HistoryTableId;
+
+            // Sample: DryRunInvalidQuery
+            BigQueryClient client = BigQueryClient.Create(projectId);
+            BigQueryTable table = client.GetTable(projectId, datasetId, tableId);
+            CreateQueryJobOptions options = new CreateQueryJobOptions { DryRun = true };
+            // Note deliberate typo in field name
+            try
+            {
+                // Output includes "Unrecognized name: playr; Did you mean player? at [1:8] [400]"
+                client.CreateQueryJob($"SELECT playr, game_started FROM {table}", options);
+            }
+            catch (GoogleApiException e)
+            {
+                Console.WriteLine(e.Error);
+            }
+            // End sample
+        }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
@@ -218,7 +218,9 @@ namespace Google.Cloud.BigQuery.V2
             {
                 Configuration = new JobConfiguration
                 {
-                    Query = query
+                    Query = query,
+                    // It's slightly annoying that this is set here rather than in ModifyRequest, but at least it's in a single place.
+                    DryRun = options?.DryRun
                 },
             }, ProjectId);
             request.ModifyRequest += _versionHeaderAction;

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateQueryJobOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateQueryJobOptions.cs
@@ -93,6 +93,15 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         public bool? UseLegacySql { get; set; }
 
+        /// <summary>
+        /// If set to true, don't actually run this job. A valid query will return a mostly empty response
+        /// with some processing statistics, while an invalid query will return the same error it would if it wasn't a dry run.
+        /// This option can be used to determine the schema of the query without running it. The resulting
+        /// <see cref="BigQueryJob"/> has no job ID, so cannot be polled for completion, but the <see cref="BigQueryJob.Resource"/>
+        /// contains all the information returned by the server.
+        /// </summary>
+        public bool? DryRun { get; set; }
+
         internal void ModifyRequest(JobConfigurationQuery query)
         {
             // Note: no validation of combinations (flatten results etc). Leave this to the server,


### PR DESCRIPTION
This makes it easy to determine the schema for a query, or to simply
validate it.

Fixes #944.