### PR TITLE
Update REST-based libraries to use v1.25

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/project.json
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.Gax.Rest": "1.0.1",
-    "Google.Apis.Bigquery.v2": "1.24.1.808"
+    "Google.Apis.Bigquery.v2": "1.25.0.819"
   },
   "frameworks": {
     "net45": { },

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/project.json
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/project.json
@@ -20,7 +20,7 @@
 
   "dependencies": {
     "Google.Api.Gax.Rest": "1.0.1",
-    "Google.Apis.Storage.v1": "1.24.1.806"
+    "Google.Apis.Storage.v1": "1.25.0.811"
   },
   "frameworks": {
     "net45": { },

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/project.json
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha01-*",
+  "version": "1.0.0-alpha02-*",
   "description": "Recommended Google client library to access the Translation API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.",
   "authors": [ "Google Inc." ],
 
@@ -19,7 +19,10 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax.Rest": "1.0.1"
+    "Google.Api.Gax.Rest": "1.0.1",
+    "Google.Apis": "1.25.0",
+    "Google.Apis.Auth": "1.25.0",
+    "Google.Apis.Core": "1.25.0"
   },
 
   "frameworks": {


### PR DESCRIPTION
The Google.Cloud.Translation.V2 library adds the dependencies
explicitly so we're not just using the versions GAX depends on. The
others update their service-specific version.

Also updated the Translation library's own version so this can be
released.