### PR TITLE
Add example of logging in REST-based APIs to the FAQ

### DIFF
--- a/docs/root/faq.md
+++ b/docs/root/faq.md
@@ -106,6 +106,24 @@ it yourself to integrate with other systems - see the
 [Grpc.Core.Logging](https://github.com/grpc/grpc/tree/master/src/csharp/Grpc.Core/Logging)
 namespace for details.
 
+## How can I trace requests and responses in REST-based APIs?
+
+For libraries that use HTTP1.1 and REST, it can be useful to perfom request and response
+logging. There are two aspects to this:
+
+- Registering a global logger
+- Configuring the events to log in a specific service
+
+The underlying service is available via the `Service` property in each `XyzClient` class. Within
+that service, you need to configure the `HttpClient`'s message handler. As a complete example,
+here's a call to the Translation API, listing all the available languages, and logging the request
+headers and the response body:
+
+[!code-cs[](obj/snippets/Google.Cloud.Docs.Faq.txt#RestLogging)]
+
+To log *all* events from the message handler, you can set the `LogEvents` property to
+`~LogEventType.None`.
+
 ## How can I use emulators?
 
 Some APIs (such as Datastore and PubSub) provide emulators in the

--- a/tools/Google.Cloud.Docs.Snippets/FaqSnippets.cs
+++ b/tools/Google.Cloud.Docs.Snippets/FaqSnippets.cs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.Logging;
 using Google.Cloud.PubSub.V1;
+using Google.Cloud.Translation.V2;
+using static Google.Apis.Http.ConfigurableMessageHandler;
 using Grpc.Core;
 using System;
 
@@ -33,6 +36,29 @@ namespace Google.Cloud.Tools.Snippets
             {
                 Console.WriteLine(topic.Name);
             }
+            // End sample
+        }
+        
+        public void RestLogging()
+        {
+            // Sample: RestLogging
+            // Required using directives:
+            // using static Google.Apis.Http.ConfigurableMessageHandler;
+            // using Google.Apis.Logging;
+            // using Google.Cloud.Translation.V2;
+
+            // Register a verbose console logger
+            ApplicationContext.RegisterLogger(new ConsoleLogger(LogLevel.All));
+
+            // Create a translation client
+            TranslationClient client = TranslationClient.Create();
+
+            // Configure which events the message handler will log.
+            client.Service.HttpClient.MessageHandler.LogEvents =
+                LogEventType.RequestHeaders | LogEventType.ResponseBody;
+
+            // Make the request
+            client.ListLanguages();
             // End sample
         }
     }

--- a/tools/Google.Cloud.Docs.Snippets/project.json
+++ b/tools/Google.Cloud.Docs.Snippets/project.json
@@ -2,7 +2,8 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "Google.Cloud.PubSub.V1": { "target": "project"},
+    "Google.Cloud.PubSub.V1": { "target": "project" },
+    "Google.Cloud.Translation.V2": { "target": "project" },
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },

--- a/tools/global.json
+++ b/tools/global.json
@@ -1,5 +1,9 @@
 ﻿{
-  "projects": [ ".", "../apis/Google.Cloud.PubSub.V1" ],
+  "projects": [
+    ".",
+    "../apis/Google.Cloud.PubSub.V1",
+    "../apis/Google.Cloud.Translation.V2"
+  ],
   "sdk": {
     "version": "1.0.0-preview2-003131"
   }


### PR DESCRIPTION
(Maybe we need `LoggingEventType.All` to avoid needing `~None`?)