### PR TITLE
Update DetectLanguage calls

### DIFF
--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/TranslationClientSnippets.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/TranslationClientSnippets.cs
@@ -129,17 +129,41 @@ namespace Google.Cloud.Translation.V2.Snippets
             // Sample: DetectLanguage
             // Additional: DetectLanguage(string)
             TranslationClient client = TranslationClient.Create();
-            IList<Detection> results = client.DetectLanguage("It is raining.");
-            foreach (Detection result in results)
-            {
-                Console.WriteLine($"Result: {result.Language}; confidence {result.Confidence}");
-            }
+            Detection result = client.DetectLanguage("It is raining.");
+            Console.WriteLine($"Language: {result.Language}; confidence {result.Confidence}");
             // End sample
+
+            Assert.Equal("en", result.Language);
+            Assert.Equal("It is raining.", result.Text);
         }
 
         // See-also: DetectLanguage(string)
         // Member: DetectLanguageAsync(string, CancellationToken)
         // See [DetectLanguage](ref) for a synchronous example.
+        // End see-also
+
+        [Fact]
+        public void DetectLanguages()
+        {
+            // Sample: DetectLanguages
+            // Additional: DetectLanguages(IEnumerable<string>)
+            TranslationClient client = TranslationClient.Create();
+            IList<Detection> results = client.DetectLanguages(new[] { "It is raining.", "Il pleut." });
+            foreach (var result in results)
+            {
+                Console.WriteLine($"Text: {result.Text}; language: {result.Language}; confidence {result.Confidence}");
+            }
+            // End sample
+
+            Assert.Equal("en", results[0].Language);
+            Assert.Equal("It is raining.", results[0].Text);
+            Assert.Equal("fr", results[1].Language);
+            Assert.Equal("Il pleut.", results[1].Text);
+        }
+
+        // See-also: DetectLanguages(IEnumerable<string>)
+        // Member: DetectLanguagesAsync(IEnumerable<string>, CancellationToken)
+        // See [DetectLanguages](ref) for a synchronous example.
         // End see-also
 
         [Fact]

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Detection.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Detection.cs
@@ -17,12 +17,18 @@ using Google.Apis.Translate.v2.Data;
 namespace Google.Cloud.Translation.V2
 {
     /// <summary>
-    /// One possible option as the result of detecting the language of a piece of text
+    /// A result of detecting the language of a piece of text
     /// via <see cref="TranslationClient.DetectLanguage(string)"/> or
-    /// <see cref="TranslationClient.DetectLanguageAsync(string, System.Threading.CancellationToken)"/>.
+    /// <see cref="TranslationClient.DetectLanguageAsync(string, System.Threading.CancellationToken)"/>,
+    /// or the multiple-item equivalents.
     /// </summary>
     public sealed class Detection
     {
+        /// <summary>
+        /// The text that was used for the input of language detection.
+        /// </summary>
+        public string Text { get; }
+
         /// <summary>
         /// The language code for the detected language.
         /// </summary>
@@ -41,17 +47,21 @@ namespace Google.Cloud.Translation.V2
         /// <summary>
         /// Constructs a new instance.
         /// </summary>
+        /// <param name="text">The text that was used for the input of language detection.</param>
         /// <param name="language">The detected language code.</param>
         /// <param name="confidence">The confidence of the detection.</param>
         /// <param name="isReliable">The reliability of the detection.</param>
-        public Detection(string language, float confidence, bool isReliable)
+        public Detection(string text, string language, float confidence, bool isReliable)
         {
+            Text = text;
             Language = language;
             Confidence = confidence;
             IsReliable = isReliable;
         }
 
-        internal static Detection FromResource(DetectionsResourceItems resource) =>
-            new Detection(resource.Language, resource.Confidence.GetValueOrDefault(), resource.IsReliable ?? false);
+        internal Detection(string text, DetectionsResourceItems resource)
+            : this(text, resource.Language, resource.Confidence.GetValueOrDefault(), resource.IsReliable ?? false)
+        {
+        }
     }
 }

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationClient.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationClient.cs
@@ -134,12 +134,11 @@ namespace Google.Cloud.Translation.V2
         /// <summary>
         /// Detects the language of the specified text synchronously.
         /// </summary>
+        /// <remarks>This implementation simply delegates to <see cref="DetectLanguages(IEnumerable{string})"/>.</remarks>
         /// <param name="text">The text to detect the language of. Must not be null.</param>
         /// <returns>The most likely detected language.</returns>
-        public virtual Detection DetectLanguage(string text)
-        {
-            throw new NotImplementedException();
-        }
+        public virtual Detection DetectLanguage(string text) =>
+            DetectLanguages(new[] { GaxPreconditions.CheckNotNull(text, nameof(text)) })[0];
 
         /// <summary>
         /// Detects the languages of the specified text items synchronously.
@@ -241,18 +240,22 @@ namespace Google.Cloud.Translation.V2
         /// <summary>
         /// Detects the language of the specified text asynchronously.
         /// </summary>
+        /// <remarks>This implementation simply delegates to <see cref="DetectLanguagesAsync(IEnumerable{string}, CancellationToken)"/>.</remarks>
         /// <param name="text">The text to detect the language of. Must not be null.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The most likely detected language.</returns>
-        public virtual Task<Detection> DetectLanguageAsync(string text, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<Detection> DetectLanguageAsync(string text, CancellationToken cancellationToken = default(CancellationToken))
         {
-            throw new NotImplementedException();
+            GaxPreconditions.CheckNotNull(text, nameof(text));
+            var list = await DetectLanguagesAsync(new[] { text }, cancellationToken).ConfigureAwait(false);
+            return list[0];
         }
 
         /// <summary>
         /// Detects the languages of the specified text items asynchronously.
         /// </summary>
         /// <param name="textItems">The text items to detect the language of. Must not be null or contain null elements.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A list of detected languages. This will be the same size as <paramref name="textItems"/>, in the same order.</returns>
         public virtual Task<IList<Detection>> DetectLanguagesAsync(IEnumerable<string> textItems, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationClient.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationClient.cs
@@ -135,8 +135,18 @@ namespace Google.Cloud.Translation.V2
         /// Detects the language of the specified text synchronously.
         /// </summary>
         /// <param name="text">The text to detect the language of. Must not be null.</param>
-        /// <returns>A list of detected language possibilities.</returns>
-        public virtual IList<Detection> DetectLanguage(string text)
+        /// <returns>The most likely detected language.</returns>
+        public virtual Detection DetectLanguage(string text)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Detects the languages of the specified text items synchronously.
+        /// </summary>
+        /// <param name="textItems">The text items to detect the language of. Must not be null or contain null elements.</param>
+        /// <returns>A list of detected languages. This will be the same size as <paramref name="textItems"/>, in the same order.</returns>
+        public virtual IList<Detection> DetectLanguages(IEnumerable<string> textItems)
         {
             throw new NotImplementedException();
         }
@@ -233,8 +243,18 @@ namespace Google.Cloud.Translation.V2
         /// </summary>
         /// <param name="text">The text to detect the language of. Must not be null.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A list of detected language possibilities.</returns>
-        public virtual Task<IList<Detection>> DetectLanguageAsync(string text, CancellationToken cancellationToken = default(CancellationToken))
+        /// <returns>The most likely detected language.</returns>
+        public virtual Task<Detection> DetectLanguageAsync(string text, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Detects the languages of the specified text items asynchronously.
+        /// </summary>
+        /// <param name="textItems">The text items to detect the language of. Must not be null or contain null elements.</param>
+        /// <returns>A list of detected languages. This will be the same size as <paramref name="textItems"/>, in the same order.</returns>
+        public virtual Task<IList<Detection>> DetectLanguagesAsync(IEnumerable<string> textItems, CancellationToken cancellationToken = default(CancellationToken))
         {
             throw new NotImplementedException();
         }

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationClientImpl.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationClientImpl.cs
@@ -132,10 +132,6 @@ namespace Google.Cloud.Translation.V2
         }
 
         /// <inheritdoc />
-        public override Detection DetectLanguage(string text) =>
-            DetectLanguages(new[] { GaxPreconditions.CheckNotNull(text, nameof(text)) })[0];
-
-        /// <inheritdoc />
         public override IList<Detection> DetectLanguages(IEnumerable<string> textItems)
         {
             GaxPreconditions.CheckNotNull(textItems, nameof(textItems));
@@ -200,15 +196,6 @@ namespace Google.Cloud.Translation.V2
             return (await request.ExecuteAsync(cancellationToken).ConfigureAwait(false)).Translations
                 .Zip(items, (result, item) => new TranslationResult(result, item, sourceLanguage, targetLanguage))
                 .ToList();
-        }
-
-        /// <inheritdoc />
-        public override async Task<Detection> DetectLanguageAsync(string text, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            GaxPreconditions.CheckNotNull(text, nameof(text));
-            var listTask = DetectLanguagesAsync(new[] { text }, cancellationToken);
-            var list = await listTask.ConfigureAwait(false);
-            return list[0];
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
The API call can handle multiple inputs, each of which can supposedly
return multiple results - but in practice, only a single result is
returned per input.

We now offer two methods (DetectLanguage and DetectLanguages) to
detect single or multiple items. (Along with the async versions, of
course.)

Fixes #995.

(I'm still verifying that it really *will* only return a single detection per input item. I'll wait until I've got that confirmation before merging.)