### PR TITLE
First pass at modified LRO to include metadata

### DIFF
--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/DatabaseAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/DatabaseAdminClientSnippets.g.cs
@@ -222,11 +222,11 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             InstanceName parent = new InstanceName("[PROJECT]", "[INSTANCE]");
             string createStatement = "";
             // Make the request
-            Operation<Database> response =
+            Operation<Database, CreateDatabaseMetadata> response =
                 await databaseAdminClient.CreateDatabaseAsync(parent, createStatement);
 
             // Poll until the returned long-running operation is complete
-            Operation<Database> completedResponse =
+            Operation<Database, CreateDatabaseMetadata> completedResponse =
                 await response.PollUntilCompletedAsync();
             // Retrieve the operation result
             Database result = completedResponse.Result;
@@ -234,7 +234,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Database> retrievedResponse =
+            Operation<Database, CreateDatabaseMetadata> retrievedResponse =
                 await databaseAdminClient.PollOnceCreateDatabaseAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -254,11 +254,11 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             InstanceName parent = new InstanceName("[PROJECT]", "[INSTANCE]");
             string createStatement = "";
             // Make the request
-            Operation<Database> response =
+            Operation<Database, CreateDatabaseMetadata> response =
                 databaseAdminClient.CreateDatabase(parent, createStatement);
 
             // Poll until the returned long-running operation is complete
-            Operation<Database> completedResponse =
+            Operation<Database, CreateDatabaseMetadata> completedResponse =
                 response.PollUntilCompleted();
             // Retrieve the operation result
             Database result = completedResponse.Result;
@@ -266,7 +266,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Database> retrievedResponse =
+            Operation<Database, CreateDatabaseMetadata> retrievedResponse =
                 databaseAdminClient.PollOnceCreateDatabase(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -289,11 +289,11 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
                 CreateStatement = "",
             };
             // Make the request
-            Operation<Database> response =
+            Operation<Database, CreateDatabaseMetadata> response =
                 await databaseAdminClient.CreateDatabaseAsync(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<Database> completedResponse =
+            Operation<Database, CreateDatabaseMetadata> completedResponse =
                 await response.PollUntilCompletedAsync();
             // Retrieve the operation result
             Database result = completedResponse.Result;
@@ -301,7 +301,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Database> retrievedResponse =
+            Operation<Database, CreateDatabaseMetadata> retrievedResponse =
                 await databaseAdminClient.PollOnceCreateDatabaseAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -324,11 +324,11 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
                 CreateStatement = "",
             };
             // Make the request
-            Operation<Database> response =
+            Operation<Database, CreateDatabaseMetadata> response =
                 databaseAdminClient.CreateDatabase(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<Database> completedResponse =
+            Operation<Database, CreateDatabaseMetadata> completedResponse =
                 response.PollUntilCompleted();
             // Retrieve the operation result
             Database result = completedResponse.Result;
@@ -336,7 +336,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Database> retrievedResponse =
+            Operation<Database, CreateDatabaseMetadata> retrievedResponse =
                 databaseAdminClient.PollOnceCreateDatabase(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -412,18 +412,18 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             DatabaseName database = new DatabaseName("[PROJECT]", "[INSTANCE]", "[DATABASE]");
             IEnumerable<string> statements = new List<string>();
             // Make the request
-            Operation<Empty> response =
+            Operation<Empty, UpdateDatabaseDdlMetadata> response =
                 await databaseAdminClient.UpdateDatabaseDdlAsync(database, statements);
 
             // Poll until the returned long-running operation is complete
-            Operation<Empty> completedResponse =
+            Operation<Empty, UpdateDatabaseDdlMetadata> completedResponse =
                 await response.PollUntilCompletedAsync();
             // The long-running operation is now complete.
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Empty> retrievedResponse =
+            Operation<Empty, UpdateDatabaseDdlMetadata> retrievedResponse =
                 await databaseAdminClient.PollOnceUpdateDatabaseDdlAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -442,18 +442,18 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             DatabaseName database = new DatabaseName("[PROJECT]", "[INSTANCE]", "[DATABASE]");
             IEnumerable<string> statements = new List<string>();
             // Make the request
-            Operation<Empty> response =
+            Operation<Empty, UpdateDatabaseDdlMetadata> response =
                 databaseAdminClient.UpdateDatabaseDdl(database, statements);
 
             // Poll until the returned long-running operation is complete
-            Operation<Empty> completedResponse =
+            Operation<Empty, UpdateDatabaseDdlMetadata> completedResponse =
                 response.PollUntilCompleted();
             // The long-running operation is now complete.
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Empty> retrievedResponse =
+            Operation<Empty, UpdateDatabaseDdlMetadata> retrievedResponse =
                 databaseAdminClient.PollOnceUpdateDatabaseDdl(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -475,18 +475,18 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
                 Statements = { },
             };
             // Make the request
-            Operation<Empty> response =
+            Operation<Empty, UpdateDatabaseDdlMetadata> response =
                 await databaseAdminClient.UpdateDatabaseDdlAsync(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<Empty> completedResponse =
+            Operation<Empty, UpdateDatabaseDdlMetadata> completedResponse =
                 await response.PollUntilCompletedAsync();
             // The long-running operation is now complete.
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Empty> retrievedResponse =
+            Operation<Empty, UpdateDatabaseDdlMetadata> retrievedResponse =
                 await databaseAdminClient.PollOnceUpdateDatabaseDdlAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -508,18 +508,18 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
                 Statements = { },
             };
             // Make the request
-            Operation<Empty> response =
+            Operation<Empty, UpdateDatabaseDdlMetadata> response =
                 databaseAdminClient.UpdateDatabaseDdl(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<Empty> completedResponse =
+            Operation<Empty, UpdateDatabaseDdlMetadata> completedResponse =
                 response.PollUntilCompleted();
             // The long-running operation is now complete.
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Empty> retrievedResponse =
+            Operation<Empty, UpdateDatabaseDdlMetadata> retrievedResponse =
                 databaseAdminClient.PollOnceUpdateDatabaseDdl(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.cs
@@ -644,7 +644,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<Database>> CreateDatabaseAsync(
+        public virtual Task<Operation<Database, CreateDatabaseMetadata>> CreateDatabaseAsync(
             InstanceName parent,
             string createStatement,
             CallSettings callSettings = null) => CreateDatabaseAsync(
@@ -680,7 +680,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<Database>> CreateDatabaseAsync(
+        public virtual Task<Operation<Database, CreateDatabaseMetadata>> CreateDatabaseAsync(
             InstanceName parent,
             string createStatement,
             CancellationToken cancellationToken) => CreateDatabaseAsync(
@@ -713,7 +713,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual Operation<Database> CreateDatabase(
+        public virtual Operation<Database, CreateDatabaseMetadata> CreateDatabase(
             InstanceName parent,
             string createStatement,
             CallSettings callSettings = null) => CreateDatabase(
@@ -743,7 +743,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<Database>> CreateDatabaseAsync(
+        public virtual Task<Operation<Database, CreateDatabaseMetadata>> CreateDatabaseAsync(
             CreateDatabaseRequest request,
             CallSettings callSettings = null)
         {
@@ -756,9 +756,9 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A task representing the result of polling the operation.</returns>
-        public virtual Task<Operation<Database>> PollOnceCreateDatabaseAsync(
+        public virtual Task<Operation<Database, CreateDatabaseMetadata>> PollOnceCreateDatabaseAsync(
             string operationName,
-            CallSettings callSettings = null) => Operation<Database>.PollOnceFromNameAsync(
+            CallSettings callSettings = null) => Operation<Database, CreateDatabaseMetadata>.PollOnceFromNameAsync(
                 GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 LongRunningOperationsClient,
                 callSettings);
@@ -782,7 +782,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual Operation<Database> CreateDatabase(
+        public virtual Operation<Database, CreateDatabaseMetadata> CreateDatabase(
             CreateDatabaseRequest request,
             CallSettings callSettings = null)
         {
@@ -795,9 +795,9 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The result of polling the operation.</returns>
-        public virtual Operation<Database> PollOnceCreateDatabase(
+        public virtual Operation<Database, CreateDatabaseMetadata> PollOnceCreateDatabase(
             string operationName,
-            CallSettings callSettings = null) => Operation<Database>.PollOnceFromName(
+            CallSettings callSettings = null) => Operation<Database, CreateDatabaseMetadata>.PollOnceFromName(
                 GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 LongRunningOperationsClient,
                 callSettings);
@@ -924,7 +924,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<Empty>> UpdateDatabaseDdlAsync(
+        public virtual Task<Operation<Empty, UpdateDatabaseDdlMetadata>> UpdateDatabaseDdlAsync(
             DatabaseName database,
             IEnumerable<string> statements,
             CallSettings callSettings = null) => UpdateDatabaseDdlAsync(
@@ -956,7 +956,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<Empty>> UpdateDatabaseDdlAsync(
+        public virtual Task<Operation<Empty, UpdateDatabaseDdlMetadata>> UpdateDatabaseDdlAsync(
             DatabaseName database,
             IEnumerable<string> statements,
             CancellationToken cancellationToken) => UpdateDatabaseDdlAsync(
@@ -985,7 +985,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual Operation<Empty> UpdateDatabaseDdl(
+        public virtual Operation<Empty, UpdateDatabaseDdlMetadata> UpdateDatabaseDdl(
             DatabaseName database,
             IEnumerable<string> statements,
             CallSettings callSettings = null) => UpdateDatabaseDdl(
@@ -1014,7 +1014,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<Empty>> UpdateDatabaseDdlAsync(
+        public virtual Task<Operation<Empty, UpdateDatabaseDdlMetadata>> UpdateDatabaseDdlAsync(
             UpdateDatabaseDdlRequest request,
             CallSettings callSettings = null)
         {
@@ -1027,9 +1027,9 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A task representing the result of polling the operation.</returns>
-        public virtual Task<Operation<Empty>> PollOnceUpdateDatabaseDdlAsync(
+        public virtual Task<Operation<Empty, UpdateDatabaseDdlMetadata>> PollOnceUpdateDatabaseDdlAsync(
             string operationName,
-            CallSettings callSettings = null) => Operation<Empty>.PollOnceFromNameAsync(
+            CallSettings callSettings = null) => Operation<Empty, UpdateDatabaseDdlMetadata>.PollOnceFromNameAsync(
                 GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 LongRunningOperationsClient,
                 callSettings);
@@ -1052,7 +1052,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual Operation<Empty> UpdateDatabaseDdl(
+        public virtual Operation<Empty, UpdateDatabaseDdlMetadata> UpdateDatabaseDdl(
             UpdateDatabaseDdlRequest request,
             CallSettings callSettings = null)
         {
@@ -1065,9 +1065,9 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The result of polling the operation.</returns>
-        public virtual Operation<Empty> PollOnceUpdateDatabaseDdl(
+        public virtual Operation<Empty, UpdateDatabaseDdlMetadata> PollOnceUpdateDatabaseDdl(
             string operationName,
-            CallSettings callSettings = null) => Operation<Empty>.PollOnceFromName(
+            CallSettings callSettings = null) => Operation<Empty, UpdateDatabaseDdlMetadata>.PollOnceFromName(
                 GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 LongRunningOperationsClient,
                 callSettings);
@@ -1835,12 +1835,12 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public override async Task<Operation<Database>> CreateDatabaseAsync(
+        public override async Task<Operation<Database, CreateDatabaseMetadata>> CreateDatabaseAsync(
             CreateDatabaseRequest request,
             CallSettings callSettings = null)
         {
             Modify_CreateDatabaseRequest(ref request, ref callSettings);
-            return new Operation<Database>(
+            return new Operation<Database, CreateDatabaseMetadata>(
                 await _callCreateDatabase.Async(request, callSettings), LongRunningOperationsClient);
         }
 
@@ -1863,12 +1863,12 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public override Operation<Database> CreateDatabase(
+        public override Operation<Database, CreateDatabaseMetadata> CreateDatabase(
             CreateDatabaseRequest request,
             CallSettings callSettings = null)
         {
             Modify_CreateDatabaseRequest(ref request, ref callSettings);
-            return new Operation<Database>(
+            return new Operation<Database, CreateDatabaseMetadata>(
                 _callCreateDatabase.Sync(request, callSettings), LongRunningOperationsClient);
         }
 
@@ -1930,12 +1930,12 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public override async Task<Operation<Empty>> UpdateDatabaseDdlAsync(
+        public override async Task<Operation<Empty, UpdateDatabaseDdlMetadata>> UpdateDatabaseDdlAsync(
             UpdateDatabaseDdlRequest request,
             CallSettings callSettings = null)
         {
             Modify_UpdateDatabaseDdlRequest(ref request, ref callSettings);
-            return new Operation<Empty>(
+            return new Operation<Empty, UpdateDatabaseDdlMetadata>(
                 await _callUpdateDatabaseDdl.Async(request, callSettings), LongRunningOperationsClient);
         }
 
@@ -1957,12 +1957,12 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public override Operation<Empty> UpdateDatabaseDdl(
+        public override Operation<Empty, UpdateDatabaseDdlMetadata> UpdateDatabaseDdl(
             UpdateDatabaseDdlRequest request,
             CallSettings callSettings = null)
         {
             Modify_UpdateDatabaseDdlRequest(ref request, ref callSettings);
-            return new Operation<Empty>(
+            return new Operation<Empty, UpdateDatabaseDdlMetadata>(
                 _callUpdateDatabaseDdl.Sync(request, callSettings), LongRunningOperationsClient);
         }
 

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/InstanceAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/InstanceAdminClientSnippets.g.cs
@@ -511,11 +511,11 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             InstanceName instanceId = new InstanceName("[PROJECT]", "[INSTANCE]");
             Instance instance = new Instance();
             // Make the request
-            Operation<Instance> response =
+            Operation<Instance, CreateInstanceMetadata> response =
                 await instanceAdminClient.CreateInstanceAsync(parent, instanceId, instance);
 
             // Poll until the returned long-running operation is complete
-            Operation<Instance> completedResponse =
+            Operation<Instance, CreateInstanceMetadata> completedResponse =
                 await response.PollUntilCompletedAsync();
             // Retrieve the operation result
             Instance result = completedResponse.Result;
@@ -523,7 +523,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Instance> retrievedResponse =
+            Operation<Instance, CreateInstanceMetadata> retrievedResponse =
                 await instanceAdminClient.PollOnceCreateInstanceAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -544,11 +544,11 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             InstanceName instanceId = new InstanceName("[PROJECT]", "[INSTANCE]");
             Instance instance = new Instance();
             // Make the request
-            Operation<Instance> response =
+            Operation<Instance, CreateInstanceMetadata> response =
                 instanceAdminClient.CreateInstance(parent, instanceId, instance);
 
             // Poll until the returned long-running operation is complete
-            Operation<Instance> completedResponse =
+            Operation<Instance, CreateInstanceMetadata> completedResponse =
                 response.PollUntilCompleted();
             // Retrieve the operation result
             Instance result = completedResponse.Result;
@@ -556,7 +556,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Instance> retrievedResponse =
+            Operation<Instance, CreateInstanceMetadata> retrievedResponse =
                 instanceAdminClient.PollOnceCreateInstance(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -580,11 +580,11 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
                 Instance = new Instance(),
             };
             // Make the request
-            Operation<Instance> response =
+            Operation<Instance, CreateInstanceMetadata> response =
                 await instanceAdminClient.CreateInstanceAsync(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<Instance> completedResponse =
+            Operation<Instance, CreateInstanceMetadata> completedResponse =
                 await response.PollUntilCompletedAsync();
             // Retrieve the operation result
             Instance result = completedResponse.Result;
@@ -592,7 +592,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Instance> retrievedResponse =
+            Operation<Instance, CreateInstanceMetadata> retrievedResponse =
                 await instanceAdminClient.PollOnceCreateInstanceAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -616,11 +616,11 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
                 Instance = new Instance(),
             };
             // Make the request
-            Operation<Instance> response =
+            Operation<Instance, CreateInstanceMetadata> response =
                 instanceAdminClient.CreateInstance(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<Instance> completedResponse =
+            Operation<Instance, CreateInstanceMetadata> completedResponse =
                 response.PollUntilCompleted();
             // Retrieve the operation result
             Instance result = completedResponse.Result;
@@ -628,7 +628,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Instance> retrievedResponse =
+            Operation<Instance, CreateInstanceMetadata> retrievedResponse =
                 instanceAdminClient.PollOnceCreateInstance(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -649,11 +649,11 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             Instance instance = new Instance();
             FieldMask fieldMask = new FieldMask();
             // Make the request
-            Operation<Instance> response =
+            Operation<Instance, CreateInstanceMetadata> response =
                 await instanceAdminClient.UpdateInstanceAsync(instance, fieldMask);
 
             // Poll until the returned long-running operation is complete
-            Operation<Instance> completedResponse =
+            Operation<Instance, CreateInstanceMetadata> completedResponse =
                 await response.PollUntilCompletedAsync();
             // Retrieve the operation result
             Instance result = completedResponse.Result;
@@ -661,7 +661,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Instance> retrievedResponse =
+            Operation<Instance, CreateInstanceMetadata> retrievedResponse =
                 await instanceAdminClient.PollOnceUpdateInstanceAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -681,11 +681,11 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             Instance instance = new Instance();
             FieldMask fieldMask = new FieldMask();
             // Make the request
-            Operation<Instance> response =
+            Operation<Instance, CreateInstanceMetadata> response =
                 instanceAdminClient.UpdateInstance(instance, fieldMask);
 
             // Poll until the returned long-running operation is complete
-            Operation<Instance> completedResponse =
+            Operation<Instance, CreateInstanceMetadata> completedResponse =
                 response.PollUntilCompleted();
             // Retrieve the operation result
             Instance result = completedResponse.Result;
@@ -693,7 +693,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Instance> retrievedResponse =
+            Operation<Instance, CreateInstanceMetadata> retrievedResponse =
                 instanceAdminClient.PollOnceUpdateInstance(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -716,11 +716,11 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
                 FieldMask = new FieldMask(),
             };
             // Make the request
-            Operation<Instance> response =
+            Operation<Instance, CreateInstanceMetadata> response =
                 await instanceAdminClient.UpdateInstanceAsync(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<Instance> completedResponse =
+            Operation<Instance, CreateInstanceMetadata> completedResponse =
                 await response.PollUntilCompletedAsync();
             // Retrieve the operation result
             Instance result = completedResponse.Result;
@@ -728,7 +728,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Instance> retrievedResponse =
+            Operation<Instance, CreateInstanceMetadata> retrievedResponse =
                 await instanceAdminClient.PollOnceUpdateInstanceAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -751,11 +751,11 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
                 FieldMask = new FieldMask(),
             };
             // Make the request
-            Operation<Instance> response =
+            Operation<Instance, CreateInstanceMetadata> response =
                 instanceAdminClient.UpdateInstance(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<Instance> completedResponse =
+            Operation<Instance, CreateInstanceMetadata> completedResponse =
                 response.PollUntilCompleted();
             // Retrieve the operation result
             Instance result = completedResponse.Result;
@@ -763,7 +763,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<Instance> retrievedResponse =
+            Operation<Instance, CreateInstanceMetadata> retrievedResponse =
                 instanceAdminClient.PollOnceUpdateInstance(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClient.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClient.cs
@@ -1014,7 +1014,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<Instance>> CreateInstanceAsync(
+        public virtual Task<Operation<Instance, CreateInstanceMetadata>> CreateInstanceAsync(
             ProjectName parent,
             InstanceName instanceId,
             Instance instance,
@@ -1082,7 +1082,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<Instance>> CreateInstanceAsync(
+        public virtual Task<Operation<Instance, CreateInstanceMetadata>> CreateInstanceAsync(
             ProjectName parent,
             InstanceName instanceId,
             Instance instance,
@@ -1147,7 +1147,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual Operation<Instance> CreateInstance(
+        public virtual Operation<Instance, CreateInstanceMetadata> CreateInstance(
             ProjectName parent,
             InstanceName instanceId,
             Instance instance,
@@ -1205,7 +1205,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<Instance>> CreateInstanceAsync(
+        public virtual Task<Operation<Instance, CreateInstanceMetadata>> CreateInstanceAsync(
             CreateInstanceRequest request,
             CallSettings callSettings = null)
         {
@@ -1218,9 +1218,9 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A task representing the result of polling the operation.</returns>
-        public virtual Task<Operation<Instance>> PollOnceCreateInstanceAsync(
+        public virtual Task<Operation<Instance, CreateInstanceMetadata>> PollOnceCreateInstanceAsync(
             string operationName,
-            CallSettings callSettings = null) => Operation<Instance>.PollOnceFromNameAsync(
+            CallSettings callSettings = null) => Operation<Instance, CreateInstanceMetadata>.PollOnceFromNameAsync(
                 GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 LongRunningOperationsClient,
                 callSettings);
@@ -1270,7 +1270,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual Operation<Instance> CreateInstance(
+        public virtual Operation<Instance, CreateInstanceMetadata> CreateInstance(
             CreateInstanceRequest request,
             CallSettings callSettings = null)
         {
@@ -1283,9 +1283,9 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The result of polling the operation.</returns>
-        public virtual Operation<Instance> PollOnceCreateInstance(
+        public virtual Operation<Instance, CreateInstanceMetadata> PollOnceCreateInstance(
             string operationName,
-            CallSettings callSettings = null) => Operation<Instance>.PollOnceFromName(
+            CallSettings callSettings = null) => Operation<Instance, CreateInstanceMetadata>.PollOnceFromName(
                 GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 LongRunningOperationsClient,
                 callSettings);
@@ -1348,7 +1348,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<Instance>> UpdateInstanceAsync(
+        public virtual Task<Operation<Instance, CreateInstanceMetadata>> UpdateInstanceAsync(
             Instance instance,
             FieldMask fieldMask,
             CallSettings callSettings = null) => UpdateInstanceAsync(
@@ -1417,7 +1417,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<Instance>> UpdateInstanceAsync(
+        public virtual Task<Operation<Instance, CreateInstanceMetadata>> UpdateInstanceAsync(
             Instance instance,
             FieldMask fieldMask,
             CancellationToken cancellationToken) => UpdateInstanceAsync(
@@ -1483,7 +1483,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual Operation<Instance> UpdateInstance(
+        public virtual Operation<Instance, CreateInstanceMetadata> UpdateInstance(
             Instance instance,
             FieldMask fieldMask,
             CallSettings callSettings = null) => UpdateInstance(
@@ -1545,7 +1545,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<Instance>> UpdateInstanceAsync(
+        public virtual Task<Operation<Instance, CreateInstanceMetadata>> UpdateInstanceAsync(
             UpdateInstanceRequest request,
             CallSettings callSettings = null)
         {
@@ -1558,9 +1558,9 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A task representing the result of polling the operation.</returns>
-        public virtual Task<Operation<Instance>> PollOnceUpdateInstanceAsync(
+        public virtual Task<Operation<Instance, CreateInstanceMetadata>> PollOnceUpdateInstanceAsync(
             string operationName,
-            CallSettings callSettings = null) => Operation<Instance>.PollOnceFromNameAsync(
+            CallSettings callSettings = null) => Operation<Instance, CreateInstanceMetadata>.PollOnceFromNameAsync(
                 GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 LongRunningOperationsClient,
                 callSettings);
@@ -1616,7 +1616,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual Operation<Instance> UpdateInstance(
+        public virtual Operation<Instance, CreateInstanceMetadata> UpdateInstance(
             UpdateInstanceRequest request,
             CallSettings callSettings = null)
         {
@@ -1629,9 +1629,9 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The result of polling the operation.</returns>
-        public virtual Operation<Instance> PollOnceUpdateInstance(
+        public virtual Operation<Instance, CreateInstanceMetadata> PollOnceUpdateInstance(
             string operationName,
-            CallSettings callSettings = null) => Operation<Instance>.PollOnceFromName(
+            CallSettings callSettings = null) => Operation<Instance, CreateInstanceMetadata>.PollOnceFromName(
                 GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 LongRunningOperationsClient,
                 callSettings);
@@ -2494,12 +2494,12 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public override async Task<Operation<Instance>> CreateInstanceAsync(
+        public override async Task<Operation<Instance, CreateInstanceMetadata>> CreateInstanceAsync(
             CreateInstanceRequest request,
             CallSettings callSettings = null)
         {
             Modify_CreateInstanceRequest(ref request, ref callSettings);
-            return new Operation<Instance>(
+            return new Operation<Instance, CreateInstanceMetadata>(
                 await _callCreateInstance.Async(request, callSettings), LongRunningOperationsClient);
         }
 
@@ -2548,12 +2548,12 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public override Operation<Instance> CreateInstance(
+        public override Operation<Instance, CreateInstanceMetadata> CreateInstance(
             CreateInstanceRequest request,
             CallSettings callSettings = null)
         {
             Modify_CreateInstanceRequest(ref request, ref callSettings);
-            return new Operation<Instance>(
+            return new Operation<Instance, CreateInstanceMetadata>(
                 _callCreateInstance.Sync(request, callSettings), LongRunningOperationsClient);
         }
 
@@ -2608,12 +2608,12 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public override async Task<Operation<Instance>> UpdateInstanceAsync(
+        public override async Task<Operation<Instance, CreateInstanceMetadata>> UpdateInstanceAsync(
             UpdateInstanceRequest request,
             CallSettings callSettings = null)
         {
             Modify_UpdateInstanceRequest(ref request, ref callSettings);
-            return new Operation<Instance>(
+            return new Operation<Instance, CreateInstanceMetadata>(
                 await _callUpdateInstance.Async(request, callSettings), LongRunningOperationsClient);
         }
 
@@ -2668,12 +2668,12 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public override Operation<Instance> UpdateInstance(
+        public override Operation<Instance, CreateInstanceMetadata> UpdateInstance(
             UpdateInstanceRequest request,
             CallSettings callSettings = null)
         {
             Modify_UpdateInstanceRequest(ref request, ref callSettings);
-            return new Operation<Instance>(
+            return new Operation<Instance, CreateInstanceMetadata>(
                 _callUpdateInstance.Sync(request, callSettings), LongRunningOperationsClient);
         }
 

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Snippets/SpeechClientSnippets.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Snippets/SpeechClientSnippets.g.cs
@@ -142,11 +142,11 @@ namespace Google.Cloud.Speech.V1.Snippets
                 Uri = "gs://bucket_name/file_name.flac",
             };
             // Make the request
-            Operation<LongRunningRecognizeResponse> response =
+            Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> response =
                 await speechClient.LongRunningRecognizeAsync(config, audio);
 
             // Poll until the returned long-running operation is complete
-            Operation<LongRunningRecognizeResponse> completedResponse =
+            Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> completedResponse =
                 await response.PollUntilCompletedAsync();
             // Retrieve the operation result
             LongRunningRecognizeResponse result = completedResponse.Result;
@@ -154,7 +154,7 @@ namespace Google.Cloud.Speech.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LongRunningRecognizeResponse> retrievedResponse =
+            Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> retrievedResponse =
                 await speechClient.PollOnceLongRunningRecognizeAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -182,11 +182,11 @@ namespace Google.Cloud.Speech.V1.Snippets
                 Uri = "gs://bucket_name/file_name.flac",
             };
             // Make the request
-            Operation<LongRunningRecognizeResponse> response =
+            Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> response =
                 speechClient.LongRunningRecognize(config, audio);
 
             // Poll until the returned long-running operation is complete
-            Operation<LongRunningRecognizeResponse> completedResponse =
+            Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> completedResponse =
                 response.PollUntilCompleted();
             // Retrieve the operation result
             LongRunningRecognizeResponse result = completedResponse.Result;
@@ -194,7 +194,7 @@ namespace Google.Cloud.Speech.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LongRunningRecognizeResponse> retrievedResponse =
+            Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> retrievedResponse =
                 speechClient.PollOnceLongRunningRecognize(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -225,11 +225,11 @@ namespace Google.Cloud.Speech.V1.Snippets
                         },
             };
             // Make the request
-            Operation<LongRunningRecognizeResponse> response =
+            Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> response =
                 await speechClient.LongRunningRecognizeAsync(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<LongRunningRecognizeResponse> completedResponse =
+            Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> completedResponse =
                 await response.PollUntilCompletedAsync();
             // Retrieve the operation result
             LongRunningRecognizeResponse result = completedResponse.Result;
@@ -237,7 +237,7 @@ namespace Google.Cloud.Speech.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LongRunningRecognizeResponse> retrievedResponse =
+            Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> retrievedResponse =
                 await speechClient.PollOnceLongRunningRecognizeAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
@@ -268,11 +268,11 @@ namespace Google.Cloud.Speech.V1.Snippets
                         },
             };
             // Make the request
-            Operation<LongRunningRecognizeResponse> response =
+            Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> response =
                 speechClient.LongRunningRecognize(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<LongRunningRecognizeResponse> completedResponse =
+            Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> completedResponse =
                 response.PollUntilCompleted();
             // Retrieve the operation result
             LongRunningRecognizeResponse result = completedResponse.Result;
@@ -280,7 +280,7 @@ namespace Google.Cloud.Speech.V1.Snippets
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LongRunningRecognizeResponse> retrievedResponse =
+            Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> retrievedResponse =
                 speechClient.PollOnceLongRunningRecognize(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.cs
@@ -456,7 +456,7 @@ namespace Google.Cloud.Speech.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<LongRunningRecognizeResponse>> LongRunningRecognizeAsync(
+        public virtual Task<Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata>> LongRunningRecognizeAsync(
             RecognitionConfig config,
             RecognitionAudio audio,
             CallSettings callSettings = null) => LongRunningRecognizeAsync(
@@ -486,7 +486,7 @@ namespace Google.Cloud.Speech.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<LongRunningRecognizeResponse>> LongRunningRecognizeAsync(
+        public virtual Task<Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata>> LongRunningRecognizeAsync(
             RecognitionConfig config,
             RecognitionAudio audio,
             CancellationToken cancellationToken) => LongRunningRecognizeAsync(
@@ -513,7 +513,7 @@ namespace Google.Cloud.Speech.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual Operation<LongRunningRecognizeResponse> LongRunningRecognize(
+        public virtual Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> LongRunningRecognize(
             RecognitionConfig config,
             RecognitionAudio audio,
             CallSettings callSettings = null) => LongRunningRecognize(
@@ -539,7 +539,7 @@ namespace Google.Cloud.Speech.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual Task<Operation<LongRunningRecognizeResponse>> LongRunningRecognizeAsync(
+        public virtual Task<Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata>> LongRunningRecognizeAsync(
             LongRunningRecognizeRequest request,
             CallSettings callSettings = null)
         {
@@ -552,9 +552,9 @@ namespace Google.Cloud.Speech.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A task representing the result of polling the operation.</returns>
-        public virtual Task<Operation<LongRunningRecognizeResponse>> PollOnceLongRunningRecognizeAsync(
+        public virtual Task<Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata>> PollOnceLongRunningRecognizeAsync(
             string operationName,
-            CallSettings callSettings = null) => Operation<LongRunningRecognizeResponse>.PollOnceFromNameAsync(
+            CallSettings callSettings = null) => Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata>.PollOnceFromNameAsync(
                 GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 LongRunningOperationsClient,
                 callSettings);
@@ -574,7 +574,7 @@ namespace Google.Cloud.Speech.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual Operation<LongRunningRecognizeResponse> LongRunningRecognize(
+        public virtual Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> LongRunningRecognize(
             LongRunningRecognizeRequest request,
             CallSettings callSettings = null)
         {
@@ -587,9 +587,9 @@ namespace Google.Cloud.Speech.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The result of polling the operation.</returns>
-        public virtual Operation<LongRunningRecognizeResponse> PollOnceLongRunningRecognize(
+        public virtual Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> PollOnceLongRunningRecognize(
             string operationName,
-            CallSettings callSettings = null) => Operation<LongRunningRecognizeResponse>.PollOnceFromName(
+            CallSettings callSettings = null) => Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata>.PollOnceFromName(
                 GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 LongRunningOperationsClient,
                 callSettings);
@@ -728,12 +728,12 @@ namespace Google.Cloud.Speech.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public override async Task<Operation<LongRunningRecognizeResponse>> LongRunningRecognizeAsync(
+        public override async Task<Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata>> LongRunningRecognizeAsync(
             LongRunningRecognizeRequest request,
             CallSettings callSettings = null)
         {
             Modify_LongRunningRecognizeRequest(ref request, ref callSettings);
-            return new Operation<LongRunningRecognizeResponse>(
+            return new Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata>(
                 await _callLongRunningRecognize.Async(request, callSettings), LongRunningOperationsClient);
         }
 
@@ -752,12 +752,12 @@ namespace Google.Cloud.Speech.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public override Operation<LongRunningRecognizeResponse> LongRunningRecognize(
+        public override Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata> LongRunningRecognize(
             LongRunningRecognizeRequest request,
             CallSettings callSettings = null)
         {
             Modify_LongRunningRecognizeRequest(ref request, ref callSettings);
-            return new Operation<LongRunningRecognizeResponse>(
+            return new Operation<LongRunningRecognizeResponse, LongRunningRecognizeMetadata>(
                 _callLongRunningRecognize.Sync(request, callSettings), LongRunningOperationsClient);
         }
 

--- a/apis/Google.LongRunning/Google.LongRunning/Operation.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/Operation.cs
@@ -28,8 +28,11 @@ namespace Google.LongRunning
     /// For simplicity, no methods on this type modify the proto message. Instead, to get up-to-date
     /// information you can use Refresh to obtain a new instance.
     /// </remarks>
-    /// <typeparam name="T">The response message type.</typeparam>
-    public class Operation<T> where T : IMessage<T>, new()
+    /// <typeparam name="TResponse">The response message type.</typeparam>
+    /// <typeparam name="TMetadata">The metata message type.</typeparam>
+    public sealed class Operation<TResponse, TMetadata>
+        where TResponse : IMessage<TResponse>, new()
+        where TMetadata : class, IMessage<TMetadata>, new()
     {
         private static readonly PollSettings s_defaultPollSettings = new PollSettings(Expiration.None, TimeSpan.FromSeconds(10));
 
@@ -47,10 +50,10 @@ namespace Google.LongRunning
         private readonly Lazy<OperationFailedException> _lazyException;
 
         /// <summary>
-        /// 
+        /// Constructs a new instance from the given RPC message.
         /// </summary>
-        /// <param name="rpcMessage"></param>
-        /// <param name="client"></param>
+        /// <param name="rpcMessage">The RPC message describing the operation. Must not be null.</param>
+        /// <param name="client">The client to use for further calls. Must not be null.</param>
         public Operation(Operation rpcMessage, OperationsClient client)
         {
             RpcMessage = GaxPreconditions.CheckNotNull(rpcMessage, nameof(rpcMessage));
@@ -96,6 +99,12 @@ namespace Google.LongRunning
         public OperationFailedException Exception => _lazyException.Value;
 
         /// <summary>
+        /// Retrieves the metadata associated with this operation, or <c>null</c> if there is no
+        /// metadata in the underlying response message.
+        /// </summary>
+        public TMetadata Metadata => RpcMessage.Metadata?.Unpack<TMetadata>();
+
+        /// <summary>
         /// Retrieves the result of the operation, throwing an exception if the operation failed or hasn't completed.
         /// Unlike <see cref="Task{T}.Result"/>, this does not block.
         /// </summary>
@@ -104,7 +113,7 @@ namespace Google.LongRunning
         /// </remarks>
         /// <exception cref="OperationFailedException">The operation completed with an error.</exception>
         /// <exception cref="InvalidOperationException">The operation has not completed yet.</exception>
-        public T Result
+        public TResponse Result
         {
             get
             {
@@ -113,7 +122,7 @@ namespace Google.LongRunning
                     case Operation.ResultOneofCase.Error:
                         throw Exception;
                     case Operation.ResultOneofCase.Response:
-                        return RpcMessage.Response.Unpack<T>();
+                        return RpcMessage.Response.Unpack<TResponse>();
                     default:
                         throw new InvalidOperationException();
                 }
@@ -130,8 +139,13 @@ namespace Google.LongRunning
         /// <param name="pollSettings">The settings to use for repeated polling, or null
         /// to use the default poll settings (poll once every 10 seconds, forever).</param>
         /// <param name="callSettings">The call settings to apply on each call, or null for default settings.</param>
+        /// <param name="metadataCallback">The callback to invoke whenever a polled result contains metadata, or null
+        /// for no callback.</param>
         /// <returns>The completed operation, which can then be checked for errors or a result.</returns>
-        public Operation<T> PollUntilCompleted(PollSettings pollSettings = null, CallSettings callSettings = null)
+        public Operation<TResponse, TMetadata> PollUntilCompleted(
+            PollSettings pollSettings = null,
+            CallSettings callSettings = null,
+            Action<TMetadata> metadataCallback = null)
         {
             if (IsCompleted)
             {
@@ -139,7 +153,18 @@ namespace Google.LongRunning
             }
             callSettings = Client.GetEffectiveCallSettingsForGetOperation(callSettings);
 
-            Func<DateTime?, Operation<T>> pollAction = deadline => PollOnce(callSettings.WithEarlierDeadline(deadline, Client.Clock));
+            Func<DateTime?, Operation<TResponse, TMetadata>> pollAction =
+                deadline =>
+                {
+                    var result = PollOnce(callSettings.WithEarlierDeadline(deadline, Client.Clock));
+                    TMetadata metadata;
+                    if (metadataCallback != null && (metadata = result.Metadata) != null)
+                    {
+                        metadataCallback.Invoke(metadata);
+                    }
+                    return result;
+                };
+
             return Polling.PollRepeatedly(
                 pollAction, o => o.IsCompleted,
                 Client.Clock, Client.Scheduler, pollSettings ?? s_defaultPollSettings,
@@ -156,15 +181,30 @@ namespace Google.LongRunning
         /// <param name="pollSettings">The settings to use for repeated polling, or null
         /// to use the default poll settings (poll once every 10 seconds, forever).</param>
         /// <param name="callSettings">The call settings to apply on each call, or null for default settings.</param>
+        /// <param name="metadataCallback">The callback to invoke whenever a polled result contains metadata, or null
+        /// for no callback.</param>
         /// <returns>The completed operation, which can then be checked for errors or a result.</returns>
-        public Task<Operation<T>> PollUntilCompletedAsync(PollSettings pollSettings = null, CallSettings callSettings = null)
+        public Task<Operation<TResponse, TMetadata>> PollUntilCompletedAsync(
+            PollSettings pollSettings = null,
+            CallSettings callSettings = null,
+            Action<TMetadata> metadataCallback = null)
         {
             if (IsCompleted)
             {
                 return Task.FromResult(this);
             }
             callSettings = Client.GetEffectiveCallSettingsForGetOperation(callSettings);
-            Func<DateTime?, Task<Operation<T>>> pollAction = deadline => PollOnceAsync(callSettings.WithEarlierDeadline(deadline, Client.Clock));
+            Func<DateTime?, Task<Operation<TResponse, TMetadata>>> pollAction =
+                async deadline =>
+                {
+                    var result = await PollOnceAsync(callSettings.WithEarlierDeadline(deadline, Client.Clock)).ConfigureAwait(false);
+                    TMetadata metadata;
+                    if (metadataCallback != null && (metadata = result.Metadata) != null)
+                    {
+                        metadataCallback.Invoke(metadata);
+                    }
+                    return result;
+                };
             return Polling.PollRepeatedlyAsync(
                 pollAction, o => o.IsCompleted,
                 Client.Clock, Client.Scheduler, pollSettings ?? s_defaultPollSettings,
@@ -177,7 +217,7 @@ namespace Google.LongRunning
         /// <param name="callSettings">Any overriding call settings to apply to the RPC.</param>
         /// <returns>The most recent state of the operation, or a reference to the same
         /// object if the operation has already completed.</returns>
-        public Operation<T> PollOnce(CallSettings callSettings = null)
+        public Operation<TResponse, TMetadata> PollOnce(CallSettings callSettings = null)
             => IsCompleted ? this : PollOnceFromName(Name, Client, callSettings);
 
         /// <summary>
@@ -187,7 +227,7 @@ namespace Google.LongRunning
         /// <returns>A task representing the asynchronous poll operation. The result of the task is 
         /// the most recent state of the operation, or a reference to the same
         /// object if the operation has already completed.</returns>
-        public Task<Operation<T>> PollOnceAsync(CallSettings callSettings = null) =>
+        public Task<Operation<TResponse, TMetadata>> PollOnceAsync(CallSettings callSettings = null) =>
             IsCompleted ? Task.FromResult(this) : PollOnceFromNameAsync(Name, Client, callSettings);
 
         /// <summary>
@@ -197,7 +237,7 @@ namespace Google.LongRunning
         /// <returns>A task representing the asynchronous poll operation. The result of the task is 
         /// the most recent state of the operation, or a reference to the same
         /// object if the operation has already completed.</returns>
-        public Task<Operation<T>> PollOnceAsync(CancellationToken cancellationToken) =>
+        public Task<Operation<TResponse, TMetadata>> PollOnceAsync(CancellationToken cancellationToken) =>
             PollOnceAsync(CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
@@ -263,12 +303,12 @@ namespace Google.LongRunning
         /// <param name="callSettings">Any overriding call settings to apply to the RPC. May be null, in which case
         /// the default settings are used.</param>
         /// <returns>The current state of the operation identified by <paramref name="name"/>.</returns>
-        public static Operation<T> PollOnceFromName(string name, OperationsClient client, CallSettings callSettings = null)
+        public static Operation<TResponse, TMetadata> PollOnceFromName(string name, OperationsClient client, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(name, nameof(name));
             GaxPreconditions.CheckNotNull(client, nameof(client));
             var operation = client.GetOperation(name, callSettings);
-            return new Operation<T>(operation, client);
+            return new Operation<TResponse, TMetadata>(operation, client);
         }
 
         /// <summary>
@@ -280,12 +320,12 @@ namespace Google.LongRunning
         /// the default settings are used.</param>
         /// <returns>A task representing the asynchronous "fetch" operation. The result of the task is
         /// the current state of the operation identified by <paramref name="name"/>.</returns>
-        public static async Task<Operation<T>> PollOnceFromNameAsync(string name, OperationsClient client, CallSettings callSettings = null)
+        public static async Task<Operation<TResponse, TMetadata>> PollOnceFromNameAsync(string name, OperationsClient client, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(name, nameof(name));
             GaxPreconditions.CheckNotNull(client, nameof(client));
             var operation = await client.GetOperationAsync(name, callSettings).ConfigureAwait(false);
-            return new Operation<T>(operation, client);
+            return new Operation<TResponse, TMetadata>(operation, client);
         }
 
         /// <summary>
@@ -296,7 +336,7 @@ namespace Google.LongRunning
         /// <param name="cancellationToken">A cancellation token for the "fetch" operation.</param>
         /// <returns>A task representing the asynchronous "fetch" operation. The result of the task is
         /// the current state of the operation identified by <paramref name="name"/>.</returns>
-        public static Task<Operation<T>> PollOnceFromNameAsync(string name, OperationsClient client, CancellationToken cancellationToken) =>
+        public static Task<Operation<TResponse, TMetadata>> PollOnceFromNameAsync(string name, OperationsClient client, CancellationToken cancellationToken) =>
             PollOnceFromNameAsync(name, client, CallSettings.FromCancellationToken(cancellationToken));
     }
 }


### PR DESCRIPTION
This is a simple approach, but the name of the returned type ends up
being very long.

(Ready for review in terms of general approach; more testing work required.)