### PR TITLE
Update how translation models are handled

### DIFF
--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/TranslationClientSnippets.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/TranslationClientSnippets.cs
@@ -22,21 +22,21 @@ namespace Google.Cloud.Translation.V2.Snippets
     public class TranslationClientSnippets
     {
         
-        public void TranslateTextNmtDefaultModel()
+        public void TranslateTextPbmtDefaultModel()
         {
-            // Sample: TranslateTextNmtDefaultModel
-            TranslationClient client = TranslationClient.Create(model: TranslationModel.NeuralMachineTranslation);
+            // Sample: TranslateTextPbmtDefaultModel
+            TranslationClient client = TranslationClient.Create(model: TranslationModel.PhraseBasedMachineTranslation);
             TranslationResult result = client.TranslateText("It is raining.", LanguageCodes.French);
             Console.WriteLine($"Result: {result.TranslatedText}; detected language {result.DetectedSourceLanguage}");
             // End sample
         }
 
-        public void TranslateTextNmtOverrideModel()
+        public void TranslateTextPbmtOverrideModel()
         {
-            // Sample: TranslateTextNmtOverrideModel
+            // Sample: TranslateTextPbmtOverrideModel
             TranslationClient client = TranslationClient.Create();
             TranslationResult result = client.TranslateText("It is raining.", LanguageCodes.French,
-                model: TranslationModel.NeuralMachineTranslation);
+                model: TranslationModel.PhraseBasedMachineTranslation);
             Console.WriteLine($"Result: {result.TranslatedText}; detected language {result.DetectedSourceLanguage}");
             // End sample
         }

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationClient.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationClient.cs
@@ -307,9 +307,9 @@ namespace Google.Cloud.Translation.V2
         /// The credentials are scoped as necessary.
         /// </remarks>
         /// <param name="credential">Optional <see cref="GoogleCredential"/>.</param>
-        /// <param name="model">The default translation model to use. Defaults to <see cref="TranslationModel.Base"/>.</param>
+        /// <param name="model">The default translation model to use. Defaults to <see cref="TranslationModel.ServiceDefault"/>.</param>
         /// <returns>The task representing the created <see cref="TranslationClient"/>.</returns>
-        public static async Task<TranslationClient> CreateAsync(GoogleCredential credential = null, TranslationModel model = TranslationModel.Base)
+        public static async Task<TranslationClient> CreateAsync(GoogleCredential credential = null, TranslationModel model = TranslationModel.ServiceDefault)
         {
             var scopedCredentials = await _credentialProvider.GetCredentialsAsync(credential).ConfigureAwait(false);
             return CreateImpl(scopedCredentials, null, model);
@@ -323,9 +323,9 @@ namespace Google.Cloud.Translation.V2
         /// from using API keys to OAuth2 credentials straightforward.
         /// </remarks>
         /// <param name="apiKey">API key to use. Must not be null.</param>
-        /// <param name="model">The default translation model to use. Defaults to <see cref="TranslationModel.Base"/>.</param>
+        /// <param name="model">The default translation model to use. Defaults to <see cref="TranslationModel.ServiceDefault"/>.</param>
         /// <returns>The created <see cref="TranslationClient"/>.</returns>
-        public static TranslationClient CreateFromApiKey(string apiKey, TranslationModel model = TranslationModel.Base)
+        public static TranslationClient CreateFromApiKey(string apiKey, TranslationModel model = TranslationModel.ServiceDefault)
         {
             GaxPreconditions.CheckNotNull(apiKey, nameof(apiKey));
             return CreateImpl(null, apiKey, model);
@@ -339,9 +339,9 @@ namespace Google.Cloud.Translation.V2
         /// The credentials are scoped as necessary.
         /// </remarks>
         /// <param name="credential">Optional <see cref="GoogleCredential"/>.</param>
-        /// <param name="model">The default translation model to use. Defaults to <see cref="TranslationModel.Base"/>.</param>
+        /// <param name="model">The default translation model to use. Defaults to <see cref="TranslationModel.ServiceDefault"/>.</param>
         /// <returns>The created <see cref="TranslationClient"/>.</returns>
-        public static TranslationClient Create(GoogleCredential credential = null, TranslationModel model = TranslationModel.Base)
+        public static TranslationClient Create(GoogleCredential credential = null, TranslationModel model = TranslationModel.ServiceDefault)
         {
             var scopedCredentials = _credentialProvider.GetCredentials(credential);
             return CreateImpl(scopedCredentials, null, model);

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationClientImpl.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationClientImpl.cs
@@ -82,8 +82,8 @@ namespace Google.Cloud.Translation.V2
         /// Constructs a new client wrapping the given <see cref="TranslateService"/>.
         /// </summary>
         /// <param name="service">The service to wrap. Must not be null.</param>
-        /// <param name="model">The default translation model to use. Defaults to <see cref="TranslationModel.Base"/>.</param>
-        public TranslationClientImpl(TranslateService service, TranslationModel model = TranslationModel.Base)
+        /// <param name="model">The default translation model to use. Defaults to <see cref="TranslationModel.ServiceDefault"/>.</param>
+        public TranslationClientImpl(TranslateService service, TranslationModel model = TranslationModel.ServiceDefault)
         {
             Service = GaxPreconditions.CheckNotNull(service, nameof(service));
             TranslationModels.ValidateModel(model);
@@ -214,8 +214,7 @@ namespace Google.Cloud.Translation.V2
             request.Format = format;
             var effectiveModel = model ?? DefaultModel;
             TranslationModels.ValidateModel(effectiveModel);
-            // Never explicitly request the base model.
-            request.Model = effectiveModel == TranslationModel.Base ? null : effectiveModel.ToApiName();
+            request.Model = effectiveModel.ToApiName();
         }      
     }
 }

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationModel.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationModel.cs
@@ -15,17 +15,23 @@
 namespace Google.Cloud.Translation.V2
 {
     /// <summary>
-    /// Underlying model used by the Google Cloud Translation API.
+    /// Underlying model used by the Google Cloud Translation API. This can be explicitly
+    /// specified on a per-client or per-method basis.
     /// </summary>
     public enum TranslationModel
     {
         /// <summary>
-        /// Standard edition translation model.
+        /// Explicitly allow the API service to decide which model to use.
         /// </summary>
-        Base,
+        ServiceDefault,
         /// <summary>
-        /// Only available in Premium edition, the Neural Machine Translation
-        /// model provides higher quality results.
+        /// The original translation Phrase-Based Machine Translation model ("base").
+        /// </summary>
+        PhraseBasedMachineTranslation,
+        /// <summary>
+        /// The Neural Machine Translation model ("nmt") provides higher quality results
+        /// where available, but is more computationally intensive, leading to
+        /// slightly higher latency.
         /// </summary>
         NeuralMachineTranslation
     }

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationModels.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationModels.cs
@@ -21,14 +21,15 @@ namespace Google.Cloud.Translation.V2
     /// </summary>
     internal static class TranslationModels
     {
-        private const string BaseApiName = "base";
+        private const string PhraseBasedMachineTranslationApiName = "base";
         private const string NeuralMachineTranslationApiName = "nmt";
 
         internal static void ValidateModel(TranslationModel model)
         {
             switch (model)
             {
-                case TranslationModel.Base: return;
+                case TranslationModel.ServiceDefault: return;
+                case TranslationModel.PhraseBasedMachineTranslation: return;
                 case TranslationModel.NeuralMachineTranslation: return;
             }
             throw new ArgumentException($"Unknown translation model {model}", nameof(model));
@@ -38,7 +39,9 @@ namespace Google.Cloud.Translation.V2
         {
             switch (model)
             {
-                case TranslationModel.Base: return BaseApiName;
+                // null in an outbound API call means "no client preference"
+                case TranslationModel.ServiceDefault: return null;
+                case TranslationModel.PhraseBasedMachineTranslation: return PhraseBasedMachineTranslationApiName;
                 case TranslationModel.NeuralMachineTranslation: return NeuralMachineTranslationApiName;
                 default: throw new InvalidOperationException($"Unknown translation model {model}");
             }
@@ -50,9 +53,12 @@ namespace Google.Cloud.Translation.V2
             {
                 return null;
             }
+            // Note: the response only contains a translation model if it was explicitly requested,
+            // so if a new model comes out and is used by default, it's fine that we wouldn't recognize its
+            // API name - we won't see that anyway.
             switch (name)
             {
-                case BaseApiName: return TranslationModel.Base;
+                case PhraseBasedMachineTranslationApiName: return TranslationModel.PhraseBasedMachineTranslation;
                 case NeuralMachineTranslationApiName: return TranslationModel.NeuralMachineTranslation;
                 default: throw new InvalidOperationException($"Unknown translation model {name}");
             }

--- a/apis/Google.Cloud.Translation.V2/docs/index.md
+++ b/apis/Google.Cloud.Translation.V2/docs/index.md
@@ -51,13 +51,25 @@ Common operations are exposed via the
 
 [!code-cs[](obj/snippets/Google.Cloud.Translation.V2.TranslationClient.txt#TranslateHtmlMultiple)]
 
-## Using Neural Machine Translation
+## Specifying a translation model
 
-[Premium Edition](https://cloud.google.com/translate/docs/premium) customers may request
-translations using the Neural Machine Translation model. This can either be set as the default model for a client:
+The Translation API is implemented by multiple underlying models. At the time of writing, the two models available are:
 
-[!code-cs[](obj/snippets/Google.Cloud.Translation.V2.TranslationClient.txt#TranslateTextNmtDefaultModel)]
+- Neural Machine Translation (NMT)
+- Phrase-Based Machine Translation (PBMT, also known as "base")
+
+The current default is to use NMT where it is available for the requested language translation pair, but this is
+more computationally-intensive than the PBMT model; if you have low latency requirements, you may wish to explicitly
+required PBMT. Explicitly requesting NMT is valid, but currently has no effect, as this is the current default. If
+no model is specified, the service will pick a model, which means if a new model is introduced as the default, you won't need
+to change your code or even update this client library package in order to use it.
+
+See the [API release notes](https://cloud.google.com/translate/release-notes) for on-going changes and new models.
+
+When specifying a model, it can either be selected as the model to use for all requests for that `TranslationClient` instance:
+
+[!code-cs[](obj/snippets/Google.Cloud.Translation.V2.TranslationClient.txt#TranslateTextPbmtDefaultModel)]
 
 ... or it can be specified on a per-request basis:
 
-[!code-cs[](obj/snippets/Google.Cloud.Translation.V2.TranslationClient.txt#TranslateTextNmtOverrideModel)]
+[!code-cs[](obj/snippets/Google.Cloud.Translation.V2.TranslationClient.txt#TranslateTextPbmtOverrideModel)]


### PR DESCRIPTION
- We now have an explicit "let the server decide" enum value. This
  is better than overloading the use of null, as otherwise if the
  client specified a particular model, it couldn't be overridden
  by a single method call.
- Documentation is updated to describe the models in more detail,
  including when you might want to explicitly use PBMT.

Fixes #1001. (More extensive than expected...)