### PR TITLE
Update versions ready for release

### DIFF
--- a/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/project.json
+++ b/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha00-*",
+  "version": "1.0.0-alpha01-*",
   "description": "Common Protocol Buffer messages for Google Cloud Developer Tools APIs.",
 
   "packOptions": {

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta08-*",
+  "version": "1.0.0-beta09-*",
   "description": "Google Stackdriver Instrumentation Libraries for ASP.NET.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/project.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha08-*",
+  "version": "1.0.0-beta01-*",
   "description": "Google Stackdriver Instrumentation Libraries for ASP.NET Core.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/project.json
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha07-*",
+  "version": "1.0.0-beta01-*",
   "description": "Google Stackdriver Instrumentation Libraries Common Components.",
   "authors": [ "Google Inc." ],
 

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/project.json
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha02-*",
+  "version": "1.0.0-alpha03-*",
   "description": "Recommended Google client library to access the Translation API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.",
   "authors": [ "Google Inc." ],
 


### PR DESCRIPTION
(I'll wait until I've got the Translation PR merged, then rebase.)

Notably, this promotes the ASP.NET Core and (Diagnostics.)Common components to beta01 and will be the first (alpha) release for Google.Cloud.DevTools.Common.

// cc @iantalarico @Deren-Liao 