### PR TITLE
Tools to download and then display NuGet dependencies, for version planning

### DIFF
--- a/tools/Google.Cloud.Tools.DownloadDependencyInfo/Google.Cloud.Tools.DownloadDependencyInfo.xproj
+++ b/tools/Google.Cloud.Tools.DownloadDependencyInfo/Google.Cloud.Tools.DownloadDependencyInfo.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>2b180e4b-dec6-42bb-823e-73225c5ddf58</ProjectGuid>
+    <RootNamespace>Google.Cloud.Tools.DownloadDependencyInfo</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tools/Google.Cloud.Tools.DownloadDependencyInfo/PackageInfo.cs
+++ b/tools/Google.Cloud.Tools.DownloadDependencyInfo/PackageInfo.cs
@@ -1,0 +1,25 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace Google.Cloud.Tools.DownloadDependencyInfo
+{
+    public class PackageInfo
+    {
+        public string Id { get; set; }
+        public string Version { get; set; }
+        public List<string> Dependencies { get; set; }
+    }
+}

--- a/tools/Google.Cloud.Tools.DownloadDependencyInfo/Program.cs
+++ b/tools/Google.Cloud.Tools.DownloadDependencyInfo/Program.cs
@@ -1,0 +1,118 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using Newtonsoft.Json;
+using NuGet.CatalogReader;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Tools.DownloadDependencyInfo
+{
+    public class Program
+    {
+        private static void Main(string[] args)
+        {
+            if (args.Length != 1)
+            {
+                Console.WriteLine("Required argument: output filename");
+                Console.WriteLine("e.g. nuget-dependencies.json");
+                return;
+            }
+            string outputFile = args[0];
+
+            // The NuGet catalog reader only has async methods. That's a pain in a console
+            // app :(
+            Run(outputFile).Wait();
+        }
+
+        private static async Task Run(string outputFile)
+        {
+            var allDependencies = await LoadAllDependenciesAsync();
+            using (var writer = File.CreateText(outputFile))
+            {
+                var serializer = JsonSerializer.CreateDefault();
+                serializer.Formatting = Formatting.Indented;
+                serializer.Serialize(writer, allDependencies);
+            }
+            Console.WriteLine($"Failures: {s_failureCount}");
+        }
+
+        private static async Task<List<PackageInfo>> LoadAllDependenciesAsync()
+        {
+            ServicePointManager.DefaultConnectionLimit = 64;
+            var feed = new Uri("https://api.nuget.org/v3/index.json");
+            
+            using (var catalog = new CatalogReader(feed, TimeSpan.FromDays(1)))
+            {
+                Console.WriteLine("Loading latest package IDs");
+                // The documentation lies: this retrieves all entries. Ignore pre-release,
+                // and find the latest version for each package.
+                var catalogEntries = (await catalog.GetFlattenedEntriesAsync())
+                    .Where(p => !p.Version.IsPrerelease)
+                    .Where(p => !p.IsDelete)
+                    .GroupBy(p => p.Id)
+                    // Spam... there must be a better way of detecting this. 
+                    .Where(g => !g.Key.Contains("1-800") && !g.Key.ToLowerInvariant().Contains("-phone-") && !g.Key.ToLowerInvariant().Contains("-number-"))
+                    .Select(g => g.OrderByDescending(p => p.Version).First())
+                    .ToList();
+
+                Console.WriteLine($"Loading dependencies for {catalogEntries.Count} packages");
+                return catalogEntries
+                    .AsParallel()
+                    .WithDegreeOfParallelism(16)
+                    .Select(GetPackageInfo)
+                    .Where(p => p != null)
+                    .ToList();
+            }
+        }
+
+        private static int s_loadedPackageCount = 0;
+        private static int s_failureCount = 0;
+        private static PackageInfo GetPackageInfo(CatalogEntry entry)
+        {
+            try
+            {
+                // This is ugly. There must be something better. Not using Task.Run as we don't have any
+                // synchronization context anyway.
+                var nuspec = entry.GetNuspecAsync().Result;
+                int loaded = Interlocked.Increment(ref s_loadedPackageCount);
+                if (loaded % 100 == 0)
+                {
+                    Console.WriteLine($"{DateTime.UtcNow:HH:mm:ss} Loaded dependencies for {loaded} packages.");
+                }
+
+                return new PackageInfo
+                {
+                    Id = entry.Id,
+                    Version = entry.Version.ToString(),
+                    Dependencies = nuspec.GetDependencyGroups()
+                        .SelectMany(dg => dg.Packages)
+                        .Select(d => d.Id)
+                        .Distinct()
+                        .ToList()
+                };
+            }
+            catch
+            {
+                Console.WriteLine($"Failed to fetch dependencies for {entry.Id}");
+                Interlocked.Increment(ref s_failureCount);
+                return null;
+            }
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.DownloadDependencyInfo/project.json
+++ b/tools/Google.Cloud.Tools.DownloadDependencyInfo/project.json
@@ -1,0 +1,14 @@
+﻿{
+  "description": "Console app to generate a dependency map JSON file for use in ShowReverseDependencies",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NuGet.CatalogReader": "1.2.0"
+  },
+  "frameworks": {
+    "net46": {
+      "Newtonsoft.Json": "10.0.2"
+    }
+  }
+}

--- a/tools/Google.Cloud.Tools.ShowReverseDependencies/Google.Cloud.Tools.ShowReverseDependencies.xproj
+++ b/tools/Google.Cloud.Tools.ShowReverseDependencies/Google.Cloud.Tools.ShowReverseDependencies.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>999ca9bf-6c9f-438f-aafc-c0677ea381eb</ProjectGuid>
+    <RootNamespace>Google.Cloud.Tools.ShowReverseDependencies</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tools/Google.Cloud.Tools.ShowReverseDependencies/PackageInfo.cs
+++ b/tools/Google.Cloud.Tools.ShowReverseDependencies/PackageInfo.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace Google.Cloud.Tools.ShowReverseDependencies
+{
+    // Copied from DownloadDependencyInfo so we can deserialize easily.
+    // Not worth trying to take a dependency...
+    public class PackageInfo
+    {
+        public string Id { get; set; }
+        public string Version { get; set; }
+        public List<string> Dependencies { get; set; }
+    }
+}

--- a/tools/Google.Cloud.Tools.ShowReverseDependencies/Program.cs
+++ b/tools/Google.Cloud.Tools.ShowReverseDependencies/Program.cs
@@ -1,0 +1,64 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Google.Cloud.Tools.ShowReverseDependencies
+{
+    public class Program
+    {
+        private static void Main(string[] args)
+        {
+            if (args.Length != 3)
+            {
+                Console.WriteLine("Required arguments: json-file package-name depth");
+                Console.WriteLine("e.g. nuget-dependencies.json Google.Apis 3");
+                return;
+            }
+
+
+            var json = File.ReadAllText(args[0]);
+            var allPackages = JsonConvert.DeserializeObject<List<PackageInfo>>(json);
+
+            string package = args[1];
+            int depth = int.Parse(args[2]);
+
+            var reverseMap = allPackages
+                .SelectMany(p => p.Dependencies.Select(d => new { from = p.Id, to = d }))
+                .ToLookup(p => p.to, p => p.from);
+
+            List<string> sourceSet = new[] { package }.ToList();
+
+            for (int i = 1; i <= depth; i++)
+            {
+                sourceSet = sourceSet
+                    .SelectMany(p => reverseMap[p])
+                    .OrderBy(p => p)
+                    .Distinct()
+                    .ToList();
+                Console.WriteLine($"Dependencies at depth {i}:");
+                foreach (var dependency in sourceSet)
+                {
+                    Console.WriteLine(dependency);
+                }
+
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ShowReverseDependencies/project.json
+++ b/tools/Google.Cloud.Tools.ShowReverseDependencies/project.json
@@ -1,0 +1,19 @@
+﻿{
+  "description": "Console app to show the reverse dependencies on NuGet packages",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "Newtonsoft.Json": "10.0.2"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      }
+    }
+  }
+}

--- a/tools/Google.Cloud.Tools.sln
+++ b/tools/Google.Cloud.Tools.sln
@@ -25,6 +25,10 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Cloud.CheckGapicConf
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Cloud.Translation.V2", "..\apis\Google.Cloud.Translation.V2\Google.Cloud.Translation.V2\Google.Cloud.Translation.V2.xproj", "{3434B211-D93C-4E78-9F62-47E404E2511C}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Cloud.Tools.ShowReverseDependencies", "Google.Cloud.Tools.ShowReverseDependencies\Google.Cloud.Tools.ShowReverseDependencies.xproj", "{999CA9BF-6C9F-438F-AAFC-C0677EA381EB}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Cloud.Tools.DownloadDependencyInfo", "Google.Cloud.Tools.DownloadDependencyInfo\Google.Cloud.Tools.DownloadDependencyInfo.xproj", "{2B180E4B-DEC6-42BB-823E-73225C5DDF58}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,6 +79,14 @@ Global
 		{3434B211-D93C-4E78-9F62-47E404E2511C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3434B211-D93C-4E78-9F62-47E404E2511C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3434B211-D93C-4E78-9F62-47E404E2511C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{999CA9BF-6C9F-438F-AAFC-C0677EA381EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{999CA9BF-6C9F-438F-AAFC-C0677EA381EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{999CA9BF-6C9F-438F-AAFC-C0677EA381EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{999CA9BF-6C9F-438F-AAFC-C0677EA381EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B180E4B-DEC6-42BB-823E-73225C5DDF58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B180E4B-DEC6-42BB-823E-73225C5DDF58}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B180E4B-DEC6-42BB-823E-73225C5DDF58}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B180E4B-DEC6-42BB-823E-73225C5DDF58}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
These are crude but pretty effective. There are about 1600 packages we can't download as they have invalid nuspecs, apparently.
