### PR TITLE
Change how external dependencies are handled in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ bin
 project.lock.json
 _site
 site
+dependencies
+# Legacy docs/external; now docs/dependencies
 external
 output
 *~

--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -2,19 +2,6 @@
 
 set -e
 
-fetch() {
-  # $1: repo (and directory name)
-  # $2: organization
-  # $3: branch
-  if [ -d "external/$1" ]
-  then
-    echo Skipping $1
-    return
-  fi
-  echo Fetching $1
-  git clone https://github.com/$2/$1 external/$1 --quiet --depth=1 -b $3
-}
-
 build_api_docs() {
   echo Building docs for $1
   local api=$1
@@ -23,6 +10,7 @@ build_api_docs() {
   if [ "$api" == "root" ]
   then
     cp -r root output/root
+    mkdir -p output/root/obj/api
   else
     dotnet run -p ../tools/Google.Cloud.Tools.GenerateDocfxSources -- $api
   fi
@@ -30,6 +18,14 @@ build_api_docs() {
   docfx metadata -f output/$api/docfx.json | tee errors.txt
   (! grep --quiet 'Build failed.' errors.txt)
   dotnet run -p ../tools/Google.Cloud.Tools.GenerateSnippetMarkdown -- $api
+  
+  # Copy external dependency yml files into the API and concatenate toc.yml
+  for dep in $(cat output/$api/dependencies)
+  do
+    cp dependencies/api/$dep/*.yml output/$api/obj/api
+    cat dependencies/api/$dep/toc >> output/$api/obj/api/toc.yml
+  done
+  
   docfx build output/$api/docfx.json | tee errors.txt
   (! grep --quiet 'Build failed.' errors.txt)
 
@@ -47,37 +43,16 @@ build_api_docs() {
   echo Finished building docs for $api
 }
 
-if [ ! -d external ]
+
+if [[ ! -d "dependencies" ]]
 then
-  mkdir external
+  echo "Fetching external dependencies repo"
+  git clone https://github.com/GoogleCloudPlatform/google-cloud-dotnet dependencies --quiet -b dependencies --depth=1
 fi
 
-# TODO: Only do this if there's a parameter?
 rm -rf output
 mkdir output
 mkdir output/assembled
-
-# For Google.Api.Gax and Google.Api.Gax.Rest
-fetch gax-dotnet googleapis master
-dotnet restore -v Warning external/gax-dotnet
-
-# For Google.Protobuf
-fetch protobuf google 3.2.x
-dotnet restore -v Warning external/protobuf/csharp/src
-# Remove // comments in project.json; dotnet cli is fine with it, but docfx isn't.
-sed -i -r 's/\s+\/\/.*//g' external/protobuf/csharp/src/Google.Protobuf/project.json
-
-# For Grpc.Core etc
-fetch grpc grpc v1.2.x
-dotnet restore -v Warning external/grpc/src/csharp
-
-# For all REST-based APIs
-fetch google-api-dotnet-client google master
-mkdir -p external/google-api-dotnet-client/NuPkgs/Support
-dotnet restore -v Warning external/google-api-dotnet-client
-
-# TODO: google/google-api-dotnet-client, but those projects
-# don't work with docfx right now
 
 apis=$@
 if [ -z "$apis" ]

--- a/docs/dependencies-docfx/README.md
+++ b/docs/dependencies-docfx/README.md
@@ -1,0 +1,3 @@
+This directory contains docfx configuration files, one for each
+external repo. These are used to generate metadata that can then be
+consumed by API builds.

--- a/docs/dependencies-docfx/docfx-gax-dotnet.json
+++ b/docs/dependencies-docfx/docfx-gax-dotnet.json
@@ -1,0 +1,24 @@
+{
+  "metadata": [
+    {
+      "src": [{ "files": ["src/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj"] }],
+      "properties": { "TargetFramework": "net45" },
+      "dest": "api/Google.Api.CommonProtos",
+    },
+    {
+      "src": [{ "files": ["src/Google.Api.Gax/Google.Api.Gax.csproj"] }],
+      "properties": { "TargetFramework": "net45" },
+      "dest": "api/Google.Api.Gax",
+    },
+    {
+      "src": [{ "files": ["src/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj"] }],
+      "properties": { "TargetFramework": "net45" },
+      "dest": "api/Google.Api.Gax.Rest",
+    },
+    {
+      "src": [{ "files": ["src/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj"] }],
+      "properties": { "TargetFramework": "net45" },
+      "dest": "api/Google.Api.Gax.Grpc",
+    },
+  ]
+}

--- a/docs/dependencies-docfx/docfx-google-api-dotnet-client.json
+++ b/docs/dependencies-docfx/docfx-google-api-dotnet-client.json
@@ -1,0 +1,24 @@
+{
+  "metadata": [
+    {
+      "src": [{ "files": ["Src/Support/GoogleApis/Net45/GoogleApis_Net45.csproj"] }],
+      "dest": "api/Google.Apis",
+    },
+    {
+      "src": [{ "files": ["Src/Support/GoogleApis.Core/Net45/GoogleApis.Core_Net45.csproj"] }],
+      "dest": "api/Google.Apis.Core",
+    },
+    {
+      "src": [{ "files": ["Src/Support/GoogleApis.Auth/Net45/GoogleApis.Auth_Net45.csproj"] }],
+      "dest": "api/Google.Apis.Auth",
+    },
+    {
+      "src": [{ "files": ["Src/Generated/Google.Apis.Storage.v1/NetStandard/Google.Apis.Storage.v1.csproj"] }],
+      "dest": "api/Google.Apis.Storage.v1",
+    },
+    {
+      "src": [{ "files": ["Src/Generated/Google.Apis.Bigquery.v2/NetStandard/Google.Apis.Bigquery.v2.csproj"] }],
+      "dest": "api/Google.Apis.Bigquery.v2",
+    }
+  ]
+}

--- a/docs/dependencies-docfx/docfx-grpc.json
+++ b/docs/dependencies-docfx/docfx-grpc.json
@@ -1,0 +1,8 @@
+{
+  "metadata": [
+    {
+      "src": [{ "files": ["src/csharp/Grpc.Core/project.json"] }],
+      "dest": "api/Grpc.Core",
+    }
+  ]
+}

--- a/docs/dependencies-docfx/docfx-protobuf.json
+++ b/docs/dependencies-docfx/docfx-protobuf.json
@@ -1,0 +1,9 @@
+{
+  "metadata": [
+    {
+      "src": [{ "files": ["csharp/src/Google.Protobuf/project.json"] }],
+      "properties": { "TargetFramework": "net45" },
+      "dest": "api/Google.Protobuf",
+    }
+  ]
+}

--- a/docs/fetchdependencies.sh
+++ b/docs/fetchdependencies.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+
+# Blow away any previous files and clone the repo
+rm -rf dependencies
+git clone https://github.com/GoogleCloudPlatform/google-cloud-dotnet dependencies --quiet -b dependencies
+# Start with a clean slate other than README.md and .gitignore
+git -C dependencies rm -rf .
+git -C dependencies reset -- README.md .gitignore
+git -C dependencies checkout README.md .gitignore
+
+echo "Cloning repositories"
+git clone https://github.com/googleapis/gax-dotnet dependencies/gax-dotnet --quiet --depth=1 -b master
+git clone https://github.com/google/protobuf dependencies/protobuf --quiet --depth=1 -b 3.2.x
+git clone https://github.com/grpc/grpc dependencies/grpc --quiet --depth=1 -b v1.2.x
+git clone https://github.com/google/google-api-dotnet-client dependencies/google-api-dotnet-client --quiet --depth=1 -b master
+
+# Minor fixups...
+
+# Remove // comments in project.json; dotnet cli is fine with it, but docfx isn't.
+sed -i -r 's/\s+\/\/.*//g' dependencies/protobuf/csharp/src/Google.Protobuf/project.json
+
+# Copy docfx files
+cp dependencies-docfx/docfx-gax-dotnet.json dependencies/gax-dotnet/docfx.json
+cp dependencies-docfx/docfx-protobuf.json dependencies/protobuf/docfx.json
+cp dependencies-docfx/docfx-grpc.json dependencies/grpc/docfx.json
+cp dependencies-docfx/docfx-google-api-dotnet-client.json dependencies/google-api-dotnet-client/docfx.json
+
+# Restore packages and build metadata
+# TODO: The last of these fails to find System.DateTime in Storage. No idea why,
+# but chances are it'll be fixed when google-api-dotnet-client updates to csproj...
+(cd dependencies/gax-dotnet; dotnet restore Gax.sln; docfx metadata)
+(cd dependencies/protobuf; dotnet restore csharp/src; docfx metadata)
+(cd dependencies/grpc; dotnet restore src/csharp; docfx metadata)
+(cd dependencies/google-api-dotnet-client; dotnet restore .; docfx metadata)
+
+# Copy the metadata into a single api directory, one subdirectory per package
+mkdir dependencies/api
+cp -r dependencies/{gax-dotnet,protobuf,grpc,google-api-dotnet-client}/api/* dependencies/api
+for dir in dependencies/api/*
+do
+  # Make the build scripts significantly simpler...
+  mv $dir/toc.yml $dir/toc
+done
+
+git -C dependencies add --all
+
+echo "Done. Commit and push new files after checking they look okay."

--- a/docs/root/dependencies
+++ b/docs/root/dependencies
@@ -1,0 +1,1 @@
+Google.Api.Gax Google.Api.Gax.Grpc Google.Api.Gax.Rest

--- a/docs/root/docfx.json
+++ b/docs/root/docfx.json
@@ -1,23 +1,14 @@
 {
   "metadata": [
     {
-      "src": [
-        {
-          "files": [
-            "gax-dotnet/src/Google.Api.Gax/project.json",
-            "gax-dotnet/src/Google.Api.Gax.Grpc/project.json",
-            "gax-dotnet/src/Google.Api.Gax.Rest/project.json"
-          ],
-          "cwd": "../../external"
-        }
-      ],
+      "src": { },
       "dest": "obj/api"
     }
   ],
   "build": {
     "content": [
       {
-        "files": [ "**/*.yml" ],
+        "files": [ "*.yml" ],
         "src": "obj/api",
         "dest": "api"
       },

--- a/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
+++ b/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
@@ -25,24 +25,6 @@ namespace Google.Cloud.Tools.GenerateDocfxSources
 {
     public class Program
     {
-        // Mapping from the dependency name to the file within "external" that docfx should generate metadata from
-        private static readonly Dictionary<string, string> s_dependencyReferences = new Dictionary<string, string>
-        {
-            { "Google.Protobuf", "protobuf/csharp/src/Google.Protobuf/project.json" },
-            { "Google.Apis", "google-api-dotnet-client/Src/Support/GoogleApis/Net45/GoogleApis_Net45.csproj" },
-            { "Google.Apis.Core", "google-api-dotnet-client/Src/Support/GoogleApis.Core/Net45/GoogleApis.Core_Net45.csproj" },
-            { "Google.Apis.Auth", "google-api-dotnet-client/Src/Support/GoogleApis.Auth/Net45/GoogleApis.Auth_Net45.csproj" },
-            { "Google.Api.Gax", "gax-dotnet/src/Google.Api.Gax/project.json" },
-            { "Google.Api.Gax.Grpc", "gax-dotnet/src/Google.Api.Gax.Grpc/project.json" },
-            { "Google.Api.Gax.Rest", "gax-dotnet/src/Google.Api.Gax.Rest/project.json" },
-            { "Google.Api.CommonProtos", "gax-dotnet/src/Google.Api.CommonProtos/project.json" },
-            { "Grpc.Core", "grpc/src/csharp/Grpc.Core/Grpc.Core.csproj" },
-
-            // It's easier to hard-code these for now than generalise them...
-            { "Google.Apis.Storage.v1", "google-api-dotnet-client/Src/Generated/Google.Apis.Storage.v1/NetStandard/Google.Apis.Storage.v1.csproj" },
-            { "Google.Apis.Bigquery.v2", "google-api-dotnet-client/Src/Generated/Google.Apis.Bigquery.v2/NetStandard/Google.Apis.Bigquery.v2.csproj" },
-        };
-
         private static int Main(string[] args)
         {
             try
@@ -96,16 +78,6 @@ namespace Google.Cloud.Tools.GenerateDocfxSources
             var dependencies = projects.SelectMany(p => p.Dependencies).OrderBy(d => d).Distinct().ToList();
             foreach (var dependency in dependencies)
             {
-                string path;
-                if (s_dependencyReferences.TryGetValue(dependency, out path))
-                {
-                    src.Add(new JObject
-                    {
-                        ["files"] = new JArray { path },
-                        ["cwd"] = $"../../external"
-                    });
-                    continue;
-                }
                 // Cross-API dependencies (currently for IAM and LRO)
                 string candidateDependency = $"../../../apis/{dependency}";
                 if (Directory.Exists(Path.Combine(outputDirectory, candidateDependency)))
@@ -133,7 +105,7 @@ namespace Google.Cloud.Tools.GenerateDocfxSources
                     ["content"] = new JArray {
                         new JObject
                         {
-                            ["files"] = new JArray { "**/*.yml" },
+                            ["files"] = "*.yml",
                             ["src"] = "obj/api",
                             ["dest"] = "api"
                         },
@@ -152,8 +124,16 @@ namespace Google.Cloud.Tools.GenerateDocfxSources
                     ["dest"] = "site"
                 }
             };
-
             File.WriteAllText(Path.Combine(outputDirectory, "docfx.json"), json.ToString());
+
+            // We let the build script do work with the dependencies:
+            // - Copy all yml files
+            // - Concatenate toc.yml files
+            var externalDependencies = dependencies
+                .Where(d => Directory.Exists(Path.Combine(outputDirectory, $"../../dependencies/api/{d}")))
+                .ToList();
+
+            File.WriteAllText(Path.Combine(outputDirectory, "dependencies"), string.Join(" ", externalDependencies));
         }
 
         private static void CopyAndGenerateArticles(string api, string inputDirectory, string outputDirectory)


### PR DESCRIPTION
This allows us to use a mixture of project.json and csproj projects.

The metadata for external dependencies is now built when the
"external" directory is first created. (That can be recreated by
calling fetchexternal.) The result is an external/api directory
containing all the metadata, broken down by package. The
GenerateDocfxSources code detects the dependencies, and then the
builddocs.sh script copies it into place alongside the other library
metadata, and concatenates the TOC files.

It would have been nice to be able to just refer to the external
dependency metadata from the docfx.json files, but if the files
start in different directories that ends up being tricky.