### PR TITLE
Fix JSON handling for strings that look like dates

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
@@ -303,6 +303,24 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Null(s["x"]);
         }
 
+        [Fact]
+        public void StringValueThatLooksLikeADate()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var row = client.CreateQueryJob("SELECT '2017-05-04T15:01:00Z' AS value")
+                .PollQueryUntilCompleted()
+                .GetRows()
+                .Single();
+
+            // Check that the schema really claims it's a string...
+            var field = row.Schema.Fields.Single();
+            Assert.Equal("value", field.Name);
+            Assert.Equal("STRING", field.Type);
+
+            // And we should be able to get the value as a string too...
+            Assert.Equal("2017-05-04T15:01:00Z", (string) row["value"]);
+        }
+
         // TODO: Struct containing array or array containing struct.
 
         [Fact]

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.cs
@@ -17,7 +17,9 @@ using Google.Api.Gax.Rest;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Bigquery.v2.Data;
+using Google.Apis.Json;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -106,6 +108,7 @@ namespace Google.Cloud.BigQuery.V2
             {
                 HttpClientInitializer = scopedCredentials,
                 ApplicationName = BigQueryClientImpl.ApplicationName,
+                Serializer = new NewtonsoftJsonSerializer(CreateJsonSerializersSettings())
             });
 
             return new BigQueryClientImpl(projectId, service);
@@ -190,5 +193,18 @@ namespace Google.Cloud.BigQuery.V2
                 ProjectId = GaxPreconditions.CheckNotNull(projectId, nameof(projectId)),
                 JobId = GaxPreconditions.CheckNotNull(jobId, nameof(jobId))
             };
+        
+        /// <summary>
+        /// Creates a set of <see cref="JsonSerializerSettings"/> suitable for specifying in
+        /// <see cref="BigqueryService"/> construction. The settings have Json.NET date parsing
+        /// detection disabled.
+        /// </summary>
+        /// <returns>A suitable set of settings.</returns>
+        public static JsonSerializerSettings CreateJsonSerializersSettings()
+        {
+            JsonSerializerSettings settings = NewtonsoftJsonSerializer.CreateDefaultSettings();
+            settings.DateParseHandling = DateParseHandling.None;
+            return settings;
+        }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.cs
@@ -77,6 +77,12 @@ namespace Google.Cloud.BigQuery.V2
         /// <summary>
         /// Constructs a new client wrapping the given <see cref="BigqueryService"/>.
         /// </summary>
+        /// <remarks>
+        /// Care should be taken when constructing the service: if the default serializer settings are used,
+        /// result values which can be parsed as date/time values can cause problems. Where possible, either use
+        /// <see cref="BigQueryClient.Create(string, Apis.Auth.OAuth2.GoogleCredential)"/> or construct a service
+        /// using serializer settings from <see cref="BigQueryClient.CreateJsonSerializersSettings"/>.
+        /// </remarks>
         /// <param name="projectId">The ID of the project to work with. Must not be null.</param>
         /// <param name="service">The service to wrap. Must not be null.</param>
         public BigQueryClientImpl(string projectId, BigqueryService service)
@@ -88,6 +94,12 @@ namespace Google.Cloud.BigQuery.V2
         /// <summary>
         /// Constructs a new client wrapping the given <see cref="BigqueryService"/>.
         /// </summary>
+        /// <remarks>
+        /// Care should be taken when constructing the service: if the default serializer settings are used,
+        /// result values which can be parsed as date/time values can cause problems. Where possible, either use
+        /// <see cref="BigQueryClient.Create(string, Apis.Auth.OAuth2.GoogleCredential)"/> or construct a service
+        /// using serializer settings from <see cref="BigQueryClient.CreateJsonSerializersSettings"/>.
+        /// </remarks>
         /// <param name="projectReference">A fully-qualified identifier for the project. Must not be null.</param>
         /// <param name="service">The service to wrap. Must not be null.</param>
         public BigQueryClientImpl(ProjectReference projectReference, BigqueryService service)

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
@@ -55,6 +55,7 @@ namespace Google.Cloud.BigQuery.V2
         };
         private static readonly Func<string, DateTime> DateConverter = v => DateTime.ParseExact(v, "yyyy-MM-dd", CultureInfo.InvariantCulture);
         private static readonly Func<string, TimeSpan> TimeConverter = v => DateTime.ParseExact(v, "HH:mm:ss.FFFFFF", CultureInfo.InvariantCulture).TimeOfDay;
+        private static readonly Func<string, DateTime> DateTimeConverter = v => DateTime.ParseExact(v, "yyyy-MM-dd'T'HH:mm:ss.FFFFFF", CultureInfo.InvariantCulture);
         private static readonly Func<string, byte[]> BytesConverter = v => Convert.FromBase64String(v);
         private static readonly Func<string, bool> BooleanConverter = v => v == "true";
 
@@ -107,7 +108,7 @@ namespace Google.Cloud.BigQuery.V2
                     case BigQueryDbType.Time:
                         return ConvertArray(array, TimeConverter);
                     case BigQueryDbType.DateTime:
-                        return ConvertArray(array, obj => (DateTime) obj);
+                        return ConvertArray(array, DateTimeConverter);
                     case BigQueryDbType.Struct:
                         return ConvertRecordArray(array, field);
                     default:
@@ -133,9 +134,7 @@ namespace Google.Cloud.BigQuery.V2
                 case BigQueryDbType.Time:
                     return TimeConverter((string) rawValue);
                 case BigQueryDbType.DateTime:
-                    return rawValue is DateTime
-                        ? (DateTime) rawValue
-                        : (DateTime) (JValue) rawValue;
+                    return DateTimeConverter((string) rawValue);
                 case BigQueryDbType.Struct:
                     return ConvertRecord((JObject)rawValue, field);
                 default:

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Rest" Version="2.0.0-beta01" />
-    <PackageReference Include="Google.Apis.Bigquery.v2" Version="1.25.0.819" />
+    <PackageReference Include="Google.Apis.Bigquery.v2" Version="1.26.2.861" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="BigQueryClient.*.cs">

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -21,7 +21,7 @@
     "type": "rest",
     "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
     "dependencies": {
-      "Google.Apis.Bigquery.v2": "1.25.0.819"
+      "Google.Apis.Bigquery.v2": "1.26.2.861"
     },
     "testDependencies": {
       "Google.Cloud.Storage.V1": "",


### PR DESCRIPTION
This will fix #1016.

Currently the test fails, because I haven't actually fixed it... but once the next release of the REST support libraries has happened, we'll be able to specify our own serializer settings to fix it.