### PR TITLE
Changes to Translation models

### DIFF
--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/TranslationClientSnippets.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/TranslationClientSnippets.cs
@@ -22,21 +22,21 @@ namespace Google.Cloud.Translation.V2.Snippets
     public class TranslationClientSnippets
     {
         
-        public void TranslateTextPbmtDefaultModel()
+        public void TranslateTextBaseDefaultModel()
         {
-            // Sample: TranslateTextPbmtDefaultModel
-            TranslationClient client = TranslationClient.Create(model: TranslationModel.PhraseBasedMachineTranslation);
+            // Sample: TranslateTextBaseDefaultModel
+            TranslationClient client = TranslationClient.Create(model: TranslationModel.Base);
             TranslationResult result = client.TranslateText("It is raining.", LanguageCodes.French);
             Console.WriteLine($"Result: {result.TranslatedText}; detected language {result.DetectedSourceLanguage}");
             // End sample
         }
 
-        public void TranslateTextPbmtOverrideModel()
+        public void TranslateTextBaseOverrideModel()
         {
-            // Sample: TranslateTextPbmtOverrideModel
+            // Sample: TranslateTextBaseOverrideModel
             TranslationClient client = TranslationClient.Create();
             TranslationResult result = client.TranslateText("It is raining.", LanguageCodes.French,
-                model: TranslationModel.PhraseBasedMachineTranslation);
+                model: TranslationModel.Base);
             Console.WriteLine($"Result: {result.TranslatedText}; detected language {result.DetectedSourceLanguage}");
             // End sample
         }

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationModel.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationModel.cs
@@ -16,7 +16,8 @@ namespace Google.Cloud.Translation.V2
 {
     /// <summary>
     /// Underlying model used by the Google Cloud Translation API. This can be explicitly
-    /// specified on a per-client or per-method basis.
+    /// specified on a per-client or per-method basis. See
+    /// https://cloud.google.com/translate/release-notes for on-going changes and new models.
     /// </summary>
     public enum TranslationModel
     {
@@ -25,13 +26,12 @@ namespace Google.Cloud.Translation.V2
         /// </summary>
         ServiceDefault,
         /// <summary>
-        /// The original translation Phrase-Based Machine Translation model ("base").
+        /// The "base" model. The exact meaning of this model may change over time.
         /// </summary>
-        PhraseBasedMachineTranslation,
+        Base,
         /// <summary>
         /// The Neural Machine Translation model ("nmt") provides higher quality results
-        /// where available, but is more computationally intensive, leading to
-        /// slightly higher latency.
+        /// where available, but is computationally intensive.
         /// </summary>
         NeuralMachineTranslation
     }

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationModels.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationModels.cs
@@ -21,7 +21,7 @@ namespace Google.Cloud.Translation.V2
     /// </summary>
     internal static class TranslationModels
     {
-        private const string PhraseBasedMachineTranslationApiName = "base";
+        private const string BaseApiName = "base";
         private const string NeuralMachineTranslationApiName = "nmt";
 
         internal static void ValidateModel(TranslationModel model)
@@ -29,7 +29,7 @@ namespace Google.Cloud.Translation.V2
             switch (model)
             {
                 case TranslationModel.ServiceDefault: return;
-                case TranslationModel.PhraseBasedMachineTranslation: return;
+                case TranslationModel.Base: return;
                 case TranslationModel.NeuralMachineTranslation: return;
             }
             throw new ArgumentException($"Unknown translation model {model}", nameof(model));
@@ -41,7 +41,7 @@ namespace Google.Cloud.Translation.V2
             {
                 // null in an outbound API call means "no client preference"
                 case TranslationModel.ServiceDefault: return null;
-                case TranslationModel.PhraseBasedMachineTranslation: return PhraseBasedMachineTranslationApiName;
+                case TranslationModel.Base: return BaseApiName;
                 case TranslationModel.NeuralMachineTranslation: return NeuralMachineTranslationApiName;
                 default: throw new InvalidOperationException($"Unknown translation model {model}");
             }
@@ -58,7 +58,7 @@ namespace Google.Cloud.Translation.V2
             // API name - we won't see that anyway.
             switch (name)
             {
-                case PhraseBasedMachineTranslationApiName: return TranslationModel.PhraseBasedMachineTranslation;
+                case BaseApiName: return TranslationModel.Base;
                 case NeuralMachineTranslationApiName: return TranslationModel.NeuralMachineTranslation;
                 default: throw new InvalidOperationException($"Unknown translation model {name}");
             }

--- a/apis/Google.Cloud.Translation.V2/docs/index.md
+++ b/apis/Google.Cloud.Translation.V2/docs/index.md
@@ -53,23 +53,16 @@ Common operations are exposed via the
 
 ## Specifying a translation model
 
-The Translation API is implemented by multiple underlying models. At the time of writing, the two models available are:
-
-- Neural Machine Translation (NMT)
-- Phrase-Based Machine Translation (PBMT, also known as "base")
-
-The current default is to use NMT where it is available for the requested language translation pair, but this is
-more computationally-intensive than the PBMT model; if you have low latency requirements, you may wish to explicitly
-required PBMT. Explicitly requesting NMT is valid, but currently has no effect, as this is the current default. If
-no model is specified, the service will pick a model, which means if a new model is introduced as the default, you won't need
-to change your code or even update this client library package in order to use it.
+The Translation API is implemented by multiple underlying models.
+At the time of writing, one model is available in addition to "base": Neural Machine Translation (NMT).
+If you don't explicitly specify a model to use, the service will pick one.
 
 See the [API release notes](https://cloud.google.com/translate/release-notes) for on-going changes and new models.
 
-When specifying a model, it can either be selected as the model to use for all requests for that `TranslationClient` instance:
+When specifying a model, it can either be selected as the model to use for all requests for that `TranslationClient` instance.
 
-[!code-cs[](obj/snippets/Google.Cloud.Translation.V2.TranslationClient.txt#TranslateTextPbmtDefaultModel)]
+[!code-cs[](obj/snippets/Google.Cloud.Translation.V2.TranslationClient.txt#TranslateTextBaseDefaultModel)]
 
 ... or it can be specified on a per-request basis:
 
-[!code-cs[](obj/snippets/Google.Cloud.Translation.V2.TranslationClient.txt#TranslateTextPbmtOverrideModel)]
+[!code-cs[](obj/snippets/Google.Cloud.Translation.V2.TranslationClient.txt#TranslateTextBaseOverrideModel)]


### PR DESCRIPTION
The meaning of "base" may change over time. This PR reverts to using
Base as the model name, and makes the documentation more circumspect
about what it means.

Fixes #1018.