### PR TITLE
Add view support for BigQuery.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryFixture.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryFixture.cs
@@ -53,7 +53,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
                     $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
             }
 
-            DatasetId = DateTime.UtcNow.ToString("'test'_yyyyMMddTHHmmssFFF", CultureInfo.InvariantCulture);
+            DatasetId = DateTime.UtcNow.ToString("'test'_yyyyMMddTHHmmssfff", CultureInfo.InvariantCulture);
 
             CreateData();
         }
@@ -85,6 +85,11 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
                     { "gameStarted", new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
                 },
                 new BigQueryInsertRow {
+                    { "player", "Bob" },
+                    { "score", 60 },
+                    { "gameStarted", new DateTime(1999, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
+                },
+                new BigQueryInsertRow {
                     { "player", "Angela" },
                     { "score", 95 },
                     { "gameStarted", new DateTime(2002, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
@@ -95,7 +100,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
                     { "gameStarted", new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
                 }
             };
-            InsertAndWait(table, () => table.InsertRows(rows), 3);
+            InsertAndWait(table, () => table.InsertRows(rows), 4);
         }
 
         private void CreatePeopleTable(BigQueryDataset dataset)

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CreateTableOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CreateTableOptionsTest.cs
@@ -68,5 +68,18 @@ namespace Google.Cloud.BigQuery.V2.Tests
             InsertRequest request = new InsertRequest(new BigqueryService(), table, "project", "dataset");
             Assert.Throws<ArgumentException>(() => options.ModifyRequest(table, request));
         }
+
+        [Fact]
+        public void ExternalConfigurationAndViewInvalid()
+        {
+            var options = new CreateTableOptions
+            {
+                ExternalDataConfiguration = new ExternalDataConfiguration(),
+                View = new ViewDefinition()
+            };
+            Table table = new Table();
+            InsertRequest request = new InsertRequest(new BigqueryService(), table, "project", "dataset");
+            Assert.Throws<ArgumentException>(() => options.ModifyRequest(table, request));
+        }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.TableCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.TableCrud.cs
@@ -95,7 +95,7 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="projectId">The project ID. Must not be null.</param>
         /// <param name="datasetId">The dataset ID. Must not be null.</param>
         /// <param name="tableId">The table ID. Must not be null.</param>
-        /// <param name="schema">The schema for the new table. Must not be null.</param>
+        /// <param name="schema">The schema for the new table. Must not be null unless the schema can be inferred (e.g. for a view).</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <returns>The newly created table.</returns>
         public virtual BigQueryTable CreateTable(string projectId, string datasetId, string tableId, TableSchema schema, CreateTableOptions options = null) =>
@@ -107,7 +107,7 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         /// <param name="datasetId">The dataset ID. Must not be null.</param>
         /// <param name="tableId">The table ID. Must not be null.</param>
-        /// <param name="schema">The schema for the new table. Must not be null.</param>
+        /// <param name="schema">The schema for the new table. Must not be null unless the schema can be inferred (e.g. for a view).</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <returns>The newly created table.</returns>
         public virtual BigQueryTable CreateTable(string datasetId, string tableId, TableSchema schema, CreateTableOptions options = null) =>
@@ -117,7 +117,7 @@ namespace Google.Cloud.BigQuery.V2
         /// Creates a table with the given schema.
         /// </summary>
         /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
-        /// <param name="schema">The schema for the new table. Must not be null.</param>
+        /// <param name="schema">The schema for the new table. Must not be null unless the schema can be inferred (e.g. for a view).</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <returns>The newly created table.</returns>
         public virtual BigQueryTable CreateTable(TableReference tableReference, TableSchema schema, CreateTableOptions options = null)
@@ -134,7 +134,7 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="tableId">The table ID. Must not be null.</param>
         /// <param name="getOptions">The options for the "get" operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="createOptions">The options for the "create" operation. May be null, in which case defaults will be supplied.</param>
-        /// <param name="schema">The schema to use to create the table if necessary. Must not be null.</param>
+        /// <param name="schema">The schema to use to create the table if necessary. Must not be null unless the schema can be inferred (e.g. for a view).</param>
         /// <returns>The existing or new table.</returns>
         public virtual BigQueryTable GetOrCreateTable(string projectId, string datasetId, string tableId, TableSchema schema,
             GetTableOptions getOptions = null, CreateTableOptions createOptions = null) =>
@@ -146,7 +146,7 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         /// <param name="datasetId">The dataset ID. Must not be null.</param>
         /// <param name="tableId">The table ID. Must not be null.</param>
-        /// <param name="schema">The schema to use to create the table if necessary. Must not be null.</param>
+        /// <param name="schema">The schema to use to create the table if necessary. Must not be null unless the schema can be inferred (e.g. for a view).</param>
         /// <param name="getOptions">The options for the "get" operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="createOptions">The options for the "create" operation. May be null, in which case defaults will be supplied.</param>
         /// <returns>The existing or new table.</returns>
@@ -158,7 +158,7 @@ namespace Google.Cloud.BigQuery.V2
         /// Attempts to fetch a table, creating it if it doesn't exist.
         /// </summary>
         /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
-        /// <param name="schema">The schema to use to create the table if necessary. Must not be null.</param>
+        /// <param name="schema">The schema to use to create the table if necessary. Must not be null unless the schema can be inferred (e.g. for a view).</param>
         /// <param name="getOptions">The options for the "get" operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="createOptions">The options for the "create" operation. May be null, in which case defaults will be supplied.</param>
         /// <returns>The existing or new table.</returns>
@@ -278,7 +278,7 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="projectId">The project ID. Must not be null.</param>
         /// <param name="datasetId">The dataset ID. Must not be null.</param>
         /// <param name="tableId">The table ID. Must not be null.</param>
-        /// <param name="schema">The schema for the new table. Must not be null.</param>
+        /// <param name="schema">The schema for the new table. Must not be null unless the schema can be inferred (e.g. for a view).</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task representing the asynchronous operation. When complete, the result is
@@ -292,7 +292,7 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         /// <param name="datasetId">The dataset ID. Must not be null.</param>
         /// <param name="tableId">The table ID. Must not be null.</param>
-        /// <param name="schema">The schema for the new table. Must not be null.</param>
+        /// <param name="schema">The schema for the new table. Must not be null unless the schema can be inferred (e.g. for a view).</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task representing the asynchronous operation. When complete, the result is
@@ -304,7 +304,7 @@ namespace Google.Cloud.BigQuery.V2
         /// Creates a table with the given schema.
         /// </summary>
         /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
-        /// <param name="schema">The schema for the new table. Must not be null.</param>
+        /// <param name="schema">The schema for the new table. Must not be null unless the schema can be inferred (e.g. for a view).</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task representing the asynchronous operation. When complete, the result is
@@ -321,7 +321,7 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="projectId">The project ID. Must not be null.</param>
         /// <param name="datasetId">The dataset ID. Must not be null.</param>
         /// <param name="tableId">The table ID. Must not be null.</param>
-        /// <param name="schema">The schema to use to create the table if necessary. Must not be null.</param>
+        /// <param name="schema">The schema to use to create the table if necessary. Must not be null unless the schema can be inferred (e.g. for a view).</param>
         /// <param name="getOptions">The options for the "get" operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="createOptions">The options for the "create" operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
@@ -337,7 +337,7 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         /// <param name="datasetId">The dataset ID. Must not be null.</param>
         /// <param name="tableId">The table ID. Must not be null.</param>
-        /// <param name="schema">The schema to use to create the table if necessary. Must not be null.</param>
+        /// <param name="schema">The schema to use to create the table if necessary. Must not be null unless the schema can be inferred (e.g. for a view).</param>
         /// <param name="getOptions">The options for the "get" operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="createOptions">The options for the "create" operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
@@ -351,7 +351,7 @@ namespace Google.Cloud.BigQuery.V2
         /// Attempts to fetch a table, creating it if it doesn't exist.
         /// </summary>
         /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
-        /// <param name="schema">The schema to use to create the table if necessary. Must not be null.</param>
+        /// <param name="schema">The schema to use to create the table if necessary. Must not be null unless the schema can be inferred (e.g. for a view).</param>
         /// <param name="getOptions">The options for the "get" operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="createOptions">The options for the "create" operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateTableOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateTableOptions.cs
@@ -59,6 +59,11 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         public ExternalDataConfiguration ExternalDataConfiguration { get; set; }
 
+        /// <summary>
+        /// The view definition, if the table should be configured as a view.
+        /// </summary>
+        public ViewDefinition View { get; set; }
+
         internal void ModifyRequest(Table table, InsertRequest request)
         {
             if (Description != null)
@@ -92,9 +97,17 @@ namespace Google.Cloud.BigQuery.V2
                 }
                 table.TimePartitioning.ExpirationMs = (long) TimePartitionExpiration.Value.TotalMilliseconds;
             }
+            if (ExternalDataConfiguration != null && View != null)
+            {
+                throw new ArgumentException($"Cannot specify both {nameof(ExternalDataConfiguration)} and {nameof(View)}");
+            }
             if (ExternalDataConfiguration != null)
             {
                 table.ExternalDataConfiguration = ExternalDataConfiguration;
+            }
+            if (View != null)
+            {
+                table.View = View;
             }
         }
     }


### PR DESCRIPTION
This is lightweight support: basically once you've created a view,
it looks like any other table, although you can't call ListRows on
it. (We let the server report that failure.)

Fixes #968.
