### PR TITLE
Update all versions

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using Google.Api.Gax.Rest;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Bigquery.v2.Data;

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta10</Version>
+    <Version>1.0.0-beta11</Version>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Rest" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="2.0.0-beta01" />
     <PackageReference Include="Google.Apis.Bigquery.v2" Version="1.25.0.819" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="2.0.0-beta01" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.8" />
     <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="2.0.0-beta01" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.8" />
     <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="2.0.0-beta01" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.8" />
     <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.csproj
+++ b/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.CommonProtos" Version="1.0.0" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="1.1.0" />
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />

--- a/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.csproj
+++ b/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha01</Version>
+    <Version>1.0.0-alpha02</Version>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta09</Version>
+    <Version>1.0.0-beta10</Version>
     <TargetFrameworks>net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
@@ -17,7 +17,7 @@
     <ProjectReference Include="../../Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />
     <ProjectReference Include="../../Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore\Google.Cloud.Diagnostics.AspNetCore.csproj" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="2.0.0-beta01" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.0" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="../../Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />
     <ProjectReference Include="../../Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore\Google.Cloud.Diagnostics.AspNetCore.csproj" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="2.0.0-beta01" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.0" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Google.Cloud.Diagnostics.AspNetCore.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Google.Cloud.Diagnostics.AspNetCore.Tests.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="../../Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />
     <ProjectReference Include="../../Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore\Google.Cloud.Diagnostics.AspNetCore.csproj" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="2.0.0-beta01" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.0" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta10</Version>
     <TargetFrameworks>netstandard1.5</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.csproj
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.csproj
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta09</Version>
+    <Version>1.0.0-beta10</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental.csproj
+++ b/apis/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental.csproj
+++ b/apis/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Google.LongRunning\Google.LongRunning\Google.LongRunning.csproj" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta06</Version>
+    <Version>1.0.0-beta07</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Google.Cloud.Logging.Log4Net.Snippets.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Google.Cloud.Logging.Log4Net.Snippets.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Google.Cloud.Logging.Log4Net\Google.Cloud.Logging.Log4Net.csproj" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="2.0.0-beta01" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.8" />
     <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/Google.Cloud.Logging.Log4Net.Tests.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/Google.Cloud.Logging.Log4Net.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Google.Cloud.Logging.Log4Net\Google.Cloud.Logging.Log4Net.csproj" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="2.0.0-beta01" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.8" />
     <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta10</Version>
+    <Version>1.0.0-beta11</Version>
     <TargetFrameworks>net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.CommonProtos" Version="1.0.0" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="1.1.0" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Google.Cloud.Logging.V2\Google.Cloud.Logging.Type\Google.Cloud.Logging.Type.csproj" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.csproj
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha04</Version>
+    <Version>1.0.0-alpha05</Version>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.csproj
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Rest" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="2.0.0-beta01" />
     <PackageReference Include="Google.Apis.Compute.v1" Version="1.24.1.802" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Google.Cloud.Iam.V1\Google.Cloud.Iam.V1\Google.Cloud.Iam.V1.csproj" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta09</Version>
+    <Version>1.0.0-beta10</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Google.Cloud.Iam.V1\Google.Cloud.Iam.V1\Google.Cloud.Iam.V1.csproj" />
     <ProjectReference Include="..\..\Google.LongRunning\Google.LongRunning\Google.LongRunning.csproj" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Google.Cloud.Iam.V1\Google.Cloud.Iam.V1\Google.Cloud.Iam.V1.csproj" />
     <ProjectReference Include="..\..\Google.LongRunning\Google.LongRunning\Google.LongRunning.csproj" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Google.LongRunning\Google.LongRunning\Google.LongRunning.csproj" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="*.raw" />

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta08</Version>
+    <Version>1.0.0-beta09</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Rest" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="2.0.0-beta01" />
     <PackageReference Include="Google.Apis.Storage.v1" Version="1.25.0.811" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta01</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using Google.Api.Gax.Rest;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha03</Version>
+    <Version>1.0.0-alpha04</Version>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Rest" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="2.0.0-beta01" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="*.txt" />

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationClient.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationClient.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using Google.Api.Gax.Rest;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Translate.v2;

--- a/apis/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Google.LongRunning\Google.LongRunning\Google.LongRunning.csproj" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha01</Version>
+    <Version>1.0.0-alpha02</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="*.jpg" />

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.LongRunning/Google.LongRunning.Snippets/Google.LongRunning.Snippets.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning.Snippets/Google.LongRunning.Snippets.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Google.LongRunning\Google.LongRunning.csproj" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="2.0.0-beta01" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.8" />
     <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />

--- a/apis/Google.LongRunning/Google.LongRunning.Tests/Google.LongRunning.Tests.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning.Tests/Google.LongRunning.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Google.LongRunning\Google.LongRunning.csproj" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="2.0.0-beta01" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.8" />
     <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />

--- a/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta08</Version>
+    <Version>1.0.0-beta09</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="1.0.1" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.0.0-beta01" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -50,7 +50,7 @@
     "description": "Common Protocol Buffer messages for Google Cloud Developer Tools APIs.",
     "tags": [ "Tools" ],
     "dependencies": {
-      "Google.Api.CommonProtos": "1.0.0",
+      "Google.Api.CommonProtos": "1.1.0",
       "Google.Protobuf": "3.3.0"
     }
   },

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -38,7 +38,7 @@
     "tags": [ "Datastore" ],
     "testDependencies": {
       "Google.Cloud.ClientTesting": "",
-      "Google.Api.Gax.Grpc.Testing": "1.0.1"
+      "Google.Api.Gax.Grpc.Testing": "2.0.0-beta01"
     },
   },
 
@@ -99,7 +99,7 @@
       "Microsoft.AspNetCore.TestHost": "1.1.0",
       "../../Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj": "",
       "../../Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj": "",
-      "Google.Api.Gax.Testing": "1.0.1"
+      "Google.Api.Gax.Testing": "2.0.0-beta01"
     }
   },
 
@@ -171,7 +171,7 @@
       "Google.Cloud.DevTools.Common": ""
     },
     "testDependencies": {
-      "Google.Api.Gax.Testing": "1.0.1"
+      "Google.Api.Gax.Testing": "2.0.0-beta01"
     }
   },
 
@@ -318,7 +318,7 @@
     "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",
     "tags": [ "LongRunning" ],
     "testDependencies": {
-      "Google.Api.Gax.Testing": "1.0.1"
+      "Google.Api.Gax.Testing": "2.0.0-beta01"
     }
   }
 ]

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -17,7 +17,7 @@
 
   {
     "id": "Google.Cloud.BigQuery.V2",
-    "version": "1.0.0-beta10",
+    "version": "1.0.0-beta11",
     "type": "rest",
     "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
     "dependencies": {
@@ -32,7 +32,7 @@
 
   {
     "id": "Google.Cloud.Datastore.V1",
-    "version": "1.0.0",
+    "version": "2.0.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",
     "tags": [ "Datastore" ],
@@ -44,7 +44,7 @@
 
   {
     "id": "Google.Cloud.DevTools.Common",
-    "version": "1.0.0-alpha01",
+    "version": "1.0.0-alpha02",
     "type": "other",
     "targetFrameworks": "netstandard1.3;net45",
     "description": "Common Protocol Buffer messages for Google Cloud Developer Tools APIs.",
@@ -57,7 +57,7 @@
 
   {
     "id": "Google.Cloud.Diagnostics.AspNet",
-    "version": "1.0.0-beta09",
+    "version": "1.0.0-beta10",
     "type": "other",
     "targetFrameworks": "net45",
     "testTargetFrameworks": "net452",
@@ -78,7 +78,7 @@
 
   {
     "id": "Google.Cloud.Diagnostics.AspNetCore",
-    "version": "1.0.0-beta01",
+    "version": "1.0.0-beta10",
     "type": "other",
     "targetFrameworks": "netstandard1.5",
     "testTargetFrameworks": "netcoreapp1.0",
@@ -105,7 +105,7 @@
 
   {
     "id": "Google.Cloud.Diagnostics.Common",
-    "version": "1.0.0-beta01",
+    "version": "1.0.0-beta02",
     "type": "other",
     "targetFrameworks": "netstandard1.5;net45",
     "testTargetFrameworks": "netcoreapp1.0;net452",
@@ -123,7 +123,7 @@
 
   {
     "id": "Google.Cloud.ErrorReporting.V1Beta1",
-    "version": "1.0.0-beta05",
+    "version": "1.0.0-beta06",
     "type": "grpc",
     "description": "Recommended Google client library to access the Stackdriver Error Reporting API, which groups and counts similar errors from cloud services. The Stackdriver Error Reporting API provides a way to report new errors and read access to error groups and their associated errors.",
     "tags": [ "ErrorReporting", "Stackdriver" ],
@@ -131,7 +131,7 @@
 
   {
     "id": "Google.Cloud.Iam.V1",
-    "version": "1.0.0-beta09",
+    "version": "1.0.0-beta10",
     "type": "grpc",
     "description": "gRPC services for the Google Identity and Access Management API. This library is typically used as a dependency for other API client libraries.",
     "tags": [ "IAM", "Identity", "Access" ],
@@ -140,7 +140,7 @@
 
   {
     "id": "Google.Cloud.Language.V1",
-    "version": "1.0.0-beta06",
+    "version": "1.0.0-beta07",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Natural Language API, which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.",
     "tags": [ "Language" ],
@@ -148,7 +148,7 @@
 
   {
     "id": "Google.Cloud.Language.V1.Experimental",
-    "version": "1.0.0-beta01",
+    "version": "1.0.0-beta02",
     "type": "grpc",
     "description": "Experimental library for the Google Cloud Natural Language API, containing features which may still change before final release.",
     "tags": [ "Language", "Experimental" ],
@@ -159,7 +159,7 @@
 
   {
     "id": "Google.Cloud.Logging.Log4Net",
-    "version": "1.0.0-beta10",
+    "version": "1.0.0-beta11",
     "type": "other",
     "targetFrameworks": "net45",
     "testTargetFrameworks": "net452",
@@ -177,7 +177,7 @@
 
   {
     "id": "Google.Cloud.Logging.V2",
-    "version": "1.0.0",
+    "version": "2.0.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Stackdriver Logging API, which writes log entries and manages your logs, log sinks, and logs-based metrics.",
     "tags": [ "Logging", "Stackdriver" ],
@@ -188,7 +188,7 @@
 
   {
     "id": "Google.Cloud.Metadata.V1",
-    "version": "1.0.0-alpha04",
+    "version": "1.0.0-alpha05",
     "type": "rest",
     "description": "Google Compute Engine Metadata v1 client library",
     "tags": [ "Metadata" ],
@@ -199,7 +199,7 @@
 
   {
     "id": "Google.Cloud.Monitoring.V3",
-    "version": "1.0.0-beta05",
+    "version": "1.0.0-beta06",
     "type": "grpc",
     "description": "Recommended Google client library to access the Stackdriver Monitoring API, which manages your Stackdriver Monitoring data and configurations. Most projects must be associated with a Stackdriver account, with a few exceptions as noted on the individual method pages.",
     "tags": [ "Monitoring", "Stackdriver" ],
@@ -207,7 +207,7 @@
 
   {
     "id": "Google.Cloud.PubSub.V1",
-    "version": "1.0.0-beta09",
+    "version": "1.0.0-beta10",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",
     "dependencies": {
@@ -218,7 +218,7 @@
 
   {
     "id": "Google.Cloud.Spanner.Admin.Database.V1",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Spanner Database Admin API.",
     "tags": [ "Spanner" ],
@@ -230,7 +230,7 @@
 
   {
     "id": "Google.Cloud.Spanner.Admin.Instance.V1",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Spanner Instance Admin API.",
     "tags": [ "Spanner" ],
@@ -242,7 +242,7 @@
 
   {
     "id": "Google.Cloud.Spanner.V1",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Spanner API.",
     "tags": [ "Spanner" ],
@@ -250,7 +250,7 @@
 
   {
     "id": "Google.Cloud.Speech.V1",
-    "version": "1.0.0-beta08",
+    "version": "1.0.0-beta09",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.",
     "tags": [ "Speech" ],
@@ -261,7 +261,7 @@
 
   {
     "id": "Google.Cloud.Storage.V1",
-    "version": "1.1.0-beta01",
+    "version": "2.0.0-beta01",
     "type": "rest",
     "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
     "dependencies": {
@@ -275,7 +275,7 @@
 
   {
     "id": "Google.Cloud.Trace.V1",
-    "version": "1.0.0-beta05",
+    "version": "1.0.0-beta06",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Trace API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
     "tags": [ "Tracing", "Trace" ],
@@ -283,7 +283,7 @@
 
   {
     "id": "Google.Cloud.Translation.V2",
-    "version": "1.0.0-alpha03",
+    "version": "1.0.0-alpha04",
     "type": "rest",
     "description": "Recommended Google client library to access the Translation API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.",
     "tags": [ "Translate", "Translation" ],
@@ -294,7 +294,7 @@
 
   {
     "id": "Google.Cloud.VideoIntelligence.V1Beta1",
-    "version": "1.0.0-alpha01",
+    "version": "1.0.0-alpha02",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Video Intelligence API.",
     "tags": [ "VideoIntelligence" ],
@@ -305,7 +305,7 @@
   
   {
     "id": "Google.Cloud.Vision.V1",
-    "version": "1.0.0-beta02",
+    "version": "1.0.0-beta03",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Vision API, which integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.",
     "tags": [ "Vision" ],
@@ -313,7 +313,7 @@
 
   {
     "id": "Google.LongRunning",
-    "version": "1.0.0-beta08",
+    "version": "1.0.0-beta09",
     "type": "grpc",
     "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",
     "tags": [ "LongRunning" ],

--- a/tools/Google.Cloud.Tools.ProjectGenerator/ApiMetadata.cs
+++ b/tools/Google.Cloud.Tools.ProjectGenerator/ApiMetadata.cs
@@ -48,11 +48,11 @@ namespace Google.Cloud.Tools.ProjectGenerator
             switch (Type)
             {
                 case "rest":
-                    dependencies.Add("Google.Api.Gax.Rest", "1.0.1");
+                    dependencies.Add("Google.Api.Gax.Rest", "2.0.0-beta01");
                     targetFrameworks = targetFrameworks ?? "netstandard1.3;net45";
                     break;
                 case "grpc":
-                    dependencies.Add("Google.Api.Gax.Grpc", "1.0.1");
+                    dependencies.Add("Google.Api.Gax.Grpc", "2.0.0-beta01");
                     targetFrameworks = targetFrameworks ?? "netstandard1.5;net45";
                     break;
             }


### PR DESCRIPTION
- Update dependencies to GAX 2.0.0-beta01 and Google.Api.CommonProtos 1.1.0
- Add imports for ScopedCredentialProvider (which has moved in GAX v2)
- Update the version number of every package. GA packages have a major version bump and are now beta; everything else just bumps up a beta version.
