### PR TITLE
Update dependencies

### DIFF
--- a/docs/dependencies-docfx/docfx-google-api-dotnet-client.json
+++ b/docs/dependencies-docfx/docfx-google-api-dotnet-client.json
@@ -1,23 +1,28 @@
 {
   "metadata": [
     {
-      "src": [{ "files": ["Src/Support/GoogleApis/Net45/GoogleApis_Net45.csproj"] }],
+      "src": [{ "files": ["Src/Support/Google.Apis/Google.Apis.csproj"] }],
+      "properties": { "TargetFramework": "net45" },
       "dest": "api/Google.Apis",
     },
     {
-      "src": [{ "files": ["Src/Support/GoogleApis.Core/Net45/GoogleApis.Core_Net45.csproj"] }],
+      "src": [{ "files": ["Src/Support/Google.Apis.Core/Google.Apis.Core.csproj"] }],
+      "properties": { "TargetFramework": "net45" },
       "dest": "api/Google.Apis.Core",
     },
     {
-      "src": [{ "files": ["Src/Support/GoogleApis.Auth/Net45/GoogleApis.Auth_Net45.csproj"] }],
+      "src": [{ "files": ["Src/Support/Google.Apis.Auth/Google.Apis.Auth.csproj"] }],
+      "properties": { "TargetFramework": "net45" },
       "dest": "api/Google.Apis.Auth",
     },
     {
-      "src": [{ "files": ["Src/Generated/Google.Apis.Storage.v1/NetStandard/Google.Apis.Storage.v1.csproj"] }],
+      "src": [{ "files": ["Src/Generated/Google.Apis.Storage.v1/Google.Apis.Storage.v1.csproj"] }],
+      "properties": { "TargetFramework": "net45" },
       "dest": "api/Google.Apis.Storage.v1",
     },
     {
-      "src": [{ "files": ["Src/Generated/Google.Apis.Bigquery.v2/NetStandard/Google.Apis.Bigquery.v2.csproj"] }],
+      "src": [{ "files": ["Src/Generated/Google.Apis.Bigquery.v2/Google.Apis.Bigquery.v2.csproj"] }],
+      "properties": { "TargetFramework": "net45" },
       "dest": "api/Google.Apis.Bigquery.v2",
     }
   ]

--- a/docs/dependencies-docfx/docfx-grpc.json
+++ b/docs/dependencies-docfx/docfx-grpc.json
@@ -1,7 +1,8 @@
 {
   "metadata": [
     {
-      "src": [{ "files": ["src/csharp/Grpc.Core/project.json"] }],
+      "src": [{ "files": ["src/csharp/Grpc.Core/Grpc.Core.csproj"] }],
+      "properties": { "TargetFramework": "net45" },
       "dest": "api/Grpc.Core",
     }
   ]

--- a/docs/fetchdependencies.sh
+++ b/docs/fetchdependencies.sh
@@ -12,8 +12,8 @@ git -C dependencies checkout README.md .gitignore
 
 echo "Cloning repositories"
 git clone https://github.com/googleapis/gax-dotnet dependencies/gax-dotnet --quiet --depth=1 -b master
-git clone https://github.com/google/protobuf dependencies/protobuf --quiet --depth=1 -b 3.2.x
-git clone https://github.com/grpc/grpc dependencies/grpc --quiet --depth=1 -b v1.2.x
+git clone https://github.com/google/protobuf dependencies/protobuf --quiet --depth=1 -b 3.3.x
+git clone https://github.com/grpc/grpc dependencies/grpc --quiet --depth=1 -b v1.3.x
 git clone https://github.com/google/google-api-dotnet-client dependencies/google-api-dotnet-client --quiet --depth=1 -b master
 
 # Minor fixups...
@@ -31,9 +31,9 @@ cp dependencies-docfx/docfx-google-api-dotnet-client.json dependencies/google-ap
 # TODO: The last of these fails to find System.DateTime in Storage. No idea why,
 # but chances are it'll be fixed when google-api-dotnet-client updates to csproj...
 (cd dependencies/gax-dotnet; dotnet restore Gax.sln; docfx metadata)
-(cd dependencies/protobuf; dotnet restore csharp/src; docfx metadata)
-(cd dependencies/grpc; dotnet restore src/csharp; docfx metadata)
-(cd dependencies/google-api-dotnet-client; dotnet restore .; docfx metadata)
+(cd dependencies/protobuf; echo '{"sdk": {"version": "1.0.0-preview2-003131"}}' > global.json && dotnet restore csharp/src; docfx metadata)
+(cd dependencies/grpc; dotnet restore src/csharp/Grpc.sln; docfx metadata)
+(cd dependencies/google-api-dotnet-client; rm NuGet.config; dotnet restore Src/Support/GoogleApisClient.sln; dotnet restore Generated.sln; docfx metadata)
 
 # Copy the metadata into a single api directory, one subdirectory per package
 mkdir dependencies/api


### PR DESCRIPTION
- gRPC now uses csproj
- google-api-dotnet-client now uses csproj
- We now use csproj, so for protobuf we need to create a global.json

(I've already pushed the result to the dependencies branch.)