### PR TITLE
Fix issue with removing label from bucket

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ModifyBucketLabelsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ModifyBucketLabelsTest.cs
@@ -239,6 +239,34 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RemoveBucketLabel_NoLabelsBefore(bool runAsync)
+        {
+            var client = _fixture.Client;
+            var bucketName = _fixture.LabelsTestBucket;
+            client.ClearBucketLabels(bucketName);
+            var result = RunMaybeAsync(runAsync,
+                () => client.RemoveBucketLabel(bucketName, "label"),
+                () => client.RemoveBucketLabelAsync(bucketName, "label"));
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ClearBucketLabels_NoLabelsBefore(bool runAsync)
+        {
+            var client = _fixture.Client;
+            var bucketName = _fixture.LabelsTestBucket;            
+            client.ClearBucketLabels(bucketName);
+            var result = RunMaybeAsync(runAsync,
+                () => client.ClearBucketLabels(bucketName),
+                () => client.ClearBucketLabelsAsync(bucketName));
+            Assert.Empty(result);
+        }
+
         // TODO: Move these somewhere common, if this proves a useful pattern.
         private static T RunMaybeAsync<T>(bool runAsync, Func<T> sync, Func<Task<T>> async)
             // Run the async func separately to explicitly avoid synchronization etc.


### PR DESCRIPTION
We now only send a PATCH request with differences between the
current labels and the ones we've asked for. This also means that
sometimes we won't send a PATCH request at all.

Fixes #1087.