### PR TITLE
Reimplementation of RateLimiterTest (and tweak to RateLimiter)

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/RateLimitingTraceOptionsFactoryTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/RateLimitingTraceOptionsFactoryTest.cs
@@ -25,7 +25,8 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         {
             var rateLimiter = TraceUtils.GetRateLimiter(1001);
             var factory = new RateLimitingTraceOptionsFactory(rateLimiter);
-            Assert.True(factory.CreateOptions().ShouldTrace);
+            Assert.True(factory.CreateOptions().ShouldTrace); // t=0ms
+            Assert.True(factory.CreateOptions().ShouldTrace); // t=1001ms
         }
 
         [Fact]
@@ -33,7 +34,8 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         {
             var rateLimiter = TraceUtils.GetRateLimiter(999);
             var factory = new RateLimitingTraceOptionsFactory(rateLimiter);
-            Assert.False(factory.CreateOptions().ShouldTrace);
+            Assert.True(factory.CreateOptions().ShouldTrace);  // t=0ms
+            Assert.False(factory.CreateOptions().ShouldTrace); // t=999ms
         }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/TraceUtils.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/TraceUtils.cs
@@ -22,12 +22,19 @@ namespace Google.Cloud.Diagnostics.Common.Tests
     internal static class TraceUtils
     {
         /// <summary>
-        /// Creates a rate limiter that will allow 1 QPS with the elapsed milliseconds.
+        /// Creates a rate limiter that will allow 1 QPS with <paramref name="elapsedMilliseconds"/>
+        /// elapsing between calls.
         /// </summary>
         internal static RateLimiter GetRateLimiter(long elapsedMilliseconds)
         {
+            long time = 0;
             var watch = new Mock<ITimer>();
-            watch.Setup(w => w.GetElapsedMilliseconds()).Returns(elapsedMilliseconds);
+            watch.Setup(w => w.GetElapsedMilliseconds()).Returns(() =>
+            {
+                long current = time;
+                time += elapsedMilliseconds;
+                return current;
+            });
             return new RateLimiter(1, watch.Object);
         }
 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/RateLimiter.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/RateLimiter.cs
@@ -61,8 +61,9 @@ namespace Google.Cloud.Diagnostics.Common
             _timer = timer;
             _timer.Start();
 
-            _lastCallMillis = 0;
             _fixedDelayMillis = Convert.ToInt64(TimeSpan.FromSeconds(1 / qps).TotalMilliseconds);
+            // Allow a trace immediately.
+            _lastCallMillis = -_fixedDelayMillis;
         }
 
         /// <summary>
@@ -74,7 +75,7 @@ namespace Google.Cloud.Diagnostics.Common
         {
             var nowMillis = _timer.GetElapsedMilliseconds();
             var lastCallMillis = _lastCallMillis;
-            return (nowMillis - lastCallMillis > _fixedDelayMillis) &&
+            return (nowMillis - lastCallMillis >= _fixedDelayMillis) &&
                 Interlocked.CompareExchange(ref _lastCallMillis, nowMillis, lastCallMillis) == lastCallMillis;
         }
     }


### PR DESCRIPTION
- Use Thread instead of Tasks
- Create a RateLimiter directly instead of populating the singleton
- Change the RateLimiter to allow tracing immediately instead of only
  after the period has elapsed once

Fixes #1094 - hopefully!
(I suspect the actual problem was tasks not starting fast enough, which creating threads directly should fix - but I'm not entirely sure.)