### PR TITLE
Fix the QPS integration test by resetting the rate limiter before each test.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/AssemblyInfo.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/AssemblyInfo.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
@@ -38,7 +38,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         public TraceTest()
         {
             // The rate limiter instance is static and only set once.  If we do not reset it at the
-            // beginning of each tests the qps will not change.  This is dependent the tests not
+            // beginning of each tests the qps will not change.  This is dependent on the tests not
             // running in parallel.
             RateLimiter._instance = null;
         }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
@@ -40,7 +40,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             // The rate limiter instance is static and only set once.  If we do not reset it at the
             // beginning of each tests the qps will not change.  This is dependent on the tests not
             // running in parallel.
-            RateLimiter._instance = null;
+            RateLimiter.Reset();
         }
 
         [Fact]
@@ -205,6 +205,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 try
                 {
                     await client.GetAsync($"/Trace/ThrowException/{testId}");
+                    Assert.True(false, "Exception should have been thrown.");
                 }
                 catch
                 {

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
@@ -35,11 +35,13 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
     {
         private readonly TraceEntryPolling _polling = new TraceEntryPolling();
 
-        private readonly TestServer _noBufferHighQps = new TestServer(
-            new WebHostBuilder().UseStartup<TraceTestNoBufferHighQpsApplication>());
-
-        private readonly TestServer _noBufferLowQps = new TestServer(
-            new WebHostBuilder().UseStartup<TraceTestNoBufferLowQpsApplication>());
+        public TraceTest()
+        {
+            // The rate limiter instance is static and only set once.  If we do not reset it at the
+            // beginning of each tests the qps will not change.  This is dependent the tests not
+            // running in parallel.
+            RateLimiter._instance = null;
+        }
 
         [Fact]
         public async Task Trace()
@@ -47,20 +49,23 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             string testId = Utils.GetTestId();
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
-            var client = _noBufferHighQps.CreateClient();
-            var response = await client.GetAsync($"/Trace/Trace/{testId}");
+            using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestNoBufferHighQpsApplication>()))
+            using (var client = server.CreateClient())
+            {
+                var response = await client.GetAsync($"/Trace/Trace/{testId}");
 
-            var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);
-            var trace = _polling.GetTrace(spanName, startTime);
+                var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);
+                var trace = _polling.GetTrace(spanName, startTime);
 
-            Assert.NotNull(trace);
-            Assert.Equal(2, trace.Spans.Count);
-            var span = trace.Spans.First(s => s.Name.StartsWith("/Trace/Trace/"));
-            Assert.NotEmpty(span.Labels);
-            Assert.Equal(span.Labels[TraceLabels.HttpMethod], "GET");
-            Assert.Equal(span.Labels[TraceLabels.HttpStatusCode], "200");
+                Assert.NotNull(trace);
+                Assert.Equal(2, trace.Spans.Count);
+                var span = trace.Spans.First(s => s.Name.StartsWith("/Trace/Trace/"));
+                Assert.NotEmpty(span.Labels);
+                Assert.Equal(span.Labels[TraceLabels.HttpMethod], "GET");
+                Assert.Equal(span.Labels[TraceLabels.HttpStatusCode], "200");
 
-            Assert.False(response.Headers.Contains(TraceHeaderContext.TraceHeader));
+                Assert.False(response.Headers.Contains(TraceHeaderContext.TraceHeader));
+            }
         }
 
         [Fact]
@@ -69,17 +74,20 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             string testId = Utils.GetTestId();
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
-            var client = _noBufferHighQps.CreateClient();
-            await client.GetAsync($"/Trace/TraceLabels/{testId}");
+            using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestNoBufferHighQpsApplication>()))
+            using (var client = server.CreateClient())
+            {
+                await client.GetAsync($"/Trace/TraceLabels/{testId}");
 
-            var spanName = TraceController.GetMessage(nameof(TraceController.TraceLabels), testId);
-            var trace = _polling.GetTrace(spanName, startTime);
+                var spanName = TraceController.GetMessage(nameof(TraceController.TraceLabels), testId);
+                var trace = _polling.GetTrace(spanName, startTime);
 
-            Assert.NotNull(trace);
-            Assert.Equal(2, trace.Spans.Count);
-            var span = trace.Spans.First(s => s.Name.StartsWith("Trace"));
-            Assert.Single(span.Labels);
-            Assert.Equal(span.Labels[TraceController.Label], TraceController.LabelValue);
+                Assert.NotNull(trace);
+                Assert.Equal(2, trace.Spans.Count);
+                var span = trace.Spans.First(s => s.Name.StartsWith("Trace"));
+                Assert.Single(span.Labels);
+                Assert.Equal(span.Labels[TraceController.Label], TraceController.LabelValue);
+            }
         }
 
         [Fact]
@@ -88,18 +96,21 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             string testId = Utils.GetTestId();
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
-            var client = _noBufferHighQps.CreateClient();
-            await client.GetAsync($"/Trace/TraceStackTrace/{testId}");
+            using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestNoBufferHighQpsApplication>()))
+            using (var client = server.CreateClient())
+            {
+                await client.GetAsync($"/Trace/TraceStackTrace/{testId}");
 
-            var spanName = TraceController.GetMessage(nameof(TraceController.TraceStackTrace), testId);
-            var trace = _polling.GetTrace(spanName, startTime);
+                var spanName = TraceController.GetMessage(nameof(TraceController.TraceStackTrace), testId);
+                var trace = _polling.GetTrace(spanName, startTime);
 
-            Assert.NotNull(trace);
-            Assert.Equal(2, trace.Spans.Count);
-            var span = trace.Spans.First(s => s.Name.StartsWith("Trace"));
-            Assert.Single(span.Labels);
-            Assert.Contains(nameof(TraceController), span.Labels[TraceLabels.StackTrace]);
-            Assert.Contains(nameof(TraceController.CreateStackTrace), span.Labels[TraceLabels.StackTrace]);
+                Assert.NotNull(trace);
+                Assert.Equal(2, trace.Spans.Count);
+                var span = trace.Spans.First(s => s.Name.StartsWith("Trace"));
+                Assert.Single(span.Labels);
+                Assert.Contains(nameof(TraceController), span.Labels[TraceLabels.StackTrace]);
+                Assert.Contains(nameof(TraceController.CreateStackTrace), span.Labels[TraceLabels.StackTrace]);
+            }
         }
 
         [Fact]
@@ -111,47 +122,44 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             string testId = Utils.GetTestId();           
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
-            var client = _noBufferLowQps.CreateClient();
-                
-            var header = TraceHeaderContext.Create(traceId, spanId, shouldTrace: true);
-            client.DefaultRequestHeaders.Add(TraceHeaderContext.TraceHeader, header.ToString());
-            var response = await client.GetAsync($"/Trace/Trace/{testId}");
+            using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestNoBufferLowQpsApplication>()))
+            using (var client = server.CreateClient())
+            {
+                var header = TraceHeaderContext.Create(traceId, spanId, shouldTrace: true);
+                client.DefaultRequestHeaders.Add(TraceHeaderContext.TraceHeader, header.ToString());
+                var response = await client.GetAsync($"/Trace/Trace/{testId}");
 
-            var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);
-            var trace = _polling.GetTrace(spanName, startTime);
+                var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);
+                var trace = _polling.GetTrace(spanName, startTime);
 
-            Assert.NotNull(trace);
-            Assert.Equal(traceId, trace.TraceId);
-            Assert.Equal(2, trace.Spans.Count);
-            var span = trace.Spans.First(s => s.Name.StartsWith("/Trace"));
-            Assert.Equal(spanId, span.ParentSpanId);
+                Assert.NotNull(trace);
+                Assert.Equal(traceId, trace.TraceId);
+                Assert.Equal(2, trace.Spans.Count);
+                var span = trace.Spans.First(s => s.Name.StartsWith("/Trace"));
+                Assert.Equal(spanId, span.ParentSpanId);
 
-            Assert.True(response.Headers.Contains(TraceHeaderContext.TraceHeader));
-            var returnedHeader = response.Headers.GetValues(TraceHeaderContext.TraceHeader).Single();
-            var headerContext = TraceHeaderContext.FromHeader(returnedHeader);
-            Assert.Equal(traceId, headerContext.TraceId);
-            Assert.Equal(spanId, headerContext.SpanId);
-            Assert.True(headerContext.ShouldTrace);
+                Assert.True(response.Headers.Contains(TraceHeaderContext.TraceHeader));
+                var returnedHeader = response.Headers.GetValues(TraceHeaderContext.TraceHeader).Single();
+                var headerContext = TraceHeaderContext.FromHeader(returnedHeader);
+                Assert.Equal(traceId, headerContext.TraceId);
+                Assert.Equal(spanId, headerContext.SpanId);
+                Assert.True(headerContext.ShouldTrace);
+            }
         }
 
-        [Fact(Skip = "Disabling as this test is about 50% flaky.  Enable once #966 is fixed.")]
-        public async Task Trace_QPS()
+        [Fact]
+        public void Trace_QPS()
         {
             string testId = Utils.GetTestId();
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
-            var builder = new WebHostBuilder().UseStartup<TraceTestNoBufferApplication>();
-            using (var server = new TestServer(builder))
+            using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestNoBufferApplication>()))
+            using (var client = server.CreateClient())
             {
-                var client = server.CreateClient();
-
-                // Wait for 4 seconds to ensure the next time we make a request it will be
-                // traced.  Then make two request, one of the two should be traced.
-                Thread.Sleep(TimeSpan.FromSeconds(4));
+                // Make two request, one of the two should be traced as they both occur at nearly the same time.
                 var traceTask = client.GetAsync($"/Trace/Trace/{testId}");
                 var traceLabelsTask = client.GetAsync($"/Trace/TraceLabels/{testId}");
-                await traceTask;
-                await traceLabelsTask;
+                Task.WaitAll(traceTask, traceLabelsTask);
 
                 var spanNameTrace = TraceController.GetMessage(nameof(TraceController.Trace), testId);
                 var spanNameLabels = TraceController.GetMessage(nameof(TraceController.TraceLabels), testId);
@@ -169,11 +177,9 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
             var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);
 
-            var builder = new WebHostBuilder().UseStartup<TraceTestBufferHighQpsApplication>();
-            using (var server = new TestServer(builder))
+            using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestBufferHighQpsApplication>()))
+            using(var client = server.CreateClient())
             {
-                var client = server.CreateClient();
-
                 // Make a trace with a small span that will not cause the buffer to flush.
                 await client.GetAsync($"/Trace/Trace/{testId}");
                 Assert.Null(_polling.GetTrace(spanName, startTime, expectTrace: false));
@@ -193,24 +199,27 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             string testId = Utils.GetTestId();
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
-            var client = _noBufferHighQps.CreateClient();
-            try
+            using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestNoBufferHighQpsApplication>()))
+            using (var client = server.CreateClient())
             {
-                await client.GetAsync($"/Trace/ThrowException/{testId}");
-            }
-            catch
-            {
-                // This will throw as the task faults.
-            }
+                try
+                {
+                    await client.GetAsync($"/Trace/ThrowException/{testId}");
+                }
+                catch
+                {
+                    // This will throw as the task faults.
+                }
 
-            var spanName = TraceController.GetMessage(nameof(TraceController.ThrowException), testId);
-            var trace = _polling.GetTrace(spanName, startTime);
+                var spanName = TraceController.GetMessage(nameof(TraceController.ThrowException), testId);
+                var trace = _polling.GetTrace(spanName, startTime);
 
-            Assert.NotNull(trace);
-            var span = trace.Spans.First(s => s.Name.StartsWith("/Trace/ThrowException"));
-            Assert.NotEmpty(span.Labels);
-            Assert.Contains(nameof(TraceController), span.Labels[TraceLabels.StackTrace]);
-            Assert.Contains(nameof(TraceController.ThrowException), span.Labels[TraceLabels.StackTrace]);
+                Assert.NotNull(trace);
+                var span = trace.Spans.First(s => s.Name.StartsWith("/Trace/ThrowException"));
+                Assert.NotEmpty(span.Labels);
+                Assert.Contains(nameof(TraceController), span.Labels[TraceLabels.StackTrace]);
+                Assert.Contains(nameof(TraceController.ThrowException), span.Labels[TraceLabels.StackTrace]);
+            }
         }
 
         [Fact]
@@ -219,11 +228,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             string testId = Utils.GetTestId();
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
-            var client = _noBufferHighQps.CreateClient();
-            await client.GetAsync("/_ah/health");
+            using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestNoBufferHighQpsApplication>()))
+            using (var client = server.CreateClient())
+            {
+                await client.GetAsync($"/_ah/health");
 
-            var trace = _polling.GetTrace("/_ah/health", startTime, expectTrace: false);
-            Assert.Null(trace);
+                var trace = _polling.GetTrace("/_ah/health", startTime, expectTrace: false);
+                Assert.Null(trace);
+            }
         }
     }
 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/RateLimiter.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/RateLimiter.cs
@@ -27,7 +27,7 @@ namespace Google.Cloud.Diagnostics.Common
         private static object _instanceMutex = new object();
 
         /// <summary>The single rate limiter instance.</summary>
-        internal static RateLimiter _instance;
+        private static RateLimiter _instance;
 
         /// <summary>The amount of time that must be waited before allowing tracing.</summary>
         private readonly long _fixedDelayMillis;
@@ -78,5 +78,11 @@ namespace Google.Cloud.Diagnostics.Common
             return (nowMillis - lastCallMillis >= _fixedDelayMillis) &&
                 Interlocked.CompareExchange(ref _lastCallMillis, nowMillis, lastCallMillis) == lastCallMillis;
         }
+
+        /// <summary>
+        /// Reset the rate limiter instance to null.  This will allow a new QPS rate limit to
+        /// be set.  For testing use only.
+        /// </summary>
+        internal static void Reset() => _instance = null;
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/RateLimiter.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/RateLimiter.cs
@@ -27,7 +27,7 @@ namespace Google.Cloud.Diagnostics.Common
         private static object _instanceMutex = new object();
 
         /// <summary>The single rate limiter instance.</summary>
-        private static RateLimiter _instance;
+        internal static RateLimiter _instance;
 
         /// <summary>The amount of time that must be waited before allowing tracing.</summary>
         private readonly long _fixedDelayMillis;


### PR DESCRIPTION
We also disable palatalization to ensure the rate limiter is correct when each test is run.

Also ensures all test servers and clients are properly disposed of.

@jskeet @evildour Any idea how to handle this in a better way?

Fixes #966