### PR TITLE
Update Vision snippet tests

### DIFF
--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/BatchAnnotateImagesResponseSnippets.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/BatchAnnotateImagesResponseSnippets.cs
@@ -23,7 +23,8 @@ namespace Google.Cloud.Vision.V1.Snippets
         public void ThrowOnAnyError()
         {
             // Snippet: ThrowOnAnyError
-            Image image = new Image(); // No content or source!
+            // We create a request which passes simple validation, but isn't a valid image.
+            Image image = Image.FromBytes(new byte[10]);
             // Just a single request in this example, but usually BatchAnnotateImages would be
             // used with multiple requests.
             var request = new AnnotateImageRequest

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.cs
@@ -315,7 +315,8 @@ namespace Google.Cloud.Vision.V1.Snippets
         public void ErrorHandling_SingleImage()
         {
             // Sample: ErrorHandling_SingleImage
-            Image image = new Image(); // No content or source!
+            // We create a request which passes simple validation, but isn't a valid image.
+            Image image = Image.FromBytes(new byte[10]);
             ImageAnnotatorClient client = ImageAnnotatorClient.Create();
             try
             {


### PR DESCRIPTION
The Vision API now applies simple validation to the request and
fails the whole RPC if anything is *obviously* wrong. Our tests for
"one of the images was broken" need to be a little sneakier.