### PR TITLE
Storage 2.1 features

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ModifyBucketLabelsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ModifyBucketLabelsTest.cs
@@ -239,6 +239,34 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RemoveBucketLabel_NoLabelsBefore(bool runAsync)
+        {
+            var client = _fixture.Client;
+            var bucketName = _fixture.LabelsTestBucket;
+            client.ClearBucketLabels(bucketName);
+            var result = RunMaybeAsync(runAsync,
+                () => client.RemoveBucketLabel(bucketName, "label"),
+                () => client.RemoveBucketLabelAsync(bucketName, "label"));
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ClearBucketLabels_NoLabelsBefore(bool runAsync)
+        {
+            var client = _fixture.Client;
+            var bucketName = _fixture.LabelsTestBucket;            
+            client.ClearBucketLabels(bucketName);
+            var result = RunMaybeAsync(runAsync,
+                () => client.ClearBucketLabels(bucketName),
+                () => client.ClearBucketLabelsAsync(bucketName));
+            Assert.Empty(result);
+        }
+
         // TODO: Move these somewhere common, if this proves a useful pattern.
         private static T RunMaybeAsync<T>(bool runAsync, Func<T> sync, Func<Task<T>> async)
             // Run the async func separately to explicitly avoid synchronization etc.

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ModifyBucketLabelsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ModifyBucketLabelsTest.cs
@@ -1,0 +1,276 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.7
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Http;
+using Google.Apis.Storage.v1.Data;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Net;
+
+namespace Google.Cloud.Storage.V1.IntegrationTests
+{
+    [Collection(nameof(StorageFixture))]
+    public class ModifyBucketLabelsTest
+    {
+        private readonly StorageFixture _fixture;
+
+        public ModifyBucketLabelsTest(StorageFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ModifyBucketLabels_Simple(bool runAsync)
+        {
+            // Test several things:
+            // - lab1: Existing label not mentioned in the request
+            // - lab2: Existing label with same value in request
+            // - lab3: Existing label with different value in request
+            // - lab4: Existing label to be deleted in request
+            // - lab5: New label in request
+            // - lab6: Non-existent label to be deleted in request
+            var client = _fixture.Client;
+            var bucketName = _fixture.LabelsTestBucket;
+            _fixture.SetUpLabels(new Dictionary<string, string> { ["lab1"] = "o1", ["lab2"] = "o2", ["lab3"] = "o3", ["lab4"] = "o4" });
+
+            var newLabels = new Dictionary<string, string>
+            {
+                ["lab2"] = "o2", // Same value
+                ["lab3"] = "n3", // New value
+                ["lab4"] = null, // To be deleted
+                ["lab5"] = "n5", // Didn't exist
+                ["lab6"] = null, // Didn't exist, would delete if it did
+            };
+
+            var result = RunMaybeAsync(runAsync,
+                () => client.ModifyBucketLabels(bucketName, newLabels),
+                () => client.ModifyBucketLabelsAsync(bucketName, newLabels));
+
+            var expectedResult = new Dictionary<string, string>
+            {
+                ["lab2"] = "o2",
+                ["lab3"] = "o3",
+                ["lab4"] = "o4",
+                ["lab5"] = null,
+                ["lab6"] = null,
+            };
+
+            Assert.Equal(expectedResult, result);
+
+            var finalLabels = client.GetBucket(bucketName).Labels;
+            var expectedFinalLabels = new Dictionary<string, string>
+            {
+                ["lab1"] = "o1",
+                ["lab2"] = "o2",
+                ["lab3"] = "n3",
+                ["lab5"] = "n5",
+            };
+
+            Assert.Equal(expectedFinalLabels, finalLabels);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ClearBucketLabels_Simple(bool runAsync)
+        {
+            var client = _fixture.Client;
+            var bucketName = _fixture.LabelsTestBucket;
+            _fixture.SetUpLabels(new Dictionary<string, string> { ["lab1"] = "o1", ["lab2"] = "o2" });
+
+            var previousLabels = RunMaybeAsync(runAsync,
+                () => client.ClearBucketLabels(bucketName),
+                () => client.ClearBucketLabelsAsync(bucketName));
+            var expected = new Dictionary<string, string> { ["lab1"] = "o1", ["lab2"] = "o2" };
+            Assert.Equal(expected, previousLabels);
+
+            var finalLabels = client.GetBucket(bucketName).Labels;
+            Assert.Null(finalLabels);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ModifyBucketLabels_RetrySucceeds(bool runAsync)
+        {
+            var evilClient = StorageClient.Create();
+            var independentClient = StorageClient.Create();
+            var bucketName = _fixture.LabelsTestBucket;
+            _fixture.SetUpLabels(new Dictionary<string, string> { { "label", "before" } });
+
+            // Just before the "set-it-to-after" patch call is made, we modify the label ourselves,
+            // which will change the metageneration and cause a conflict response to the patch.
+            // We only do this twice though - on the third time, the read/modify/write cycle will work
+            // - but we'll be able to tell that it *did* intercept twice, as the "old" value will be
+            // the one set by the final intercept.
+            var interceptor = new PatchFoilingInterceptor(2, count => independentClient.SetBucketLabel(bucketName, "label", $"intercept{count}"));
+            evilClient.Service.HttpClient.MessageHandler.AddExecuteInterceptor(interceptor);
+
+            var options = new ModifyBucketLabelsOptions { Retries = 2 };
+            var result = RunMaybeAsync(runAsync,
+                () => evilClient.SetBucketLabel(bucketName, "label", "after", options),
+                () => evilClient.SetBucketLabelAsync(bucketName, "label", "after", options));
+            Assert.Equal("intercept2", result);
+
+            var finalLabels = independentClient.GetBucket(bucketName).Labels;
+            Assert.Equal("after", finalLabels["label"]);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ModifyBucketLabels_RetryFails(bool runAsync)
+        {
+            var evilClient = StorageClient.Create();
+            var independentClient = StorageClient.Create();
+            var bucketName = _fixture.LabelsTestBucket;
+            _fixture.SetUpLabels(new Dictionary<string, string> { { "label", "before" } });
+
+            // Just before the "set-it-to-after" patch call is made, we modify the label ourselves,
+            // which will change the metageneration and cause a conflict response to the patch.
+            // We do this three times - which is why the overall result is failure.
+            var interceptor = new PatchFoilingInterceptor(3, count => independentClient.SetBucketLabel(bucketName, "label", $"intercept{count}"));
+            evilClient.Service.HttpClient.MessageHandler.AddExecuteInterceptor(interceptor);
+
+            var options = new ModifyBucketLabelsOptions { Retries = 2 };
+            var exception = AssertThrowsMaybeAsync<GoogleApiException>(runAsync,
+                () => evilClient.SetBucketLabel(bucketName, "label", "after", options),
+                () => evilClient.SetBucketLabelAsync(bucketName, "label", "after", options));
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ModifyBucketLabels_ExplicitPreconditionFail(bool runAsync)
+        {
+            var client = _fixture.Client;
+            var bucketName = _fixture.LabelsTestBucket;
+            var bucket = client.GetBucket(bucketName);
+
+            var options = new ModifyBucketLabelsOptions { IfMetagenerationMatch = bucket.Metageneration + 1 };
+            var exception = AssertThrowsMaybeAsync<GoogleApiException>(runAsync,
+                () => client.SetBucketLabel(bucketName, "label", "value", options),
+                () => client.SetBucketLabelAsync(bucketName, "label", "value", options));
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ClearBucketLabels_RetrySucceeds(bool runAsync)
+        {
+            var evilClient = StorageClient.Create();
+            var independentClient = StorageClient.Create();
+            var bucketName = _fixture.LabelsTestBucket;
+            _fixture.SetUpLabels(new Dictionary<string, string> { { "label", "before" } });
+
+            // Just before the "set-it-to-after" patch call is made, we modify the label ourselves,
+            // which will change the metageneration and cause a conflict response to the patch.
+            // We only do this twice though - on the third time, the read/modify/write cycle will work
+            // - but we'll be able to tell that it *did* intercept twice, as the "old" value will be
+            // the one set by the final intercept.
+            var interceptor = new PatchFoilingInterceptor(2, count => independentClient.SetBucketLabel(bucketName, "label", $"intercept{count}"));
+            evilClient.Service.HttpClient.MessageHandler.AddExecuteInterceptor(interceptor);
+
+            var options = new ModifyBucketLabelsOptions { Retries = 2 };
+            var result = RunMaybeAsync(runAsync,
+                () => evilClient.ClearBucketLabels(bucketName, options),
+                () => evilClient.ClearBucketLabelsAsync(bucketName, options));
+            Assert.Equal(new Dictionary<string, string> { { "label", "intercept2" } }, result);
+
+            Assert.Null(independentClient.GetBucket(bucketName).Labels);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ClearBucketLabels_RetryFails(bool runAsync)
+        {
+            var evilClient = StorageClient.Create();
+            var independentClient = StorageClient.Create();
+            var bucketName = _fixture.LabelsTestBucket;
+            _fixture.SetUpLabels(new Dictionary<string, string> { { "label", "before" } });
+
+            // Just before the "set-it-to-after" patch call is made, we modify the label ourselves,
+            // which will change the metageneration and cause a conflict response to the patch.
+            // We do this three times - which is why the overall result is failure.
+            var interceptor = new PatchFoilingInterceptor(3, count => independentClient.SetBucketLabel(bucketName, "label", $"intercept{count}"));
+            evilClient.Service.HttpClient.MessageHandler.AddExecuteInterceptor(interceptor);
+
+            var options = new ModifyBucketLabelsOptions { Retries = 2 };
+            var exception = AssertThrowsMaybeAsync<GoogleApiException>(runAsync,
+                () => evilClient.ClearBucketLabels(bucketName, options),
+                () => evilClient.ClearBucketLabelsAsync(bucketName, options));
+
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ClearBucketLabels_ExplicitPreconditionFail(bool runAsync)
+        {
+            var client = _fixture.Client;
+            var bucketName = _fixture.LabelsTestBucket;
+            var bucket = client.GetBucket(bucketName);
+
+            var options = new ModifyBucketLabelsOptions { IfMetagenerationMatch = bucket.Metageneration + 1 };
+            var exception = AssertThrowsMaybeAsync<GoogleApiException>(runAsync,
+                () => client.ClearBucketLabels(bucketName, options),
+                () => client.ClearBucketLabelsAsync(bucketName, options));
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+        }
+
+        // TODO: Move these somewhere common, if this proves a useful pattern.
+        private static T RunMaybeAsync<T>(bool runAsync, Func<T> sync, Func<Task<T>> async)
+            // Run the async func separately to explicitly avoid synchronization etc.
+            => runAsync ? Task.Run(() => async().Result).Result : sync();
+
+        private static TException AssertThrowsMaybeAsync<TException>(bool runAsync, Action sync, Func<Task> async)
+            where TException : Exception =>
+            runAsync
+                ? Task.Run(() => Assert.ThrowsAsync<TException>(async).Result).Result
+                : Assert.Throws<TException>(sync);
+
+        private class PatchFoilingInterceptor : IHttpExecuteInterceptor
+        {
+            private int interceptCount;
+            private readonly int maxIntercepts;
+            private readonly Action<int> action;
+
+            public PatchFoilingInterceptor(int maxIntercepts, Action<int> action)
+            {
+                this.maxIntercepts = maxIntercepts;
+                this.action = action;
+            }
+
+            public Task InterceptAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (request.Method.Method == "PATCH" && interceptCount < maxIntercepts)
+                {
+                    interceptCount++;
+                    action(interceptCount);
+                }
+                return Task.FromResult(0);
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/RequesterPaysTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/RequesterPaysTest.cs
@@ -1,0 +1,116 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using Xunit;
+
+namespace Google.Cloud.Storage.V1.IntegrationTests
+{
+    // TODO: Make this indicate that tests are skipped when the environment variables aren't set.
+    // It's doable with Xunit, but a bit fiddly. See
+    // https://github.com/xunit/samples.xunit/tree/master/DynamicSkipExample
+
+    [Collection(nameof(StorageFixture))]
+    public class RequesterPaysTest
+    {
+        private readonly StorageFixture _fixture;
+        private readonly bool _skip;
+
+        public RequesterPaysTest(StorageFixture fixture)
+        {
+            _fixture = fixture;
+            _skip = _fixture.RequesterPaysBucket == null;
+        }
+
+        [Fact]
+        public void DownloadObject_WithoutOption()
+        {
+            if (_skip)
+            {
+                return;
+            }
+
+            var exception = Assert.Throws<GoogleApiException>(
+                () => _fixture.Client.DownloadObject(_fixture.RequesterPaysBucket, _fixture.SmallObject, new MemoryStream()));
+            Assert.Equal(HttpStatusCode.BadRequest, exception.HttpStatusCode);
+        }
+
+        [Fact]
+        public void DownloadObject_WithOption()
+        {
+            if (_skip)
+            {
+                return;
+            }
+
+            var destination = new MemoryStream();
+            _fixture.Client.DownloadObject(_fixture.RequesterPaysBucket, _fixture.SmallObject, destination,
+                new DownloadObjectOptions { UserProject = _fixture.ProjectId });
+        }
+
+        [Fact]
+        public void ListObjects_WithoutOption()
+        {
+            if (_skip)
+            {
+                return;
+            }
+
+            var exception = Assert.Throws<GoogleApiException>(
+                () => _fixture.Client.ListObjects(_fixture.RequesterPaysBucket).ToList());
+            Assert.Equal(HttpStatusCode.BadRequest, exception.HttpStatusCode);
+        }
+
+        [Fact]
+        public void ListObjects_WithOption()
+        {
+            if (_skip)
+            {
+                return;
+            }
+
+            var objects = _fixture.Client
+                .ListObjects(_fixture.RequesterPaysBucket, options: new ListObjectsOptions { UserProject = _fixture.ProjectId })
+                .ToList();
+            Assert.Contains(_fixture.SmallObject, objects.Select(o => o.Name));
+        }
+
+        [Fact]
+        public void UploadObject_WithoutOption()
+        {
+            if (_skip)
+            {
+                return;
+            }
+
+            var exception = Assert.Throws<GoogleApiException>(
+                () => _fixture.Client.UploadObject(_fixture.RequesterPaysBucket, "other-upload.txt", "text/plain", new MemoryStream(_fixture.SmallContent)));
+            Assert.Equal(HttpStatusCode.BadRequest, exception.HttpStatusCode);
+        }
+
+        [Fact]
+        public void UploadObject_WithOption()
+        {
+            if (_skip)
+            {
+                return;
+            }
+
+            _fixture.Client.UploadObject(_fixture.RequesterPaysBucket, "other-upload.txt", "text/plain",
+                new MemoryStream(_fixture.SmallContent), new UploadObjectOptions { UserProject = _fixture.ProjectId });            
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
@@ -40,6 +40,8 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
     public sealed class StorageFixture : IDisposable, ICollectionFixture<StorageFixture>
     {
         private const string ProjectEnvironmentVariable = "TEST_PROJECT";
+        private const string RequesterPaysProjectEnvironmentVariable = "REQUESTER_PAYS_TEST_PROJECT";
+        private const string RequesterPaysCredentialsEnvironmentVariable = "REQUESTER_PAYS_CREDENTIALS";
         public const string DelayTestSuffix = "_InitDelayTest";
 
         private static TypeInfo _delayTestsTypeBeingRegistered;
@@ -70,6 +72,20 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
         /// Bucket with versioning enabled, which tests can write to.
         /// </summary>
         public string MultiVersionBucket => BucketPrefix + "multi";
+
+        /// <summary>
+        /// Bucket to be used for requester-pays testing, or null if requester-pays is not configured.
+        /// </summary>
+        public string RequesterPaysBucket { get; }
+        /// <summary>
+        /// Project ID of the requester-pays bucket, or null if requester-pays is not configured.
+        /// (This may be removable later, when we don't need to specify it in options.)
+        /// </summary>
+        private string RequesterPaysProjectId { get; }
+        /// <summary>
+        /// Storage client set up with requester-pays credentials, or null if requester-pays is not configured.
+        /// </summary>
+        private StorageClient RequesterPaysClient { get; }
 
         /// <summary>
         /// Bucket which tests should *not* write to, so that tests can
@@ -148,6 +164,43 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             CreateAndPopulateReadBucket();
             CreateBucket(BucketBeginningWithZ, false);
             CreateBucket(LabelsTestBucket, false);
+
+            RequesterPaysClient = CreateRequesterPaysClient();
+            if (RequesterPaysClient != null)
+            {
+                RequesterPaysProjectId = Environment.GetEnvironmentVariable(RequesterPaysProjectEnvironmentVariable);
+                if (string.IsNullOrEmpty(RequesterPaysProjectId))
+                {
+                    throw new Exception($"{RequesterPaysCredentialsEnvironmentVariable} set, but not {RequesterPaysProjectEnvironmentVariable}");
+                }
+
+                RequesterPaysBucket = CreateRequesterPaysBucket();
+            }
+        }
+
+        private static StorageClient CreateRequesterPaysClient()
+        {
+            string file = Environment.GetEnvironmentVariable(RequesterPaysCredentialsEnvironmentVariable);
+            if (string.IsNullOrEmpty(file))
+            {
+                return null;
+            }
+            using (var stream = File.OpenRead(file))
+            {
+                var credential = GoogleCredential.FromStream(stream);
+                return StorageClient.Create(credential);
+            }
+        }
+
+        private string CreateRequesterPaysBucket()
+        {
+            string name = "dotnet-requesterpays-" + Guid.NewGuid().ToString().ToLowerInvariant();
+            RequesterPaysClient.CreateBucket(RequesterPaysProjectId, new Bucket { Name = name, Billing = new Bucket.BillingData { RequesterPays = true } },
+                new CreateBucketOptions { PredefinedAcl = PredefinedBucketAcl.PublicReadWrite, PredefinedDefaultObjectAcl = PredefinedObjectAcl.PublicRead });
+            // TODO: We shouldn't need the project ID here.
+            RequesterPaysClient.UploadObject(name, SmallObject, "text/plain", new MemoryStream(SmallContent),
+                new UploadObjectOptions { UserProject = RequesterPaysProjectId });
+            return name;
         }
 
         internal void CreateBucket(string name, bool multiVersion)
@@ -248,13 +301,23 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             var client = StorageClient.Create();
             foreach (var bucket in _bucketsToDelete)
             {
-                var objects = client.ListObjects(bucket, null, new ListObjectsOptions { Versions = true }).ToList();
-                foreach (var obj in objects)
-                {
-                    client.DeleteObject(obj, new DeleteObjectOptions { Generation = obj.Generation });
-                }
-                client.DeleteBucket(bucket);
+                DeleteBucket(client, bucket, null);
             }
+            if (RequesterPaysBucket != null)
+            {
+                DeleteBucket(RequesterPaysClient, RequesterPaysBucket, RequesterPaysProjectId);
+            }
+        }
+
+        private void DeleteBucket(StorageClient client, string bucket, string userProject)
+        {
+            // TODO: We shouldn't need the project ID here.
+            var objects = client.ListObjects(bucket, null, new ListObjectsOptions { Versions = true, UserProject = userProject }).ToList();
+            foreach (var obj in objects)
+            {
+                client.DeleteObject(obj, new DeleteObjectOptions { Generation = obj.Generation, UserProject = userProject });
+            }
+            client.DeleteBucket(bucket, new DeleteBucketOptions { UserProject = userProject });
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/StorageClientSnippets.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/StorageClientSnippets.cs
@@ -17,6 +17,7 @@ using Google.Apis.Storage.v1.Data;
 using Google.Apis.Upload;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -691,6 +692,109 @@ namespace Google.Cloud.Storage.V1.Snippets
         // See-also: TestBucketIamPermissions(string,*,*)
         // Member: TestBucketIamPermissionsAsync(string,*,*,*)
         // See [TestBucketIamPermissions](ref) for a synchronous example.
+        // End see-also
+
+        [Fact]
+        public void SetBucketLabel()
+        {
+            var bucketName = _fixture.BucketName;
+            // Snippet: SetBucketLabel(string, string, string, *)
+            StorageClient client = StorageClient.Create();
+
+            string now = DateTime.UtcNow.ToString("yyyy-MM-dd_HH-mm-ss", CultureInfo.InvariantCulture);
+            string newValue = "new_value_" + now;
+            string oldValue = client.SetBucketLabel(bucketName, "label", newValue);
+            Console.WriteLine($"Old value: {oldValue}");
+            // Verify the label is now correct...
+            Bucket bucket = client.GetBucket(bucketName);
+            string fetchedValue = bucket.Labels?["label"];
+            Console.WriteLine($"Fetched value: {fetchedValue}");
+            // End snippet
+
+            Assert.Equal(newValue, fetchedValue);
+        }
+
+        // See-also: SetBucketLabel(string, string, string, *)
+        // Member: SetBucketLabelAsync(string, string, string, *, *)
+        // See [SetBucketLabel](ref) for a synchronous example.
+        // End see-also
+
+        [Fact]
+        public void RemoveBucketLabel()
+        {
+            var bucketName = _fixture.BucketName;
+            // Snippet: RemoveBucketLabel(string, string, *)
+            StorageClient client = StorageClient.Create();
+
+            string oldValue = client.RemoveBucketLabel(bucketName, "label");
+            Console.WriteLine($"Old value: {oldValue}");
+            // Verify the label is now gone...
+            Bucket bucket = client.GetBucket(bucketName);
+            string fetchedValue = null;
+            bucket.Labels?.TryGetValue("label", out fetchedValue);
+            Console.WriteLine($"Fetched value: {fetchedValue}");
+            // End snippet
+
+            Assert.Null(fetchedValue);
+        }
+
+        // See-also: RemoveBucketLabel(string, string, *)
+        // Member: RemoveBucketLabelAsync(string, string, *, *)
+        // See [RemoveBucketLabel](ref) for a synchronous example.
+        // End see-also
+
+        [Fact]
+        public void ClearBucketLabels()
+        {
+            var bucketName = _fixture.BucketName;
+            // Snippet: ClearBucketLabels(string, *)
+            StorageClient client = StorageClient.Create();
+
+            IDictionary<string, string> oldLabels = client.ClearBucketLabels(bucketName);
+            Console.WriteLine($"Number of labels before clearing: {oldLabels.Count}");
+            // End snippet
+
+            Assert.Null(client.GetBucket(bucketName).Labels);
+        }
+
+        // See-also: ClearBucketLabels(string, *)
+        // Member: ClearBucketLabelsAsync(string, *, *)
+        // See [ClearBucketLabels](ref) for a synchronous example.
+        // End see-also
+
+        [Fact]
+        public void ModifyBucketLabels()
+        {
+            var bucketName = _fixture.BucketName;
+
+            // Snippet: ModifyBucketLabels(string, *, *)
+            StorageClient client = StorageClient.Create();
+
+            string now = DateTime.UtcNow.ToString("yyyy-MM-dd_HH-mm-ss", CultureInfo.InvariantCulture);
+            IDictionary<string, string> labelChanges = new Dictionary<string, string>
+            {
+                { "label1", "new_value_1_" + now },
+                { "label2", "new_value_2_" + now },
+            };
+
+            IDictionary<string, string> oldValues = client.ModifyBucketLabels(bucketName, labelChanges);
+            Console.WriteLine("Old values for changed labels:");
+            foreach (KeyValuePair<string, string> entry in oldValues)
+            {
+                Console.WriteLine($"  {entry.Key}: {entry.Value}");
+            }
+            Console.WriteLine("All labels:");
+            IDictionary<string, string> allLabels = client.GetBucket(bucketName).Labels ?? new Dictionary<string, string>();
+            foreach (KeyValuePair<string, string> entry in allLabels)
+            {
+                Console.WriteLine($"  {entry.Key}: {entry.Value}");
+            }
+            // End snippet
+        }
+
+        // See-also: ModifyBucketLabels(string, *, *)
+        // Member: ModifyBucketLabelsAsync(string, *, *, *)
+        // See [ModifyBucketLabels](ref) for a synchronous example.
         // End see-also
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/CopyObjectOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/CopyObjectOptionsTest.cs
@@ -37,6 +37,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(request.IfSourceMetagenerationNotMatch);
             Assert.Null(request.Projection);
             Assert.Null(request.SourceGeneration);
+            Assert.Null(request.UserProject);
         }
 
         [Fact]
@@ -51,7 +52,8 @@ namespace Google.Cloud.Storage.V1.Tests
                 IfSourceGenerationMatch = 3L,
                 IfSourceMetagenerationMatch = 4L,
                 Projection = Projection.Full,
-                SourceGeneration = 5L
+                SourceGeneration = 5L,
+                UserProject = "proj"
             };
             options.ModifyRequest(request);
             Assert.Equal(RewriteRequest.DestinationPredefinedAclEnum.Private__, request.DestinationPredefinedAcl);
@@ -64,6 +66,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Equal(4L, request.IfSourceMetagenerationMatch);
             Assert.Null(request.IfSourceMetagenerationNotMatch);
             Assert.Equal(5L, request.SourceGeneration);
+            Assert.Equal("proj", request.UserProject);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/DeleteBucketOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/DeleteBucketOptionsTest.cs
@@ -28,6 +28,7 @@ namespace Google.Cloud.Storage.V1.Tests
             options.ModifyRequest(request);
             Assert.Null(request.IfMetagenerationMatch);
             Assert.Null(request.IfMetagenerationNotMatch);
+            Assert.Null(request.UserProject);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/DeleteObjectOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/DeleteObjectOptionsTest.cs
@@ -31,6 +31,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(request.IfGenerationNotMatch);
             Assert.Null(request.IfMetagenerationMatch);
             Assert.Null(request.IfMetagenerationNotMatch);
+            Assert.Null(request.UserProject);
         }
 
         [Fact]
@@ -41,7 +42,8 @@ namespace Google.Cloud.Storage.V1.Tests
             {
                 IfGenerationMatch = 1L,
                 IfMetagenerationMatch = 2L,
-                Generation = 3L
+                Generation = 3L,
+                UserProject = "proj"
             };
             options.ModifyRequest(request);
             Assert.Equal(1L, request.IfGenerationMatch);
@@ -49,6 +51,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Equal(2L, request.IfMetagenerationMatch);
             Assert.Null(request.IfMetagenerationNotMatch);
             Assert.Equal(3L, request.Generation);
+            Assert.Equal("proj", request.UserProject);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/DownloadObjectOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/DownloadObjectOptionsTest.cs
@@ -45,12 +45,15 @@ namespace Google.Cloud.Storage.V1.Tests
             {
                 IfGenerationMatch = 1L,
                 IfMetagenerationMatch = 2L,
-                Generation = 3L
+                Generation = 3L,
+                UserProject = "my proj"
             };
             var uri = options.GetUri("http://url/foo?x=y");
             Assert.Contains("&ifGenerationMatch=1", uri);
             Assert.Contains("&ifMetagenerationMatch=2", uri);
             Assert.Contains("&generation=3", uri);
+            // I don't expect project IDs to actually need escaping, but let's check that it works.
+            Assert.Contains("&userProject=my%20proj", uri);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/GetBucketIamPolicyOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/GetBucketIamPolicyOptionsTest.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,43 +13,30 @@
 // limitations under the License.
 
 using Xunit;
-using static Google.Apis.Storage.v1.ObjectsResource;
-using static Google.Apis.Storage.v1.ObjectsResource.ListRequest;
+using static Google.Apis.Storage.v1.BucketsResource;
 
 namespace Google.Cloud.Storage.V1.Tests
 {
-    public class ListObjectsOptionsTest
+    public class GetBucketIamPolicyOptionsTest
     {
         [Fact]
         public void ModifyRequest_DefaultOptions()
         {
-            var request = new ListRequest(null, "bucket");
-            var options = new ListObjectsOptions();
+            var request = new GetIamPolicyRequest(null, "bucket");
+            var options = new GetBucketIamPolicyOptions();
             options.ModifyRequest(request);
-            Assert.Null(request.Delimiter);
-            Assert.Null(request.Projection);
-            Assert.Null(request.MaxResults);
-            Assert.Null(request.Versions);
             Assert.Null(request.UserProject);
         }
 
         [Fact]
         public void ModifyRequest_AllOptions()
         {
-            var request = new ListRequest(null, "bucket");
-            var options = new ListObjectsOptions
+            var request = new GetIamPolicyRequest(null, "bucket");
+            var options = new GetBucketIamPolicyOptions
             {
-                PageSize = 10,
-                Delimiter = "/",
-                Projection = Projection.Full,
-                Versions = true,
                 UserProject = "proj"
             };
             options.ModifyRequest(request);
-            Assert.Equal(10, request.MaxResults);
-            Assert.Equal("/", request.Delimiter);
-            Assert.Equal(ProjectionEnum.Full, request.Projection);
-            Assert.True(request.Versions);
             Assert.Equal("proj", request.UserProject);
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/GetBucketOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/GetBucketOptionsTest.cs
@@ -30,6 +30,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(request.IfMetagenerationMatch);
             Assert.Null(request.IfMetagenerationNotMatch);
             Assert.Null(request.Projection);
+            Assert.Null(request.UserProject);
         }
 
         [Fact]
@@ -39,12 +40,14 @@ namespace Google.Cloud.Storage.V1.Tests
             var options = new GetBucketOptions
             {
                 IfMetagenerationMatch = 1L,
-                Projection = Projection.Full
+                Projection = Projection.Full,
+                UserProject = "proj"
             };
             options.ModifyRequest(request);
             Assert.Equal(1L, request.IfMetagenerationMatch);
             Assert.Null(request.IfMetagenerationNotMatch);
             Assert.Equal(ProjectionEnum.Full, request.Projection);
+            Assert.Equal("proj", request.UserProject);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/GetObjectOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/GetObjectOptionsTest.cs
@@ -33,6 +33,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(request.IfMetagenerationMatch);
             Assert.Null(request.IfMetagenerationNotMatch);
             Assert.Null(request.Projection);
+            Assert.Null(request.UserProject);
         }
 
         [Fact]
@@ -44,7 +45,8 @@ namespace Google.Cloud.Storage.V1.Tests
                 IfGenerationMatch = 1L,
                 IfMetagenerationMatch = 2L,
                 Generation = 3L,
-                Projection = Projection.Full
+                Projection = Projection.Full,
+                UserProject = "proj"
             };
             options.ModifyRequest(request);
             Assert.Equal(1L, request.IfGenerationMatch);
@@ -53,6 +55,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(request.IfMetagenerationNotMatch);
             Assert.Equal(3L, request.Generation);
             Assert.Equal(ProjectionEnum.Full, request.Projection);
+            Assert.Equal("proj", request.UserProject);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ModifyBucketLabelsOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ModifyBucketLabelsOptionsTest.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Xunit;
+
+namespace Google.Cloud.Storage.V1.Tests
+{
+    public class ModifyBucketLabelsOptionsTest
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(int.MaxValue)]
+        [InlineData(null)]
+        public void Retries_Valid(int? retries)
+        {
+            var options = new ModifyBucketLabelsOptions { Retries = retries };
+            Assert.Equal(retries, options.Retries);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(int.MinValue)]
+        public void Retries_Invalid(int? retries)
+        {
+            var options = new ModifyBucketLabelsOptions();
+            Assert.Throws<ArgumentOutOfRangeException>(() => options.Retries = retries);
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ModifyBucketLabelsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ModifyBucketLabelsTest.cs
@@ -1,0 +1,91 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Moq;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Storage.V1.Tests
+{
+    public class ModifyBucketLabelsTest
+    {
+        [Fact]
+        public void SetLabel()
+        {
+            var bucketName = "bucket";
+            var key = "key";
+            var oldValue = "old-value";
+            var newValue = "new-value";
+            var options = new ModifyBucketLabelsOptions();
+            var mock = new Mock<StorageClient> { CallBase = true };
+            mock.Setup(obj => obj.ModifyBucketLabels(bucketName, new Dictionary<string, string> { { key, newValue } }, options))
+                .Returns(new Dictionary<string, string> { { key, oldValue } });
+
+            var actual = mock.Object.SetBucketLabel(bucketName, key, newValue, options);
+            Assert.Equal(oldValue, actual);
+            mock.VerifyAll();
+        }
+
+        [Fact]
+        public void RemoveLabel()
+        {
+            var bucketName = "bucket";
+            var key = "key";
+            var options = new ModifyBucketLabelsOptions();
+            var mock = new Mock<StorageClient> { CallBase = true };
+            mock.Setup(obj => obj.ModifyBucketLabels(bucketName, new Dictionary<string, string> { { key, null } }, options))
+                .Returns(new Dictionary<string, string> { { key, null } });
+
+            var actual = mock.Object.RemoveBucketLabel(bucketName, key, options);
+            Assert.Null(actual);
+            mock.VerifyAll();
+        }
+
+        [Fact]
+        public void SetLabelAsync()
+        {
+            var bucketName = "bucket";
+            var key = "key";
+            var oldValue = "old-value";
+            var newValue = "new-value";
+            var options = new ModifyBucketLabelsOptions();
+            var token = new CancellationTokenSource().Token;
+            var mock = new Mock<StorageClient> { CallBase = true };
+            mock.Setup(obj => obj.ModifyBucketLabelsAsync(bucketName, new Dictionary<string, string> { { key, newValue } }, options, token))
+                .Returns(Task.FromResult<IDictionary<string, string>>(new Dictionary<string, string> { { key, oldValue } }));
+
+            var actual = mock.Object.SetBucketLabelAsync(bucketName, key, newValue, options, token).Result;
+            Assert.Equal(oldValue, actual);
+            mock.VerifyAll();
+        }
+
+        [Fact]
+        public void RemoveLabelAsync()
+        {
+            var bucketName = "bucket";
+            var key = "key";
+            var options = new ModifyBucketLabelsOptions();
+            var token = new CancellationTokenSource().Token;
+            var mock = new Mock<StorageClient> { CallBase = true };
+            mock.Setup(obj => obj.ModifyBucketLabelsAsync(bucketName, new Dictionary<string, string> { { "key", null } }, options, token))
+                .Returns(Task.FromResult<IDictionary<string, string>>(new Dictionary<string, string> { { "key", null } }));
+
+            var actual = mock.Object.RemoveBucketLabelAsync(bucketName, key, options, token).Result;
+            Assert.Null(actual);
+            mock.VerifyAll();
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/PatchBucketOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/PatchBucketOptionsTest.cs
@@ -32,6 +32,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(request.PredefinedAcl);
             Assert.Null(request.PredefinedDefaultObjectAcl);
             Assert.Null(request.Projection);
+            Assert.Null(request.UserProject);
         }
 
         [Fact]
@@ -43,7 +44,8 @@ namespace Google.Cloud.Storage.V1.Tests
                 IfMetagenerationMatch = 1L,
                 PredefinedAcl = PredefinedBucketAcl.AuthenticatedRead,
                 PredefinedDefaultObjectAcl = PredefinedObjectAcl.BucketOwnerFullControl,
-                Projection = Projection.Full
+                Projection = Projection.Full,
+                UserProject = "proj"
             };
             options.ModifyRequest(request);
             Assert.Equal(1L, request.IfMetagenerationMatch);
@@ -51,6 +53,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Equal(PredefinedAclEnum.AuthenticatedRead, request.PredefinedAcl);
             Assert.Equal(PredefinedDefaultObjectAclEnum.BucketOwnerFullControl, request.PredefinedDefaultObjectAcl);
             Assert.Equal(ProjectionEnum.Full, request.Projection);
+            Assert.Equal("proj", request.UserProject);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/PatchObjectOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/PatchObjectOptionsTest.cs
@@ -34,6 +34,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(request.IfMetagenerationNotMatch);
             Assert.Null(request.PredefinedAcl);
             Assert.Null(request.Projection);
+            Assert.Null(request.UserProject);
         }
 
         [Fact]
@@ -46,7 +47,8 @@ namespace Google.Cloud.Storage.V1.Tests
                 IfGenerationMatch = 2L,
                 IfMetagenerationMatch = 3L,
                 PredefinedAcl = PredefinedObjectAcl.AuthenticatedRead,
-                Projection = Projection.Full
+                Projection = Projection.Full,
+                UserProject = "proj"
             };
             options.ModifyRequest(request);
             Assert.Equal(1L, request.Generation);
@@ -56,6 +58,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(request.IfMetagenerationNotMatch);
             Assert.Equal(PredefinedAclEnum.AuthenticatedRead, request.PredefinedAcl);
             Assert.Equal(ProjectionEnum.Full, request.Projection);
+            Assert.Equal("proj", request.UserProject);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/SetBucketIamPolicyOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/SetBucketIamPolicyOptionsTest.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,43 +13,30 @@
 // limitations under the License.
 
 using Xunit;
-using static Google.Apis.Storage.v1.ObjectsResource;
-using static Google.Apis.Storage.v1.ObjectsResource.ListRequest;
+using static Google.Apis.Storage.v1.BucketsResource;
 
 namespace Google.Cloud.Storage.V1.Tests
 {
-    public class ListObjectsOptionsTest
+    public class SetBucketIamPolicyOptionsTest
     {
         [Fact]
         public void ModifyRequest_DefaultOptions()
         {
-            var request = new ListRequest(null, "bucket");
-            var options = new ListObjectsOptions();
+            var request = new SetIamPolicyRequest(null, null, "bucket");
+            var options = new SetBucketIamPolicyOptions();
             options.ModifyRequest(request);
-            Assert.Null(request.Delimiter);
-            Assert.Null(request.Projection);
-            Assert.Null(request.MaxResults);
-            Assert.Null(request.Versions);
             Assert.Null(request.UserProject);
         }
 
         [Fact]
         public void ModifyRequest_AllOptions()
         {
-            var request = new ListRequest(null, "bucket");
-            var options = new ListObjectsOptions
+            var request = new SetIamPolicyRequest(null, null, "bucket");
+            var options = new SetBucketIamPolicyOptions
             {
-                PageSize = 10,
-                Delimiter = "/",
-                Projection = Projection.Full,
-                Versions = true,
                 UserProject = "proj"
             };
             options.ModifyRequest(request);
-            Assert.Equal(10, request.MaxResults);
-            Assert.Equal("/", request.Delimiter);
-            Assert.Equal(ProjectionEnum.Full, request.Projection);
-            Assert.True(request.Versions);
             Assert.Equal("proj", request.UserProject);
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/TestBucketIamPermissionsOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/TestBucketIamPermissionsOptionsTest.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,44 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.Util;
 using Xunit;
-using static Google.Apis.Storage.v1.ObjectsResource;
-using static Google.Apis.Storage.v1.ObjectsResource.ListRequest;
+using static Google.Apis.Storage.v1.BucketsResource;
 
 namespace Google.Cloud.Storage.V1.Tests
 {
-    public class ListObjectsOptionsTest
+    public class TestBucketIamPermissionsOptionsTest
     {
         [Fact]
         public void ModifyRequest_DefaultOptions()
         {
-            var request = new ListRequest(null, "bucket");
-            var options = new ListObjectsOptions();
+            var request = new TestIamPermissionsRequest(null, "bucket", new Repeatable<string>(new string[0]));
+            var options = new TestBucketIamPermissionsOptions();
             options.ModifyRequest(request);
-            Assert.Null(request.Delimiter);
-            Assert.Null(request.Projection);
-            Assert.Null(request.MaxResults);
-            Assert.Null(request.Versions);
             Assert.Null(request.UserProject);
         }
 
         [Fact]
         public void ModifyRequest_AllOptions()
         {
-            var request = new ListRequest(null, "bucket");
-            var options = new ListObjectsOptions
+            var request = new TestIamPermissionsRequest(null, "bucket", new Repeatable<string>(new string[0]));
+            var options = new TestBucketIamPermissionsOptions
             {
-                PageSize = 10,
-                Delimiter = "/",
-                Projection = Projection.Full,
-                Versions = true,
                 UserProject = "proj"
             };
             options.ModifyRequest(request);
-            Assert.Equal(10, request.MaxResults);
-            Assert.Equal("/", request.Delimiter);
-            Assert.Equal(ProjectionEnum.Full, request.Projection);
-            Assert.True(request.Versions);
             Assert.Equal("proj", request.UserProject);
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UpdateBucketOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UpdateBucketOptionsTest.cs
@@ -34,6 +34,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(request.PredefinedAcl);
             Assert.Null(request.PredefinedDefaultObjectAcl);
             Assert.Null(request.Projection);
+            Assert.Null(request.UserProject);
         }
 
         [Fact]
@@ -60,7 +61,8 @@ namespace Google.Cloud.Storage.V1.Tests
                 IfMetagenerationMatch = 1L,
                 PredefinedAcl = PredefinedBucketAcl.AuthenticatedRead,
                 PredefinedDefaultObjectAcl = PredefinedObjectAcl.BucketOwnerFullControl,
-                Projection = Projection.Full
+                Projection = Projection.Full,
+                UserProject = "proj"
             };
             options.ModifyRequest(request, bucket);
             Assert.Equal(1L, request.IfMetagenerationMatch);
@@ -68,6 +70,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Equal(PredefinedAclEnum.AuthenticatedRead, request.PredefinedAcl);
             Assert.Equal(PredefinedDefaultObjectAclEnum.BucketOwnerFullControl, request.PredefinedDefaultObjectAcl);
             Assert.Equal(ProjectionEnum.Full, request.Projection);
+            Assert.Equal("proj", request.UserProject);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UpdateObjectOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UpdateObjectOptionsTest.cs
@@ -36,6 +36,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(request.IfMetagenerationNotMatch);
             Assert.Null(request.PredefinedAcl);
             Assert.Null(request.Projection);
+            Assert.Null(request.UserProject);
         }
 
         [Fact]
@@ -65,7 +66,8 @@ namespace Google.Cloud.Storage.V1.Tests
                 IfGenerationMatch = 2L,
                 IfMetagenerationMatch = 3L,
                 PredefinedAcl = PredefinedObjectAcl.AuthenticatedRead,
-                Projection = Projection.Full
+                Projection = Projection.Full,
+                UserProject = "proj"
             };
             options.ModifyRequest(request, obj);
             Assert.Equal(1L, request.Generation);
@@ -75,6 +77,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(request.IfMetagenerationNotMatch);
             Assert.Equal(PredefinedAclEnum.AuthenticatedRead, request.PredefinedAcl);
             Assert.Equal(ProjectionEnum.Full, request.Projection);
+            Assert.Equal("proj", request.UserProject);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UploadObjectOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UploadObjectOptionsTest.cs
@@ -63,6 +63,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(upload.IfMetagenerationNotMatch);
             Assert.Null(upload.PredefinedAcl);
             Assert.Null(upload.Projection);
+            Assert.Null(upload.UserProject);
         }
 
         [Fact]
@@ -75,7 +76,8 @@ namespace Google.Cloud.Storage.V1.Tests
                 IfGenerationMatch = 1L,
                 IfMetagenerationMatch = 2L,
                 PredefinedAcl = PredefinedObjectAcl.BucketOwnerRead,
-                Projection = Projection.Full
+                Projection = Projection.Full,
+                UserProject = "proj"
             };
             options.ModifyMediaUpload(upload);
             Assert.Equal(1L, upload.IfGenerationMatch);
@@ -84,6 +86,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(upload.IfMetagenerationNotMatch);
             Assert.Equal(PredefinedAclEnum.BucketOwnerRead, upload.PredefinedAcl);
             Assert.Equal(ProjectionEnum.Full, upload.Projection);
+            Assert.Equal("proj", upload.UserProject);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/CopyObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/CopyObjectOptions.cs
@@ -110,6 +110,13 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public EncryptionKey SourceEncryptionKey { get; set; }
 
+
+        /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
         internal void ModifyRequest(RewriteRequest request)
         {
             // Note the use of ArgumentException here, as this will basically be the result of invalid
@@ -177,6 +184,10 @@ namespace Google.Cloud.Storage.V1
             if (IfSourceMetagenerationNotMatch != null)
             {
                 request.IfSourceMetagenerationNotMatch = IfSourceMetagenerationNotMatch;
+            }
+            if (UserProject != null)
+            {
+                request.UserProject = UserProject;
             }
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DeleteBucketOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DeleteBucketOptions.cs
@@ -34,6 +34,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public long? IfMetagenerationNotMatch { get; set; }
 
+        /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
         internal void ModifyRequest(BucketsResource.DeleteRequest request)
         {
             if (IfMetagenerationMatch != null && IfMetagenerationNotMatch != null)
@@ -47,6 +53,10 @@ namespace Google.Cloud.Storage.V1
             if (IfMetagenerationNotMatch != null)
             {
                 request.IfMetagenerationNotMatch = IfMetagenerationNotMatch;
+            }
+            if (UserProject != null)
+            {
+                request.UserProject = UserProject;
             }
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DeleteObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DeleteObjectOptions.cs
@@ -52,6 +52,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public long? IfMetagenerationNotMatch { get; set; }
 
+        /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
         internal void ModifyRequest(ObjectsResource.DeleteRequest request)
         {
             // Note the use of ArgumentException here, as this will basically be the result of invalid
@@ -84,6 +90,10 @@ namespace Google.Cloud.Storage.V1
             if (IfMetagenerationNotMatch != null)
             {
                 request.IfMetagenerationNotMatch = IfMetagenerationNotMatch;
+            }
+            if (UserProject != null)
+            {
+                request.UserProject = UserProject;
             }
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DownloadObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DownloadObjectOptions.cs
@@ -67,6 +67,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public EncryptionKey EncryptionKey { get; set; }
 
+        /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
         internal void ModifyDownloader(MediaDownloader downloader)
         {
             if (ChunkSize != null)
@@ -103,10 +109,14 @@ namespace Google.Cloud.Storage.V1
             uri = MaybeAppendParameter(uri, "ifGenerationNotMatch", IfGenerationNotMatch);
             uri = MaybeAppendParameter(uri, "ifMetagenerationMatch", IfMetagenerationMatch);
             uri = MaybeAppendParameter(uri, "ifMetagenerationNotMatch", IfMetagenerationNotMatch);
+            uri = MaybeAppendParameter(uri, "userProject", UserProject);
             return uri;
         }
 
         private static string MaybeAppendParameter(string uri, string name, long? value) =>
             value == null ? uri : $"{uri}&{name}={value.Value.ToString(CultureInfo.InvariantCulture)}";
+
+        private static string MaybeAppendParameter(string uri, string name, string value) =>
+            value == null ? uri : $"{uri}&{name}={Uri.EscapeDataString(value)}";
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/GetBucketIamPolicyOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/GetBucketIamPolicyOptions.cs
@@ -21,8 +21,18 @@ namespace Google.Cloud.Storage.V1
     /// </summary>
     public sealed class GetBucketIamPolicyOptions
     {
+        /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
         internal void ModifyRequest(GetIamPolicyRequest request)
         {
+            if (UserProject != null)
+            {
+                request.UserProject = UserProject;
+            }
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/GetBucketOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/GetBucketOptions.cs
@@ -41,6 +41,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public Projection? Projection { get; set; }
 
+        /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
         internal void ModifyRequest(GetRequest request)
         {
             if (IfMetagenerationMatch != null && IfMetagenerationNotMatch != null)
@@ -59,6 +65,10 @@ namespace Google.Cloud.Storage.V1
             if (IfMetagenerationNotMatch != null)
             {
                 request.IfMetagenerationNotMatch = IfMetagenerationNotMatch;
+            }
+            if (UserProject != null)
+            {
+                request.UserProject = UserProject;
             }
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/GetObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/GetObjectOptions.cs
@@ -65,6 +65,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public EncryptionKey EncryptionKey { get; set; }
 
+        /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
         internal void ModifyRequest(GetRequest request)
         {
             // Note the use of ArgumentException here, as this will basically be the result of invalid
@@ -101,6 +107,10 @@ namespace Google.Cloud.Storage.V1
             if (Projection != null)
             {
                 request.Projection = GaxPreconditions.CheckEnumValue((ProjectionEnum) Projection, nameof(Projection));
+            }
+            if (UserProject != null)
+            {
+                request.UserProject = UserProject;
             }
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0-beta00</Version>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListObjectsOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListObjectsOptions.cs
@@ -52,6 +52,12 @@ namespace Google.Cloud.Storage.V1
         public Projection? Projection { get; set; }
 
         /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
+        /// <summary>
         /// Modifies the specified request for all non-null properties of this options object.
         /// </summary>
         /// <param name="request">The request to modify</param>
@@ -72,6 +78,10 @@ namespace Google.Cloud.Storage.V1
             if (Projection != null)
             {
                 request.Projection = GaxPreconditions.CheckEnumValue((ProjectionEnum) Projection, nameof(Projection));
+            }
+            if (UserProject != null)
+            {
+                request.UserProject = UserProject;
             }
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ModifyBucketLabelsOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ModifyBucketLabelsOptions.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Storage.V1
+{
+    /// <summary>
+    /// Options for operations which modify bucket labels.
+    /// </summary>
+    public sealed class ModifyBucketLabelsOptions
+    {
+        /// <summary>
+        /// Precondition for modification: the labels are only modified if its current
+        /// meta-generation matches the given value.
+        /// </summary>
+        public long? IfMetagenerationMatch { get; set; }
+
+        /// <summary>
+        /// The number of times to retry the modification if the bucket's metageneration changes
+        /// in the read/modify/write cycle. If this property is not set, a suitable default is used.
+        /// </summary>
+        /// <remarks>
+        /// Modifying bucket labels involves reading the bucket metadata in one request,
+        /// then sending another request with the new labels, including a metageneration check
+        /// to ensure that the bucket hasn't changed between the two requests. If the metageneration
+        /// *has* changed, the overall operation can be retried from the start. This property indicates
+        /// the number of retries, so it has a minimum value of 0.
+        /// </remarks>
+        public int? Retries { get; set; }
+
+        // Anything else?
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ModifyBucketLabelsOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ModifyBucketLabelsOptions.cs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax;
+using System;
+
 namespace Google.Cloud.Storage.V1
 {
     /// <summary>
@@ -20,14 +23,22 @@ namespace Google.Cloud.Storage.V1
     public sealed class ModifyBucketLabelsOptions
     {
         /// <summary>
+        /// The default number of retries.
+        /// </summary>
+        internal const int DefaultRetries = 3;
+
+        /// <summary>
         /// Precondition for modification: the labels are only modified if its current
         /// meta-generation matches the given value.
         /// </summary>
         public long? IfMetagenerationMatch { get; set; }
 
+        private int? _retries;
+
         /// <summary>
         /// The number of times to retry the modification if the bucket's metageneration changes
         /// in the read/modify/write cycle. If this property is not set, a suitable default is used.
+        /// The value must not be negative.
         /// </summary>
         /// <remarks>
         /// Modifying bucket labels involves reading the bucket metadata in one request,
@@ -36,8 +47,18 @@ namespace Google.Cloud.Storage.V1
         /// *has* changed, the overall operation can be retried from the start. This property indicates
         /// the number of retries, so it has a minimum value of 0.
         /// </remarks>
-        public int? Retries { get; set; }
-
-        // Anything else?
+        public int? Retries
+        {
+            get => _retries;
+            set
+            {
+                if (value < 0) // False for null implicitly
+                {
+                    // Simplest way to get the right exception...
+                    GaxPreconditions.CheckArgumentRange(value.Value, nameof(value), 0, int.MaxValue);
+                }
+                _retries = value;
+            }
+        }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/PatchBucketOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/PatchBucketOptions.cs
@@ -51,6 +51,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public PredefinedObjectAcl? PredefinedDefaultObjectAcl { get; set; }
 
+        /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
         internal void ModifyRequest(PatchRequest request)
         {
             if (IfMetagenerationMatch != null && IfMetagenerationNotMatch != null)
@@ -79,6 +85,10 @@ namespace Google.Cloud.Storage.V1
             {
                 request.PredefinedDefaultObjectAcl =
                     GaxPreconditions.CheckEnumValue((PredefinedDefaultObjectAclEnum) PredefinedDefaultObjectAcl, nameof(PredefinedDefaultObjectAcl));
+            }
+            if (UserProject != null)
+            {
+                request.UserProject = UserProject;
             }
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/PatchObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/PatchObjectOptions.cs
@@ -69,6 +69,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public EncryptionKey EncryptionKey { get; set; }
 
+        /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
         internal void ModifyRequest(PatchRequest request)
         {
             // Note the use of ArgumentException here, as this will basically be the result of invalid
@@ -110,6 +116,10 @@ namespace Google.Cloud.Storage.V1
             {
                 request.PredefinedAcl =
                     GaxPreconditions.CheckEnumValue((PredefinedAclEnum) PredefinedAcl, nameof(PredefinedAcl));
+            }
+            if (UserProject != null)
+            {
+                request.UserProject = UserProject;
             }
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/SetBucketIamPolicyOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/SetBucketIamPolicyOptions.cs
@@ -21,8 +21,18 @@ namespace Google.Cloud.Storage.V1
     /// </summary>
     public sealed class SetBucketIamPolicyOptions
     {
+        /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
         internal void ModifyRequest(SetIamPolicyRequest request)
         {
+            if (UserProject != null)
+            {
+                request.UserProject = UserProject;
+            }
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.ModifyBucketLabels.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.ModifyBucketLabels.cs
@@ -15,6 +15,8 @@
 using Google.Api.Gax;
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Google.Cloud.Storage.V1
 {
@@ -82,6 +84,91 @@ namespace Google.Cloud.Storage.V1
         public virtual IDictionary<string, string> ModifyBucketLabels(string bucket, IDictionary<string, string> labels, ModifyBucketLabelsOptions options = null) =>
             throw new NotImplementedException();
 
-        // TODO: Async equivalents
+        /// <summary>
+        /// Clears all labels on a bucket.
+        /// </summary>
+        /// <param name="bucket">The name of the bucket. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>A dictionary with the labels on the bucket before they were cleared.</returns>
+        public virtual IDictionary<string, string> ClearBucketLabels(string bucket, ModifyBucketLabelsOptions options = null) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Sets the value for a single label on a bucket asynchronously. The label will be added if it does
+        /// not exist, or updated if it already exists.
+        /// </summary>
+        /// <remarks>
+        /// This method is implemented by creating a single-element dictionary which is passed to
+        /// <see cref="ModifyBucketLabelsAsync(string, IDictionary{string, string}, ModifyBucketLabelsOptions, CancellationToken)"/>.
+        /// </remarks>
+        /// <param name="bucket">The name of the bucket. Must not be null.</param>
+        /// <param name="labelName">The name of the label to set. Must not be null.</param>
+        /// <param name="labelValue">The value of the label to set. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The previous value of the label, or null if the label did not previously exist.</returns>
+        public virtual async Task<string> SetBucketLabelAsync(string bucket, string labelName, string labelValue, ModifyBucketLabelsOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            StorageClientImpl.ValidateBucketName(bucket);
+            GaxPreconditions.CheckNotNull(labelName, nameof(labelName));
+            GaxPreconditions.CheckNotNull(labelValue, nameof(labelValue));
+            var newLabels = new Dictionary<string, string> { [labelName] = labelValue };
+            var oldLabels = await ModifyBucketLabelsAsync(bucket, newLabels, options, cancellationToken).ConfigureAwait(false);
+            return oldLabels[labelName];
+        }
+
+        /// <summary>
+        /// Removes a label from a bucket, if it previously existed, asynchronously. It is not an error to
+        /// attempt to remove a label that doesn't already exist.
+        /// </summary>
+        /// <remarks>
+        /// This method is implemented by creating a single-element dictionary which is passed to
+        /// <see cref="ModifyBucketLabelsAsync(string, IDictionary{string, string}, ModifyBucketLabelsOptions, CancellationToken)"/>.
+        /// </remarks>
+        /// <param name="bucket">The name of the bucket. Must not be null.</param>
+        /// <param name="labelName">The name of the label to remove. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The previous value of the label, or null if the label did not previously exist.</returns>
+        public virtual async Task<string> RemoveBucketLabelAsync(string bucket, string labelName, ModifyBucketLabelsOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            StorageClientImpl.ValidateBucketName(bucket);
+            GaxPreconditions.CheckNotNull(labelName, nameof(labelName));
+            var newLabels = new Dictionary<string, string> { [labelName] = null };
+            var oldLabels = await ModifyBucketLabelsAsync(bucket, newLabels, options).ConfigureAwait(false);
+            return oldLabels[labelName];
+        }
+
+        /// <summary>
+        /// Sets or removes one or more labels on a bucket asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// Each entry in <paramref name="labels"/> is treated as a label to set or remove. If the value is null,
+        /// it will be removed from the bucket; otherwise, it will be set/added. Labels which do not have an entry
+        /// in the dictionary will be ignored.
+        /// </remarks>
+        /// <param name="bucket">The name of the bucket. Must not be null.</param>
+        /// <param name="labels">The labels to set. Must contain at least one entry; keys must not be null, but values
+        /// may be (indicating label removal).</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A dictionary with the same keys as <paramref name="labels"/>, and values indicating the corresponding label value
+        /// before this operation completed. Labels which weren't present on the bucket before the modification have corresponding
+        /// null values in the returned dictionary.</returns>
+        public virtual Task<IDictionary<string, string>> ModifyBucketLabelsAsync(
+            string bucket, IDictionary<string, string> labels,
+            ModifyBucketLabelsOptions options = null,
+            CancellationToken cancellationToken = default(CancellationToken)) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Clears all labels on a bucket asynchronously.
+        /// </summary>
+        /// <param name="bucket">The name of the bucket. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A dictionary with the labels on the bucket before they were cleared.</returns>
+        public virtual IDictionary<string, string> ClearBucketLabelsAsync(string bucket, ModifyBucketLabelsOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            throw new NotImplementedException();
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.ModifyBucketLabels.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.ModifyBucketLabels.cs
@@ -135,7 +135,7 @@ namespace Google.Cloud.Storage.V1
             StorageClientImpl.ValidateBucketName(bucket);
             GaxPreconditions.CheckNotNull(labelName, nameof(labelName));
             var newLabels = new Dictionary<string, string> { [labelName] = null };
-            var oldLabels = await ModifyBucketLabelsAsync(bucket, newLabels, options).ConfigureAwait(false);
+            var oldLabels = await ModifyBucketLabelsAsync(bucket, newLabels, options, cancellationToken).ConfigureAwait(false);
             return oldLabels[labelName];
         }
 
@@ -168,7 +168,7 @@ namespace Google.Cloud.Storage.V1
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A dictionary with the labels on the bucket before they were cleared.</returns>
-        public virtual IDictionary<string, string> ClearBucketLabelsAsync(string bucket, ModifyBucketLabelsOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+        public virtual Task<IDictionary<string, string>> ClearBucketLabelsAsync(string bucket, ModifyBucketLabelsOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
             throw new NotImplementedException();
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.ModifyBucketLabels.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.ModifyBucketLabels.cs
@@ -1,0 +1,87 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System;
+using System.Collections.Generic;
+
+namespace Google.Cloud.Storage.V1
+{
+    public abstract partial class StorageClient
+    {
+        /// <summary>
+        /// Sets the value for a single label on a bucket. The label will be added if it does
+        /// not exist, or updated if it already exists.
+        /// </summary>
+        /// <remarks>
+        /// This method is implemented by creating a single-element dictionary which is passed to
+        /// <see cref="ModifyBucketLabels(string, IDictionary{string, string}, ModifyBucketLabelsOptions)"/>.
+        /// </remarks>
+        /// <param name="bucket">The name of the bucket. Must not be null.</param>
+        /// <param name="labelName">The name of the label to set. Must not be null.</param>
+        /// <param name="labelValue">The value of the label to set. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The previous value of the label, or null if the label did not previously exist.</returns>
+        public virtual string SetBucketLabel(string bucket, string labelName, string labelValue, ModifyBucketLabelsOptions options = null)
+        {
+            StorageClientImpl.ValidateBucketName(bucket);
+            GaxPreconditions.CheckNotNull(labelName, nameof(labelName));
+            GaxPreconditions.CheckNotNull(labelValue, nameof(labelValue));
+            var newLabels = new Dictionary<string, string> { [labelName] = labelValue };
+            var oldLabels = ModifyBucketLabels(bucket, newLabels, options);
+            return oldLabels[labelName];
+        }
+
+        /// <summary>
+        /// Removes a label from a bucket, if it previously existed. It is not an error to
+        /// attempt to remove a label that doesn't already exist.
+        /// </summary>
+        /// <remarks>
+        /// This method is implemented by creating a single-element dictionary which is passed to
+        /// <see cref="ModifyBucketLabels(string, IDictionary{string, string}, ModifyBucketLabelsOptions)"/>.
+        /// </remarks>
+        /// <param name="bucket">The name of the bucket. Must not be null.</param>
+        /// <param name="labelName">The name of the label to remove. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The previous value of the label, or null if the label did not previously exist.</returns>
+        public virtual string RemoveBucketLabel(string bucket, string labelName, ModifyBucketLabelsOptions options = null)
+        {
+            StorageClientImpl.ValidateBucketName(bucket);
+            GaxPreconditions.CheckNotNull(labelName, nameof(labelName));
+            var newLabels = new Dictionary<string, string> { [labelName] = null };
+            var oldLabels = ModifyBucketLabels(bucket, newLabels, options);
+            return oldLabels[labelName];
+        }
+
+        /// <summary>
+        /// Sets or removes one or more labels on a bucket.
+        /// </summary>
+        /// <remarks>
+        /// Each entry in <paramref name="labels"/> is treated as a label to set or remove. If the value is null,
+        /// it will be removed from the bucket; otherwise, it will be set/added. Labels which do not have an entry
+        /// in the dictionary will be ignored.
+        /// </remarks>
+        /// <param name="bucket">The name of the bucket. Must not be null.</param>
+        /// <param name="labels">The labels to set. Must contain at least one entry; keys must not be null, but values
+        /// may be (indicating label removal).</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>A dictionary with the same keys as <paramref name="labels"/>, and values indicating the corresponding label value
+        /// before this operation completed. Labels which weren't present on the bucket before the modification have corresponding
+        /// null values in the returned dictionary.</returns>
+        public virtual IDictionary<string, string> ModifyBucketLabels(string bucket, IDictionary<string, string> labels, ModifyBucketLabelsOptions options = null) =>
+            throw new NotImplementedException();
+
+        // TODO: Async equivalents
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.ModifyBucketLabels.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.ModifyBucketLabels.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Google.Cloud.Storage.V1
+{
+    public sealed partial class StorageClientImpl
+    {
+        /// <inheritdoc />
+        public override IDictionary<string, string> ModifyBucketLabels(string bucket, IDictionary<string, string> labels, ModifyBucketLabelsOptions options = null)
+        {
+            // TODO: Implement:
+            // - Fetch bucket with GetBucket
+            // - Modify the in-memory dictionary (and remember old values)
+            // - Call PatchBucket pass in the metageneration
+            // - Repeat from scratch up to N times as per options if we get conflicts.
+
+            // In theory, many label modifications could be performed with just a single call rather than
+            // read-modify-write, but:
+            // - Always doing a read-modify-write simplifies the code
+            // - This way we get to return the previous values as well
+            throw new NotImplementedException();
+        }
+
+        // TODO: Async
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.ModifyBucketLabels.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.ModifyBucketLabels.cs
@@ -14,6 +14,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Google.Cloud.Storage.V1
 {
@@ -35,6 +37,25 @@ namespace Google.Cloud.Storage.V1
             throw new NotImplementedException();
         }
 
-        // TODO: Async
+        /// <inheritdoc />
+        public override IDictionary<string, string> ClearBucketLabels(string bucket, ModifyBucketLabelsOptions options = null)
+        {
+            // TODO: Implement
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override Task<IDictionary<string, string>> ModifyBucketLabelsAsync(string bucket, IDictionary<string, string> labels, ModifyBucketLabelsOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // TODO: Implement
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override IDictionary<string, string> ClearBucketLabelsAsync(string bucket, ModifyBucketLabelsOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // TODO: Implement
+            throw new NotImplementedException();
+        }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/TestBucketIamPermissionsOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/TestBucketIamPermissionsOptions.cs
@@ -21,8 +21,18 @@ namespace Google.Cloud.Storage.V1
     /// </summary>
     public sealed class TestBucketIamPermissionsOptions
     {
+        /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
         internal void ModifyRequest(TestIamPermissionsRequest request)
         {
+            if (UserProject != null)
+            {
+                request.UserProject = UserProject;
+            }
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UpdateBucketOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UpdateBucketOptions.cs
@@ -59,6 +59,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public bool? ForceNoPreconditions { get; set; }
 
+        /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
         private bool AnyExplicitPreconditions => IfMetagenerationMatch != null || IfMetagenerationNotMatch != null;
 
         internal void ModifyRequest(UpdateRequest request, Bucket bucket)
@@ -100,6 +106,10 @@ namespace Google.Cloud.Storage.V1
             {
                 request.PredefinedDefaultObjectAcl =
                     GaxPreconditions.CheckEnumValue((PredefinedDefaultObjectAclEnum) PredefinedDefaultObjectAcl, nameof(PredefinedDefaultObjectAcl));
+            }
+            if (UserProject != null)
+            {
+                request.UserProject = UserProject;
             }
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UpdateObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UpdateObjectOptions.cs
@@ -77,6 +77,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public EncryptionKey EncryptionKey { get; set; }
 
+        /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
         private bool AnyExplicitPreconditions =>
             IfGenerationMatch != null || IfGenerationNotMatch != null || IfMetagenerationMatch != null || IfMetagenerationNotMatch != null;
 
@@ -133,6 +139,10 @@ namespace Google.Cloud.Storage.V1
             {
                 request.PredefinedAcl =
                     GaxPreconditions.CheckEnumValue((PredefinedAclEnum) PredefinedAcl, nameof(PredefinedAcl));
+            }
+            if (UserProject != null)
+            {
+                request.UserProject = UserProject;
             }
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UploadObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UploadObjectOptions.cs
@@ -91,6 +91,12 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public EncryptionKey EncryptionKey { get; set; }
 
+        /// <summary>
+        /// If set, this is the ID of the project which will be billed for the request, for requester-pays buckets.
+        /// The caller must have suitable permissions for the project being billed.
+        /// </summary>
+        public string UserProject { get; set; }
+
         internal void ModifyMediaUpload(InsertMediaUpload upload)
         {
             // Note the use of ArgumentException here, as this will basically be the result of invalid
@@ -132,6 +138,10 @@ namespace Google.Cloud.Storage.V1
             if (Projection != null)
             {
                 upload.Projection = GaxPreconditions.CheckEnumValue((ProjectionEnum) Projection, nameof(Projection));
+            }
+            if (UserProject != null)
+            {
+                upload.UserProject = UserProject;
             }
         }
     }

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -288,7 +288,7 @@
 
   {
     "id": "Google.Cloud.Storage.V1",
-    "version": "2.0.0",
+    "version": "2.1.0-beta00",
     "type": "rest",
     "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
     "dependencies": {


### PR DESCRIPTION
This merges the storage-requester-pays and storage-labels branches into master, and updates the version number for Storage to 2.1-beta00.

Let me know if you'd rather I merge each feature in individually.