### PR TITLE
Update release tagging

### DIFF
--- a/tagreleases.sh
+++ b/tagreleases.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e 
+
+if [ -z "$1" ]
+then
+  echo Please specify a github access token
+  exit 1
+fi
+
+dotnet restore tools > /dev/null
+dotnet run -p tools/Google.Cloud.Tools.TagReleases/Google.Cloud.Tools.TagReleases.csproj $1

--- a/tools/Google.Cloud.Tools.TagReleases/Program.cs
+++ b/tools/Google.Cloud.Tools.TagReleases/Program.cs
@@ -64,16 +64,22 @@ namespace Google.Cloud.Tools.TagReleases
             var tags = (await client.Repository.GetAllTags(RepositoryOwner, RepositoryName)).Select(tag => tag.Name);
 
             var apis = LoadApis();
-            var noChange = apis.Where(api => tags.Contains($"{api.Id}-{api.Version}")).ToList();
+            var noChange = apis.Where(api => tags.Contains($"{api.Id}-{api.Version}") || api.Version.EndsWith("00")).ToList();
             var changed = apis.Except(noChange).ToList();
 
-            Console.WriteLine("APIs already tagged at current version:");
+            Console.WriteLine("APIs already tagged at current version (or not ready for release):");
             noChange.ForEach(Console.WriteLine);
             Console.WriteLine();
             Console.WriteLine("APIs requiring a new release:");
             changed.ForEach(Console.WriteLine);
 
             Console.WriteLine();
+
+            if (!changed.Any())
+            {
+                Console.WriteLine("No releases need to be created. Exiting.");
+                return;
+            }
 
             Console.WriteLine("Go ahead and create releases? (y/n)");
             string response = Console.ReadLine();


### PR DESCRIPTION
- Ignore version numbers ending with 00. This is for alpha00 etc
  which are preparing for a later release.
- Add a shell script to make it easier to run