### PR TITLE
Code fix for the omitted argument analyzer

### DIFF
--- a/tools/Google.Cloud.Tools.Analyzers/InternalOptionalParametersRequiredAnalyzer.cs
+++ b/tools/Google.Cloud.Tools.Analyzers/InternalOptionalParametersRequiredAnalyzer.cs
@@ -86,13 +86,13 @@ namespace Google.Cloud.Tools.Analyzers
             }
         }
 
-        internal static List<ISymbol> GetVariablesInScope(SyntaxNode syntaxNode, SemanticModel semanticModel) =>
-            (from symbol in semanticModel.LookupSymbols(syntaxNode.SpanStart)
-             where symbol.Kind == SymbolKind.Local || symbol.Kind == SymbolKind.Parameter
-             select symbol).ToList();
+        internal static IEnumerable<ISymbol> GetVariablesInScope(SyntaxNode syntaxNode, SemanticModel semanticModel) =>
+            from symbol in semanticModel.LookupSymbols(syntaxNode.SpanStart)
+            where symbol.Kind == SymbolKind.Local || symbol.Kind == SymbolKind.Parameter
+            select symbol;
 
         internal static ISymbol TryGetVariableForArgument(
-            IParameterSymbol parameter, Compilation compilation, List<ISymbol> variablesInScope)
+            IParameterSymbol parameter, Compilation compilation, IEnumerable<ISymbol> variablesInScope)
         {
             var parameterType = parameter.Type;
             var convertibleVariables = variablesInScope.Where(

--- a/tools/Google.Cloud.Tools.Analyzers/InternalOptionalParametersRequiredAnalyzer.cs
+++ b/tools/Google.Cloud.Tools.Analyzers/InternalOptionalParametersRequiredAnalyzer.cs
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Semantics;
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 
 namespace Google.Cloud.Tools.Analyzers
 {
@@ -28,7 +29,7 @@ namespace Google.Cloud.Tools.Analyzers
     /// but only when there is a suitable local variable or parameter available in scope which can be used for the argument.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class InternalOptionalParametersRequired : DiagnosticAnalyzer
+    public class InternalOptionalParametersRequiredAnalyzer : DiagnosticAnalyzer
     {
         public const string DiagnosticId = "GCP0001";
         private const string Category = "Usage";
@@ -53,8 +54,6 @@ namespace Google.Cloud.Tools.Analyzers
 
         private static void AnalyzeInvocation(OperationAnalysisContext context)
         {
-            // TODO: Move some of this to a helper and share with a code fix provider to auto-insert the missing argument.
-
             // Only perform the check on calls to externally visible methods which are defined within the same assembly.
             var invocation = (IInvocationExpression)context.Operation;
             if (invocation.Syntax is InvocationExpressionSyntax invocationExpression &&
@@ -62,10 +61,7 @@ namespace Google.Cloud.Tools.Analyzers
                 context.Compilation.Assembly == invocation.TargetMethod.ContainingAssembly)
             {
                 var semanticModel = context.Compilation.GetSemanticModel(context.Operation.Syntax.SyntaxTree);
-                var variablesInScope =
-                    (from symbol in semanticModel.LookupSymbols(context.Operation.Syntax.SpanStart)
-                     where symbol.Kind == SymbolKind.Local || symbol.Kind == SymbolKind.Parameter
-                     select symbol).ToList();
+                var variablesInScope = GetVariablesInScope(context.Operation.Syntax, semanticModel);
 
                 foreach (var arg in invocation.ArgumentsInParameterOrder)
                 {
@@ -74,29 +70,12 @@ namespace Google.Cloud.Tools.Analyzers
                         continue;
                     }
 
-                    var parameterType = arg.Parameter.Type;
-                    var convertibleVariables = variablesInScope.Where(
-                        symbol => context.Compilation.ClassifyConversion(symbol.GetVariableType(), parameterType).IsImplicit).ToList();
-                    if (convertibleVariables.Count == 0)
+                    var preferredVariable = TryGetVariableForArgument(arg.Parameter, context.Compilation, variablesInScope);
+                    if (preferredVariable == null)
                     {
                         continue;
                     }
 
-                    var nameMatch = convertibleVariables.FirstOrDefault(
-                        symbol => symbol.Name.Equals(arg.Parameter.Name, StringComparison.OrdinalIgnoreCase));
-
-                    // If the parameter's type is String or any primitive type, only show the diagnostic when there is
-                    // some variable with the same (case-insensitive) name as the argument. Strings are too common, for
-                    // example, to assume that any string in scope should be supplied for a default parameter.
-                    if ((parameterType.SpecialType == SpecialType.System_String || parameterType.IsPrimitive()) &&
-                        nameMatch == null)
-                    {
-                        continue;
-                    }
-
-                    // Report the missing argument with a suggested variable to be used. Prefer one with a name matching
-                    // the missing parameter's name if available.
-                    var preferredVariable = nameMatch ?? convertibleVariables[0];
                     context.ReportDiagnostic(
                         Diagnostic.Create(
                             Rule,
@@ -105,6 +84,39 @@ namespace Google.Cloud.Tools.Analyzers
                             preferredVariable.Name));
                 }
             }
+        }
+
+        internal static List<ISymbol> GetVariablesInScope(SyntaxNode syntaxNode, SemanticModel semanticModel) =>
+            (from symbol in semanticModel.LookupSymbols(syntaxNode.SpanStart)
+             where symbol.Kind == SymbolKind.Local || symbol.Kind == SymbolKind.Parameter
+             select symbol).ToList();
+
+        internal static ISymbol TryGetVariableForArgument(
+            IParameterSymbol parameter, Compilation compilation, List<ISymbol> variablesInScope)
+        {
+            var parameterType = parameter.Type;
+            var convertibleVariables = variablesInScope.Where(
+                symbol => compilation.ClassifyConversion(symbol.GetVariableType(), parameterType).IsImplicit).ToList();
+            if (convertibleVariables.Count == 0)
+            {
+                return null;
+            }
+
+            var nameMatch = convertibleVariables.FirstOrDefault(
+                symbol => symbol.Name.Equals(parameter.Name, StringComparison.OrdinalIgnoreCase));
+
+            // If the parameter's type is String or any primitive type, only show the diagnostic when there is
+            // some variable with the same (case-insensitive) name as the argument. Strings are too common, for
+            // example, to assume that any string in scope should be supplied for a default parameter.
+            if ((parameterType.SpecialType == SpecialType.System_String || parameterType.IsPrimitive()) &&
+                nameMatch == null)
+            {
+                return null;
+            }
+
+            // Report the missing argument with a suggested variable to be used. Prefer one with a name matching
+            // the missing parameter's name if available.
+            return nameMatch ?? convertibleVariables[0];
         }
     }
 }

--- a/tools/Google.Cloud.Tools.Analyzers/InternalOptionalParametersRequiredCodeFixProvider.cs
+++ b/tools/Google.Cloud.Tools.Analyzers/InternalOptionalParametersRequiredCodeFixProvider.cs
@@ -1,0 +1,115 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Semantics;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Tools.Analyzers
+{
+    /// <summary>
+    /// Code fix provider for the <see cref="InternalOptionalParametersRequiredAnalyzer"/>.
+    /// </summary>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(InternalOptionalParametersRequiredCodeFixProvider)), Shared]
+    public class InternalOptionalParametersRequiredCodeFixProvider : CodeFixProvider
+    {
+        private const string Title = "Insert optional arguments";
+
+        public sealed override ImmutableArray<string> FixableDiagnosticIds
+        {
+            get { return ImmutableArray.Create(InternalOptionalParametersRequiredAnalyzer.DiagnosticId); }
+        }
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var document = context.Document;
+            var semanticModel = await document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+            var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            var argumentListExpression =
+                root.FindToken(context.Span.Start).Parent.AncestorsAndSelf().OfType<ArgumentListSyntax>().FirstOrDefault();
+            if (argumentListExpression == null)
+            {
+                return;
+            }
+
+            var invocation =
+                semanticModel.GetOperation(argumentListExpression, context.CancellationToken) as IInvocationExpression;
+            if (invocation == null)
+            {
+                return;
+            }
+
+            var variablesInScope =
+                InternalOptionalParametersRequiredAnalyzer.GetVariablesInScope(argumentListExpression, semanticModel);
+
+            var omittedParameterVariablePairs = new List<Tuple<IParameterSymbol, ISymbol>>();
+            bool useNamedArguments = false;
+            foreach (var argument in invocation.ArgumentsInParameterOrder)
+            {
+                switch (argument.ArgumentKind)
+                {
+                    case ArgumentKind.Positional:
+                        break;
+                    case ArgumentKind.Named:
+                        useNamedArguments = true;
+                        break;
+                    case ArgumentKind.DefaultValue:
+                        {
+                            var preferredVariable = InternalOptionalParametersRequiredAnalyzer.TryGetVariableForArgument(
+                                argument.Parameter, semanticModel.Compilation, variablesInScope);
+                            if (preferredVariable == null)
+                            {
+                                return;
+                            }
+                            omittedParameterVariablePairs.Add(Tuple.Create(argument.Parameter, preferredVariable));
+                            break;
+                        }
+                    default:
+                        return;
+                }
+            }
+
+            var generator = SyntaxGenerator.GetGenerator(document);
+            var newArguments = omittedParameterVariablePairs.Select(
+                entry => (ArgumentSyntax)generator.Argument(
+                    useNamedArguments ? entry.Item1.Name : null,
+                    RefKind.None,
+                    generator.IdentifierName(entry.Item2.Name))).ToArray();
+            var newDocument = document.WithSyntaxRoot(
+                root.ReplaceNode(argumentListExpression, argumentListExpression.AddArguments(newArguments)));
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: Title,
+                    createChangedDocument: c => Task.FromResult(newDocument),
+                    equivalenceKey: Title),
+                context.Diagnostics);
+        }
+    }
+}


### PR DESCRIPTION
Unfortunately, the code fixes don't seem to be available with the new style projects. I believe it is this issue: https://github.com/dotnet/project-system/issues/285 since all symptoms of that bug can be seen in this repo's main projects. It is already fixed, so we just need to wait until that becomes available to take advantage of this code fix.