### PR TITLE
Update to docfx 2.19.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   # Download and unpack docfx
   - mkdir docfx
   - cd docfx
-  - curl -SL https://github.com/dotnet/docfx/releases/download/v2.16/docfx.zip -o docfx.zip
+  - curl -SL https://github.com/dotnet/docfx/releases/download/v2.19.2/docfx.zip -o docfx.zip
   - unzip docfx.zip
   - cd ..
   # add dotnet and docfx to PATH


### PR DESCRIPTION
I've validated that this builds the docs with no problems, but I'm
not replacing the currently-deployed docs.