### PR TITLE
Update fetchdependencies.sh for new code layout

### DIFF
--- a/docs/fetchdependencies.sh
+++ b/docs/fetchdependencies.sh
@@ -13,7 +13,7 @@ git -C dependencies checkout README.md .gitignore
 echo "Cloning repositories"
 git clone https://github.com/googleapis/gax-dotnet dependencies/gax-dotnet --quiet --depth=1 -b master
 git clone https://github.com/google/protobuf dependencies/protobuf --quiet --depth=1 -b 3.3.x
-git clone https://github.com/grpc/grpc dependencies/grpc --quiet --depth=1 -b v1.3.x
+git clone https://github.com/grpc/grpc dependencies/grpc --quiet --depth=1 -b v1.4.x
 git clone https://github.com/google/google-api-dotnet-client dependencies/google-api-dotnet-client --quiet --depth=1 -b master
 
 # Minor fixups...
@@ -28,10 +28,26 @@ cp dependencies-docfx/docfx-grpc.json dependencies/grpc/docfx.json
 cp dependencies-docfx/docfx-google-api-dotnet-client.json dependencies/google-api-dotnet-client/docfx.json
 
 # Restore packages and build metadata
-(cd dependencies/gax-dotnet; dotnet restore Gax.sln; docfx metadata)
-(cd dependencies/protobuf; echo '{"sdk": {"version": "1.0.0-preview2-003131"}}' > global.json && dotnet restore csharp/src; docfx metadata)
-(cd dependencies/grpc; dotnet restore src/csharp/Grpc.sln; docfx metadata)
-(cd dependencies/google-api-dotnet-client; rm NuGet.config; dotnet restore Src/Support/GoogleApisClient.sln; dotnet restore Generated.sln; docfx metadata)
+(cd dependencies/gax-dotnet; 
+ dotnet restore Gax.sln;
+ docfx metadata)
+
+(cd dependencies/protobuf;
+ echo '{"sdk": {"version": "1.0.0-preview2-003131"}}' > global.json;
+ dotnet restore csharp/src;
+ docfx metadata)
+
+(cd dependencies/grpc; 
+ dotnet restore src/csharp/Grpc.sln;
+ docfx metadata)
+
+(cd dependencies/google-api-dotnet-client;
+ rm NuGet.config;
+ dotnet restore Src/Support/GoogleApisClient.sln;
+ dotnet new sln --name Generated;
+ dotnet sln Generated.sln add Src/Generated/*/*.csproj;
+ dotnet restore Generated.sln;
+ docfx metadata)
 
 # Copy the metadata into a single api directory, one subdirectory per package
 mkdir dependencies/api


### PR DESCRIPTION
This now pulls gRPC 1.4, and handles the lack of a `Generated.sln` in google-api-dotnet-client.

The rest is just reformatting.