### PR TITLE
Downgrade docfx to 2.18.5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   # Download and unpack docfx
   - mkdir docfx
   - cd docfx
-  - curl -SL https://github.com/dotnet/docfx/releases/download/v2.19.2/docfx.zip -o docfx.zip
+  - curl -SL https://github.com/dotnet/docfx/releases/download/v2.18.5/docfx.zip -o docfx.zip
   - unzip docfx.zip
   - cd ..
   # add dotnet and docfx to PATH


### PR DESCRIPTION
This is until https://github.com/dotnet/docfx/issues/1823 is fixed

While 2.19.2 generated correct documentation, I suspect it was
generating rather too much. (Discovered when updating the dependencies
branch.)