### PR TITLE
ClientPool and SessionPool unit tests (including some individual stre…

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/StressTestBase.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/StressTestBase.cs
@@ -85,11 +85,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         protected static void ValidatePoolInfo()
         {
             StringBuilder s = new StringBuilder();
-            Assert.InRange(SessionPool.GetPoolInfo(s), 0, 1);
+            Assert.InRange(SessionPool.Default.GetPoolInfo(s), 0, 1);
             Logger.Instance.Info(s.ToString());
 
             s.Clear();
-            Assert.Equal(0, ClientPool.GetPoolInfo(s));
+            Assert.Equal(0, ClientPool.Default.GetPoolInfo(s));
             Logger.Instance.Info(s.ToString());
         }
     }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/ClientPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/ClientPoolTests.cs
@@ -1,0 +1,169 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Google.Cloud.Spanner.V1;
+using Google.Cloud.Spanner.V1.Logging;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Google.Cloud.Spanner.Data.Tests
+{
+    public class ClientPoolTests
+    {
+        public ClientPoolTests(ITestOutputHelper outputHelper)
+        {
+            TestLogger.TestOutputHelper = outputHelper;
+            TestLogger.Install();
+            Logger.LogLevel = V1.Logging.LogLevel.Debug;
+        }
+
+        private static MockClientFactory SetupMockClientFactory(Mock<SpannerClient> firstClient = null)
+        {
+            if (firstClient == null)
+            {
+                firstClient = new Mock<SpannerClient>();
+            }
+            return new MockClientFactory(firstClient.Object);
+        }
+
+        private static async Task<SpannerClient> GetSpannerClientAsync(ClientPool pool)
+        {
+            //immediately yield to increase contention for stress testing.
+            await Task.Yield();
+            return await pool.AcquireClientAsync();
+        }
+
+        [Fact]
+        public async Task ClientsCreatedOnDemandAsync()
+        {
+            //SpannerClients should not be precreated, but be created lazily.
+            var mockClientFactory = SetupMockClientFactory();
+
+            var testPool = new ClientPool(mockClientFactory);
+            var clientAcquired = await testPool.AcquireClientAsync();
+            testPool.ReleaseClient(clientAcquired);
+
+            Assert.Equal(1, mockClientFactory.Invocations);
+            var s = new StringBuilder();
+            Assert.Equal(0, testPool.GetPoolInfo(s));
+            Logger.Instance.Info(s.ToString());
+        }
+
+        [Fact]
+        public async Task ConcurrencyStress()
+        {
+            const int multiplier = 10;
+            var mockClientFactory = SetupMockClientFactory();
+
+            //A mini stress test that hits the client pool with multiple concurrent client requests.
+            var concurrentQueries = new List<Task<SpannerClient>>();
+            var testPool = new ClientPool(mockClientFactory);
+
+            for (var i = 0; i < SpannerOptions.Instance.MaximumGrpcChannels * multiplier; i++)
+            {
+                concurrentQueries.Add(GetSpannerClientAsync(testPool));
+            }
+
+            await Task.WhenAll(concurrentQueries);
+            Assert.Equal(SpannerOptions.Instance.MaximumGrpcChannels, mockClientFactory.Invocations);
+
+            var grouping = concurrentQueries.GroupBy(x => x.Result).ToList();
+            Assert.Equal(SpannerOptions.Instance.MaximumGrpcChannels, grouping.Count);
+            foreach (var group in grouping)
+            {
+                Assert.Equal(multiplier, group.Count());
+            }
+
+            foreach (var client in concurrentQueries.Select(x => x.Result))
+            {
+                testPool.ReleaseClient(client);
+            }
+            var s = new StringBuilder();
+            Assert.Equal(0, testPool.GetPoolInfo(s));
+            Logger.Instance.Info(s.ToString());
+        }
+
+        [Fact]
+        public async Task RoundRobin()
+        {
+            var mockClientFactory = SetupMockClientFactory();
+
+            var testPool = new ClientPool(mockClientFactory);
+
+            var clientList = new List<SpannerClient>();
+            for (var i = 0; i < SpannerOptions.Instance.MaximumGrpcChannels; i++)
+            {
+                var newClient = await testPool.AcquireClientAsync();
+                Assert.False(clientList.Contains(newClient));
+                clientList.Add(newClient);
+            }
+
+            //now we wrap around.
+            var firstReusedClient = await testPool.AcquireClientAsync();
+            Assert.Same(clientList[0], firstReusedClient);
+            testPool.ReleaseClient(firstReusedClient);
+
+            foreach (var client in clientList)
+            {
+                testPool.ReleaseClient(client);
+            }
+            var s = new StringBuilder();
+            Assert.Equal(0, testPool.GetPoolInfo(s));
+            Logger.Instance.Info(s.ToString());
+
+            //now that everything got released, lets ensure the client order is preserved so
+            //that we again get the first client.
+            Assert.Same(firstReusedClient, await testPool.AcquireClientAsync());
+            testPool.ReleaseClient(firstReusedClient);
+
+            Assert.Equal(SpannerOptions.Instance.MaximumGrpcChannels, mockClientFactory.Invocations);
+        }
+
+        [Fact]
+        public async Task SequentialCreatesOnlyUseOneChannel()
+        {
+            //SpannerClients if created sequentially should only use a single channel.
+            //This is to faciliate good session pool hits (which is per channel).  If we always
+            //round robin'd clients, then we would get hard cache misses until we populated all
+            //of the caches per channel.
+            //Since channels are lazily created, this also saves resources for scenarios like rich clients
+            //that may only need a single session for multiple sequential workloads.
+            //Our default setting for # channels = 4 needs to work well for all scenarios.
+            var firstReturnedClient = new Mock<SpannerClient>();
+            var mockClientFactory = SetupMockClientFactory(firstReturnedClient);
+
+            var testPool = new ClientPool(mockClientFactory);
+            var expectedClient = firstReturnedClient.Object;
+
+            Assert.Same(expectedClient, await testPool.AcquireClientAsync());
+            testPool.ReleaseClient(expectedClient);
+
+            Assert.Same(expectedClient, await testPool.AcquireClientAsync());
+            testPool.ReleaseClient(expectedClient);
+
+            Assert.Same(expectedClient, await testPool.AcquireClientAsync());
+            testPool.ReleaseClient(expectedClient);
+
+            var s = new StringBuilder();
+            Assert.Equal(0, testPool.GetPoolInfo(s));
+            Logger.Instance.Info(s.ToString());
+            Assert.Equal(1, mockClientFactory.Invocations);
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/MockClientFactory.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/MockClientFactory.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using Google.Api.Gax.Grpc;
+using Google.Apis.Auth.OAuth2;
+using Google.Cloud.Spanner.V1;
+using Moq;
+
+namespace Google.Cloud.Spanner.Data.Tests
+{
+    internal class MockClientFactory : ISpannerClientFactory
+    {
+        private SpannerClient _currentClient;
+
+        public int Invocations { get; private set; }
+
+        public MockClientFactory(SpannerClient firstClient) => _currentClient = firstClient;
+
+        public Task<SpannerClient> CreateClientAsync(ServiceEndpoint endpoint, ITokenAccess credential)
+        {
+            Invocations++;
+            var result = _currentClient;
+            _currentClient = new Mock<SpannerClient>().Object;
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SessionPoolTests.cs
@@ -1,0 +1,464 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Spanner.V1;
+using Google.Protobuf;
+using Grpc.Core;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+// ReSharper disable AccessToDisposedClosure
+
+namespace Google.Cloud.Spanner.Data.Tests
+{
+    public class SessionPoolTests
+    {
+        // ReSharper disable once UnusedParameter.Local
+        public SessionPoolTests(ITestOutputHelper outputHelper)
+        {
+            //Uncomment these lines to debug a specific test.
+//            TestLogger.TestOutputHelper = outputHelper;
+//            TestLogger.Install();
+//            Logger.LogLevel = V1.Logging.LogLevel.Debug;
+        }
+
+        private static readonly DatabaseName s_defaultName =
+            DatabaseName.Parse("projects/project1/instances/instance1/databases/database1");
+
+        private readonly ConcurrentDictionary<Mock<SpannerClient>, List<Session>> _createdSessions =
+            new ConcurrentDictionary<Mock<SpannerClient>, List<Session>>();
+
+        private readonly ConcurrentStack<Transaction> _transactions = new ConcurrentStack<Transaction>();
+
+        //Creates a client that will log created sessions in the _createdSession dictionary.
+        private Mock<SpannerClient> CreateMockClient(DatabaseName dbName = null)
+        {
+            var mockClient = new Mock<SpannerClient>();
+            if (dbName == null)
+            {
+                dbName = s_defaultName;
+            }
+            var sessionList = new List<Session>();
+            _createdSessions.TryAdd(mockClient, sessionList);
+
+            mockClient.Setup(
+                    x => x.CreateSessionAsync(
+                        It.Is<DatabaseName>(y => y.Equals(dbName)),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    () =>
+                    {
+                        var mockSession = new Session
+                        {
+                            Name = $"{s_defaultName}/sessions/{Guid.NewGuid()}"
+                        };
+                        lock (sessionList)
+                        {
+                            sessionList.Add(mockSession);
+                        }
+                        return mockSession;
+                    });
+
+            mockClient.Setup(
+                    x => x.BeginTransactionAsync(It.IsAny<BeginTransactionRequest>(), It.IsAny<CallSettings>()))
+                .ReturnsAsync(
+                    () =>
+                    {
+                        var tx = new Transaction {Id = ByteString.CopyFromUtf8(Guid.NewGuid().ToString())};
+                        _transactions.Push(tx);
+                        return tx;
+                    });
+
+            mockClient.Setup(
+                    x => x.CommitAsync(
+                        It.IsAny<SessionName>(), It.IsAny<ByteString>(),
+                        It.IsAny<IEnumerable<Mutation>>(), It.IsAny<CallSettings>()))
+                .ReturnsAsync(() => new CommitResponse());
+
+            return mockClient;
+        }
+
+        private static T[] DuplicateTaskAsync<T>(Func<T> factory, int count) =>
+            Enumerable.Range(0, count).Select(_ => factory()).ToArray();
+
+        /// <summary>
+        /// Creates <paramref name="parallelCount"/> write sessions simultaneously over
+        /// <paramref name="iterations"/> number of iterations.
+        /// </summary>
+        private async Task CreateReleaseWriteSessions(
+            SessionPool pool,
+            SpannerClient client,
+            int iterations,
+            int parallelCount)
+        {
+            // We yield to increase contention among parallel tasks that are kicked off.
+            // This increases the amount of work they are doing on another thread.
+            await Task.Yield();
+            for (var i = 0; i < iterations; i++)
+            {
+                var readWriteOptions = new TransactionOptions {ReadWrite = new TransactionOptions.Types.ReadWrite()};
+                var writeSessions = await Task.WhenAll(
+                        DuplicateTaskAsync(
+                            () =>
+                                pool.CreateSessionFromPoolAsync(
+                                    client, s_defaultName.ProjectId,
+                                    s_defaultName.InstanceId, s_defaultName.DatabaseId, readWriteOptions,
+                                    CancellationToken.None),
+                            parallelCount))
+                    .ConfigureAwait(false);
+
+                await Task.Delay(TimeSpan.FromMilliseconds(10)).ConfigureAwait(false);
+
+                foreach (var session in writeSessions)
+                {
+                    var transaction = await client.BeginPooledTransactionAsync(session, readWriteOptions)
+                        .ConfigureAwait(false);
+                    await transaction.CommitAsync(session, null).ConfigureAwait(false);
+                    pool.ReleaseToPool(client, session);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates <paramref name="parallelCount"/> read sessions simultaneously over
+        /// <paramref name="iterations"/> number of iterations.
+        /// </summary>
+        private async Task CreateReleaseReadSessions(
+            SessionPool pool,
+            SpannerClient client,
+            int iterations,
+            int parallelCount)
+        {
+            // We yield to increase contention among parallel tasks that are kicked off.
+            // This increases the amount of work they are doing on another thread.
+            await Task.Yield();
+            for (var i = 0; i < iterations; i++)
+            {
+                var readOptions = new TransactionOptions {ReadOnly = new TransactionOptions.Types.ReadOnly()};
+                var readSessions = await Task.WhenAll(
+                        DuplicateTaskAsync(
+                            () =>
+                                pool.CreateSessionFromPoolAsync(
+                                    client, s_defaultName.ProjectId,
+                                    s_defaultName.InstanceId, s_defaultName.DatabaseId, readOptions,
+                                    CancellationToken.None),
+                            parallelCount))
+                    .ConfigureAwait(false);
+
+                await Task.Delay(TimeSpan.FromMilliseconds(10)).ConfigureAwait(false);
+
+                foreach (var session in readSessions)
+                {
+                    pool.ReleaseToPool(client, session);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanCreateSessionPool()
+        {
+            using (new SessionPool()) { }
+        }
+
+        [Fact]
+        public async Task ClientsHaveDifferentPools()
+        {
+            using (var pool = new SessionPool())
+            {
+                var client1 = CreateMockClient();
+                var client2 = CreateMockClient();
+
+                var session = await pool.CreateSessionFromPoolAsync(
+                        client1.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None)
+                    .ConfigureAwait(false);
+                pool.ReleaseToPool(client1.Object, session);
+
+                var session2 = await pool.CreateSessionFromPoolAsync(
+                        client2.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.NotSame(session, session2);
+                Assert.Equal(2, _createdSessions.Count);
+                Assert.Equal(1, _createdSessions[client1].Count);
+                Assert.Equal(1, _createdSessions[client2].Count);
+            }
+        }
+
+        [Fact]
+        public async Task DatabasesHaveDifferentPools()
+        {
+            using (var pool = new SessionPool())
+            {
+                var client = CreateMockClient();
+
+                var session = await pool.CreateSessionFromPoolAsync(
+                        client.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None)
+                    .ConfigureAwait(false);
+                pool.ReleaseToPool(client.Object, session);
+
+                var session2 = await pool.CreateSessionFromPoolAsync(
+                        client.Object, "newproject", "newinstance", "newdbid", null, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.NotSame(session, session2);
+                Assert.Equal(1, _createdSessions.Count);
+                Assert.Equal(1, _createdSessions[client].Count);
+            }
+        }
+
+        [Fact]
+        public async Task EmptyPoolCreatesNewSession()
+        {
+            using (var pool = new SessionPool())
+            {
+                var client = CreateMockClient();
+                var session = await pool.CreateSessionFromPoolAsync(
+                        client.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.Equal(1, _createdSessions.Count);
+                Assert.Equal(1, _createdSessions[client].Count);
+                Assert.Same(session, _createdSessions[client][0]);
+                client.Verify(
+                    x => x.CreateSessionAsync(
+                        It.Is<DatabaseName>(y => y.Equals(s_defaultName)),
+                        It.IsAny<CancellationToken>()), Times.Once);
+            }
+        }
+
+        [Fact]
+        public async Task ExpiredSessionsNotPooled()
+        {
+            using (var pool = new SessionPool())
+            {
+                var client = CreateMockClient();
+                var session = await pool.CreateSessionFromPoolAsync(
+                        client.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                SessionPool.MarkSessionExpired(session);
+                pool.ReleaseToPool(client.Object, session);
+                var session2 = await pool.CreateSessionFromPoolAsync(
+                        client.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.NotSame(session, session2);
+                Assert.Equal(1, _createdSessions.Count);
+                Assert.Equal(2, _createdSessions[client].Count);
+            }
+        }
+
+        [Fact]
+        public async Task MaxActiveViolationBlocks()
+        {
+            using (var pool = new SessionPool())
+            {
+                pool.Options.WaitOnResourcesExhausted = true;
+                pool.Options.MaximumActiveSessions = 2;
+
+                var client = CreateMockClient();
+                var session1 = await pool.CreateSessionFromPoolAsync(
+                        client.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None)
+                    .ConfigureAwait(false);
+                await pool.CreateSessionFromPoolAsync(
+                        client.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                async Task ReleaseTask()
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(10));
+                    pool.ReleaseToPool(client.Object, session1);
+                }
+
+                var createTask = pool.CreateSessionFromPoolAsync(
+                    client.Object, s_defaultName.ProjectId,
+                    s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None);
+
+                await Task.WhenAll(createTask, ReleaseTask()).ConfigureAwait(false);
+                Assert.Same(session1, createTask.ResultWithUnwrappedExceptions());
+            }
+        }
+
+        [Fact]
+        public async Task MaxActiveViolationThrows()
+        {
+            using (var pool = new SessionPool())
+            {
+                pool.Options.WaitOnResourcesExhausted = false;
+                pool.Options.MaximumActiveSessions = 2;
+                var exceptionThrown = false;
+
+                var client = CreateMockClient();
+                await pool.CreateSessionFromPoolAsync(
+                        client.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None)
+                    .ConfigureAwait(false);
+                await pool.CreateSessionFromPoolAsync(
+                        client.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None)
+                    .ConfigureAwait(false);
+                try
+                {
+                    await pool.CreateSessionFromPoolAsync(
+                            client.Object, s_defaultName.ProjectId,
+                            s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch (RpcException e)
+                {
+                    Assert.Equal(StatusCode.ResourceExhausted, e.Status.StatusCode);
+                    exceptionThrown = true;
+                }
+
+                Assert.True(exceptionThrown);
+            }
+        }
+
+        [Fact]
+        public async Task MaxPoolSizeNotViolated()
+        {
+            using (var pool = new SessionPool())
+            {
+                pool.Options.MaximumPooledSessions = 2;
+
+                var client = CreateMockClient();
+                var sessions = await Task.WhenAll(
+                        pool.CreateSessionFromPoolAsync(
+                            client.Object, s_defaultName.ProjectId,
+                            s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None),
+                        pool.CreateSessionFromPoolAsync(
+                            client.Object, s_defaultName.ProjectId,
+                            s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None),
+                        pool.CreateSessionFromPoolAsync(
+                            client.Object, s_defaultName.ProjectId,
+                            s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None))
+                    .ConfigureAwait(false);
+
+                pool.ReleaseToPool(client.Object, sessions[0]);
+                pool.ReleaseToPool(client.Object, sessions[1]);
+                pool.ReleaseToPool(client.Object, sessions[2]);
+
+                Assert.Equal(
+                    2, pool.GetPoolSize(
+                        client.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId));
+            }
+        }
+
+        [Fact]
+        public async Task SessionPreWarmTx()
+        {
+            using (var pool = new SessionPool())
+            {
+                var client = CreateMockClient();
+
+                var txOptions = new TransactionOptions {ReadWrite = new TransactionOptions.Types.ReadWrite()};
+                var session1 = await pool.CreateSessionFromPoolAsync(
+                        client.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, txOptions, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                var transactionAwaited = await client.Object.BeginPooledTransactionAsync(session1, txOptions)
+                    .ConfigureAwait(false);
+
+                Transaction transaction;
+                Assert.True(_transactions.TryPop(out transaction));
+                Assert.Same(transaction, transactionAwaited);
+                await transaction.CommitAsync(session1, null).ConfigureAwait(false);
+
+                //Releasing should start the tx prewarm
+                pool.ReleaseToPool(client.Object, session1);
+                Transaction preWarmTx;
+                var stopwatch = Stopwatch.StartNew();
+                while (!_transactions.TryPop(out preWarmTx))
+                {
+                    await Task.Yield();
+                    //everything is simulated, so the prewarm should be immediate.
+                    Assert.True(stopwatch.Elapsed < TimeSpan.FromMilliseconds(500));
+                }
+
+                var session2 = await pool.CreateSessionFromPoolAsync(
+                        client.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, txOptions, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                var transaction2 = await client.Object.BeginPooledTransactionAsync(session2, txOptions)
+                    .ConfigureAwait(false);
+
+                Assert.Same(preWarmTx, transaction2);
+                Assert.True(_transactions.IsEmpty);
+            }
+        }
+
+        [Fact]
+        public async Task SessionStress()
+        {
+            using (var pool = new SessionPool())
+            {
+                var client = CreateMockClient();
+                var stressTasks = new List<Task>();
+                stressTasks.AddRange(
+                    DuplicateTaskAsync(() => CreateReleaseReadSessions(pool, client.Object, 25, 3), 5));
+                stressTasks.AddRange(
+                    DuplicateTaskAsync(() => CreateReleaseWriteSessions(pool, client.Object, 25, 3), 5));
+                await Task.WhenAll(stressTasks).ConfigureAwait(false);
+
+                //There are 10 parallel stressors each creating no more than
+                // 3 simultaneous sessions.  Therefore the maximum number of created
+                // sessions should be no more than 30.
+                Assert.Equal(1, _createdSessions.Count);
+                Assert.True(_createdSessions[client].Count <= 30);
+            }
+        }
+
+        [Fact]
+        public async Task SynchronousRelease()
+        {
+            using (var pool = new SessionPool())
+            {
+                var client = CreateMockClient();
+                var session = await pool.CreateSessionFromPoolAsync(
+                        client.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                pool.ReleaseToPool(client.Object, session);
+                var session2 = await pool.CreateSessionFromPoolAsync(
+                        client.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.Same(session, session2);
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/TestLogger.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/TestLogger.cs
@@ -16,7 +16,7 @@ using System;
 using Google.Cloud.Spanner.V1.Logging;
 using Xunit.Abstractions;
 
-namespace Google.Cloud.Spanner.Data.IntegrationTests
+namespace Google.Cloud.Spanner.Data.Tests
 {
     internal class TestLogger : DefaultLogger
     {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.sln
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.sln
@@ -16,7 +16,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.LongRunning", "..\Go
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Iam.V1", "..\Google.Cloud.Iam.V1\Google.Cloud.Iam.V1\Google.Cloud.Iam.V1.csproj", "{188EB2ED-9C99-41BD-948C-79604EDBE68C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Spanner.Data.Tests", "Google.Cloud.Spanner.Data.Tests\Google.Cloud.Spanner.Data.Tests.csproj", "{27CBB26A-6F78-4247-9E3C-7A80C4FD965A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Spanner.Data.Tests", "Google.Cloud.Spanner.Data.Tests\Google.Cloud.Spanner.Data.Tests.csproj", "{27CBB26A-6F78-4247-9E3C-7A80C4FD965A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerClientFactory.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerClientFactory.cs
@@ -1,0 +1,97 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Apis.Auth.OAuth2;
+using Google.Cloud.Spanner.V1;
+using Google.Cloud.Spanner.V1.Logging;
+using Grpc.Auth;
+using Grpc.Core;
+
+namespace Google.Cloud.Spanner.Data
+{
+    internal interface ISpannerClientFactory
+    {
+        Task<SpannerClient> CreateClientAsync(ServiceEndpoint endpoint, ITokenAccess credential);
+    }
+
+    /// <summary>
+    /// For mockability and testability of the <see cref="ClientPool"/> class.
+    /// </summary>
+    internal class SpannerClientFactory : ISpannerClientFactory
+    {
+        internal static readonly ISpannerClientFactory Default = new SpannerClientFactory();
+
+        private SpannerClientFactory()
+        {
+        }
+
+        private static async Task<ChannelCredentials> CreateDefaultChannelCredentialsAsync()
+        {
+            var appDefaultCredentials = await GoogleCredential.GetApplicationDefaultAsync().ConfigureAwait(false);
+            if (appDefaultCredentials.IsCreateScopedRequired)
+            {
+                appDefaultCredentials = appDefaultCredentials.CreateScoped(SpannerClient.DefaultScopes);
+            }
+            return appDefaultCredentials.ToChannelCredentials();
+        }
+
+        /// <inheritdoc />
+        public async Task<SpannerClient> CreateClientAsync(ServiceEndpoint endpoint, ITokenAccess credential)
+        {
+            ChannelCredentials channelCredentials;
+
+            if (credential == null)
+            {
+                channelCredentials = await CreateDefaultChannelCredentialsAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                channelCredentials = credential.ToChannelCredentials();
+            }
+
+            var channel = new Channel(
+                endpoint.Host,
+                endpoint.Port,
+                channelCredentials);
+            Logger.LogPerformanceCounterFn("SpannerClient.RawCreateCount", x => x + 1);
+
+            //Pull the timeout from spanner options.
+            //The option must be set before OpenAsync is called.
+            var idempotentCallSettings = CallSettings.FromCallTiming(
+                CallTiming.FromRetry(
+                    new RetrySettings(
+                        SpannerSettings.GetDefaultRetryBackoff(),
+                        SpannerSettings.GetDefaultTimeoutBackoff(),
+                        Expiration.FromTimeout(SpannerOptions.Instance.Timeout),
+                        SpannerSettings.IdempotentRetryFilter
+                    )));
+
+            return SpannerClient.Create(
+                channel, new SpannerSettings
+                {
+                    CreateSessionSettings = idempotentCallSettings,
+                    GetSessionSettings = idempotentCallSettings,
+                    DeleteSessionSettings = idempotentCallSettings,
+                    ExecuteSqlSettings = idempotentCallSettings,
+                    ReadSettings = idempotentCallSettings,
+                    BeginTransactionSettings = idempotentCallSettings,
+                    CommitSettings = idempotentCallSettings,
+                    RollbackSettings = idempotentCallSettings
+                });
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerOptions.cs
@@ -36,8 +36,8 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         public int MaximumPooledSessions
         {
-            get => SessionPool.MaximumPooledSessions;
-            set => SessionPool.MaximumPooledSessions = value;
+            get => SessionPool.Default.Options.MaximumPooledSessions;
+            set => SessionPool.Default.Options.MaximumPooledSessions = value;
         }
 
         /// <summary>
@@ -59,14 +59,14 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         public int MaximumActiveSessions
         {
-            get => SessionPool.MaximumActiveSessions;
-            set => SessionPool.MaximumActiveSessions = value;
+            get => SessionPool.Default.Options.MaximumActiveSessions;
+            set => SessionPool.Default.Options.MaximumActiveSessions = value;
         }
 
         /// <summary>
         /// The maximum number of grpc channels used per credential.
-        /// Grpc channels are used in round robin fashion and can be used for multiple
-        /// <see cref="SpannerConnection"/> instances.
+        /// Grpc channels are used in round robin fashion and are assigned to
+        /// <see cref="SpannerConnection"/> instances on creation.
         /// </summary>
         public int MaximumGrpcChannels { get; set; } = 4;
 
@@ -125,8 +125,8 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         public TimeSpan PoolEvictionDelay
         {
-            get => SessionPool.PoolEvictionDelay;
-            set => SessionPool.PoolEvictionDelay = value;
+            get => SessionPool.Default.Options.PoolEvictionDelay;
+            set => SessionPool.Default.Options.PoolEvictionDelay = value;
         }
 
         internal bool ResetPerformanceTracesEachInterval
@@ -150,10 +150,10 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         public ResourcesExhaustedBehavior ResourcesExhaustedBehavior
         {
-            get => SessionPool.WaitOnResourcesExhausted
+            get => SessionPool.Default.Options.WaitOnResourcesExhausted
                 ? ResourcesExhaustedBehavior.Block
                 : ResourcesExhaustedBehavior.Fail;
-            set => SessionPool.WaitOnResourcesExhausted = value == ResourcesExhaustedBehavior.Block;
+            set => SessionPool.Default.Options.WaitOnResourcesExhausted = value == ResourcesExhaustedBehavior.Block;
         }
 
         /// <summary>
@@ -163,8 +163,8 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         public TimeSpan Timeout
         {
-            get => SessionPool.Timeout;
-            set => SessionPool.Timeout = value;
+            get => SessionPool.Default.Options.Timeout;
+            set => SessionPool.Default.Options.Timeout = value;
         }
 
         private SpannerOptions() { }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPoolOptions.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPoolOptions.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Google.Cloud.Spanner.V1
+{
+    internal sealed class SessionPoolOptions
+    {
+        /// <summary>
+        /// Maximum number of active sessions that can be in use by the application at any one time.
+        /// </summary>
+        public int MaximumActiveSessions { get; set; } = 400;
+
+        /// <summary>
+        /// The maximum number of sessions that can be held in the session pool.
+        /// </summary>
+        public int MaximumPooledSessions { get; set; } = 400;
+
+        /// <summary>
+        /// If true, then CreateSessionFromPoolAsync will block until CurrentActiveSessions is less than MaximumActiveSessions
+        /// If false, then CreateSessionFromPoolAsync will throw an exception if CurrentActiveSessions is equal to or greater than
+        /// MaximumActiveSessions
+        /// </summary>
+        public bool WaitOnResourcesExhausted { get; set; } = true;
+
+        /// <summary>
+        /// The amount of time before sessions get forcibly evicted from the session pool.
+        /// A lower value will cause the process to free sessions more aggressively when they get released
+        /// at the cost of performance due to lower reuse of sessions.
+        /// This value must be less than the expire timer on the Spanner server which is currently set at 60 minutes.
+        /// </summary>
+        public TimeSpan PoolEvictionDelay { get; set; } = TimeSpan.FromMinutes(15);
+
+        /// <summary>
+        /// If set to true, Sessions placed back into the pool will have a new transaction created in the background with
+        /// the same settings that were just used.  This will allow a later consumer of this session to skip creating a new
+        /// transaction if the options were identical.
+        /// </summary>
+        public bool UseTransactionWarming { get; set; } = true;
+
+        /// <summary>
+        /// The total time allowed for a network call to the Cloud Spanner server, including retries.
+        /// </summary>
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(60);
+    }
+}


### PR DESCRIPTION
…ss/threading tests).

Runtime changes:
 Changes pool classes to be nonstatic so that pool unit tests can run concurrently and not affect other tests.
 All options on sessionpool are now instance based (except for marking sessions as expired, which is still static)
 Minor change in transaction mode where we account for mode not being set (encountered during testing).