### PR TITLE
Upgrade to docfx 2.20

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   # Download and unpack docfx
   - mkdir docfx
   - cd docfx
-  - curl -SL https://github.com/dotnet/docfx/releases/download/v2.18.5/docfx.zip -o docfx.zip
+  - curl -SL https://github.com/dotnet/docfx/releases/download/v2.20/docfx.zip -o docfx.zip
   - unzip docfx.zip
   - cd ..
   # add dotnet and docfx to PATH


### PR DESCRIPTION
This fixes two issues that are important to us:

- The .manifest file is now stable and formatted, so changes wil
  be much easier to understand
- The bug around dependencies being pulled in automatically has
  been fixed

Quotes are now escaped in the YAML file, which seems to be harmless.
I've already pushed the new "dependencies" branch using 2.20.