### PR TITLE
Session create throttling.  This ensures that we never attempt to cre…

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerOptions.cs
@@ -167,6 +167,17 @@ namespace Google.Cloud.Spanner.Data
             set => SessionPool.Default.Options.Timeout = value;
         }
 
+        /// <summary>
+        /// The maximum number of session create operations allowed to occur simultaneously.
+        /// Spanner has limits on the number of sessions that can be created concurrently without affecting performance.
+        /// This value is not typically changed.
+        /// </summary>
+        public int MaximumConcurrentSessionCreates
+        {
+            get => SessionPool.Default.Options.MaximumConcurrentSessionCreates;
+            set => SessionPool.Default.Options.MaximumConcurrentSessionCreates = value;
+        }
+
         private SpannerOptions() { }
     }
 }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPoolImpl.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPoolImpl.cs
@@ -35,6 +35,7 @@ namespace Google.Cloud.Spanner.V1
         private const int MaximumLinearSearchDepth = 50;
 
         private readonly List<SessionPoolEntry> _sessionMruStack = new List<SessionPoolEntry>();
+        private readonly SemaphoreSlim _sessionCreateThrottle;
         private int _lastAccessTime;
         private static int s_activeSessionsPooled;
 
@@ -45,6 +46,7 @@ namespace Google.Cloud.Spanner.V1
         internal SessionPoolImpl(SessionPoolKey key, SessionPoolOptions options)
         {
             _options = GaxPreconditions.CheckNotNull(options, nameof(options));
+            _sessionCreateThrottle = new SemaphoreSlim(_options.MaximumConcurrentSessionCreates, _options.MaximumConcurrentSessionCreates);
             Key = key;
         }
 
@@ -198,20 +200,37 @@ namespace Google.Cloud.Spanner.V1
             SessionPoolEntry sessionEntry;
             if (!TryPop(options, out sessionEntry))
             {
-                Logger.Debug(() => "Attempting to acquire a session from the pool failed - creating a new instance.");
-                Stopwatch sw = null;
-                if (Logger.LogPerformanceTraces)
-                {
-                    sw = new Stopwatch();
-                    sw.Start();
-                }
                 //create a new session, blocking or throwing if at the limit.
-                var result = await Key.Client.CreateSessionAsync(new DatabaseName(Key.Project, Key.Instance, Key.Database), cancellationToken).ConfigureAwait(false);
-                if (sw != null)
+                await _sessionCreateThrottle.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
                 {
-                    Logger.LogPerformanceCounterFn("Session.CreateTime", x => sw.ElapsedMilliseconds);
+                    // Try to pop a session again after acquiring a throttle semaphore.
+                    // we may have waited for quite a while and the pool may now have entries.
+                    if (!TryPop(options, out sessionEntry))
+                    {
+                        Logger.Debug(
+                            () => "Attempting to acquire a session from the pool failed - creating a new instance.");
+                        Stopwatch sw = null;
+                        if (Logger.LogPerformanceTraces)
+                        {
+                            sw = new Stopwatch();
+                            sw.Start();
+                        }
+
+                        var result = await Key.Client.CreateSessionAsync(
+                                new DatabaseName(Key.Project, Key.Instance, Key.Database), cancellationToken)
+                            .ConfigureAwait(false);
+                        if (sw != null)
+                        {
+                            Logger.LogPerformanceCounterFn("Session.CreateTime", x => sw.ElapsedMilliseconds);
+                        }
+                        return result;
+                    }
                 }
-                return result;
+                finally
+                {
+                    _sessionCreateThrottle.Release();
+                }
             }
             MarkUsed();
             //note that the evict task will only actually delete the session if it was able to remove it from the pool.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPoolOptions.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPoolOptions.cs
@@ -57,5 +57,12 @@ namespace Google.Cloud.Spanner.V1
         /// The total time allowed for a network call to the Cloud Spanner server, including retries.
         /// </summary>
         public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(60);
+
+        /// <summary>
+        /// The maximum number of session create operations allowed to occur simultaneously.
+        /// Spanner has limits on the number of sessions that can be created concurrently without affecting performance.
+        /// This value is not typically changed.
+        /// </summary>
+        public int MaximumConcurrentSessionCreates { get; set; } = 10;
     }
 }


### PR DESCRIPTION
…ate too many sessions concurrently.

Creating too many sessions concurrently can result in severe perf penalties server side (on the order of several seconds if several hundred sessions are created in one go).  This change throttles all session creates to ensure this cannot happen.