### PR TITLE
Disable AppVeyor test reporting

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,10 @@ set -e
 
 cd $(dirname $0)
 
+# Disable automatic test reporting to AppVeyor.
+# See https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/1232
+unset APPVEYOR_API_URL
+
 # Make it easier to handle globbing that doesn't
 # match anything, e.g. when looking for tests.
 shopt -s nullglob


### PR DESCRIPTION
We'll still see test results in the log, but not in the tests tab.

Fixes #1232.