### PR TITLE
Allow a job ID or prefix to be specified on all job-creation operations

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.InsertData.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.InsertData.cs
@@ -42,7 +42,7 @@ namespace Google.Cloud.BigQuery.V2
             };
             options?.ModifyConfiguration(configuration);
 
-            return UploadData(configuration, input, "text/csv", options?.ProjectId ?? ProjectId);
+            return UploadData(configuration, input, "text/csv", options);
         }
 
         /// <inheritdoc />
@@ -60,7 +60,7 @@ namespace Google.Cloud.BigQuery.V2
             };
             options?.ModifyConfiguration(configuration);
 
-            return UploadData(configuration, input, "application/vnd.apache.avro+binary", options?.ProjectId ?? ProjectId);
+            return UploadData(configuration, input, "application/vnd.apache.avro+binary", options);
         }
 
         /// <inheritdoc />
@@ -82,7 +82,7 @@ namespace Google.Cloud.BigQuery.V2
             };
             options?.ModifyConfiguration(configuration);
 
-            return UploadData(configuration, input, "text/json", options?.ProjectId ?? ProjectId);
+            return UploadData(configuration, input, "text/json", options);
         }
 
         private TableSchema GetSchema(TableReference tableReference)
@@ -92,10 +92,10 @@ namespace Google.Cloud.BigQuery.V2
             return table.Schema;
         }
 
-        private BigQueryJob UploadData(JobConfigurationLoad loadConfiguration, Stream input, string contentType, string projectId)
+        private BigQueryJob UploadData(JobConfigurationLoad loadConfiguration, Stream input, string contentType, JobCreationOptions options)
         {
-            var job = new Job { Configuration = new JobConfiguration { Load = loadConfiguration } };
-            var mediaUpload = new CustomMediaUpload(Service, job, projectId, input, contentType);
+            var job = CreateJob(new JobConfiguration { Load = loadConfiguration }, options);
+            var mediaUpload = new CustomMediaUpload(Service, job, job.JobReference.ProjectId, input, contentType);
             mediaUpload.Options.ModifySessionInitiationRequest += _versionHeaderAction;
             var finalProgress = mediaUpload.Upload();
             if (finalProgress.Exception != null)
@@ -164,7 +164,7 @@ namespace Google.Cloud.BigQuery.V2
             };
             options?.ModifyConfiguration(configuration);
 
-            return await UploadDataAsync(configuration, input, "text/csv", options?.ProjectId ?? ProjectId, cancellationToken).ConfigureAwait(false);
+            return await UploadDataAsync(configuration, input, "text/csv", options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -182,7 +182,7 @@ namespace Google.Cloud.BigQuery.V2
             };
             options?.ModifyConfiguration(configuration);
 
-            return await UploadDataAsync(configuration, input, "application/vnd.apache.avro+binary", options?.ProjectId ?? ProjectId, cancellationToken).ConfigureAwait(false);
+            return await UploadDataAsync(configuration, input, "application/vnd.apache.avro+binary", options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -206,7 +206,7 @@ namespace Google.Cloud.BigQuery.V2
             };
             options?.ModifyConfiguration(configuration);
 
-            return await UploadDataAsync(configuration, input, "text/json", options?.ProjectId ?? ProjectId, cancellationToken).ConfigureAwait(false);
+            return await UploadDataAsync(configuration, input, "text/json", options, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<TableSchema> GetSchemaAsync(TableReference tableReference, CancellationToken cancellationToken)
@@ -216,10 +216,10 @@ namespace Google.Cloud.BigQuery.V2
             return table.Schema;
         }
 
-        private async Task<BigQueryJob> UploadDataAsync(JobConfigurationLoad loadConfiguration, Stream input, string contentType, string projectId, CancellationToken cancellationToken)
+        private async Task<BigQueryJob> UploadDataAsync(JobConfigurationLoad loadConfiguration, Stream input, string contentType, JobCreationOptions options, CancellationToken cancellationToken)
         {
-            var job = new Job { Configuration = new JobConfiguration { Load = loadConfiguration } };
-            var mediaUpload = new CustomMediaUpload(Service, job, projectId, input, contentType);
+            var job = CreateJob(new JobConfiguration { Load = loadConfiguration }, options);
+            var mediaUpload = new CustomMediaUpload(Service, job, job.JobReference.ProjectId, input, contentType);
             mediaUpload.Options.ModifySessionInitiationRequest += _versionHeaderAction;
             var finalProgress = await mediaUpload.UploadAsync(cancellationToken).ConfigureAwait(false);
             if (finalProgress.Exception != null)

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
@@ -185,17 +185,7 @@ namespace Google.Cloud.BigQuery.V2
         private JobsResource.InsertRequest CreateInsertQueryJobRequest(JobConfigurationQuery query, QueryOptions options)
         {
             options?.ModifyRequest(query);
-            var request = Service.Jobs.Insert(new Job
-            {
-                Configuration = new JobConfiguration
-                {
-                    Query = query,
-                    // It's slightly annoying that this is set here rather than in ModifyRequest, but at least it's in a single place.
-                    DryRun = options?.DryRun
-                },
-            }, options?.ProjectId ?? ProjectId);
-            request.ModifyRequest += _versionHeaderAction;
-            return request;
+            return CreateInsertJobRequest(new JobConfiguration { Query = query, DryRun = options?.DryRun }, options);
         }
 
         private static readonly long s_maxGetQueryResultsRequestTimeout = (long) TimeSpan.FromMinutes(1).TotalMilliseconds;

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateCopyJobOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateCopyJobOptions.cs
@@ -19,7 +19,7 @@ namespace Google.Cloud.BigQuery.V2
     /// <summary>
     /// Options for <c>CreateCopyJob</c> operations.
     /// </summary>
-    public sealed class CreateCopyJobOptions
+    public sealed class CreateCopyJobOptions : JobCreationOptions
     {
         /// <summary>
         /// The behavior if the destination table doesn't exist. If this
@@ -32,12 +32,6 @@ namespace Google.Cloud.BigQuery.V2
         /// If not set, this is effectively <see cref="WriteDisposition.WriteIfEmpty"/>.
         /// </summary>
         public WriteDisposition? WriteDisposition { get; set; }
-
-        /// <summary>
-        /// The ID of the project in which to create the job. If this is not set,
-        /// it defaults to the project ID of the client.
-        /// </summary>
-        public string ProjectId { get; set; }
 
         internal void ModifyRequest(JobConfigurationTableCopy copy)
         {

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateExtractJobOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateExtractJobOptions.cs
@@ -14,16 +14,13 @@
 
 using Google.Apis.Bigquery.v2.Data;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Google.Cloud.BigQuery.V2
 {
     /// <summary>
     /// Options for <c>CreateExtractJob</c> operations.
     /// </summary>
-    public sealed class CreateExtractJobOptions
+    public sealed class CreateExtractJobOptions : JobCreationOptions
     {
         /// <summary>
         /// The file format to use for output. If this is unspecified,
@@ -48,12 +45,6 @@ namespace Google.Cloud.BigQuery.V2
         /// is unspecified, the default is true.
         /// </summary>
         public bool? PrintHeader { get; set; }
-
-        /// <summary>
-        /// The ID of the project in which to create the job. If this is not set,
-        /// it defaults to the project ID of the client.
-        /// </summary>
-        public string ProjectId { get; set; }
 
         internal void ModifyRequest(JobConfigurationExtract extract)
         {

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateLoadJobOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateLoadJobOptions.cs
@@ -20,7 +20,7 @@ namespace Google.Cloud.BigQuery.V2
     /// <summary>
     /// Options for <c>CreateLoadJob</c> operations.
     /// </summary>
-    public sealed class CreateLoadJobOptions
+    public sealed class CreateLoadJobOptions : JobCreationOptions
     {
         /// <summary>
         /// The number of rows to skip, usually for headers.
@@ -104,12 +104,6 @@ namespace Google.Cloud.BigQuery.V2
         /// The format of the source files.
         /// </summary>
         public FileFormat? SourceFormat { get; set; }
-
-        /// <summary>
-        /// The ID of the project in which to create the job. If this is not set,
-        /// it defaults to the project ID of the client.
-        /// </summary>
-        public string ProjectId { get; set; }
 
         internal void ModifyRequest(JobConfigurationLoad load)
         {

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/JobCreationOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/JobCreationOptions.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// Base class for options for operations that create jobs.
+    /// </summary>
+    public abstract class JobCreationOptions
+    {
+        /// <summary>
+        /// The ID of the project in which to create the job. If this is not set,
+        /// it defaults to the project ID of the client.
+        /// </summary>
+        public string ProjectId { get; set; }
+
+        /// <summary>
+        /// If specified, use this prefix when generating a job ID. (Job IDs are always generated client-side
+        /// by this library, to allow insertion to be retried where necessary.) It is an error to set both this
+        /// property and <see cref="JobId"/>.
+        /// </summary>
+        public string JobIdPrefix { get; set; }
+
+        /// <summary>
+        /// If specified, this ID will be used to create the job. It is an error to set both this property
+        /// and <see cref="JobIdPrefix"/>.
+        /// </summary>
+        public string JobId { get; set; }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/QueryOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/QueryOptions.cs
@@ -17,9 +17,9 @@ using Google.Apis.Bigquery.v2.Data;
 namespace Google.Cloud.BigQuery.V2
 {
     /// <summary>
-    /// Options for <c>CreateQueryJob</c> operations.
+    /// Options for <c>CreateQueryJob</c> and <c>ExecuteQuery</c> operations.
     /// </summary>
-    public sealed class QueryOptions
+    public sealed class QueryOptions : JobCreationOptions
     {
         /// <summary>
         /// A destination table to write the results into.
@@ -99,12 +99,6 @@ namespace Google.Cloud.BigQuery.V2
         /// contains all the information returned by the server.
         /// </summary>
         public bool? DryRun { get; set; }
-
-        /// <summary>
-        /// The ID of the project in which to create the job. If this is not set,
-        /// it defaults to the project ID of the client.
-        /// </summary>
-        public string ProjectId { get; set; }
 
         internal void ModifyRequest(JobConfigurationQuery query)
         {

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/UploadAvroOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/UploadAvroOptions.cs
@@ -19,7 +19,7 @@ namespace Google.Cloud.BigQuery.V2
     /// <summary>
     /// Options for <c>UploadAvro</c> operations.
     /// </summary>
-    public sealed class UploadAvroOptions
+    public sealed class UploadAvroOptions : JobCreationOptions
     {
         /// <summary>
         /// Whether or not to accept rows with fields that are not specified in the schema,
@@ -39,12 +39,6 @@ namespace Google.Cloud.BigQuery.V2
         /// If not set, this is effectively <see cref="CreateDisposition.CreateIfNeeded"/>.
         /// </summary>
         public CreateDisposition? CreateDisposition { get; set; }
-
-        /// <summary>
-        /// The ID of the project in which to create the job. If this is not set,
-        /// it defaults to the project ID of the client.
-        /// </summary>
-        public string ProjectId { get; set; }
 
         /// <summary>
         /// Specifies the behavior if the destination table exists.

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/UploadCsvOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/UploadCsvOptions.cs
@@ -20,7 +20,7 @@ namespace Google.Cloud.BigQuery.V2
     /// <summary>
     /// Options for <c>UploadCsv</c> operations.
     /// </summary>
-    public sealed class UploadCsvOptions
+    public sealed class UploadCsvOptions : JobCreationOptions
     {
         /// <summary>
         /// The number of rows to skip, usually for headers.
@@ -85,13 +85,7 @@ namespace Google.Cloud.BigQuery.V2
         /// Specifies a string that represents a null value in a CSV file.
         /// If not set, this is effectively the empty string.
         /// </summary>
-        public string NullMarker { get; set; }
-
-        /// <summary>
-        /// The ID of the project in which to create the job. If this is not set,
-        /// it defaults to the project ID of the client.
-        /// </summary>
-        public string ProjectId { get; set; }
+        public string NullMarker { get; set; }        
 
         internal void ModifyConfiguration(JobConfigurationLoad loadRequest)
         {

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/UploadJsonOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/UploadJsonOptions.cs
@@ -19,7 +19,7 @@ namespace Google.Cloud.BigQuery.V2
     /// <summary>
     /// Options for <c>UploadJson</c> operations.
     /// </summary>
-    public sealed class UploadJsonOptions
+    public sealed class UploadJsonOptions : JobCreationOptions
     {
         /// <summary>
         /// Whether or not to accept rows with fields that are not specified in the schema,
@@ -51,12 +51,6 @@ namespace Google.Cloud.BigQuery.V2
         /// If not set, this is effectively false.
         /// </summary>
         public bool? Autodetect { get; set; }
-
-        /// <summary>
-        /// The ID of the project in which to create the job. If this is not set,
-        /// it defaults to the project ID of the client.
-        /// </summary>
-        public string ProjectId { get; set; }
 
         internal void ModifyConfiguration(JobConfigurationLoad loadRequest)
         {


### PR DESCRIPTION
Commonality is extracted in terms of a JobCreationOptions base class.