### PR TITLE
Spanner Threadsafe fixes.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/MySqlStressTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/MySqlStressTests.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         private static readonly string s_guid = Guid.NewGuid().ToString();
         private static int s_myCounter = 1;
 
-        protected override async Task<TimeSpan> TestWriteOneRow(Stopwatch sw)
+        private async Task<TimeSpan> TestWriteOneRow(Stopwatch sw)
         {
             using (var connection = new MySqlConnection(MySqlConnectionString))
             {
@@ -77,7 +77,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
 
             //now run the test.
-            double result = await TestWriteLatencyWithQps(TargetQps, TestDuration);
+            double result = await TestWriteLatencyWithQps(TargetQps, TestDuration, TestWriteOneRow);
             Logger.Instance.Info($"MySql latency= {result}ms");
 
             ValidatePoolInfo();

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -161,6 +161,7 @@ namespace Google.Cloud.Spanner.Data
         /// Begins a readonly transaction using the optionally provided <see cref="CancellationToken" />.
         /// Read transactions are preferred if possible because they do not impose locks internally.
         /// ReadOnly transactions run with strong consistency and return the latest copy of data.
+        /// This method is thread safe.
         /// </summary>
         /// <param name="cancellationToken">An optional token for canceling the call. May be null.</param>
         /// <returns>a new <see cref="SpannerTransaction" /></returns>
@@ -174,6 +175,7 @@ namespace Google.Cloud.Spanner.Data
         /// of data.
         /// Read transactions are preferred if possible because they do not impose locks internally.
         /// Stale read-only transactions can execute more quickly than strong or read-write transactions,.
+        /// This method is thread safe.
         /// </summary>
         /// <param name="targetReadTimestamp">Specifies the timestamp or allowed staleness of data. Must not be null.</param>
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
@@ -233,6 +235,7 @@ namespace Google.Cloud.Spanner.Data
 
         /// <summary>
         /// Begins a new read/write transaction.
+        /// This method is thread safe.
         /// </summary>
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns>A new <see cref="SpannerTransaction" /></returns>
@@ -297,6 +300,7 @@ namespace Google.Cloud.Spanner.Data
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to delete rows from a Spanner database table.
+        /// This method is thread safe.
         /// </summary>
         /// <param name="databaseTable">The name of the table from which to delete rows. Must not be null.</param>
         /// <param name="primaryKeys">The set of columns that form the primary key of the table.</param>
@@ -309,6 +313,7 @@ namespace Google.Cloud.Spanner.Data
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to insert rows into a Spanner database table.
+        /// This method is thread safe.
         /// </summary>
         /// <param name="databaseTable">The name of the table to insert rows into. Must not be null.</param>
         /// <param name="insertedColumns">
@@ -325,6 +330,7 @@ namespace Google.Cloud.Spanner.Data
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to insert or update rows into a Spanner database table.
+        /// This method is thread safe.
         /// </summary>
         /// <param name="databaseTable">The name of the table to insert or updates rows. Must not be null.</param>
         /// <param name="insertUpdateColumns">
@@ -341,6 +347,7 @@ namespace Google.Cloud.Spanner.Data
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to select rows using a SQL query statement.
+        /// This method is thread safe.
         /// </summary>
         /// <param name="sqlQueryStatement">
         /// A full SQL query statement that may optionally have
@@ -359,6 +366,7 @@ namespace Google.Cloud.Spanner.Data
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to update rows in a Spanner database table.
+        /// This method is thread safe.
         /// </summary>
         /// <param name="databaseTable">The name of the table to update rows. Must not be null.</param>
         /// <param name="updateColumns">
@@ -376,6 +384,7 @@ namespace Google.Cloud.Spanner.Data
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to execute a DDL (CREATE/DROP TABLE, etc) statement.
+        /// This method is thread safe.
         /// </summary>
         /// <param name="ddlStatement">The DDL statement (eg 'CREATE TABLE MYTABLE ...').  Must not be null.</param>
         /// <returns>A configured <see cref="SpannerCommand" /></returns>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReader.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReader.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
@@ -42,7 +43,7 @@ namespace Google.Cloud.Spanner.Data
         private readonly SpannerConnection _connectionToClose;
         private readonly List<Value> _innerList = new List<Value>();
         private readonly ReliableStreamReader _resultSet;
-        private Dictionary<string, int> _fieldIndex;
+        private ConcurrentDictionary<string, int> _fieldIndex = new ConcurrentDictionary<string, int>();
         private ResultSetMetadata _metadata;
         private readonly SingleUseTransaction _txToClose;
 
@@ -281,9 +282,8 @@ namespace Google.Cloud.Spanner.Data
         private async Task<int> GetFieldIndexAsync(string fieldName, CancellationToken cancellationToken)
         {
             GaxPreconditions.CheckNotNullOrEmpty(fieldName, nameof(fieldName));
-            if (_fieldIndex == null)
+            if (_fieldIndex.Count == 0)
             {
-                _fieldIndex = new Dictionary<string, int>();
                 var metadata = await PopulateMetadataAsync(cancellationToken).ConfigureAwait(false);
                 if (metadata != null)
                 {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameterCollection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameterCollection.cs
@@ -230,11 +230,8 @@ namespace Google.Cloud.Spanner.Data
             }
         }
 
-#if NET45 // It's odd that these are required, but it looks like it's due to a discrepancy
-// between the reference assemblies and real assemblies. See
-// https://stackoverflow.com/questions/44197176 for details.
-// Fortunately the real implementations all just return false too.
-/// <inheritdoc />
+#if NET45
+        /// <inheritdoc />
         public override bool IsFixedSize => false;
 
         /// <inheritdoc />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/VolatileResourceManager.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/VolatileResourceManager.cs
@@ -44,7 +44,7 @@ namespace Google.Cloud.Spanner.Data
 
         public void Commit(Enlistment enlistment)
         {
-            if (_transaction != null && !_transaction.Mutations.Any())
+            if (_transaction != null && !_transaction.HasMutations)
             {
                 //In the case where our resource manager doesn't have any mutations, it was a read,
                 //which we will no-op and allow through even if it was a two phase commit.
@@ -73,7 +73,7 @@ namespace Google.Cloud.Spanner.Data
 
         public void Prepare(PreparingEnlistment preparingEnlistment)
         {
-            if (_transaction != null && !_transaction.Mutations.Any()) {
+            if (_transaction != null && !_transaction.HasMutations) {
                 //In the case where our resource manager doesn't have any mutations, it was a read,
                 //which we will no-op and allow through even if it was a two phase commit.
                 //This allows cases such as nested transactions where the inner transaction is a readonly


### PR DESCRIPTION
This makes async methods static where appropriate.
This ensures that the async method runs on local state and eliminates a few race conditions that existed.