### PR TITLE
scope.Complete for ReadOnlyTransactions should no-op.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="MySql.ConnectorNET.Data">
       <Version>6.8.3.2</Version>
     </PackageReference>
+    <Reference Include="System.Transactions" />
   </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>


### PR DESCRIPTION
found during doc sample writing.
We should simply accept the scope.Complete because there may be another resource that is being used.