### PR TITLE
First pass at operations to update datasets

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryFixture.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryFixture.cs
@@ -19,6 +19,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using Xunit;
 
 
@@ -36,6 +37,11 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
     public class BigQueryFixture : IDisposable, ICollectionFixture<BigQueryFixture>
     {
         private const string ProjectEnvironmentVariable = "TEST_PROJECT";
+
+        /// <summary>
+        /// Used to generate dataset IDs which are still clearly identifiable with this test.
+        /// </summary>
+        private int extraDatasetCounter;
 
         public string ProjectId { get; }
         public string DatasetId { get; }
@@ -248,6 +254,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
         }
 
         internal string CreateTableId() => "test_" + Guid.NewGuid().ToString().Replace("-", "_");
+        internal string CreateDatasetId() => $"{DatasetId}_{Interlocked.Increment(ref extraDatasetCounter)}";
 
         public void Dispose()
         {

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/DatasetsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/DatasetsTest.cs
@@ -1,0 +1,149 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2.Data;
+using System.Net;
+using Xunit;
+
+namespace Google.Cloud.BigQuery.V2.IntegrationTests
+{
+    // Note: some of these tests fetch the dataset in a way that looks unnecessary.
+    // Currently, the etag changes between a dataset being created and it first being fetched,
+    // which breaks the "create, update" approach. I'm investigating why this happens.
+
+    [Collection(nameof(BigQueryFixture))]
+    public class DatasetsTest
+    {
+        private readonly BigQueryFixture _fixture;
+
+        public DatasetsTest(BigQueryFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public void UpdateDataset()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var id = _fixture.CreateDatasetId();
+
+            var original = client.CreateDataset(id, new CreateDatasetOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+
+            // Modify locally...
+            original.Resource.Description = "Description2";
+            original.Resource.FriendlyName = "FriendlyName2";
+
+            // FIXME: I shouldn't need to do this.
+            original.Resource.ETag = client.GetDataset(id).Resource.ETag;
+
+            // Check the results of the update
+            var updated = original.Update();
+            Assert.Equal("Description2", updated.Resource.Description);
+            Assert.Equal("FriendlyName2", updated.Resource.FriendlyName);
+
+            // Check that it's still valid if fetched directly
+            var fetched = client.GetDataset(id);
+            Assert.Equal("Description2", fetched.Resource.Description);
+            Assert.Equal("FriendlyName2", fetched.Resource.FriendlyName);
+        }
+
+        [Fact]
+        public void UpdateDataset_Conflict()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var id = _fixture.CreateDatasetId();
+
+            var original = client.CreateDataset(id, new CreateDatasetOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+
+            // Modify on the server, which will change the etag
+            var sneaky = client.GetDataset(id);
+            sneaky.Resource.FriendlyName = "Sneak attack!";
+            sneaky.Update();
+
+            // Modify the originally-created version...
+            original.Resource.Description = "Description2";
+
+            // Fails due to the conflict.
+            var exception = Assert.Throws<GoogleApiException>(() => original.Update());
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+        }
+
+        [Fact]
+        public void PatchDataset()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var id = _fixture.CreateDatasetId();
+
+            var original = client.CreateDataset(id, new CreateDatasetOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+            var patched = original.Patch(new Dataset { Description = "Description2" }, matchEtag: false);
+
+            // Check the results of the patch
+            Assert.Equal("Description2", patched.Resource.Description);
+            Assert.Equal("FriendlyName1", patched.Resource.FriendlyName);
+
+            // Check that it's still valid if fetched directly
+            var fetched = client.GetDataset(id);
+            Assert.Equal("Description2", fetched.Resource.Description);
+            Assert.Equal("FriendlyName1", fetched.Resource.FriendlyName);
+        }
+
+        [Fact]
+        public void PatchDataset_ConflictMatchEtag()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var id = _fixture.CreateDatasetId();
+
+            var original = client.CreateDataset(id, new CreateDatasetOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+            // FIXME: I shouldn't need to do this.
+            original.Resource.ETag = client.GetDataset(id).Resource.ETag;
+
+            // Modify on the server, which will change the etag
+            var sneaky = client.GetDataset(id);
+            sneaky.Resource.FriendlyName = "Sneak attack!";
+            sneaky.Update();
+
+            // Fails due to the conflict.
+            var exception = Assert.Throws<GoogleApiException>(() => original.Patch(new Dataset { Description = "Description2" }, matchEtag: true));
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+        }
+
+        [Fact]
+        public void PatchDataset_ConflictDontMatchEtag()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var id = _fixture.CreateDatasetId();
+
+            var original = client.CreateDataset(id, new CreateDatasetOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+            // FIXME: I shouldn't need to do this.
+            original.Resource.ETag = client.GetDataset(id).Resource.ETag;
+
+            // Modify on the server, which will change the etag
+            var sneaky = client.GetDataset(id);
+            sneaky.Resource.FriendlyName = "Sneak attack!";
+            sneaky.Update();
+
+            // Patch from the original, but don't bother with optimistic concurrency checks. (Don't propagate the etag.)
+            var patched = original.Patch(new Dataset { Description = "Description2" }, matchEtag: false);
+
+            // Check the results of the patch
+            Assert.Equal("Description2", patched.Resource.Description);
+            Assert.Equal("Sneak attack!", patched.Resource.FriendlyName);
+
+            // Check that it's still valid if fetched directly
+            var fetched = client.GetDataset(id);
+            Assert.Equal("Description2", fetched.Resource.Description);
+            Assert.Equal("Sneak attack!", fetched.Resource.FriendlyName);
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/BigQueryClientSnippets.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/BigQueryClientSnippets.cs
@@ -1423,8 +1423,8 @@ namespace Google.Cloud.BigQuery.V2.Snippets
         // TODO: Repeated fields and record types.
 
         // TODO:
-        // Dataset update/patch
         // Table update/patch
+        // Job update/patch
 
         [Fact]
         public void DryRunValidQuery()
@@ -1474,5 +1474,66 @@ namespace Google.Cloud.BigQuery.V2.Snippets
             }
             // End sample
         }
+
+        [Fact]
+        public void UpdateDataset()
+        {
+            string projectId = _fixture.ProjectId;
+            string datasetId = _fixture.GenerateDatasetId();
+
+            BigQueryClient.Create(projectId).CreateDataset(datasetId);
+
+            // Snippet: UpdateDataset(string, Dataset, *)
+            BigQueryClient client = BigQueryClient.Create(projectId);
+            BigQueryDataset dataset = client.GetDataset(datasetId);
+            Dataset resource = dataset.Resource;
+            resource.FriendlyName = "Updated dataset";
+
+            // Alternatively, just call dataset.Update(). In either case,
+            // the etag in the resource will automatically be used for optimistic concurrency.
+            client.UpdateDataset(datasetId, resource);
+
+            // Fetch just to make sure it's really changed...
+            BigQueryDataset fetched = client.GetDataset(datasetId);
+            Console.WriteLine($"Fetched dataset friendly name: {fetched.Resource.FriendlyName}");
+            // End snippet
+
+            Assert.Equal("Updated dataset", fetched.Resource.FriendlyName);
+        }
+
+        // See-also: UpdateDataset(string, Dataset, *)
+        // Member: UpdateDataset(DatasetReference, Dataset, *)
+        // Member: UpdateDataset(string, string, Dataset, *)
+        // See [UpdateDataset](ref) for an example using an alternative overload.
+        // End see-also
+
+        [Fact]
+        public void PatchDataset()
+        {
+            string projectId = _fixture.ProjectId;
+            string datasetId = _fixture.GenerateDatasetId();
+
+            BigQueryClient.Create(projectId).CreateDataset(datasetId);
+
+            // Snippet: PatchDataset(string, Dataset, *)
+            BigQueryClient client = BigQueryClient.Create(projectId);
+
+            // There's no ETag in this Dataset, so the patch will be applied unconditionally.
+            // If we specified an ETag, the patch would only be applied if it matched.
+            client.PatchDataset(datasetId, new Dataset { FriendlyName = "Patched dataset" } );
+
+            // Fetch just to make sure it's really changed...
+            BigQueryDataset fetched = client.GetDataset(datasetId);
+            Console.WriteLine($"Fetched dataset friendly name: {fetched.Resource.FriendlyName}");
+            // End snippet
+
+            Assert.Equal("Patched dataset", fetched.Resource.FriendlyName);
+        }
+
+        // See-also: PatchDataset(string, Dataset, *)
+        // Member: PatchDataset(DatasetReference, Dataset, *)
+        // Member: PatchDataset(string, string, Dataset, *)
+        // See [PatchDataset](ref) for an example using an alternative overload.
+        // End see-also
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/BigQueryClientSnippets.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/BigQueryClientSnippets.cs
@@ -1507,6 +1507,13 @@ namespace Google.Cloud.BigQuery.V2.Snippets
         // See [UpdateDataset](ref) for an example using an alternative overload.
         // End see-also
 
+        // See-also: UpdateDataset(string, Dataset, *)
+        // Member: UpdateDatasetAsync(DatasetReference, Dataset, *, *)
+        // Member: UpdateDatasetAsync(string, Dataset, *, *)
+        // Member: UpdateDatasetAsync(string, string, Dataset, *, *)
+        // See [UpdateDataset](ref) for a synchronous example.
+        // End see-also
+
         [Fact]
         public void PatchDataset()
         {
@@ -1534,6 +1541,13 @@ namespace Google.Cloud.BigQuery.V2.Snippets
         // Member: PatchDataset(DatasetReference, Dataset, *)
         // Member: PatchDataset(string, string, Dataset, *)
         // See [PatchDataset](ref) for an example using an alternative overload.
+        // End see-also
+
+        // See-also: PatchDataset(string, Dataset, *)
+        // Member: PatchDatasetAsync(DatasetReference, Dataset, *, *)
+        // Member: PatchDatasetAsync(string, Dataset, *, *)
+        // Member: PatchDatasetAsync(string, string, Dataset, *, *)
+        // See [PatchDataset](ref) for a synchronous example.
         // End see-also
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryClientTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryClientTest.cs
@@ -170,6 +170,32 @@ namespace Google.Cloud.BigQuery.V2.Tests
         }
 
         [Fact]
+        public void UpdateDatasetEquivalents()
+        {
+            var datasetId = "dataset";
+            var reference = GetDatasetReference(datasetId);
+            var resource = new Dataset();
+            var options = new UpdateDatasetOptions();
+            VerifyEquivalent(new BigQueryDataset(new DerivedBigQueryClient(), resource),
+                client => client.UpdateDataset(MatchesWhenSerialized(reference), resource, options),
+                client => client.UpdateDataset(datasetId, resource, options),
+                client => client.UpdateDataset(ProjectId, datasetId, resource, options));
+        }
+
+        [Fact]
+        public void PatchDatasetEquivalents()
+        {
+            var datasetId = "dataset";
+            var reference = GetDatasetReference(datasetId);
+            var resource = new Dataset();
+            var options = new PatchDatasetOptions();
+            VerifyEquivalent(new BigQueryDataset(new DerivedBigQueryClient(), resource),
+                client => client.PatchDataset(MatchesWhenSerialized(reference), resource, options),
+                client => client.PatchDataset(datasetId, resource, options),
+                client => client.PatchDataset(ProjectId, datasetId, resource, options));
+        }
+
+        [Fact]
         public void GetOrCreateDatasetEquivalents()
         {
             var datasetId = "dataset";

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/PatchDatasetOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/PatchDatasetOptionsTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+using static Google.Apis.Bigquery.v2.DatasetsResource;
+
+namespace Google.Cloud.BigQuery.V2.Tests
+{
+    public class PatchDatasetOptionsTest
+    {
+        // The test doesn't do anything yet... but neither does the code.
+        [Fact]
+        public void ModifyRequest_NoOp()
+        {
+            var request = new PatchRequest(null, null, "project", "dataset");
+            var options = new PatchDatasetOptions();
+            options.ModifyRequest(request);
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/UpdateDatasetOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/UpdateDatasetOptionsTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+using static Google.Apis.Bigquery.v2.DatasetsResource;
+
+namespace Google.Cloud.BigQuery.V2.Tests
+{
+    public class UpdateDatasetOptionsTest
+    {
+        // The test doesn't do anything yet... but neither does the code.
+        [Fact]
+        public void ModifyRequest_NoOp()
+        {
+            var request = new UpdateRequest(null, null, "project", "dataset");
+            var options = new UpdateDatasetOptions();
+            options.ModifyRequest(request);
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.DatasetCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.DatasetCrud.cs
@@ -442,12 +442,104 @@ namespace Google.Cloud.BigQuery.V2
         /// Asynchronously deletes the specified dataset.
         /// </summary>
         /// <param name="datasetReference">A fully-qualified identifier for the dataset. Must not be null.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         public virtual Task DeleteDatasetAsync(DatasetReference datasetReference, DeleteDatasetOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Asynchronously updates the specified dataset to match the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="resource">The dataset resource representation to use for the update. All updatable fields will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated dataset.</returns>
+        public virtual Task<BigQueryDataset> UpdateDatasetAsync(string projectId, string datasetId, Dataset resource, UpdateDatasetOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            UpdateDatasetAsync(GetDatasetReference(projectId, datasetId), resource, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously updates the specified dataset within this client's project to match the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="resource">The dataset resource representation to use for the update. All updatable fields will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated dataset.</returns>
+        public virtual Task<BigQueryDataset> UpdateDatasetAsync(string datasetId, Dataset resource, UpdateDatasetOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            UpdateDatasetAsync(GetDatasetReference(datasetId), resource, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously updates the specified dataset to match the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="datasetReference">A fully-qualified identifier for the dataset. Must not be null.</param>
+        /// <param name="resource">The dataset resource representation to use for the update. All updatable fields will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated dataset.</returns>
+        public virtual Task<BigQueryDataset> UpdateDatasetAsync(DatasetReference datasetReference, Dataset resource, UpdateDatasetOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Asynchronously patches the specified dataset with fields in the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="resource">The dataset resource representation to use for the patch. Only fields present in the resource will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated dataset.</returns>
+        public virtual Task<BigQueryDataset> PatchDatasetAsync(string projectId, string datasetId, Dataset resource, PatchDatasetOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            PatchDatasetAsync(GetDatasetReference(projectId, datasetId), resource, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously patches the specified dataset within this client's project with fields in the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="resource">The dataset resource representation to use for the patch. Only fields present in the resource will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated dataset.</returns>
+        public virtual Task<BigQueryDataset> PatchDatasetAsync(string datasetId, Dataset resource, PatchDatasetOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            PatchDatasetAsync(GetDatasetReference(datasetId), resource, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously patches the specified dataset with fields in the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="datasetReference">A fully-qualified identifier for the dataset. Must not be null.</param>
+        /// <param name="resource">The dataset resource representation to use for the patch. Only fields present in the resource will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated dataset.</returns>
+        public virtual Task<BigQueryDataset> PatchDatasetAsync(DatasetReference datasetReference, Dataset resource, PatchDatasetOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            throw new NotImplementedException();
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.DatasetCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.DatasetCrud.cs
@@ -181,6 +181,86 @@ namespace Google.Cloud.BigQuery.V2
         }
 
         /// <summary>
+        /// Updates the specified dataset to match the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="resource">The dataset resource representation to use for the update. All updatable fields will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated dataset.</returns>
+        public virtual BigQueryDataset UpdateDataset(string projectId, string datasetId, Dataset resource, UpdateDatasetOptions options = null) =>
+            UpdateDataset(GetDatasetReference(projectId, datasetId), resource, options);
+
+        /// <summary>
+        /// Updates the specified dataset within this client's project to match the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="resource">The dataset resource representation to use for the update. All updatable fields will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated dataset.</returns>
+        public virtual BigQueryDataset UpdateDataset(string datasetId, Dataset resource, UpdateDatasetOptions options = null) =>
+            UpdateDataset(GetDatasetReference(datasetId), resource, options);
+
+        /// <summary>
+        /// Updates the specified dataset to match the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="datasetReference">A fully-qualified identifier for the dataset. Must not be null.</param>
+        /// <param name="resource">The dataset resource representation to use for the update. All updatable fields will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated dataset.</returns>
+        public virtual BigQueryDataset UpdateDataset(DatasetReference datasetReference, Dataset resource, UpdateDatasetOptions options = null) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Patches the specified dataset with fields in the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="resource">The dataset resource representation to use for the patch. Only fields present in the resource will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated dataset.</returns>
+        public virtual BigQueryDataset PatchDataset(string projectId, string datasetId, Dataset resource, PatchDatasetOptions options = null) =>
+            PatchDataset(GetDatasetReference(projectId, datasetId), resource, options);
+
+        /// <summary>
+        /// Patches the specified dataset within this client's project with fields in the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="resource">The dataset resource representation to use for the patch. Only fields present in the resource will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated dataset.</returns>
+        public virtual BigQueryDataset PatchDataset(string datasetId, Dataset resource, PatchDatasetOptions options = null) =>
+            PatchDataset(GetDatasetReference(datasetId), resource, options);
+
+        /// <summary>
+        /// Patches the specified dataset with fields in the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="datasetReference">A fully-qualified identifier for the dataset. Must not be null.</param>
+        /// <param name="resource">The dataset resource representation to use for the patch. Only fields present in the resource will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated dataset.</returns>
+        public virtual BigQueryDataset PatchDataset(DatasetReference datasetReference, Dataset resource, PatchDatasetOptions options = null) =>
+            throw new NotImplementedException();
+
+        /// <summary>
         /// Asynchronously retrieves a dataset within this client's project given the dataset ID.
         /// This method just creates a <see cref="DatasetReference"/> and delegates to <see cref="GetDatasetAsync(DatasetReference,GetDatasetOptions,CancellationToken)"/>.
         /// </summary>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.DatasetCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.DatasetCrud.cs
@@ -182,6 +182,7 @@ namespace Google.Cloud.BigQuery.V2
 
         /// <summary>
         /// Updates the specified dataset to match the given resource.
+        /// This method just creates a <see cref="DatasetReference"/> and delegates to <see cref="UpdateDataset(DatasetReference, Dataset, UpdateDatasetOptions)"/>.
         /// </summary>
         /// <remarks>
         /// If the resource contains an ETag, it is used for optimistic concurrency validation.
@@ -196,6 +197,7 @@ namespace Google.Cloud.BigQuery.V2
 
         /// <summary>
         /// Updates the specified dataset within this client's project to match the given resource.
+        /// This method just creates a <see cref="DatasetReference"/> and delegates to <see cref="UpdateDataset(DatasetReference, Dataset, UpdateDatasetOptions)"/>.
         /// </summary>
         /// <remarks>
         /// If the resource contains an ETag, it is used for optimistic concurrency validation.
@@ -222,6 +224,7 @@ namespace Google.Cloud.BigQuery.V2
 
         /// <summary>
         /// Patches the specified dataset with fields in the given resource.
+        /// This method just creates a <see cref="DatasetReference"/> and delegates to <see cref="PatchDataset(DatasetReference, Dataset, PatchDatasetOptions)"/>.
         /// </summary>
         /// <remarks>
         /// If the resource contains an ETag, it is used for optimistic concurrency validation.
@@ -236,6 +239,7 @@ namespace Google.Cloud.BigQuery.V2
 
         /// <summary>
         /// Patches the specified dataset within this client's project with fields in the given resource.
+        /// This method just creates a <see cref="DatasetReference"/> and delegates to <see cref="PatchDataset(DatasetReference, Dataset, PatchDatasetOptions)"/>.
         /// </summary>
         /// <remarks>
         /// If the resource contains an ETag, it is used for optimistic concurrency validation.
@@ -452,6 +456,7 @@ namespace Google.Cloud.BigQuery.V2
 
         /// <summary>
         /// Asynchronously updates the specified dataset to match the given resource.
+        /// This method just creates a <see cref="DatasetReference"/> and delegates to <see cref="UpdateDatasetAsync(DatasetReference, Dataset, UpdateDatasetOptions, CancellationToken)"/>.
         /// </summary>
         /// <remarks>
         /// If the resource contains an ETag, it is used for optimistic concurrency validation.
@@ -468,6 +473,7 @@ namespace Google.Cloud.BigQuery.V2
 
         /// <summary>
         /// Asynchronously updates the specified dataset within this client's project to match the given resource.
+        /// This method just creates a <see cref="DatasetReference"/> and delegates to <see cref="UpdateDatasetAsync(DatasetReference, Dataset, UpdateDatasetOptions, CancellationToken)"/>.
         /// </summary>
         /// <remarks>
         /// If the resource contains an ETag, it is used for optimistic concurrency validation.
@@ -498,6 +504,7 @@ namespace Google.Cloud.BigQuery.V2
 
         /// <summary>
         /// Asynchronously patches the specified dataset with fields in the given resource.
+        /// This method just creates a <see cref="DatasetReference"/> and delegates to <see cref="PatchDatasetAsync(DatasetReference, Dataset, PatchDatasetOptions, CancellationToken)"/>.
         /// </summary>
         /// <remarks>
         /// If the resource contains an ETag, it is used for optimistic concurrency validation.
@@ -514,6 +521,7 @@ namespace Google.Cloud.BigQuery.V2
 
         /// <summary>
         /// Asynchronously patches the specified dataset within this client's project with fields in the given resource.
+        /// This method just creates a <see cref="DatasetReference"/> and delegates to <see cref="PatchDatasetAsync(DatasetReference, Dataset, PatchDatasetOptions, CancellationToken)"/>.
         /// </summary>
         /// <remarks>
         /// If the resource contains an ETag, it is used for optimistic concurrency validation.

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.DatasetCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.DatasetCrud.cs
@@ -182,5 +182,27 @@ namespace Google.Cloud.BigQuery.V2
             options?.ModifyRequest(request);
             await request.ExecuteAsync(cancellationToken).ConfigureAwait(false);
         }
+
+        /// <inheritdoc />
+        public override async Task<BigQueryDataset> UpdateDatasetAsync(DatasetReference datasetReference, Dataset resource, UpdateDatasetOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            GaxPreconditions.CheckNotNull(datasetReference, nameof(datasetReference));
+            GaxPreconditions.CheckNotNull(resource, nameof(resource));
+            var request = Service.Datasets.Update(resource, datasetReference.ProjectId, datasetReference.DatasetId);
+            request.ModifyRequest += _versionHeaderAction;
+            options?.ModifyRequest(request);
+            return new BigQueryDataset(this, await request.ExecuteAsync(cancellationToken).ConfigureAwait(false));
+        }
+
+        /// <inheritdoc />
+        public override async Task<BigQueryDataset> PatchDatasetAsync(DatasetReference datasetReference, Dataset resource, PatchDatasetOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            GaxPreconditions.CheckNotNull(datasetReference, nameof(datasetReference));
+            GaxPreconditions.CheckNotNull(resource, nameof(resource));
+            var request = Service.Datasets.Patch(resource, datasetReference.ProjectId, datasetReference.DatasetId);
+            request.ModifyRequest += _versionHeaderAction;
+            options?.ModifyRequest(request);
+            return new BigQueryDataset(this, await request.ExecuteAsync(cancellationToken).ConfigureAwait(false));
+        }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.DatasetCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.DatasetCrud.cs
@@ -106,6 +106,28 @@ namespace Google.Cloud.BigQuery.V2
         }
 
         /// <inheritdoc />
+        public override BigQueryDataset UpdateDataset(DatasetReference datasetReference, Dataset resource, UpdateDatasetOptions options = null)
+        {
+            GaxPreconditions.CheckNotNull(datasetReference, nameof(datasetReference));
+            GaxPreconditions.CheckNotNull(resource, nameof(resource));
+            var request = Service.Datasets.Update(resource, datasetReference.ProjectId, datasetReference.DatasetId);
+            request.ModifyRequest += _versionHeaderAction;
+            options?.ModifyRequest(request);
+            return new BigQueryDataset(this, request.Execute());
+        }
+
+        /// <inheritdoc />
+        public override BigQueryDataset PatchDataset(DatasetReference datasetReference, Dataset resource, PatchDatasetOptions options = null)
+        {
+            GaxPreconditions.CheckNotNull(datasetReference, nameof(datasetReference));
+            GaxPreconditions.CheckNotNull(resource, nameof(resource));
+            var request = Service.Datasets.Patch(resource, datasetReference.ProjectId, datasetReference.DatasetId);
+            request.ModifyRequest += _versionHeaderAction;
+            options?.ModifyRequest(request);
+            return new BigQueryDataset(this, request.Execute());
+        }
+
+        /// <inheritdoc />
         public override async Task<BigQueryDataset> GetDatasetAsync(DatasetReference datasetReference, GetDatasetOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             GaxPreconditions.CheckNotNull(datasetReference, nameof(datasetReference));

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDataset.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDataset.cs
@@ -161,6 +161,45 @@ namespace Google.Cloud.BigQuery.V2
         public void Delete(DeleteDatasetOptions options = null) => _client.DeleteDataset(Reference, options);
 
         /// <summary>
+        /// Updates this dataset to match the specified resource.
+        /// </summary>
+        /// <remarks>
+        /// This method delegates to <see cref="BigQueryClient.UpdateDataset(DatasetReference, Dataset, UpdateDatasetOptions)"/>.
+        /// A simple way of updating the dataset is to modify <see cref="Resource"/> and then call this method with no arguments.
+        /// This is convenient, but it's important to understand that modifying <see cref="Resource"/> in this way leaves this object
+        /// in an unusual state - it represents "the dataset as it was when fetched, but then modified locally". For example, the etag
+        /// will be the original etag, rather than the one associated with the updated dataset. To avoid this causing confusion,
+        /// we recommend only taking this approach if the object will not be used afterwards. Use the value returned by this method
+        /// as the new, self-consistent representation of the dataset.
+        /// </remarks>
+        /// <param name="resource">The resource to update with. If null, the <see cref="Resource"/> property is
+        /// used.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated dataset.</returns>
+        public BigQueryDataset Update(Dataset resource = null, UpdateDatasetOptions options = null) =>
+            _client.UpdateDataset(Reference, resource ?? Resource, options);
+
+        /// <summary>
+        /// Patches this dataset with fields in the specified resource.
+        /// </summary>
+        /// <remarks>
+        /// This method delegates to <see cref="BigQueryClient.PatchDataset(DatasetReference, Dataset, PatchDatasetOptions)"/>.
+        /// </remarks>
+        /// <param name="resource">The resource to patch with. Must not be null.</param>
+        /// <param name="matchEtag">If true, the etag from <see cref="Resource"/> is propagated into <paramref name="resource"/> for
+        /// optimistic concurrency. Otherwise, <paramref name="resource"/> is left unchanged.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated dataset.</returns>
+        public BigQueryDataset Patch(Dataset resource, bool matchEtag, PatchDatasetOptions options = null)
+        {
+            if (matchEtag)
+            {
+                resource.ETag = Resource.ETag;
+            }
+            return _client.PatchDataset(Reference, resource, options);
+        }
+
+        /// <summary>
         /// Asynchronously uploads a stream of CSV data to a table.
         /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigQueryClient.UploadCsvAsync(TableReference, TableSchema, Stream, UploadCsvOptions, CancellationToken)"/>.
         /// </summary>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDataset.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDataset.cs
@@ -292,10 +292,53 @@ namespace Google.Cloud.BigQuery.V2
         /// Deletes this dataset.
         /// This method just creates a <see cref="DatasetReference"/> and delegates to <see cref="BigQueryClient.DeleteDatasetAsync(string, string, DeleteDatasetOptions, CancellationToken)"/>.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         public Task DeleteAsync(DeleteDatasetOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
             _client.DeleteDatasetAsync(Reference, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously updates this dataset to match the specified resource.
+        /// </summary>
+        /// <remarks>
+        /// This method delegates to <see cref="BigQueryClient.UpdateDataset(DatasetReference, Dataset, UpdateDatasetOptions)"/>.
+        /// A simple way of updating the dataset is to modify <see cref="Resource"/> and then call this method with no arguments.
+        /// This is convenient, but it's important to understand that modifying <see cref="Resource"/> in this way leaves this object
+        /// in an unusual state - it represents "the dataset as it was when fetched, but then modified locally". For example, the etag
+        /// will be the original etag, rather than the one associated with the updated dataset. To avoid this causing confusion,
+        /// we recommend only taking this approach if the object will not be used afterwards. Use the value returned by this method
+        /// as the new, self-consistent representation of the dataset.
+        /// </remarks>
+        /// <param name="resource">The resource to update with. If null, the <see cref="Resource"/> property is
+        /// used.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated dataset.</returns>
+        public Task<BigQueryDataset> UpdateAsync(Dataset resource = null, UpdateDatasetOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            _client.UpdateDatasetAsync(Reference, resource ?? Resource, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously patches this dataset with fields in the specified resource.
+        /// </summary>
+        /// <remarks>
+        /// This method delegates to <see cref="BigQueryClient.PatchDataset(DatasetReference, Dataset, PatchDatasetOptions)"/>.
+        /// </remarks>
+        /// <param name="resource">The resource to patch with. Must not be null.</param>
+        /// <param name="matchEtag">If true, the etag from <see cref="Resource"/> is propagated into <paramref name="resource"/> for
+        /// optimistic concurrency. Otherwise, <paramref name="resource"/> is left unchanged.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated dataset.</returns>
+        public Task<BigQueryDataset> PatchAsync(Dataset resource, bool matchEtag, PatchDatasetOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (matchEtag)
+            {
+                resource.ETag = Resource.ETag;
+            }
+            return _client.PatchDatasetAsync(Reference, resource, options, cancellationToken);
+        }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDataset.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDataset.cs
@@ -302,7 +302,7 @@ namespace Google.Cloud.BigQuery.V2
         /// Asynchronously updates this dataset to match the specified resource.
         /// </summary>
         /// <remarks>
-        /// This method delegates to <see cref="BigQueryClient.UpdateDataset(DatasetReference, Dataset, UpdateDatasetOptions)"/>.
+        /// This method delegates to <see cref="BigQueryClient.UpdateDatasetAsync(DatasetReference, Dataset, UpdateDatasetOptions, CancellationToken)"/>.
         /// A simple way of updating the dataset is to modify <see cref="Resource"/> and then call this method with no arguments.
         /// This is convenient, but it's important to understand that modifying <see cref="Resource"/> in this way leaves this object
         /// in an unusual state - it represents "the dataset as it was when fetched, but then modified locally". For example, the etag
@@ -323,7 +323,7 @@ namespace Google.Cloud.BigQuery.V2
         /// Asynchronously patches this dataset with fields in the specified resource.
         /// </summary>
         /// <remarks>
-        /// This method delegates to <see cref="BigQueryClient.PatchDataset(DatasetReference, Dataset, PatchDatasetOptions)"/>.
+        /// This method delegates to <see cref="BigQueryClient.PatchDatasetAsync(DatasetReference, Dataset, PatchDatasetOptions, CancellationToken)"/>.
         /// </remarks>
         /// <param name="resource">The resource to patch with. Must not be null.</param>
         /// <param name="matchEtag">If true, the etag from <see cref="Resource"/> is propagated into <paramref name="resource"/> for

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/PatchDatasetOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/PatchDatasetOptions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// Options for <c>PatchDataset</c> operations.
+    /// </summary>
+    public sealed class PatchDatasetOptions
+    {
+        internal void ModifyRequest(DatasetsResource.PatchRequest request)
+        {
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/UpdateDatasetOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/UpdateDatasetOptions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// Options for <c>UpdateDataset</c> operations.
+    /// </summary>
+    public sealed class UpdateDatasetOptions
+    {
+        internal void ModifyRequest(DatasetsResource.UpdateRequest request)
+        {
+        }
+    }
+}


### PR DESCRIPTION
To be done in later PRs:

- Helper methods to modify labels conveniently
- The same pattern for tables and jobs
