### PR TITLE
Update to docfx v2.21.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   # Download and unpack docfx
   - mkdir docfx
   - cd docfx
-  - curl -SL https://github.com/dotnet/docfx/releases/download/v2.20/docfx.zip -o docfx.zip
+  - curl -SL https://github.com/dotnet/docfx/releases/download/v2.21.1/docfx.zip -o docfx.zip
   - unzip docfx.zip
   - cd ..
   # add dotnet and docfx to PATH


### PR DESCRIPTION
(This isn't quite the latest, but it's the version used to build the
docs that are currently on github pages.)