### PR TITLE
CI code coverage using dotcover and codecov.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.BigQuery.V2.IntegrationTests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.BigQuery.V2.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Datastore.V1.IntegrationTests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Datastore.V1.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.Tests/coverage.xml
+++ b/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.DevTools.Common.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Diagnostics.AspNet.IntegrationTests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Diagnostics.AspNet.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f netcoreapp1.0 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f netcoreapp1.0 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Diagnostics.AspNetCore.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Diagnostics.Common.IntegrationTests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Diagnostics.Common.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental.Tests/coverage.xml
+++ b/apis/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Language.V1.Experimental.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Language.V1.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/coverage.xml
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Logging.Log4Net.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Metadata.V1.IntegrationTests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Metadata.V1.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.PubSub.V1.IntegrationTests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Tasks/TestScheduler.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Tasks/TestScheduler.cs
@@ -450,7 +450,7 @@ namespace Google.Cloud.PubSub.V1.Tests.Tasks
         public T Run<T>(Func<Task<T>> taskProvider)
         {
             var simulatedTimeout = Clock.GetCurrentDateTimeUtc() + TimeSpan.FromHours(24);
-            var realCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var realCts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
             Task<Task<T>> mainTask = Task<Task<T>>.Factory.StartNew(taskProvider, CancellationToken.None, TaskCreationOptions.None, _taskScheduler);
             while (true)
             {

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.PubSub.V1.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Spanner.Data.IntegrationTests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Spanner.Data.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Storage.V1.IntegrationTests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Storage.V1.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Translation.V2.IntegrationTests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Translation.V2.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.IntegrationTests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Vision.V1.IntegrationTests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Vision.V1.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.LongRunning/Google.LongRunning.Tests/coverage.xml
+++ b/apis/Google.LongRunning/Google.LongRunning.Tests/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.LongRunning.Tests.dvcr</Output>
+</CoverageParams>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,14 +34,20 @@ build_script:
   - dotnet --info
   - echo "Regenerating projects: if this fails, run generateprojects.sh and commit changes"
   - generateprojects.sh && git diff --exit-code
-  - bash build.sh
+  - bash build.sh --notests
   - cd docs
   - bash builddocs.sh
+  - cd ..
 
-# TODO: Reinstate these...
-#  - bash runcoverage.sh
-#  - bash coveralls.sh
+# scripts to run before tests
+before_test:
+  - choco install codecov
 
+# scripts to run after tests
+after_test:
+  - bash createcoveragereport.sh
+  - codecov -f "coverage/coverage.xml"
 
-# The tests are run as part of the build.
-test: off
+# to run your custom scripts instead of automatic tests
+test_script:
+  - bash runcoverage.sh

--- a/build.sh
+++ b/build.sh
@@ -21,8 +21,20 @@ dotnet publish -c Release -f netstandard1.3 tools/Google.Cloud.Tools.Analyzers/G
 # Command line arguments are the APIs to build. Each argument
 # should be the name of a directory, either relative to the location
 # of this script, or under apis.
-apis=$@
-if [ -z "$apis" ]
+apis=()
+runtests=true
+while (( "$#" )); do
+  if [[ "$1" == "--notests" ]]
+  then 
+    echo "Not Running Tests..."
+    runtests=false
+  else 
+    apis+=($1)
+  fi
+  shift
+done
+
+if [ ${#apis[@]} -eq 0 ]
 then
   apis="tools $(echo apis/Google.* | sed 's/apis\///g')"
 fi
@@ -77,9 +89,12 @@ dotnet restore AllProjects.sln
 echo "$(date +%T) Building solution"
 dotnet build -c Release AllProjects.sln
 
-# Could use xargs, but this is more flexible
-while read testproject
-do  
-  echo "$(date +%T) Testing $testproject"
-  dotnet test -c Release $testproject
-done < AllTests.txt
+if [[ "$runtests" = true ]]
+then
+  # Could use xargs, but this is more flexible
+  while read testproject
+  do  
+    echo "$(date +%T) Testing $testproject"
+    dotnet test -c Release $testproject
+  done < AllTests.txt
+fi

--- a/createcoveragereport.sh
+++ b/createcoveragereport.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# This script merges all coverage files found under the 'coverage' directory
+# and then creates a dotcover XML report and from that creates a browsable
+# ReportGenerator html report.
+
+# Use an appropriate version of nuget... preferring
+# first an existing NUGET variable, then NuGet, then
+# just falling back to the path.
+if [ -z "$NUGET" ]
+then
+  if [ -n "$NuGet" ]
+  then
+    NUGET="$NuGet"
+  else
+    NUGET="nuget"
+  fi
+fi
+set -e
+
+$NUGET install -Verbosity quiet -OutputDirectory packages -Version 2017.1.20170613.162720 JetBrains.dotCover.CommandLineTools
+$NUGET install -Verbosity quiet -OutputDirectory packages -Version 2.4.5.0 ReportGenerator
+
+DOTCOVER=$PWD/packages/JetBrains.dotCover.CommandLineTools.2017.1.20170613.162720/tools/dotCover.exe
+REPORTGENERATOR=$PWD/packages/ReportGenerator.2.4.5.0/tools/ReportGenerator.exe
+FIND=/usr/bin/find
+
+if [ ! -d coverage ]
+then
+ mkdir coverage
+fi
+
+[ -f coverage/all.dvcr ] && rm coverage/all.dvcr
+
+echo "Merging reports..."
+$DOTCOVER merge -Source=$(echo coverage/*.dvcr | sed 's/ /;/g') -Output=coverage/all.dvcr ""
+
+echo "Generating detailed xml report..."
+$DOTCOVER report -Source=coverage/all.dvcr -Output=coverage/coverage.xml -ReportType=DetailedXML ""
+
+echo "Running ReportGenerator to create an html report..."
+
+$REPORTGENERATOR \
+   -reports:coverage/coverage.xml \
+   -targetdir:coverage/report \
+   -verbosity:Error
+
+# TODO(benwu): upload coverage/report to public blob storage

--- a/tools/Google.Cloud.ClientTesting/CodeHealthTester.cs
+++ b/tools/Google.Cloud.ClientTesting/CodeHealthTester.cs
@@ -23,6 +23,14 @@ namespace Google.Cloud.ClientTesting
 {
     public static class CodeHealthTester
     {
+        private static readonly HashSet<string> s_exemptedFields = new HashSet<string>()
+        {
+            "DataOnStack.Pointer",
+            "DataOnStack.StatementCount",
+            "DataOnStack.MetadataIndex",
+            "DataOnStack.MethodToken"
+        };
+
         /// <summary>
         /// Asserts that all the fields in the assembly containing the given type are private,
         /// other than for constants.
@@ -39,6 +47,8 @@ namespace Google.Cloud.ClientTesting
                             where !field.IsPrivate && !field.IsLiteral
                             // Allow internal static readonly fields, e.g. for singletons
                             where !(field.IsAssembly && field.IsStatic && field.IsInitOnly)
+                            // Exempt fields added for coverage by dotCover
+                            where !s_exemptedFields.Contains($"{type.Name}.{field.Name}")
                             select $"{type.Name}.{field.Name}";
             // Force output to show the bad fields
             Assert.Equal(new string[0], badFields.ToList());


### PR DESCRIPTION
This currently only runs coverage on unit tests for CI (not integration tests).

Jon -- I'm testing the appveyor integration with codecov.  I've tested runcoverage.sh with reportgenerator and it's looking good. 

Another thing we can do is run this with integrationtests, generating a combined report and publishing the results.  If codecov doesn't pan out, we can still get reportgenerator output somewhere, which would be good.