### PR TITLE
Update versions ready for release

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta15</Version>
+    <Version>1.0.0-beta16</Version>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <Features>IOperation</Features>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <Features>IOperation</Features>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -21,9 +21,9 @@
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Google.Cloud.DevTools.Common\Google.Cloud.DevTools.Common\Google.Cloud.DevTools.Common.csproj" />
-    <ProjectReference Include="..\..\Google.Cloud.Logging.V2\Google.Cloud.Logging.V2\Google.Cloud.Logging.V2.csproj" />
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />
+    <PackageReference Include="Google.Cloud.DevTools.Common" Version="1.0.0" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="2.0.0" />
     <PackageReference Include="Grpc.Core" Version="1.4.0" PrivateAssets="None" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.1.2" PrivateAssets="All" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -19,7 +19,7 @@
     "id": "Google.Cloud.BigQuery.V2",
     "productName": "Google BigQuery",
     "productUrl": "https://cloud.google.com/bigquery/",
-    "version": "1.0.0-beta15",
+    "version": "1.0.0-beta16",
     "type": "rest",
     "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
     "dependencies": {
@@ -200,7 +200,7 @@
 
   {
     "id": "Google.Cloud.Logging.Log4Net",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "type": "other",
     "targetFrameworks": "netstandard1.5;net45",
     "testTargetFrameworks": "netcoreapp1.0;net452",
@@ -208,8 +208,8 @@
     "tags": [ "Log4Net", "Logging", "Stackdriver" ],
     "dependencies": {
       "log4net": "2.0.8",
-      "Google.Cloud.Logging.V2": "",
-      "Google.Cloud.DevTools.Common": "",
+      "Google.Cloud.Logging.V2": "2.0.0",
+      "Google.Cloud.DevTools.Common": "1.0.0",
       "Grpc.Core": ""
     },
     "testDependencies": {


### PR DESCRIPTION
Google.Cloud.Logging.Log4Net now has package references rather than
project references.