### PR TITLE
Make the release tagging process more rigorous

### DIFF
--- a/tools/Google.Cloud.Tools.TagReleases/Google.Cloud.Tools.TagReleases.csproj
+++ b/tools/Google.Cloud.Tools.TagReleases/Google.Cloud.Tools.TagReleases.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="LibGit2Sharp" Version="0.24.0" />
     <PackageReference Include="Octokit" Version="0.24.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- Fetch the github master branch head commit, and use this consistently
- Local repo must be at the same commit
- Local repo must not have changes apis/apis.json
- Project references for packages to release must not "escape" that
  set of packages. (If package X has a project reference to package Y,
  both X and Y must be released together.)