### PR TITLE
Fix project generation version for Grpc.Core

### DIFF
--- a/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
+++ b/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
@@ -240,7 +240,7 @@ namespace Google.Cloud.Tools.ProjectGenerator
                     break;
                 case "grpc":
                     dependencies.Add("Google.Api.Gax.Grpc", DefaultVersionValue);
-                    dependencies.Add("Grpc.Core", GrpcVersion);
+                    dependencies.Add("Grpc.Core", DefaultVersionValue);
                     targetFrameworks = targetFrameworks ?? DefaultGrpcTargetFrameworks;
                     break;
             }


### PR DESCRIPTION
We still end up using the default version for Grpc.Core where we
can, but GA projects should be banned from defaulting.