### PR TITLE
Reinstate coverage option for integration tests

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.BigQuery.V2.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Bigtable.V2.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Datastore.V1.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Diagnostics.AspNet.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f netcoreapp1.0 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Diagnostics.AspNetCore.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Dlp.V2Beta1/Google.Cloud.Dlp.V2Beta1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Dlp.V2Beta1/Google.Cloud.Dlp.V2Beta1.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Dlp.V2Beta1.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.ErrorReporting.V1Beta1.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Language.V1.Experimental.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Language.V1.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Logging.Log4Net.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Logging.V2.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Metadata.V1.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Monitoring.V3.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.PubSub.V1.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Spanner.Admin.Database.V1.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Spanner.Admin.Instance.V1.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Spanner.Data.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Spanner.V1.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Speech.V1.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Storage.V1.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Trace.V1.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Translation.V2.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.VideoIntelligence.V1Beta1.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Vision.V1.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.LongRunning/Google.LongRunning.Snippets/coverage.xml
+++ b/apis/Google.LongRunning/Google.LongRunning.Snippets/coverage.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.LongRunning.Snippets.dvcr</Output>
+</CoverageParams>

--- a/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
+++ b/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
@@ -148,12 +148,10 @@ namespace Google.Cloud.Tools.ProjectGenerator
                         GenerateMainProject(api, dir, apiNames);
                         break;
                     case ".IntegrationTests":
+                    case ".Snippets":
                     case ".Tests":
                         GenerateTestProject(api, dir, apiNames);
                         GenerateCoverageFile(api, dir);
-                        break;
-                    case ".Snippets":
-                        GenerateTestProject(api, dir, apiNames);
                         break;
                 }
             }


### PR DESCRIPTION
Note that this and #1307 both change the coverage XML files; whichever is merged first, the other will need to be rebased and generateprojects will need to be rerun. (I'll take care of doing that.)