### PR TITLE
Minor tweaks to AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,19 +35,19 @@ build_script:
   - echo "Regenerating projects: if this fails, run generateprojects.sh and commit changes"
   - generateprojects.sh && git diff --exit-code
   - bash build.sh --notests
-  - cd docs
-  - bash builddocs.sh
-  - cd ..
 
 # scripts to run before tests
 before_test:
   - choco install codecov
 
+# run the tests with coverage
+test_script:
+  - bash runcoverage.sh
+  
 # scripts to run after tests
 after_test:
   - bash createcoveragereport.sh
   - codecov -f "coverage/coverage.xml"
-
-# to run your custom scripts instead of automatic tests
-test_script:
-  - bash runcoverage.sh
+  - cd docs
+  - bash builddocs.sh
+  - cd ..

--- a/runcoverage.sh
+++ b/runcoverage.sh
@@ -10,6 +10,10 @@
 # only to be executed on Windows, and only after build.sh
 # has been run (so we already have an AllTests.txt file).
 
+# Disable automatic test reporting to AppVeyor.
+# See https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/1232
+unset APPVEYOR_API_URL
+
 # Use an appropriate version of nuget... preferring
 # first an existing NUGET variable, then NuGet, then
 # just falling back to the path.


### PR DESCRIPTION
- Build the docs after running the tests (as tests are more likely
  to fail)
- Specify scripts in appveyor.yaml in execution order
- Make sure we don't use automatic AppVeyor test reporting (which
  can be flaky) when running tests under coverage