### PR TITLE
Make Spanner snippets use same instance as integration tests

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SnippetFixture.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SnippetFixture.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Spanner.Data.Snippets
     {
         private readonly Lazy<Task> _creationTask;
 
-        public string TestInstanceName => "spannerinstance";
+        public string TestInstanceName => "spannerintegration";
 
         public string TestProjectName => Environment.GetEnvironmentVariable("TEST_PROJECT") ?? "cloud-sharp-jenkins";
 


### PR DESCRIPTION
(Arguably "spanner-integration-tests" would be even clearer than
"spannerintegration" but the cost of getting all current users to
create a new instance outweighs the benefit, I think.)