### PR TITLE
Add table update/patch functionality

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/TablesTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/TablesTest.cs
@@ -1,0 +1,275 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2.Data;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.BigQuery.V2.IntegrationTests
+{
+    // Note: some of these tests fetch the table in a way that looks unnecessary.
+    // Currently, the etag changes between a table being created and it first being fetched,
+    // which breaks the "create, update" approach. I'm investigating why this happens.
+
+    [Collection(nameof(BigQueryFixture))]
+    public class TablesTest
+    {
+        private readonly BigQueryFixture _fixture;
+
+        public TablesTest(BigQueryFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public void UpdateTable()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            var tableId = _fixture.CreateTableId();
+
+            var original = client.CreateTable(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+
+            // Modify locally...
+            original.Resource.Description = "Description2";
+            original.Resource.FriendlyName = "FriendlyName2";
+
+            // FIXME: I shouldn't need to do this.
+            original.Resource.ETag = client.GetTable(datasetId, tableId).Resource.ETag;
+
+            // Check the results of the update
+            var updated = original.Update();
+            Assert.Equal("Description2", updated.Resource.Description);
+            Assert.Equal("FriendlyName2", updated.Resource.FriendlyName);
+
+            // Check that it's still valid if fetched directly
+            var fetched = client.GetTable(datasetId, tableId);
+            Assert.Equal("Description2", fetched.Resource.Description);
+            Assert.Equal("FriendlyName2", fetched.Resource.FriendlyName);
+        }
+
+        [Fact]
+        public void UpdateTable_Conflict()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            var tableId = _fixture.CreateTableId();
+
+            var original = client.CreateTable(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+
+            // Modify on the server, which will change the etag
+            var sneaky = client.GetTable(datasetId, tableId);
+            sneaky.Resource.FriendlyName = "Sneak attack!";
+            sneaky.Update();
+
+            // Modify the originally-created version...
+            original.Resource.Description = "Description2";
+
+            // Fails due to the conflict.
+            var exception = Assert.Throws<GoogleApiException>(() => original.Update());
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+        }
+
+        [Fact]
+        public void PatchTable()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            var tableId = _fixture.CreateTableId();
+
+            var original = client.CreateTable(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+            var patched = original.Patch(new Table { Description = "Description2" }, matchEtag: false);
+
+            // Check the results of the patch
+            Assert.Equal("Description2", patched.Resource.Description);
+            Assert.Equal("FriendlyName1", patched.Resource.FriendlyName);
+
+            // Check that it's still valid if fetched directly
+            var fetched = client.GetTable(datasetId, tableId);
+            Assert.Equal("Description2", fetched.Resource.Description);
+            Assert.Equal("FriendlyName1", fetched.Resource.FriendlyName);
+        }
+
+        [Fact]
+        public void PatchTable_ConflictMatchEtag()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            var tableId = _fixture.CreateTableId();
+
+            var original = client.CreateTable(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+            // FIXME: I shouldn't need to do this.
+            original.Resource.ETag = client.GetTable(datasetId, tableId).Resource.ETag;
+
+            // Modify on the server, which will change the etag
+            var sneaky = client.GetTable(datasetId, tableId);
+            sneaky.Resource.FriendlyName = "Sneak attack!";
+            sneaky.Update();
+
+            // Fails due to the conflict.
+            var exception = Assert.Throws<GoogleApiException>(() => original.Patch(new Table { Description = "Description2" }, matchEtag: true));
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+        }
+
+        [Fact]
+        public void PatchTable_ConflictDontMatchEtag()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            var tableId = _fixture.CreateTableId();
+
+            var original = client.CreateTable(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+            // FIXME: I shouldn't need to do this.
+            original.Resource.ETag = client.GetTable(datasetId, tableId).Resource.ETag;
+
+            // Modify on the server, which will change the etag
+            var sneaky = client.GetTable(datasetId, tableId);
+            sneaky.Resource.FriendlyName = "Sneak attack!";
+            sneaky.Update();
+
+            // Patch from the original, but don't bother with optimistic concurrency checks. (Don't propagate the etag.)
+            var patched = original.Patch(new Table { Description = "Description2" }, matchEtag: false);
+
+            // Check the results of the patch
+            Assert.Equal("Description2", patched.Resource.Description);
+            Assert.Equal("Sneak attack!", patched.Resource.FriendlyName);
+
+            // Check that it's still valid if fetched directly
+            var fetched = client.GetTable(datasetId, tableId);
+            Assert.Equal("Description2", fetched.Resource.Description);
+            Assert.Equal("Sneak attack!", fetched.Resource.FriendlyName);
+        }
+
+        [Fact]
+        public async Task UpdateTableAsync()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            var tableId = _fixture.CreateTableId();
+
+            var original = await client.CreateTableAsync(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+
+            // Modify locally...
+            original.Resource.Description = "Description2";
+            original.Resource.FriendlyName = "FriendlyName2";
+
+            // FIXME: I shouldn't need to do this.
+            original.Resource.ETag = client.GetTable(datasetId, tableId).Resource.ETag;
+
+            // Check the results of the update
+            var updated = await original.UpdateAsync();
+            Assert.Equal("Description2", updated.Resource.Description);
+            Assert.Equal("FriendlyName2", updated.Resource.FriendlyName);
+
+            // Check that it's still valid if fetched directly
+            var fetched = await client.GetTableAsync(datasetId, tableId);
+            Assert.Equal("Description2", fetched.Resource.Description);
+            Assert.Equal("FriendlyName2", fetched.Resource.FriendlyName);
+        }
+
+        [Fact]
+        public async Task UpdateTableAsync_Conflict()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            var tableId = _fixture.CreateTableId();
+
+            var original = await client.CreateTableAsync(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+
+            // Modify on the server, which will change the etag
+            var sneaky = await client.GetTableAsync(datasetId, tableId);
+            sneaky.Resource.FriendlyName = "Sneak attack!";
+            sneaky.Update();
+
+            // Modify the originally-created version...
+            original.Resource.Description = "Description2";
+
+            // Fails due to the conflict.
+            var exception = await Assert.ThrowsAsync<GoogleApiException>(() => original.UpdateAsync());
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+        }
+
+        [Fact]
+        public async Task PatchTableAsync()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            var tableId = _fixture.CreateTableId();
+
+            var original = await client.CreateTableAsync(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+            var patched = await original.PatchAsync(new Table { Description = "Description2" }, matchEtag: false);
+
+            // Check the results of the patch
+            Assert.Equal("Description2", patched.Resource.Description);
+            Assert.Equal("FriendlyName1", patched.Resource.FriendlyName);
+
+            // Check that it's still valid if fetched directly
+            var fetched = await client.GetTableAsync(datasetId, tableId);
+            Assert.Equal("Description2", fetched.Resource.Description);
+            Assert.Equal("FriendlyName1", fetched.Resource.FriendlyName);
+        }
+
+        [Fact]
+        public async Task PatchTableAsync_ConflictMatchEtag()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            var tableId = _fixture.CreateTableId();
+
+            var original = await client.CreateTableAsync(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+            // FIXME: I shouldn't need to do this.
+            original.Resource.ETag = client.GetTable(datasetId, tableId).Resource.ETag;
+
+            // Modify on the server, which will change the etag
+            var sneaky = await client.GetTableAsync(datasetId, tableId);
+            sneaky.Resource.FriendlyName = "Sneak attack!";
+            sneaky.Update();
+
+            // Fails due to the conflict.
+            var exception = await Assert.ThrowsAsync<GoogleApiException>(() => original.PatchAsync(new Table { Description = "Description2" }, matchEtag: true));
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+        }
+
+        [Fact]
+        public async Task PatchTableAsync_ConflictDontMatchEtag()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            var tableId = _fixture.CreateTableId();
+
+            var original = await client.CreateTableAsync(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+            // FIXME: I shouldn't need to do this.
+            original.Resource.ETag = client.GetTable(datasetId, tableId).Resource.ETag;
+
+            // Modify on the server, which will change the etag
+            var sneaky = await client.GetTableAsync(datasetId, tableId);
+            sneaky.Resource.FriendlyName = "Sneak attack!";
+            sneaky.Update();
+
+            // Patch from the original, but don't bother with optimistic concurrency checks. (Don't propagate the etag.)
+            var patched = await original.PatchAsync(new Table { Description = "Description2" }, matchEtag: false);
+
+            // Check the results of the patch
+            Assert.Equal("Description2", patched.Resource.Description);
+            Assert.Equal("Sneak attack!", patched.Resource.FriendlyName);
+
+            // Check that it's still valid if fetched directly
+            var fetched = await client.GetTableAsync(datasetId, tableId);
+            Assert.Equal("Description2", fetched.Resource.Description);
+            Assert.Equal("Sneak attack!", fetched.Resource.FriendlyName);
+        }
+
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/BigQueryClientSnippets.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/BigQueryClientSnippets.cs
@@ -1423,7 +1423,6 @@ namespace Google.Cloud.BigQuery.V2.Snippets
         // TODO: Repeated fields and record types.
 
         // TODO:
-        // Table update/patch
         // Job update/patch
 
         [Fact]
@@ -1537,17 +1536,92 @@ namespace Google.Cloud.BigQuery.V2.Snippets
             Assert.Equal("Patched dataset", fetched.Resource.FriendlyName);
         }
 
-        // See-also: PatchDataset(string, Dataset, *)
-        // Member: PatchDataset(DatasetReference, Dataset, *)
-        // Member: PatchDataset(string, string, Dataset, *)
-        // See [PatchDataset](ref) for an example using an alternative overload.
+        // See-also: PatchTable(string, Table, *)
+        // Member: PatchTable(TableReference, Table, *)
+        // Member: PatchTable(string, string, Table, *)
+        // See [PatchTable](ref) for an example using an alternative overload.
         // End see-also
 
-        // See-also: PatchDataset(string, Dataset, *)
-        // Member: PatchDatasetAsync(DatasetReference, Dataset, *, *)
-        // Member: PatchDatasetAsync(string, Dataset, *, *)
-        // Member: PatchDatasetAsync(string, string, Dataset, *, *)
-        // See [PatchDataset](ref) for a synchronous example.
+        // See-also: PatchTable(string, Table, *)
+        // Member: PatchTableAsync(TableReference, Table, *, *)
+        // Member: PatchTableAsync(string, Table, *, *)
+        // Member: PatchTableAsync(string, string, Table, *, *)
+        // See [PatchTable](ref) for a synchronous example.
+        // End see-also
+
+        [Fact]
+        public void UpdateTable()
+        {
+            string projectId = _fixture.ProjectId;
+            string datasetId = _fixture.GameDatasetId;
+            string tableId = _fixture.GenerateTableId();
+            BigQueryClient.Create(projectId).CreateTable(datasetId, tableId, new TableSchema());
+
+            // Snippet: CreateTable(string,string,*,*)
+            BigQueryClient client = BigQueryClient.Create(projectId);
+            BigQueryTable table = client.GetTable(datasetId, tableId);
+            Table resource = table.Resource;
+            resource.FriendlyName = "Updated table";
+
+            // Alternatively, just call table.Update(). In either case,
+            // the etag in the resource will automatically be used for optimistic concurrency.
+            client.UpdateTable(datasetId, tableId, resource);
+
+            // Fetch just to make sure it's really changed...
+            BigQueryTable fetched = client.GetTable(datasetId, tableId);
+            Console.WriteLine($"Fetched table friendly name: {fetched.Resource.FriendlyName}");
+            // End snippet
+
+            Assert.Equal("Updated table", fetched.Resource.FriendlyName);
+        }
+
+        // See-also: UpdateTable(string, string, Table, *)
+        // Member: UpdateTable(TableReference, Table, *)
+        // Member: UpdateTable(string, string, string, Table, *)
+        // See [UpdateTable](ref) for an example using an alternative overload.
+        // End see-also
+
+        // See-also: UpdateTable(string, string, Table, *)
+        // Member: UpdateTableAsync(TableReference, Table, *, *)
+        // Member: UpdateTableAsync(string, string, Table, *, *)
+        // Member: UpdateTableAsync(string, string, string, Table, *, *)
+        // See [UpdateTable](ref) for a synchronous example.
+        // End see-also
+
+        [Fact]
+        public void PatchTable()
+        {
+            string projectId = _fixture.ProjectId;
+            string datasetId = _fixture.GameDatasetId;
+            string tableId = _fixture.GenerateTableId();
+            BigQueryClient.Create(projectId).CreateTable(datasetId, tableId, new TableSchema());
+
+            // Snippet: PatchTable(string, string, Table, *)
+            BigQueryClient client = BigQueryClient.Create(projectId);
+
+            // There's no ETag in this Table, so the patch will be applied unconditionally.
+            // If we specified an ETag, the patch would only be applied if it matched.
+            client.PatchTable(datasetId, tableId, new Table { FriendlyName = "Patched table" });
+
+            // Fetch just to make sure it's really changed...
+            BigQueryTable fetched = client.GetTable(datasetId, tableId);
+            Console.WriteLine($"Fetched table friendly name: {fetched.Resource.FriendlyName}");
+            // End snippet
+
+            Assert.Equal("Patched table", fetched.Resource.FriendlyName);
+        }
+
+        // See-also: PatchTable(string, Table, *)
+        // Member: PatchTable(TableReference, Table, *)
+        // Member: PatchTable(string, string, string, Table, *)
+        // See [PatchTable](ref) for an example using an alternative overload.
+        // End see-also
+
+        // See-also: PatchTable(string, string, Table, *)
+        // Member: PatchTableAsync(TableReference, Table, *, *)
+        // Member: PatchTableAsync(string, string, Table, *, *)
+        // Member: PatchTableAsync(string, string, string, Table, *, *)
+        // See [PatchTable](ref) for a synchronous example.
         // End see-also
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/PatchTableOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/PatchTableOptionsTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+using static Google.Apis.Bigquery.v2.TablesResource;
+
+namespace Google.Cloud.BigQuery.V2.Tests
+{
+    public class PatchTableOptionsTest
+    {
+        // The test doesn't do anything yet... but neither does the code.
+        [Fact]
+        public void ModifyRequest_NoOp()
+        {
+            var request = new PatchRequest(null, null, "project", "dataset", "table");
+            var options = new PatchTableOptions();
+            options.ModifyRequest(request);
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/UpdateTableOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/UpdateTableOptionsTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+using static Google.Apis.Bigquery.v2.TablesResource;
+
+namespace Google.Cloud.BigQuery.V2.Tests
+{
+    public class UpdateTableOptionsTest
+    {
+        // The test doesn't do anything yet... but neither does the code.
+        [Fact]
+        public void ModifyRequest_NoOp()
+        {
+            var request = new UpdateRequest(null, null, "project", "dataset", "table");
+            var options = new UpdateTableOptions();
+            options.ModifyRequest(request);
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.TableCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.TableCrud.cs
@@ -200,6 +200,94 @@ namespace Google.Cloud.BigQuery.V2
         }
 
         /// <summary>
+        /// Updates the specified table to match the given resource.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="UpdateTable(TableReference, Table, UpdateTableOptions)"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="resource">The table resource representation to use for the update. All updatable fields will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated table.</returns>
+        public virtual BigQueryTable UpdateTable(string projectId, string datasetId, string tableId, Table resource, UpdateTableOptions options = null) =>
+            UpdateTable(GetTableReference(projectId, datasetId, tableId), resource, options);
+
+        /// <summary>
+        /// Updates the specified table within this client's project to match the given resource.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="UpdateTable(TableReference, Table, UpdateTableOptions)"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="resource">The table resource representation to use for the update. All updatable fields will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated table.</returns>
+        public virtual BigQueryTable UpdateTable(string datasetId, string tableId, Table resource, UpdateTableOptions options = null) =>
+            UpdateTable(GetTableReference(datasetId, tableId), resource, options);
+
+        /// <summary>
+        /// Updates the specified table to match the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
+        /// <param name="resource">The table resource representation to use for the update. All updatable fields will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated table.</returns>
+        public virtual BigQueryTable UpdateTable(TableReference tableReference, Table resource, UpdateTableOptions options = null) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Patches the specified table with fields in the given resource.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="PatchTable(TableReference, Table, PatchTableOptions)"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="resource">The table resource representation to use for the patch. Only fields present in the resource will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated table.</returns>
+        public virtual BigQueryTable PatchTable(string projectId, string datasetId, string tableId, Table resource, PatchTableOptions options = null) =>
+            PatchTable(GetTableReference(projectId, datasetId, tableId), resource, options);
+
+        /// <summary>
+        /// Patches the specified table within this client's project with fields in the given resource.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="PatchTable(TableReference, Table, PatchTableOptions)"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="resource">The table resource representation to use for the patch. Only fields present in the resource will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated table.</returns>
+        public virtual BigQueryTable PatchTable(string datasetId, string tableId, Table resource, PatchTableOptions options = null) =>
+            PatchTable(GetTableReference(datasetId, tableId), resource, options);
+
+        /// <summary>
+        /// Patches the specified table with fields in the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
+        /// <param name="resource">The table resource representation to use for the patch. Only fields present in the resource will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated table.</returns>
+        public virtual BigQueryTable PatchTable(TableReference tableReference, Table resource, PatchTableOptions options = null) =>
+            throw new NotImplementedException();
+
+        /// <summary>
         /// Retrieves a table given a project ID, dataset ID and table ID.
         /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="GetTableAsync(TableReference,GetTableOptions,CancellationToken)"/>.
         /// </summary>
@@ -399,5 +487,105 @@ namespace Google.Cloud.BigQuery.V2
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Asynchronously updates the specified table to match the given resource.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="UpdateTableAsync(TableReference, Table, UpdateTableOptions, CancellationToken)"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="resource">The table resource representation to use for the update. All updatable fields will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated table.</returns>
+        public virtual Task<BigQueryTable> UpdateTableAsync(string projectId, string datasetId, string tableId, Table resource, UpdateTableOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            UpdateTableAsync(GetTableReference(projectId, datasetId, tableId), resource, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously updates the specified table within this client's project to match the given resource.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="UpdateTableAsync(TableReference, Table, UpdateTableOptions, CancellationToken)"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="resource">The table resource representation to use for the update. All updatable fields will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated table.</returns>
+        public virtual Task<BigQueryTable> UpdateTableAsync(string datasetId, string tableId, Table resource, UpdateTableOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            UpdateTableAsync(GetTableReference(datasetId, tableId), resource, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously updates the specified table to match the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
+        /// <param name="resource">The table resource representation to use for the update. All updatable fields will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated table.</returns>
+        public virtual Task<BigQueryTable> UpdateTableAsync(TableReference tableReference, Table resource, UpdateTableOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Asynchronously patches the specified table with fields in the given resource.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="PatchTableAsync(TableReference, Table, PatchTableOptions, CancellationToken)"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="resource">The table resource representation to use for the patch. Only fields present in the resource will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated table.</returns>
+        public virtual Task<BigQueryTable> PatchTableAsync(string projectId, string datasetId, string tableId, Table resource, PatchTableOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            PatchTableAsync(GetTableReference(projectId, datasetId, tableId), resource, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously patches the specified table within this client's project with fields in the given resource.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="PatchTableAsync(TableReference, Table, PatchTableOptions, CancellationToken)"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="datasetId">The dataset ID. Must not be null.</param>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="resource">The table resource representation to use for the patch. Only fields present in the resource will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated table.</returns>
+        public virtual Task<BigQueryTable> PatchTableAsync(string datasetId, string tableId, Table resource, PatchTableOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            PatchTableAsync(GetTableReference(datasetId, tableId), resource, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously patches the specified table with fields in the given resource.
+        /// </summary>
+        /// <remarks>
+        /// If the resource contains an ETag, it is used for optimistic concurrency validation.
+        /// </remarks>
+        /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
+        /// <param name="resource">The table resource representation to use for the patch. Only fields present in the resource will be updated.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated table.</returns>
+        public virtual Task<BigQueryTable> PatchTableAsync(TableReference tableReference, Table resource, PatchTableOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            throw new NotImplementedException();
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.TableCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.TableCrud.cs
@@ -113,6 +113,28 @@ namespace Google.Cloud.BigQuery.V2
         }
 
         /// <inheritdoc />
+        public override BigQueryTable UpdateTable(TableReference tableReference, Table resource, UpdateTableOptions options = null)
+        {
+            GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
+            GaxPreconditions.CheckNotNull(resource, nameof(resource));
+            var request = Service.Tables.Update(resource, tableReference.ProjectId, tableReference.DatasetId, tableReference.TableId);
+            request.ModifyRequest += _versionHeaderAction;
+            options?.ModifyRequest(request);
+            return new BigQueryTable(this, request.Execute());
+        }
+
+        /// <inheritdoc />
+        public override BigQueryTable PatchTable(TableReference tableReference, Table resource, PatchTableOptions options = null)
+        {
+            GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
+            GaxPreconditions.CheckNotNull(resource, nameof(resource));
+            var request = Service.Tables.Patch(resource, tableReference.ProjectId, tableReference.DatasetId, tableReference.TableId);
+            request.ModifyRequest += _versionHeaderAction;
+            options?.ModifyRequest(request);
+            return new BigQueryTable(this, request.Execute());
+        }
+        
+        /// <inheritdoc />
         public override async Task<BigQueryTable> GetTableAsync(TableReference tableReference, GetTableOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
@@ -176,5 +198,26 @@ namespace Google.Cloud.BigQuery.V2
             await request.ExecuteAsync(cancellationToken).ConfigureAwait(false);
         }
 
+        /// <inheritdoc />
+        public override async Task<BigQueryTable> UpdateTableAsync(TableReference tableReference, Table resource, UpdateTableOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
+            GaxPreconditions.CheckNotNull(resource, nameof(resource));
+            var request = Service.Tables.Update(resource, tableReference.ProjectId, tableReference.DatasetId, tableReference.TableId);
+            request.ModifyRequest += _versionHeaderAction;
+            options?.ModifyRequest(request);
+            return new BigQueryTable(this, await request.ExecuteAsync(cancellationToken).ConfigureAwait(false));
+        }
+
+        /// <inheritdoc />
+        public override async Task<BigQueryTable> PatchTableAsync(TableReference tableReference, Table resource, PatchTableOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
+            GaxPreconditions.CheckNotNull(resource, nameof(resource));
+            var request = Service.Tables.Patch(resource, tableReference.ProjectId, tableReference.DatasetId, tableReference.TableId);
+            request.ModifyRequest += _versionHeaderAction;
+            options?.ModifyRequest(request);
+            return new BigQueryTable(this, await request.ExecuteAsync(cancellationToken).ConfigureAwait(false));
+        }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryTable.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryTable.cs
@@ -197,6 +197,45 @@ namespace Google.Cloud.BigQuery.V2
             _client.CreateCopyJob(Reference, destination, options);
 
         /// <summary>
+        /// Updates this table to match the specified resource.
+        /// </summary>
+        /// <remarks>
+        /// This method delegates to <see cref="BigQueryClient.UpdateTable(TableReference, Table, UpdateTableOptions)"/>.
+        /// A simple way of updating the table is to modify <see cref="Resource"/> and then call this method with no arguments.
+        /// This is convenient, but it's important to understand that modifying <see cref="Resource"/> in this way leaves this object
+        /// in an unusual state - it represents "the table as it was when fetched, but then modified locally". For example, the etag
+        /// will be the original etag, rather than the one associated with the updated table. To avoid this causing confusion,
+        /// we recommend only taking this approach if the object will not be used afterwards. Use the value returned by this method
+        /// as the new, self-consistent representation of the table.
+        /// </remarks>
+        /// <param name="resource">The resource to update with. If null, the <see cref="Resource"/> property is
+        /// used.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated table.</returns>
+        public BigQueryTable Update(Table resource = null, UpdateTableOptions options = null) =>
+            _client.UpdateTable(Reference, resource ?? Resource, options);
+
+        /// <summary>
+        /// Patches this table with fields in the specified resource.
+        /// </summary>
+        /// <remarks>
+        /// This method delegates to <see cref="BigQueryClient.PatchTable(TableReference, Table, PatchTableOptions)"/>.
+        /// </remarks>
+        /// <param name="resource">The resource to patch with. Must not be null.</param>
+        /// <param name="matchEtag">If true, the etag from <see cref="Resource"/> is propagated into <paramref name="resource"/> for
+        /// optimistic concurrency. Otherwise, <paramref name="resource"/> is left unchanged.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>The updated table.</returns>
+        public BigQueryTable Patch(Table resource, bool matchEtag, PatchTableOptions options = null)
+        {
+            if (matchEtag)
+            {
+                resource.ETag = Resource.ETag;
+            }
+            return _client.PatchTable(Reference, resource, options);
+        }
+        
+        /// <summary>
         /// Asynchronously uploads a stream of CSV data to this table.
         /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigQueryClient.UploadCsvAsync(TableReference, TableSchema, Stream, UploadCsvOptions, CancellationToken)"/>.
         /// </summary>
@@ -336,6 +375,49 @@ namespace Google.Cloud.BigQuery.V2
         /// <returns>A task representing the asynchronous operation. When complete, the result is the job created for the copy operation.</returns>
         public Task<BigQueryJob> CreateCopyJobAsync(TableReference destination, CreateCopyJobOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
             _client.CreateCopyJobAsync(Reference, destination, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously updates this table to match the specified resource.
+        /// </summary>
+        /// <remarks>
+        /// This method delegates to <see cref="BigQueryClient.UpdateTableAsync(TableReference, Table, UpdateTableOptions, CancellationToken)"/>.
+        /// A simple way of updating the table is to modify <see cref="Resource"/> and then call this method with no arguments.
+        /// This is convenient, but it's important to understand that modifying <see cref="Resource"/> in this way leaves this object
+        /// in an unusual state - it represents "the table as it was when fetched, but then modified locally". For example, the etag
+        /// will be the original etag, rather than the one associated with the updated table. To avoid this causing confusion,
+        /// we recommend only taking this approach if the object will not be used afterwards. Use the value returned by this method
+        /// as the new, self-consistent representation of the table.
+        /// </remarks>
+        /// <param name="resource">The resource to update with. If null, the <see cref="Resource"/> property is
+        /// used.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated table.</returns>
+        public Task<BigQueryTable> UpdateAsync(Table resource = null, UpdateTableOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            _client.UpdateTableAsync(Reference, resource ?? Resource, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously patches this table with fields in the specified resource.
+        /// </summary>
+        /// <remarks>
+        /// This method delegates to <see cref="BigQueryClient.PatchTableAsync(TableReference, Table, PatchTableOptions, CancellationToken)"/>.
+        /// </remarks>
+        /// <param name="resource">The resource to patch with. Must not be null.</param>
+        /// <param name="matchEtag">If true, the etag from <see cref="Resource"/> is propagated into <paramref name="resource"/> for
+        /// optimistic concurrency. Otherwise, <paramref name="resource"/> is left unchanged.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// the updated table.</returns>
+        public Task<BigQueryTable> PatchAsync(Table resource, bool matchEtag, PatchTableOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (matchEtag)
+            {
+                resource.ETag = Resource.ETag;
+            }
+            return _client.PatchTableAsync(Reference, resource, options, cancellationToken);
+        }
 
         /// <summary>
         /// Returns the fully-qualified ID of the table in Legacy SQL format. The Legacy SQL

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/PatchTableOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/PatchTableOptions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// Options for <c>PatchTable</c> operations.
+    /// </summary>
+    public sealed class PatchTableOptions
+    {
+        internal void ModifyRequest(TablesResource.PatchRequest request)
+        {
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/UpdateTableOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/UpdateTableOptions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// Options for <c>UpdateTable</c> operations.
+    /// </summary>
+    public sealed class UpdateTableOptions
+    {
+        internal void ModifyRequest(TablesResource.UpdateRequest request)
+        {
+        }
+    }
+}


### PR DESCRIPTION
This is a copy/paste of dataset functionality, with the only
difference being that specifying a table reference requires three
pieces of information instead of two.