### PR TITLE
Ensure the RpcRetryConsumer retry logic does not run if the retry type is "NoRetry".

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/RetryOptionsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/RetryOptionsTest.cs
@@ -52,8 +52,8 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             RetryOptions.Retry(retryAttempts: 0);
             Assert.Throws<ArgumentOutOfRangeException>(() => RetryOptions.Retry(retryAttempts: -1));
 
-            RetryOptions.Retry(retryInterval: TimeSpan.Zero);
-            Assert.Throws<ArgumentException>(() => RetryOptions.Retry(retryInterval: TimeSpan.FromSeconds(-1)));
+            RetryOptions.Retry(retryInterval: TimeSpan.FromMilliseconds(1));
+            Assert.Throws<ArgumentException>(() => RetryOptions.Retry(retryInterval: TimeSpan.Zero));
         }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/RpcRetryConsumerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/RpcRetryConsumerTest.cs
@@ -208,7 +208,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         /// </summary>
         private class FakeSequentialThreadingTimer : ISequentialThreadingTimer
         {
-            internal Action Callback = null;
+            internal Action Callback { get; private set; }
 
             public void Initialize(Action callback, TimeSpan waitTime) => Callback = callback;
 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/RpcRetryConsumerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/RpcRetryConsumerTest.cs
@@ -64,8 +64,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
                 Assert.Throws<RpcException>(() => { retryConsumer.Receive(intArray); });
 
                 mockConsumer.Verify(c => c.Receive(intArray), Times.Once);
-                timer.Call();
-                mockConsumer.Verify(c => c.Receive(intArray), Times.Once);
+                Assert.Null(timer.Callback);
             }, RetryOptions.NoRetry(ExceptionHandling.Propagate));
         }
 
@@ -78,8 +77,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
                 retryConsumer.Receive(intArray);
 
                 mockConsumer.Verify(c => c.Receive(intArray), Times.Once);
-                timer.Call();
-                mockConsumer.Verify(c => c.Receive(intArray), Times.Once);
+                Assert.Null(timer.Callback);
             }, RetryOptions.NoRetry());
         }
 
@@ -210,11 +208,11 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         /// </summary>
         private class FakeSequentialThreadingTimer : ISequentialThreadingTimer
         {
-            private Action _callback;
+            internal Action Callback = null;
 
-            public void Initialize(Action callback, TimeSpan waitTime) => _callback = callback;
+            public void Initialize(Action callback, TimeSpan waitTime) => Callback = callback;
 
-            public void Call() => _callback();
+            public void Call() => Callback();
 
             public void Dispose() { }
         }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/RetryOptions.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/RetryOptions.cs
@@ -93,8 +93,11 @@ namespace Google.Cloud.Diagnostics.Common
             RetryAttempts = GaxPreconditions.CheckArgumentRange(
                 retryAttempts ?? 0, nameof(retryAttempts), 0, int.MaxValue);
             RetryInterval = retryInterval ?? TimeSpan.Zero;
-            GaxPreconditions.CheckArgument(RetryInterval >= TimeSpan.Zero, nameof(retryInterval),
-                $"{nameof(retryInterval)} must be greater than 0");
+            if (retryType != RetryType.None)
+            {
+                GaxPreconditions.CheckArgument(RetryInterval > TimeSpan.Zero, nameof(retryInterval),
+                    $"{nameof(retryInterval)} must be greater than 0");
+            }
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/RpcRetryConsumer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/RpcRetryConsumer.cs
@@ -72,7 +72,10 @@ namespace Google.Cloud.Diagnostics.Common
             _timerFactory = GaxPreconditions.CheckNotNull(timerFactory, nameof(timerFactory));
 
             // Start the background timer that will retry failed requests.
-            _timer = _timerFactory(FlushBuffer, _options);
+            if (options.RetryType != RetryType.None)
+            {
+                _timer = _timerFactory(FlushBuffer, _options);
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Also ensure that the RetryInterval is greater than 0 to avoid a loop without a pause.

Fixes #1305.