### PR TITLE
Introduce a single place for tool versions to be specified

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,16 +18,8 @@ environment:
 
 # Install the pre-requisites for the build.
 install:
-  # Make sure curl is available
-  - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
-  # Download and unpack docfx
-  - mkdir docfx
-  - cd docfx
-  - curl -SL https://github.com/dotnet/docfx/releases/download/v2.21.1/docfx.zip -o docfx.zip
-  - unzip docfx.zip
-  - cd ..
-  # add dotnet and docfx to PATH
-  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$pwd\docfx;$env:Path"
+  # add dotnet and curl to PATH
+  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;C:\Program Files\Git\mingw64\bin;$env:Path"
 
 # Perform the build.
 build_script:

--- a/coveralls.sh
+++ b/coveralls.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Only push to coveralls when code is committed; secure variables
-# aren't decoded in pull requests.
-if [ -n "$COVERALLS_REPO_TOKEN" ]
-then
-  nuget install -OutputDirectory packages -Version 0.7.0 coveralls.net
-  packages/coveralls.net.0.7.0/tools/csmacnz.Coveralls.exe --opencover -i coverage/coverage.xml --useRelativePaths
-fi

--- a/createcoveragereport.sh
+++ b/createcoveragereport.sh
@@ -1,29 +1,10 @@
 #!/bin/bash
 
-# This script merges all coverage files found under the 'coverage' directory
-# and then creates a dotcover XML report and from that creates a browsable
-# ReportGenerator html report.
-
-# Use an appropriate version of nuget... preferring
-# first an existing NUGET variable, then NuGet, then
-# just falling back to the path.
-if [ -z "$NUGET" ]
-then
-  if [ -n "$NuGet" ]
-  then
-    NUGET="$NuGet"
-  else
-    NUGET="nuget"
-  fi
-fi
 set -e
+source toolversions.sh
 
-$NUGET install -Verbosity quiet -OutputDirectory packages -Version 2017.1.20170613.162720 JetBrains.dotCover.CommandLineTools
-$NUGET install -Verbosity quiet -OutputDirectory packages -Version 2.4.5.0 ReportGenerator
-
-DOTCOVER=$PWD/packages/JetBrains.dotCover.CommandLineTools.2017.1.20170613.162720/tools/dotCover.exe
-REPORTGENERATOR=$PWD/packages/ReportGenerator.2.4.5.0/tools/ReportGenerator.exe
-FIND=/usr/bin/find
+install_dotcover
+install_reportgenerator
 
 if [ ! -d coverage ]
 then

--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 set -e
+source ../toolversions.sh
+
+install_docfx
 
 build_api_docs() {
   echo "$(date +%T) Building docs for $1"
@@ -15,7 +18,7 @@ build_api_docs() {
     dotnet run -p ../tools/Google.Cloud.Tools.GenerateDocfxSources/*.csproj -- $api
   fi
   cp filterConfig.yml output/$api
-  docfx metadata -f output/$api/docfx.json | tee errors.txt
+  $DOCFX metadata -f output/$api/docfx.json | tee errors.txt
   (! grep --quiet 'Build failed.' errors.txt)
   dotnet run -p ../tools/Google.Cloud.Tools.GenerateSnippetMarkdown/*.csproj -- $api
   
@@ -26,7 +29,7 @@ build_api_docs() {
     cat dependencies/api/$dep/toc >> output/$api/obj/api/toc.yml
   done
   
-  docfx build output/$api/docfx.json | tee errors.txt
+  $DOCFX build output/$api/docfx.json | tee errors.txt
   (! grep --quiet 'Build failed.' errors.txt)
 
   # Special case root: that should end up in the root of the assembled
@@ -42,7 +45,6 @@ build_api_docs() {
   fi
   echo Finished building docs for $api
 }
-
 
 if [[ ! -d "dependencies" ]]
 then

--- a/docs/fetchdependencies.sh
+++ b/docs/fetchdependencies.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 set -e
+source ../toolversions.sh
+install_docfx
+
+declare -r PROTOBUF_BRANCH=3.3.x
+declare -r GRPC_BRANCH=v1.4.x
 
 # Blow away any previous files and clone the repo
 rm -rf dependencies
@@ -12,8 +17,8 @@ git -C dependencies checkout README.md .gitignore
 
 echo "Cloning repositories"
 git clone https://github.com/googleapis/gax-dotnet dependencies/gax-dotnet --quiet --depth=1 -b master
-git clone https://github.com/google/protobuf dependencies/protobuf --quiet --depth=1 -b 3.3.x
-git clone https://github.com/grpc/grpc dependencies/grpc --quiet --depth=1 -b v1.4.x
+git clone https://github.com/google/protobuf dependencies/protobuf --quiet --depth=1 -b $PROTOBUF_BRANCH
+git clone https://github.com/grpc/grpc dependencies/grpc --quiet --depth=1 -b $GRPC_BRANCH
 git clone https://github.com/google/google-api-dotnet-client dependencies/google-api-dotnet-client --quiet --depth=1 -b master
 
 # Minor fixups...
@@ -30,16 +35,16 @@ cp dependencies-docfx/docfx-google-api-dotnet-client.json dependencies/google-ap
 # Restore packages and build metadata
 (cd dependencies/gax-dotnet; 
  dotnet restore Gax.sln;
- docfx metadata)
+ $DOCFX metadata)
 
 (cd dependencies/protobuf;
  echo '{"sdk": {"version": "1.0.0-preview2-003131"}}' > global.json;
  dotnet restore csharp/src;
- docfx metadata)
+ $DOCFX metadata)
 
 (cd dependencies/grpc; 
  dotnet restore src/csharp/Grpc.sln;
- docfx metadata)
+ $DOCFX metadata)
 
 (cd dependencies/google-api-dotnet-client;
  rm NuGet.config;
@@ -47,7 +52,7 @@ cp dependencies-docfx/docfx-google-api-dotnet-client.json dependencies/google-ap
  dotnet new sln --name Generated;
  dotnet sln Generated.sln add Src/Generated/*/*.csproj;
  dotnet restore Generated.sln;
- docfx metadata)
+ $DOCFX metadata)
 
 # Copy the metadata into a single api directory, one subdirectory per package
 mkdir dependencies/api

--- a/generateapis.sh
+++ b/generateapis.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# TODO: Use toolversions.sh
+# This script needs to work on Linux machines without nuget, unlike other scripts...
+
 # TODO: Use some appropriate way of determining OS. Ideally, shouldn't need dotnet installed.
 #[[ $(dotnet --info | grep "OS Platform" | grep -c Windows) -ne 0 ]] && OS=windows || OS=linux
 OS=linux

--- a/runcoverage.sh
+++ b/runcoverage.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+set -e
+
+source toolversions.sh
+install_dotcover
+
 # We use the dotCover CLI for coverage.
 # Other options considered include OpenCover, but that doesn't support portable PDBs.
 # See https://github.com/OpenCover/opencover/issues/601 for current status of OpenCover,
@@ -12,29 +17,6 @@
 # Disable automatic test reporting to AppVeyor.
 # See https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/1232
 unset APPVEYOR_API_URL
-
-# Use an appropriate version of nuget... preferring
-# first an existing NUGET variable, then NuGet, then
-# just falling back to the path.
-if [ -z "$NUGET" ]
-then
-  if [ -n "$NuGet" ]
-  then
-    NUGET="$NuGet"
-  else
-    NUGET="nuget"
-  fi
-fi
-set -e
-
-declare -r DOTCOVER_VERSION=2017.1.20170613.162720 
-declare -r REPORTGENERATOR_VERSION=2.4.5.0
-
-$NUGET install -Verbosity quiet -OutputDirectory packages -Version $DOTCOVER_VERSION JetBrains.dotCover.CommandLineTools
-
-DOTCOVER=$PWD/packages/JetBrains.dotCover.CommandLineTools.$DOTCOVER_VERSION/tools/dotCover.exe
-REPORTGENERATOR=$PWD/packages/ReportGenerator.$REPORTGENERATOR_VERSION/tools/ReportGenerator.exe
-FIND=/usr/bin/find
 
 if [ ! -d coverage ]
 then
@@ -56,4 +38,3 @@ do
 
   popd
 done < AllTests.txt
-

--- a/runintegrationtests.sh
+++ b/runintegrationtests.sh
@@ -4,6 +4,7 @@
 # coverage, you've already installed the relevant package.
 
 set -e
+source toolversions.sh
 
 CONTINUE_ARG=
 COVERAGE_ARG=
@@ -15,7 +16,7 @@ do
     CONTINUE_ARG=yes
     ;;
   --coverage)
-    DOTCOVER=$PWD/packages/JetBrains.dotCover.CommandLineTools.2017.1.20170613.162720/tools/dotCover.exe
+    install_dotcover
     COVERAGE_ARG=yes
     ;;
   *)
@@ -26,7 +27,6 @@ do
 done
 
 PROGRESS_FILE=`realpath integrationprogress.txt`
-FIND=/usr/bin/find
 
 [[ "$CONTINUE_ARG" == "yes" ]] || rm -f $PROGRESS_FILE
 touch $PROGRESS_FILE

--- a/toolversions.sh
+++ b/toolversions.sh
@@ -1,0 +1,52 @@
+# This is intended to be imported using the "source" function from
+# any scripts that use tools.
+
+declare -r REPO_ROOT=$(realpath $(dirname ${BASH_SOURCE}))
+
+declare -r DOCFX_VERSION=2.21.1
+declare -r DOTCOVER_VERSION=2017.1.20170613.162720 
+declare -r REPORTGENERATOR_VERSION=2.4.5.0
+
+# Variables to use to invoke the tools themselves
+
+declare -r DOCFX=$REPO_ROOT/packages/docfx.$DOCFX_VERSION/docfx.exe
+declare -r FIND=/usr/bin/find
+declare -r DOTCOVER=$REPO_ROOT/packages/JetBrains.dotCover.CommandLineTools.$DOTCOVER_VERSION/tools/dotCover.exe
+declare -r REPORTGENERATOR=$REPO_ROOT/packages/ReportGenerator.$REPORTGENERATOR_VERSION/tools/ReportGenerator.exe
+
+# Use an appropriate version of nuget... preferring
+# first an existing NUGET variable, then NuGet, then
+# just falling back to the path.
+if [ -z "$NUGET" ]
+then
+  if [ -n "$NuGet" ]
+  then
+    declare -r NUGET="$NuGet"
+  else
+    declare -r NUGET="nuget"
+  fi
+fi
+
+# Installation functions, all of which should be unconditionally called
+# when required. (They handle the case where the tool is already installed.)
+
+install_dotcover() {
+  $NUGET install -Verbosity quiet -OutputDirectory $REPO_ROOT/packages -Version $DOTCOVER_VERSION JetBrains.dotCover.CommandLineTools
+}
+
+install_reportgenerator() {
+  $NUGET install -Verbosity quiet -OutputDirectory $REPO_ROOT/packages -Version $REPORTGENERATOR_VERSION ReportGenerator
+}
+
+install_docfx() {
+  if [[ ! -f $DOCFX ]]
+  then
+    (echo "Fetching docfx v${DOCFX_VERSION}";
+     cd $REPO_ROOT/packages;
+     mkdir docfx.$DOCFX_VERSION;
+     cd docfx.$DOCFX_VERSION;
+     curl -sSL https://github.com/dotnet/docfx/releases/download/v${DOCFX_VERSION}/docfx.zip -o tmp.zip;
+     unzip -q tmp.zip;
+     rm tmp.zip)
+  fi
+}


### PR DESCRIPTION
This also declares variables to run the tools, and installation
scripts. Arguably as it contains more than version numbers,
toolversions.sh should be called something else - suggestions welcome.

docfx is now installed within the scripts that use it rather than as
part of the AppVeyor script: it doesn't matter which version of
docfx a user might have on the path.

In tidying up tooling in general, I've removed coveralls.sh which is
no longer needed (as we're using codecov).

The generateapis.sh script is slightly different from all the rest
here; we can address that later.

Fixes #1324.