### PR TITLE
Improve BigQuery unit tests

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
@@ -462,6 +462,18 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Throws<GoogleApiException>(() => results.ThrowOnAnyError());
         }
 
+        [Fact]
+        public void DryRun_GetResults()
+        {
+            var projectId = _fixture.ProjectId;
+            var client = BigQueryClient.Create(projectId);
+            var table = client.GetTable(PublicDatasetsProject, PublicDatasetsDataset, ShakespeareTable);
+
+            var sql = $"SELECT corpus as title, COUNT(word) as unique_words FROM {table} GROUP BY title ORDER BY unique_words DESC LIMIT 10";
+            var job = client.CreateQueryJob(sql, new QueryOptions { DryRun = true });
+            Assert.Throws<InvalidOperationException>(() => job.GetQueryResults());
+        }
+
         private class TitleComparer : IEqualityComparer<BigQueryRow>
         {
             public bool Equals(BigQueryRow x, BigQueryRow y) => (string)x["title"] == (string)y["title"];

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryDatasetTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryDatasetTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,27 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using Google.Apis.Bigquery.v2.Data;
+using Moq;
 using Xunit;
 
 namespace Google.Cloud.BigQuery.V2.Tests
 {
-    public class TableSchemaExtensionsTest
+    public class BigQueryDatasetTest
     {
+        // Most aspects are tested via equivalent in BigQueryClientTest
+
         [Fact]
-        public void GetFieldIndex()
+        public void FullyQualifiedId()
         {
-            var schema = new TableSchema
-            {
-                Fields = new List<TableFieldSchema>
-                {
-                    new TableFieldSchema { Name = "foo" },
-                    new TableFieldSchema { Name = "bar" }
-                }
-            };
-            Assert.Equal(1, schema.GetFieldIndex("bar"));
-            Assert.Throws<KeyNotFoundException>(() => schema.GetFieldIndex("qux"));
+            var reference = new DatasetReference { ProjectId = "my-project", DatasetId = "my-dataset" };
+            var dataset = new BigQueryDataset(new Mock<BigQueryClient>().Object, new Dataset { DatasetReference = reference });
+            Assert.Equal("my-project:my-dataset", dataset.FullyQualifiedId);
         }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryJobTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryJobTest.cs
@@ -1,0 +1,127 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2;
+using Google.Apis.Bigquery.v2.Data;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.BigQuery.V2.Tests
+{
+    public class BigQueryJobTest
+    {
+        [Fact]
+        public void Properties()
+        {
+            var resource = new Job
+            {
+                JobReference = new JobReference { ProjectId = "project", JobId = "job" },
+                Status = new JobStatus { State = "RUNNING" },
+                Statistics = new JobStatistics { CreationTime = 1000L }
+            };
+            var job = new BigQueryJob(new SimpleClient(), resource);
+            Assert.Same(resource, job.Resource);
+            Assert.Same(resource.JobReference, job.Reference);
+            Assert.Same(resource.Statistics, job.Statistics);
+            Assert.Same(resource.Status, job.Status);
+            Assert.Equal(JobState.Running, job.State);
+        }
+
+        [Fact]
+        public void ThrowOnAnyError_WithErrors()
+        {
+            var resource = new Job
+            {
+                JobReference = new JobReference { ProjectId = "project", JobId = "job" },
+                Status = new JobStatus
+                {
+                    State = "completed",
+                    Errors = new[] { new ErrorProto { Message = "Error 1" }, new ErrorProto { Message = "Error 2" } }
+                }
+            };
+            var job = new BigQueryJob(new SimpleClient(), resource);
+            var exception = Assert.Throws<GoogleApiException>(() => job.ThrowOnAnyError());
+            var requestError = exception.Error;
+            Assert.Equal(new[] { "Error 1", "Error 2" }, requestError.Errors.Select(e => e.Message));
+        }
+
+        [Fact]
+        public void ThrowOnAnyError_NoErrors()
+        {
+            var resource = new Job
+            {
+                Status = new JobStatus { State = "completed" },
+            };
+            var job = new BigQueryJob(new SimpleClient(), resource);
+            job.ThrowOnAnyError();
+        }
+
+        [Fact]
+        public async Task GetQueryResults_NonQuery()
+        {
+            var resource = new Job
+            {
+                JobReference = new JobReference { ProjectId = "project", JobId = "job" },
+                Configuration = new JobConfiguration
+                {
+                    Copy = new JobConfigurationTableCopy { }
+                }
+            };
+            var job = new BigQueryJob(new SimpleClient(), resource);
+            Assert.Throws<InvalidOperationException>(() => job.GetQueryResults());
+            await Assert.ThrowsAsync<InvalidOperationException>(() => job.GetQueryResultsAsync());
+        }
+
+        [Fact]
+        public async Task GetQueryResults_NoDestinationTable()
+        {
+            var resource = new Job
+            {
+                JobReference = new JobReference { ProjectId = "project", JobId = "job" },
+                Configuration = new JobConfiguration
+                {
+                    DryRun = true,
+                    Query = new JobConfigurationQuery { } // No destination table
+                }
+            };
+            var job = new BigQueryJob(new SimpleClient(), resource);
+            Assert.Throws<InvalidOperationException>(() => job.GetQueryResults());
+            await Assert.ThrowsAsync<InvalidOperationException>(() => job.GetQueryResultsAsync());
+        }
+
+        [Fact]
+        public async Task GetQueryResults_NoJobReference()
+        {
+            var resource = new Job
+            {
+                Configuration = new JobConfiguration
+                {
+                    DryRun = true,
+                    Query = new JobConfigurationQuery { DestinationTable = new TableReference { ProjectId = "project", DatasetId = "dataset", TableId = "table" } }
+                }
+            };
+            var job = new BigQueryJob(new SimpleClient(), resource);
+            Assert.Throws<InvalidOperationException>(() => job.GetQueryResults());
+            await Assert.ThrowsAsync<InvalidOperationException>(() => job.GetQueryResultsAsync());
+        }
+
+        // ThrowOnAnyError uses the client service name. This is simpler than mocking that.
+        private class SimpleClient : BigQueryClient
+        {
+            public override BigqueryService Service { get; } = new FakeBigqueryService();
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryPageTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryPageTest.cs
@@ -1,0 +1,57 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Apis.Bigquery.v2.Data;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Google.Cloud.BigQuery.V2.Tests
+{
+    public class BigQueryPageTest
+    {
+        [Fact]
+        public void PublicConstructor()
+        {
+            var rows = new List<BigQueryRow>();
+            var schema = new TableSchema();
+            var jobReference = new JobReference { ProjectId = "project", JobId = "job" };
+            var tableReference = new TableReference { ProjectId = "project", DatasetId = "dataset", TableId = "table" };
+            var nextPageToken = "token";
+            var page = new BigQueryPage(rows, schema, jobReference, tableReference, nextPageToken);
+            Assert.Same(rows, page.Rows);
+            Assert.Same(schema, page.Schema);
+            Assert.Same(jobReference, page.JobReference);
+            Assert.Same(tableReference, page.TableReference);
+            Assert.Same(nextPageToken, page.NextPageToken);
+        }
+
+        [Fact]
+        public void InternalConstructor()
+        {
+            var nextPageToken = "token";
+            var schema = new TableSchema();
+            var row = new BigQueryRow(new TableRow(), schema);
+            var rawPage = new Page<BigQueryRow>(new List<BigQueryRow> { row }, nextPageToken);
+            var jobReference = new JobReference { ProjectId = "project", JobId = "job" };
+            var tableReference = new TableReference { ProjectId = "project", DatasetId = "dataset", TableId = "table" };
+            var page = new BigQueryPage(rawPage, schema, jobReference, tableReference);
+            Assert.Equal(new[] { row }, page.Rows);
+            Assert.Same(schema, page.Schema);
+            Assert.Same(jobReference, page.JobReference);
+            Assert.Same(tableReference, page.TableReference);
+            Assert.Same(nextPageToken, page.NextPageToken);
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 using Google.Apis.Bigquery.v2.Data;
+using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Google.Cloud.BigQuery.V2.Tests
@@ -31,6 +34,10 @@ namespace Google.Cloud.BigQuery.V2.Tests
                 { "float", BigQueryDbType.Float64 },
                 { "string", BigQueryDbType.String },
                 { "timestamp", BigQueryDbType.Timestamp },
+                { "date", BigQueryDbType.Date },
+                { "dateTime", BigQueryDbType.DateTime },
+                { "time", BigQueryDbType.Time },
+                { "struct", new TableSchemaBuilder { { "x", BigQueryDbType.Int64 }, { "y", BigQueryDbType.String } } }
             }.Build();
             var rawRow = new TableRow
             {
@@ -42,6 +49,10 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     new TableCell { V = "2.5" },
                     new TableCell { V = "text" },
                     new TableCell { V = "1477566580.5" }, // 2016-10-27T11:09:40.500Z
+                    new TableCell { V = "2017-08-09" },
+                    new TableCell { V = "2017-08-09T12:34:56.123" },
+                    new TableCell { V = "12:34:56.123" },
+                    new TableCell { V = new JObject { ["f"] = new JArray {new JObject { ["v"] = "100" }, new JObject { ["v"] = "xyz" } } } }
                 }
             };
             var row = new BigQueryRow(rawRow, schema);
@@ -51,6 +62,107 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.Equal(2.5d, (double)row["float"]);
             Assert.Equal("text", (string)row["string"]);
             Assert.Equal(new DateTime(2016, 10, 27, 11, 9, 40, 500, DateTimeKind.Utc), (DateTime)row["timestamp"]);
+            Assert.Equal(new DateTime(2017, 8, 9, 0, 0, 0, DateTimeKind.Utc), (DateTime)row["date"]);
+            Assert.Equal(new DateTime(2017, 8, 9, 12, 34, 56, 123, DateTimeKind.Utc), (DateTime)row["dateTime"]);
+            Assert.Equal(new TimeSpan(0, 12, 34, 56, 123), (TimeSpan)row["time"]);
+            Assert.Equal(new Dictionary<string, object> { { "x", 100L }, { "y", "xyz" } }, (Dictionary<string, object>)row["struct"]);
         }
+
+        [Fact]
+        public void Arrays()
+        {
+            var schema = new TableSchemaBuilder
+            {
+                { "integer", BigQueryDbType.Int64, BigQueryFieldMode.Repeated },
+                { "bool", BigQueryDbType.Bool, BigQueryFieldMode.Repeated },
+                { "bytes", BigQueryDbType.Bytes, BigQueryFieldMode.Repeated },
+                { "float", BigQueryDbType.Float64, BigQueryFieldMode.Repeated },
+                { "string", BigQueryDbType.String, BigQueryFieldMode.Repeated },
+                { "timestamp", BigQueryDbType.Timestamp, BigQueryFieldMode.Repeated },
+                { "date", BigQueryDbType.Date, BigQueryFieldMode.Repeated },
+                { "dateTime", BigQueryDbType.DateTime, BigQueryFieldMode.Repeated },
+                { "time", BigQueryDbType.Time, BigQueryFieldMode.Repeated },
+                { "struct", new TableSchemaBuilder { { "x", BigQueryDbType.Int64 }, { "y", BigQueryDbType.String } }, BigQueryFieldMode.Repeated }
+            }.Build();
+            var rawRow = new TableRow
+            {
+                F = new[]
+                {
+                    new TableCell { V = CreateArray("10", "20") },
+                    new TableCell { V = CreateArray("true", "false") },
+                    new TableCell { V = CreateArray("AQI=", "AQM=") }, // [1, 2], [1, 3]
+                    new TableCell { V = CreateArray("2.5", "3.5") },
+                    new TableCell { V = CreateArray("text", "more text") },
+                    new TableCell { V = CreateArray("1477566580.5", "1477566581.5") }, // 2016-10-27T11:09:40.500Z, 2016-10-27T11:09:41.500Z
+                    new TableCell { V = CreateArray("2017-08-09", "2017-08-10") },
+                    new TableCell { V = CreateArray("2017-08-09T12:34:56.123","2017-08-09T12:34:57.123") },
+                    new TableCell { V = CreateArray("12:34:56.123", "12:34:57.123") },
+                    new TableCell { V = new JArray {
+                        new JObject { ["v"] = new JObject { ["f"] = new JArray { new JObject { ["v"] = "100" }, new JObject { ["v"] = "xyz" } } } },
+                        new JObject { ["v"] = new JObject { ["f"] = new JArray { new JObject { ["v"] = "200" }, new JObject { ["v"] = "abc" } } } }
+                    } }
+                }
+            };
+            var row = new BigQueryRow(rawRow, schema);
+            Assert.Equal(new[] { 10L, 20L }, (long[])row["integer"]);
+            Assert.Equal(new[] { true, false }, (bool[])row["bool"]);
+            Assert.Equal(new[] { new byte[] { 1, 2 }, new byte[] { 1, 3 } }, (byte[][])row["bytes"]);
+            Assert.Equal(new[] { 2.5d, 3.5d }, (double[])row["float"]);
+            Assert.Equal(new[] { "text", "more text" }, (string[])row["string"]);
+            Assert.Equal(new[] { new DateTime(2016, 10, 27, 11, 9, 40, 500, DateTimeKind.Utc), new DateTime(2016, 10, 27, 11, 9, 41, 500, DateTimeKind.Utc) },
+                (DateTime[])row["timestamp"]);
+            Assert.Equal(new[] { new DateTime(2017, 8, 9, 0, 0, 0, DateTimeKind.Utc), new DateTime(2017, 8, 10, 0, 0, 0, DateTimeKind.Utc) },
+                (DateTime[])row["date"]);
+            Assert.Equal(new[] { new DateTime(2017, 8, 9, 12, 34, 56, 123, DateTimeKind.Utc), new DateTime(2017, 8, 9, 12, 34, 57, 123, DateTimeKind.Utc) },
+                (DateTime[])row["dateTime"]);
+            Assert.Equal(new[] { new TimeSpan(0, 12, 34, 56, 123), new TimeSpan(0, 12, 34, 57, 123) }, (TimeSpan[])row["time"]);
+            Assert.Equal(new[]
+                {
+                    new Dictionary<string, object> { { "x", 100L }, { "y", "xyz" } },
+                    new Dictionary<string, object> { { "x", 200L }, { "y", "abc" } }
+                },
+                (Dictionary<string, object>[])row["struct"]);
+        }
+
+        [Fact]
+        public void Null()
+        {
+            var schema = new TableSchemaBuilder
+            {
+                { "text", BigQueryDbType.String },
+            }.Build();
+            var rawRow = new TableRow
+            {
+                F = new[]
+                {
+                    new TableCell { V = null }
+                }
+            };
+            var row = new BigQueryRow(rawRow, schema);
+            Assert.Null(row["text"]);
+        }
+
+        [Fact]
+        public void RecordWrongFieldCount()
+        {
+            var schema = new TableSchemaBuilder
+            {
+                { "struct", new TableSchemaBuilder { { "x", BigQueryDbType.Int64 }, { "y", BigQueryDbType.String } } }
+            }.Build();
+            var rawRow = new TableRow
+            {
+                F = new[]
+                {
+                    // No value for y
+                    new TableCell { V = new JObject { ["f"] = new JArray {new JObject { ["v"] = "100" } } } }
+                }
+            };
+            var row = new BigQueryRow(rawRow, schema);
+            Assert.Throws<InvalidOperationException>(() => row["struct"]);
+        }
+
+        private JArray CreateArray(params string[] values) => new JArray(values.Select(CreateObject));
+
+        private JObject CreateObject(string value) => new JObject { ["v"] = value };
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CloudProjectTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CloudProjectTest.cs
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.Bigquery.v2;
 using Google.Apis.Bigquery.v2.Data;
 using Moq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 using static Google.Apis.Bigquery.v2.Data.ProjectList;
 
@@ -40,6 +37,27 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.Equal(name, project.FriendlyName);
             Assert.Equal(id, project.ProjectId);
             Assert.Equal(id, project.Reference.ProjectId);
+        }
+
+        [Fact]
+        public void CreateClient()
+        {
+            string projectId = "project";
+            var data = new ProjectsData
+            {
+                Id = projectId,
+                ProjectReference = new ProjectReference { ProjectId = projectId }
+            };
+            var originalClient = new SimpleClient();
+            var project = new CloudProject(originalClient, data);
+            var newClient = project.CreateClient();
+            Assert.Equal(projectId, newClient.ProjectId);
+            Assert.Same(originalClient.Service, newClient.Service);
+        }
+
+        private class SimpleClient : BigQueryClient
+        {
+            public override BigqueryService Service { get; } = new FakeBigqueryService();
         }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/ListRowsOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/ListRowsOptionsTest.cs
@@ -61,5 +61,20 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var request = new ListRequest(new BigqueryService(), "project", "dataset", "table");
             Assert.Throws<ArgumentException>(() => options.ModifyRequest(request));
         }
+
+        [Fact]
+        public void Clone()
+        {
+            var options = new ListRowsOptions
+            {
+                PageSize = 25,
+                StartIndex = 10
+            };
+            var clone = options.Clone();
+            options.PageSize = 20;
+            options.StartIndex = 5;
+            Assert.Equal(25, clone.PageSize);
+            Assert.Equal(10UL, clone.StartIndex);
+        }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDataset.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDataset.cs
@@ -14,6 +14,7 @@
 
 using Google.Api.Gax;
 using Google.Apis.Bigquery.v2.Data;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -104,6 +105,23 @@ namespace Google.Cloud.BigQuery.V2
         /// <returns>A data upload job.</returns>
         public BigQueryJob UploadJson(string tableId, TableSchema schema, Stream input, UploadJsonOptions options = null) =>
             _client.UploadJson(GetTableReference(tableId), schema, input, options);
+
+        /// <summary>
+        /// Uploads a stream of JSON data to a table.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigQueryClient.UploadJson(TableReference, TableSchema, IEnumerable{string}, UploadJsonOptions)"/>.
+        /// </summary>
+        /// <remarks>
+        /// Each element of <paramref name="rows"/> is converted into a single line of text by replacing carriage returns and line
+        /// feeds with spaces. This is safe as they cannot exist within well-formed JSON keys or values, and simply means that the
+        /// original JSON can be formatted however you choose.
+        /// </remarks>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="schema">The schema of the data. May be null if the table already exists, in which case the table schema will be fetched and used.</param>
+        /// <param name="rows">The sequence of JSON strings to upload. Must not be null, and must not contain null elements.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <returns>A data upload job.</returns>
+        public BigQueryJob UploadJson(string tableId, TableSchema schema, IEnumerable<string> rows, UploadJsonOptions options = null) =>
+            _client.UploadJson(GetTableReference(tableId), schema, rows, options);
 
         /// <summary>
         /// Lists the tables within this dataset.
@@ -229,6 +247,25 @@ namespace Google.Cloud.BigQuery.V2
 
         /// <summary>
         /// Asynchronously uploads a stream of JSON data to a table.
+        /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigQueryClient.UploadJsonAsync(TableReference, TableSchema, IEnumerable{string}, UploadJsonOptions, CancellationToken)"/>.
+        /// </summary>
+        /// <remarks>
+        /// Each element of <paramref name="rows"/> is converted into a single line of text by replacing carriage returns and line
+        /// feeds with spaces. This is safe as they cannot exist within well-formed JSON keys or values, and simply means that the
+        /// original JSON can be formatted however you choose.
+        /// </remarks>
+        /// <param name="tableId">The table ID. Must not be null.</param>
+        /// <param name="schema">The schema of the data. May be null if the table already exists, in which case the table schema will be fetched and used.</param>
+        /// <param name="rows">The sequence of JSON strings to upload. Must not be null, and must not contain null elements.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// a data upload job.</returns>
+        public Task<BigQueryJob> UploadJsonAsync(string tableId, TableSchema schema, IEnumerable<string> rows, UploadJsonOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            _client.UploadJsonAsync(GetTableReference(tableId), schema, rows, options, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously uploads a stream of JSON data to a table.
         /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigQueryClient.UploadJsonAsync(TableReference, TableSchema, Stream, UploadJsonOptions, CancellationToken)"/>.
         /// </summary>
         /// <param name="tableId">The table ID. Must not be null.</param>
@@ -290,7 +327,7 @@ namespace Google.Cloud.BigQuery.V2
 
         /// <summary>
         /// Deletes this dataset.
-        /// This method just creates a <see cref="DatasetReference"/> and delegates to <see cref="BigQueryClient.DeleteDatasetAsync(string, string, DeleteDatasetOptions, CancellationToken)"/>.
+        /// This method just creates a <see cref="DatasetReference"/> and delegates to <see cref="BigQueryClient.DeleteDatasetAsync(DatasetReference, DeleteDatasetOptions, CancellationToken)"/>.
         /// </summary>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryJob.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryJob.cs
@@ -98,7 +98,7 @@ namespace Google.Cloud.BigQuery.V2
             var errors = Resource.Status?.Errors;
             if (errors?.Count > 0)
             {
-                throw new GoogleApiException(_client.Service.Name, $"Job {Reference.ProjectId}/{Reference.JobId} contained errors")
+                throw new GoogleApiException(_client.Service.Name, $"Job {Reference?.ProjectId}/{Reference?.JobId} contained errors")
                 {
                     Error = new RequestError
                     {
@@ -196,14 +196,18 @@ namespace Google.Cloud.BigQuery.V2
             {
                 throw new InvalidOperationException("Job doesn't represent a query");
             }
-            ThrowOnAnyError();
-            var reference = query.DestinationTable;
-            if (reference == null)
+            if (Reference == null || Reference.ProjectId == null || Reference.JobId == null)
             {
-                // TODO: Work out when this could happen.
+                throw new InvalidOperationException("Job has no ID. (This can happen for dry run queries.)");
+            }
+            ThrowOnAnyError();
+            var tableReference = query.DestinationTable;
+            if (tableReference == null)
+            {
+                // This can happen if it's been fetched with an odd field mask.
                 throw new InvalidOperationException("Query doesn't have a destination table");
             }
-            return reference;
+            return tableReference;
         }
 
         // TODO: Refresh? Could easily call GetJob, but can't easily modify *this* job...

--- a/tools/Google.Cloud.ClientTesting/AbstractClientTester.cs
+++ b/tools/Google.Cloud.ClientTesting/AbstractClientTester.cs
@@ -31,6 +31,12 @@ namespace Google.Cloud.ClientTesting
                 .Where(m => m.IsPublic && !m.IsStatic && !m.IsSpecialName)
                 .Select(m => new object[] { m });
 
+        public static IEnumerable<object[]> AllInstanceGetters =>
+            typeof(TAbstract).GetTypeInfo().DeclaredProperties
+                .Select(p => p.GetGetMethod())
+                .Where(m => m.IsPublic && !m.IsStatic)
+                .Select(m => new object[] { m });
+
         protected void AssertNotImplemented(MethodInfo method)
         {
             var exception = Assert.Throws<NotImplementedException>(() => Invoke(method));


### PR DESCRIPTION
- More equivalence testing for BigQueryClient
- Array and date/time/dateTime testing for BigQueryRow
- Trivial tests for BigQueryPage
- Validation tests for BigQueryInsertRow
- Validate behavior of calling GetQueryResults on a dry-run query
  (with code change)
- Add missing overload for UploadJson
- Validate properties aren't implemented in BigQueryClient
- (A few other bits and pieces)

At this point I think that's all the low-hanging fruit. Most of the
uncovered code would require mocking out the service. (Feasible, but
fairly painful.)