### PR TITLE
Add tests for loading from files/HTTP

### DIFF
--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Tests/Google.Cloud.Speech.V1.Tests.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Tests/Google.Cloud.Speech.V1.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
+    <Features>IOperation</Features>
+    <IsPackable>false</IsPackable>
+    <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1701;1702;1705;4014</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Cloud.Speech.V1\Google.Cloud.Speech.V1.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Moq" Version="4.7.8" />
+    <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta1-build1309" />
+    <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
+    <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
+</Project>

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Tests/RecognitionAudioTest.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Tests/RecognitionAudioTest.cs
@@ -1,0 +1,102 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Speech.V1;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Vision.V1.Tests
+{
+    public class RecognitionAudioTest
+    {
+        // The tests which use a URI don't actually care that we're loading an image instead of an audio file.
+        // If we could find a nice stable URL with an audio file, that would be good...
+        private const string IconUri = "https://cloud.google.com/images/devtools-icon-64x64.png";
+        private const int IconContentSize = 1776;
+
+        [Fact]
+        public void FromFile()
+        {
+            using (var tempFile = TempFile.Generate(500))
+            {
+                var audio = RecognitionAudio.FromFile(tempFile.Name);
+                Assert.Equal(tempFile.Bytes, audio.Content.ToByteArray());
+            }
+        }
+
+        [Fact]
+        public async Task FromFileAsync()
+        {
+            using (var tempFile = TempFile.Generate(500))
+            {
+                var audio = await RecognitionAudio.FromFileAsync(tempFile.Name);
+                Assert.Equal(tempFile.Bytes, audio.Content.ToByteArray());
+            }
+        }
+
+        [Fact]
+        public void FetchFromUri_String()
+        {
+            var audio = RecognitionAudio.FetchFromUri(IconUri);
+            Assert.Equal(IconContentSize, audio.Content.Length);
+        }
+
+        [Fact]
+        public void FetchFromUri_Uri()
+        {
+            var audio = RecognitionAudio.FetchFromUri(new Uri(IconUri));
+            Assert.Equal(IconContentSize, audio.Content.Length);
+        }
+
+        [Fact]
+        public async Task FetchFromUriAsync_String()
+        {
+            var audio = await RecognitionAudio.FetchFromUriAsync(IconUri);
+            Assert.Equal(IconContentSize, audio.Content.Length);
+        }
+
+        [Fact]
+        public async Task FetchFromUriAsync_Uri()
+        {
+            var audio = await RecognitionAudio.FetchFromUriAsync(new Uri(IconUri));
+            Assert.Equal(IconContentSize, audio.Content.Length);
+        }
+
+        private class TempFile : IDisposable
+        {
+            public string Name { get; }
+            public byte[] Bytes { get; }
+
+            private TempFile(string name, byte[] bytes)
+            {
+                Name = name;
+                Bytes = bytes;
+            }
+
+            public static TempFile Generate(int byteCount)
+            {
+                Random rng = new Random();
+                var bytes = new byte[byteCount];
+                rng.NextBytes(bytes);
+                string name = Path.GetTempFileName();
+                File.WriteAllBytes(name, bytes);
+                return new TempFile(name, bytes);
+            }
+
+            public void Dispose() => File.Delete(Name);
+        }
+    }
+}

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Tests/coverage.xml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <Filters>
+    <IncludeFilters>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Speech.V1</ModuleMask>
+      </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.LongRunning</ModuleMask>
+      </FilterEntry>
+    </IncludeFilters>
+  </Filters>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Speech.V1.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.sln
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26114.2
@@ -11,10 +11,18 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.LongRunning", "..\Go
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Speech.V1.LanguageCodeGenerator", "Google.Cloud.Speech.V1.LanguageCodeGenerator\Google.Cloud.Speech.V1.LanguageCodeGenerator.csproj", "{1E891B79-7EA0-441D-83E1-A1D492B68ED9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Speech.V1.IntegrationTests", "Google.Cloud.Speech.V1.IntegrationTests\Google.Cloud.Speech.V1.IntegrationTests.csproj", "{5F1B9414-A591-4CDC-A907-5DBF1DC3B61C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Speech.V1.Tests", "Google.Cloud.Speech.V1.Tests\Google.Cloud.Speech.V1.Tests.csproj", "{BA5E2E84-EB19-4404-9CEC-CCA834021ADC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A2D62EF9-1F25-42A3-98D9-01C1D5838CFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -33,6 +41,30 @@ Global
 		{1E891B79-7EA0-441D-83E1-A1D492B68ED9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1E891B79-7EA0-441D-83E1-A1D492B68ED9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E891B79-7EA0-441D-83E1-A1D492B68ED9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F1B9414-A591-4CDC-A907-5DBF1DC3B61C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F1B9414-A591-4CDC-A907-5DBF1DC3B61C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F1B9414-A591-4CDC-A907-5DBF1DC3B61C}.Debug|x64.ActiveCfg = Debug|x64
+		{5F1B9414-A591-4CDC-A907-5DBF1DC3B61C}.Debug|x64.Build.0 = Debug|x64
+		{5F1B9414-A591-4CDC-A907-5DBF1DC3B61C}.Debug|x86.ActiveCfg = Debug|x86
+		{5F1B9414-A591-4CDC-A907-5DBF1DC3B61C}.Debug|x86.Build.0 = Debug|x86
+		{5F1B9414-A591-4CDC-A907-5DBF1DC3B61C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F1B9414-A591-4CDC-A907-5DBF1DC3B61C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F1B9414-A591-4CDC-A907-5DBF1DC3B61C}.Release|x64.ActiveCfg = Release|x64
+		{5F1B9414-A591-4CDC-A907-5DBF1DC3B61C}.Release|x64.Build.0 = Release|x64
+		{5F1B9414-A591-4CDC-A907-5DBF1DC3B61C}.Release|x86.ActiveCfg = Release|x86
+		{5F1B9414-A591-4CDC-A907-5DBF1DC3B61C}.Release|x86.Build.0 = Release|x86
+		{BA5E2E84-EB19-4404-9CEC-CCA834021ADC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA5E2E84-EB19-4404-9CEC-CCA834021ADC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA5E2E84-EB19-4404-9CEC-CCA834021ADC}.Debug|x64.ActiveCfg = Debug|x64
+		{BA5E2E84-EB19-4404-9CEC-CCA834021ADC}.Debug|x64.Build.0 = Debug|x64
+		{BA5E2E84-EB19-4404-9CEC-CCA834021ADC}.Debug|x86.ActiveCfg = Debug|x86
+		{BA5E2E84-EB19-4404-9CEC-CCA834021ADC}.Debug|x86.Build.0 = Debug|x86
+		{BA5E2E84-EB19-4404-9CEC-CCA834021ADC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA5E2E84-EB19-4404-9CEC-CCA834021ADC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA5E2E84-EB19-4404-9CEC-CCA834021ADC}.Release|x64.ActiveCfg = Release|x64
+		{BA5E2E84-EB19-4404-9CEC-CCA834021ADC}.Release|x64.Build.0 = Release|x64
+		{BA5E2E84-EB19-4404-9CEC-CCA834021ADC}.Release|x86.ActiveCfg = Release|x86
+		{BA5E2E84-EB19-4404-9CEC-CCA834021ADC}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Tests/ImageTest.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Tests/ImageTest.cs
@@ -20,6 +20,10 @@ namespace Google.Cloud.Vision.V1.Tests
 {
     public class ImageTest
     {
+        // Very unlikely this icon will change...
+        private const string IconUri = "https://cloud.google.com/images/devtools-icon-64x64.png";
+        private const int IconContentSize = 1776;
+
         [Fact]
         public void FromUri_String()
         {
@@ -61,6 +65,78 @@ namespace Google.Cloud.Vision.V1.Tests
             var data = new byte[] { 0, 0, 1, 2, 3, 0, 0 };
             var image = Image.FromBytes(data, 2, 3);
             Assert.Equal(new byte[] { 1, 2, 3 }, image.Content.ToByteArray());
+        }
+
+        [Fact]
+        public void FromFile()
+        {
+            using (var tempFile = TempFile.Generate(500))
+            {
+                var image = Image.FromFile(tempFile.Name);
+                Assert.Equal(tempFile.Bytes, image.Content.ToByteArray());
+            }
+        }
+
+        [Fact]
+        public async Task FromFileAsync()
+        {
+            using (var tempFile = TempFile.Generate(500))
+            {
+                var image = await Image.FromFileAsync(tempFile.Name);
+                Assert.Equal(tempFile.Bytes, image.Content.ToByteArray());
+            }
+        }
+
+        [Fact]
+        public void FetchFromUri_String()
+        {
+            var image = Image.FetchFromUri(IconUri);
+            Assert.Equal(IconContentSize, image.Content.Length);
+        }
+
+        [Fact]
+        public void FetchFromUri_Uri()
+        {
+            var image = Image.FetchFromUri(new Uri(IconUri));
+            Assert.Equal(IconContentSize, image.Content.Length);
+        }
+
+        [Fact]
+        public async Task FetchFromUriAsync_String()
+        {
+            var image = await Image.FetchFromUriAsync(IconUri);
+            Assert.Equal(IconContentSize, image.Content.Length);
+        }
+
+        [Fact]
+        public async Task FetchFromUriAsync_Uri()
+        {
+            var image = await Image.FetchFromUriAsync(new Uri(IconUri));
+            Assert.Equal(IconContentSize, image.Content.Length);
+        }
+
+        private class TempFile : IDisposable
+        {
+            public string Name { get; }
+            public byte[] Bytes { get; }
+
+            private TempFile(string name, byte[] bytes)
+            {
+                Name = name;
+                Bytes = bytes;
+            }
+
+            public static TempFile Generate(int byteCount)
+            {
+                Random rng = new Random();
+                var bytes = new byte[byteCount];
+                rng.NextBytes(bytes);
+                string name = Path.GetTempFileName();
+                File.WriteAllBytes(name, bytes);
+                return new TempFile(name, bytes);
+            }
+
+            public void Dispose() => File.Delete(Name);
         }
     }
 }


### PR DESCRIPTION
I don't particularly like using HTTP from unit tests, but they're
not integration tests with the service, and I don't think it'll
actually cause problems on any systems where we run the unit tests.