### PR TITLE
While individual rpc methods within spanner.data are all idempotent, …

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
@@ -408,7 +408,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                     }).ConfigureAwait(false);
 
                 Assert.Equal(ErrorCode.DeadlineExceeded, e.ErrorCode);
-                Assert.True(e.IsTransientSpannerFault());
+                Assert.False(e.IsTransientSpannerFault());
                 Assert.Equal(0, result);
             }
             finally

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerException.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerException.cs
@@ -73,9 +73,7 @@ namespace Google.Cloud.Spanner.Data
             {
                 switch (ErrorCode)
                 {
-                    case ErrorCode.DeadlineExceeded:
                     case ErrorCode.Aborted:
-                    case ErrorCode.Unavailable:
                         return true;
                     default:
                         return false;


### PR DESCRIPTION
…the entire transaction is not.

Therefore, allowing retries at the transaction level on deadline_exceeded is especially dangerous.

Also, unavailable is already retried at the rpc level -- so allowing another set of exponential backoff
retries at the transaction level is unnecessary (but not as harmful as deadline_exceeded).

The only error that should be retried at the transaction level is aborted -- which indicates a transaction deadlock.
Verified that this behavior is now fully in sync with the java client.