### PR TITLE
Create the 'packages' directory if it does not exist when installing docfx

### DIFF
--- a/toolversions.sh
+++ b/toolversions.sh
@@ -42,6 +42,7 @@ install_docfx() {
   if [[ ! -f $DOCFX ]]
   then
     (echo "Fetching docfx v${DOCFX_VERSION}";
+     mkdir -p $REPO_ROOT/packages;
      cd $REPO_ROOT/packages;
      mkdir docfx.$DOCFX_VERSION;
      cd docfx.$DOCFX_VERSION;


### PR DESCRIPTION
The packages directory may not exist when building a release from a clean client.

Fixes #1337