### PR TITLE
Do not swallow exceptions thrown by an application if the diagnostics library fails. 

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerMiddleware.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerMiddleware.cs
@@ -54,7 +54,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             }
             catch (Exception exception)
             {
-                await _logger.LogAsync(exception, httpContext).ConfigureAwait(false);
+                try
+                {
+                    await _logger.LogAsync(exception, httpContext).ConfigureAwait(false);
+                }
+                catch (Exception innerException)
+                {
+                    throw new AggregateException(innerException, exception);
+                }
                 throw;
             }
         }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceMiddleware.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceMiddleware.cs
@@ -84,10 +84,17 @@ namespace Google.Cloud.Diagnostics.AspNetCore
                 {
                     await _next(httpContext).ConfigureAwait(false);
                 }
-                catch (Exception e)
+                catch (Exception exception)
                 {
-                    StackTrace stackTrace = new StackTrace(e, true);
-                    tracer.SetStackTrace(stackTrace);
+                    try
+                    {
+                        StackTrace stackTrace = new StackTrace(exception, true);
+                        tracer.SetStackTrace(stackTrace);
+                    }
+                    catch (Exception innerException)
+                    {
+                        throw new AggregateException(innerException, exception);
+                    }
                     throw;
                 }
                 finally


### PR DESCRIPTION
Currently when an exception occurs in an application and the diagnostics library needs to report this state it will and then rethrow.  However, if the diagnostics library throws and exception the application's exception is lost. Instead rethrow both as an AggregateException so no information is lost.

Fixes #1350