### PR TITLE
Add an explicit note about when an AggregateException will be thrown in AspNetCore Diagnostics libraries

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerExtension.cs
@@ -79,6 +79,13 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// </summary>
         /// <param name="services">The service collection. Cannot be null.</param>
         /// <param name="setupAction">Action to set up options. Cannot be null.</param>
+        /// <remarks>
+        /// If <see cref="RetryOptions.ExceptionHandling"/> is set to <see cref="ExceptionHandling.Propagate"/>
+        /// and the <see cref="RequestDelegate"/> executed by this middleware throws an exception and this
+        /// diagnostics library also throws an exception trying to report it an <see cref="AggregateException"/>
+        /// with both exceptions will be thrown.  Otherwise only the exception from the <see cref="RequestDelegate"/>
+        /// will be thrown.
+        /// </remarks>
         public static void AddGoogleExceptionLogging(
             this IServiceCollection services, Action<ErrorReportingServiceOptions> setupAction)
         {

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
@@ -89,7 +89,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// Adds the needed services for Google Cloud Tracing. Used with <see cref="UseGoogleTrace"/>.
         /// </summary>
         /// <param name="services">The service collection. Cannot be null.</param>
-        /// /// <param name="setupAction">Action to set up options. Cannot be null.</param>
+        /// <param name="setupAction">Action to set up options. Cannot be null.</param>
+        /// <remarks>
+        /// If <see cref="RetryOptions.ExceptionHandling"/> is set to <see cref="ExceptionHandling.Propagate"/>
+        /// and the <see cref="RequestDelegate"/> executed by this middleware throws ad exception and this
+        /// diagnostics library also throws an exception trying to report it and <see cref="AggregateException"/>
+        /// with both exceptions will be thrown.  Otherwise only the exception from the <see cref="RequestDelegate"/>
+        /// will be thrown.
+        /// </remarks>
         public static void AddGoogleTrace(
             this IServiceCollection services, Action<TraceServiceOptions> setupAction)
         {


### PR DESCRIPTION
Extra comments for #1352