### PR TITLE
Make DefaultPollSettings in OperationsSettings settable

### DIFF
--- a/apis/Google.LongRunning/Google.LongRunning/OperationsClientPartial.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/OperationsClientPartial.cs
@@ -23,7 +23,7 @@ namespace Google.LongRunning
         /// <summary>
         /// The poll settings used by default for repeated polling operations.
         /// </summary>
-        public PollSettings DefaultPollSettings { get; private set; }
+        public PollSettings DefaultPollSettings { get; set; }
 
         partial void OnCopy(OperationsSettings existing)
         {


### PR DESCRIPTION
I think when this is private it's impossible to set anywhere, so it should be public.