### PR TITLE
While running integration tests filter during the initial request instead of after

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryPolling.cs
@@ -56,7 +56,8 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
                     {
                         ProjectName = _projectName.ToString(),
                         GroupId = group.Group.GroupId,
-                        TimeRange = s_oneHour
+                        TimeRange = s_oneHour,
+                        PageSize = 250
                     };
 
                     var events = _client.ListEvents(request);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Logging/LogEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Logging/LogEntryPolling.cs
@@ -50,11 +50,10 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
                 var request = new ListLogEntriesRequest
                 {
                     ResourceNames = { $"projects/{_projectId}" },
-                    Filter = $"timestamp >= \"{time}\""
+                    Filter = $"timestamp >= \"{time}\" AND textPayload:{testId}",
+                    PageSize = 250,
                 };
-
-                var results = _client.ListLogEntries(request);
-                return results.Where(p => p.TextPayload.Contains(testId)).ToList();
+                return _client.ListLogEntries(request);
             });
         }
     }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceEntryPolling.cs
@@ -46,10 +46,11 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
                 {
                     ProjectId = _projectId,
                     StartTime = startTime,
-                    View = ListTracesRequest.Types.ViewType.Complete
+                    View = ListTracesRequest.Types.ViewType.Complete,
+                    Filter = $"span:\"{spanName}\"",
+                    PageSize = 250
                 };
-                var traces = _client.ListTraces(request);
-                return traces.Where(t => t.Spans.Any(s => s.Name == spanName));
+                return _client.ListTraces(request);
             });
             return traceList.FirstOrDefault();
         }


### PR DESCRIPTION
Also add to the page size as the default is 50.

I think we are seeing the integration tests failures when we do large runs as we generate a lot of logs at once and then filter on test id after we get results back.

Hopefully fixes #1304