### PR TITLE
Initial API skeleton for BQ ADO.NET

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CodeHealthTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CodeHealthTest.cs
@@ -22,7 +22,8 @@ namespace Google.Cloud.BigQuery.V2.Tests
         [Fact]
         public void PrivateFields()
         {
-            CodeHealthTester.AssertAllFieldsPrivate(typeof(BigQueryClient));
+            // BigQueryProviderFactory must have a public Instance field to work properly as its loaded and instantiated via reflection.
+            CodeHealthTester.AssertAllFieldsPrivate(typeof(BigQueryClient), new []{ typeof(BigQueryProviderFactory)});
         }
 
         [Fact]

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryCommand.Data.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryCommand.Data.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Data;
+using System.Data.Common;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    public sealed partial class BigQueryCommand : DbCommand
+    {
+        /// <inheritdoc />
+        public override void Cancel()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override int ExecuteNonQuery()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override object ExecuteScalar()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void Prepare()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override string CommandText { get; set; }
+        /// <inheritdoc />
+        public override int CommandTimeout { get; set; }
+        /// <inheritdoc />
+        public override CommandType CommandType { get; set; }
+        /// <inheritdoc />
+        public override UpdateRowSource UpdatedRowSource { get; set; }
+        /// <inheritdoc />
+        protected override DbConnection DbConnection { get; set; }
+        /// <inheritdoc />
+        protected override DbParameterCollection DbParameterCollection { get; }
+        /// <inheritdoc />
+        protected override DbTransaction DbTransaction { get; set; }
+        /// <inheritdoc />
+        public override bool DesignTimeVisible { get; set; }
+
+        /// <inheritdoc />
+        protected override DbParameter CreateDbParameter()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryCommand.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryCommand.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Data.Common;
 using Google.Api.Gax;
 using Google.Apis.Bigquery.v2.Data;
 using System.Linq;
@@ -22,7 +23,7 @@ namespace Google.Cloud.BigQuery.V2
     /// A SQL query (or DML command) to be sent to BigQuery, optionally
     /// including parameters.
     /// </summary>
-    public sealed class BigQueryCommand
+    public sealed partial class BigQueryCommand
     {
         /// <summary>
         /// The SQL of the command. This must not be null by the time
@@ -44,7 +45,7 @@ namespace Google.Cloud.BigQuery.V2
         /// <summary>
         /// The parameters used within this command.
         /// </summary>
-        public BigQueryParameterCollection Parameters { get; } = new BigQueryParameterCollection();
+        public new BigQueryParameterCollection Parameters { get; } = new BigQueryParameterCollection();
 
         /// <summary>
         /// Constructs an instance with no SQL set yet.

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryConnection.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryConnection.cs
@@ -1,0 +1,70 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Data;
+using System.Data.Common;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// </summary>
+    public sealed class BigQueryConnection : DbConnection
+    {
+        /// <inheritdoc />
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void ChangeDatabase(string databaseName)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void Close()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void Open()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override string ConnectionString { get; set; }
+
+        /// <inheritdoc />
+        public override string Database { get; }
+
+        /// <inheritdoc />
+        public override ConnectionState State { get; }
+
+        /// <inheritdoc />
+        public override string DataSource { get; }
+
+        /// <inheritdoc />
+        public override string ServerVersion { get; }
+
+        /// <inheritdoc />
+        protected override DbCommand CreateDbCommand()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryConnectionStringBuilder.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryConnectionStringBuilder.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Data.Common;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// </summary>
+    public sealed class BigQueryConnectionStringBuilder : DbConnectionStringBuilder
+    {
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDataReader.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDataReader.cs
@@ -1,0 +1,210 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections;
+using System.Data;
+using System.Data.Common;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// </summary>
+    public sealed class BigQueryDataReader : DbDataReader
+    {
+#if NET45
+
+        /// <inheritdoc />
+        public override void Close()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override DataTable GetSchemaTable()
+        {
+            throw new NotImplementedException();
+        }
+#endif
+
+        /// <inheritdoc />
+        public override bool NextResult()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override bool Read()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override int Depth { get; }
+        /// <inheritdoc />
+        public override bool IsClosed { get; }
+        /// <inheritdoc />
+        public override int RecordsAffected { get; }
+
+        /// <inheritdoc />
+        public override bool GetBoolean(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override byte GetByte(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override char GetChar(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override Guid GetGuid(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override short GetInt16(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override int GetInt32(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override long GetInt64(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override DateTime GetDateTime(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override string GetString(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override decimal GetDecimal(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override double GetDouble(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override float GetFloat(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override string GetName(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override int GetValues(object[] values)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override bool IsDBNull(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override int FieldCount { get; }
+
+        /// <inheritdoc />
+        public override object this[int ordinal]
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        /// <inheritdoc />
+        public override object this[string name]
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        /// <inheritdoc />
+        public override bool HasRows { get; }
+
+        /// <inheritdoc />
+        public override int GetOrdinal(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override string GetDataTypeName(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override Type GetFieldType(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override object GetValue(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override IEnumerator GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameter.Data.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameter.Data.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Data;
+using System.Data.Common;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    public sealed partial class BigQueryParameter : DbParameter 
+    {
+        /// <inheritdoc />
+        public override void ResetDbType()
+        {
+            throw new NotImplementedException();
+        }
+        /// <inheritdoc />
+        public override DbType DbType { get; set; }
+        /// <inheritdoc />
+        public override ParameterDirection Direction { get; set; }
+        /// <inheritdoc />
+        public override bool IsNullable { get; set; }
+        /// <inheritdoc />
+        public override string ParameterName { get; set; }
+        /// <inheritdoc />
+        public override string SourceColumn { get; set; }
+#if NET45
+        /// <inheritdoc />
+        public override DataRowVersion SourceVersion { get; set; }
+#endif
+        /// <inheritdoc />
+        public override bool SourceColumnNullMapping { get; set; }
+        /// <inheritdoc />
+        public override int Size { get; set; }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameter.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameter.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.BigQuery.V2
     /// Struct parameters are currently not supported.
     /// </para>
     /// </remarks>
-    public sealed class BigQueryParameter
+    public sealed partial class BigQueryParameter
     {
         private static HashSet<Type> s_validSingleTypes = new HashSet<Type>
         {
@@ -144,7 +144,7 @@ namespace Google.Cloud.BigQuery.V2
         /// The value of the parameter. If this is null, the type of the parameter must be specified
         /// explicitly.
         /// </summary>
-        public object Value
+        public override object Value
         {
             get { return _value; }
             set

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameterCollection.Data.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameterCollection.Data.cs
@@ -1,0 +1,130 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// </summary>
+    public sealed partial class BigQueryParameterCollection : DbParameterCollection
+    {
+        /// <inheritdoc />
+        public override int Add(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override bool Contains(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override bool Contains(string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override int IndexOf(string parameterName)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void RemoveAt(string parameterName)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        protected override void SetParameter(int index, DbParameter value)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        protected override void SetParameter(string parameterName, DbParameter value)
+        {
+            throw new NotImplementedException();
+        }
+
+#if NET45
+        /// <inheritdoc />
+        public override bool IsFixedSize { get; }
+        /// <inheritdoc />
+        public override bool IsReadOnly { get; }
+        /// <inheritdoc />
+        public override bool IsSynchronized { get; }
+#endif
+        /// <inheritdoc />
+        public override object SyncRoot { get; }
+
+        /// <inheritdoc />
+        public override void Insert(int index, object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void Remove(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void RemoveAt(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void CopyTo(Array array, int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override IEnumerator GetEnumerator() => ((IEnumerable<BigQueryParameter>) this).GetEnumerator();
+
+        /// <inheritdoc />
+        protected override DbParameter GetParameter(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        protected override DbParameter GetParameter(string parameterName)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override int IndexOf(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void AddRange(Array values)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameterCollection.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameterCollection.cs
@@ -21,7 +21,7 @@ namespace Google.Cloud.BigQuery.V2
     /// <summary>
     /// A collection of <see cref="BigQueryParameter"/> elements, as part of a <see cref="BigQueryCommand"/>.
     /// </summary>
-    public sealed class BigQueryParameterCollection : IReadOnlyList<BigQueryParameter>
+    public sealed partial class BigQueryParameterCollection : IReadOnlyList<BigQueryParameter>
     {
         private readonly List<BigQueryParameter> _parameters = new List<BigQueryParameter>();
 
@@ -75,16 +75,16 @@ namespace Google.Cloud.BigQuery.V2
         }
 
         /// <inheritdoc />
-        public void Clear() => _parameters.Clear();
+        public override void Clear() => _parameters.Clear();
 
         /// <inheritdoc />
-        public int Count => _parameters.Count;
+        public override int Count => _parameters.Count;
 
         /// <inheritdoc />
-        public BigQueryParameter this[int index] => _parameters[index];
+        public new BigQueryParameter this[int index] => _parameters[index];
 
         /// <inheritdoc />
-        public IEnumerator<BigQueryParameter> GetEnumerator() => _parameters.GetEnumerator();
+        IEnumerator<BigQueryParameter> IEnumerable<BigQueryParameter>.GetEnumerator() => _parameters.GetEnumerator();
 
         /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryProviderFactory.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryProviderFactory.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Data.Common;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// </summary>
+    public sealed class BigQueryProviderFactory : DbProviderFactory
+    {
+        /// <summary>
+        /// </summary>
+        // ReSharper disable once InconsistentNaming
+        public static readonly BigQueryProviderFactory Instance = new BigQueryProviderFactory();
+
+        private BigQueryProviderFactory() { }
+
+        /// <inheritdoc />
+        public override DbCommand CreateCommand() => new BigQueryCommand();
+
+        /// <inheritdoc />
+        public override DbConnection CreateConnection() => new BigQueryConnection();
+
+        /// <inheritdoc />
+        public override DbConnectionStringBuilder CreateConnectionStringBuilder() =>
+            new BigQueryConnectionStringBuilder();
+
+        /// <inheritdoc />
+        public override DbParameter CreateParameter() => new BigQueryParameter();
+
+#if NET45
+        /// <inheritdoc />
+        public override DbDataAdapter CreateDataAdapter()
+        {
+            throw new NotSupportedException("todo");
+        }
+#endif
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -45,5 +45,18 @@
       <DependentUpon>BigQueryClientImpl.cs</DependentUpon>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <Reference Include="System.Transactions" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Data.Common">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="BigQueryConnection.cs">
+      <SubType>Component</SubType>
+    </Compile>
+  </ItemGroup>
   <Import Project="..\..\..\StripDesktopOnNonWindows.xml" />
 </Project>


### PR DESCRIPTION
finally getting on this jon.  I dont think this will be too bad.
I'm pulling into a main repo branch and will iterate there before pushing into main/master.  sound good?

My biggest concerns so far:

namespace:  Its inconsistent with the overall approach for spanner where we had a "data" namespace completely isolated from the vkit ns.  This approach means that when we move to grpc, it will be a new namespace or breaking change -- but I don't see another clean alternative here.  Maybe we should consider this approach for spanner?

transactions:  I'm not sure how bigquery implicit transactions (which are not idempotent) are going to work here with transactionscope especially.  There might be places where we need to push on BQ folks to give us a better ACID-like mechanism (like at least idempotency) so we don't create false assumptions from consumers.

type conversions:  We might want to do a shared library depending on how similar BQ is.

all tests continue to pass...