### PR TITLE
Change how we run integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ toolkit
 
 # Testing
 integrationprogress.txt
+integration-test-failures.txt
+integration-test-failures.txt.tmp
 results.xml
 
 # Speech language codes temporary output


### PR DESCRIPTION
(I'm still testing this, but thought I'd show you while I'm doing so.)

- Instead of --continue, have --retry, which retries failures
  (We store failures in a file, rather than successes.)
- Continue on failure, having emitted the failure

This means that from Jenkins we can just run:

```sh
./runintegrationtests.sh --coverage
./runintegrationtests.sh --retry --coverage
./runintegrationtests.sh --retry --coverage
```

If there are no failures, the retries will be no-ops basically...
and otherwise, we'll have a list of test failures.

While we could retry a given number of times within the script,
doing it this way improves the chances of success in the face of
transient errors and makes quota failures less likely.