### PR TITLE
Temporarily disable building docs on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,8 @@ test_script:
 after_test:
   - bash createcoveragereport.sh
   - codecov -f "coverage/coverage-filtered.xml"
-  - cd docs
-  - bash builddocs.sh
-  - cd ..
+# Docs disabled until https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/1380
+# is better understood
+  - # cd docs
+  - # bash builddocs.sh
+  - # cd ..


### PR DESCRIPTION
This will get us back to green after the Core 2.0 change, but
obviously we want to go back to building the docs in CI.