### PR TITLE
Pull default timeout from commitsettings in case of gapic change.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SessionPoolTests.cs
@@ -484,6 +484,16 @@ namespace Google.Cloud.Spanner.Data.Tests
             }
         }
 
+        [Fact]
+        public void SessionPoolDefaultTimeout()
+        {
+            SessionPoolOptions options = new SessionPoolOptions();
+            Assert.Equal(options.Timeout,
+                // ReSharper disable once PossibleInvalidOperationException
+                (int)SpannerSettings.GetDefault().CommitSettings.Timing.Retry
+                    .TotalExpiration.Timeout.Value.TotalSeconds);
+        }
+
         private class ParallelSpannerClient : SpannerClient
         {
             private int _concurrentRequests = 0;

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPoolOptions.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPoolOptions.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Diagnostics;
 
 namespace Google.Cloud.Spanner.V1
 {
@@ -21,6 +22,16 @@ namespace Google.Cloud.Spanner.V1
     /// </summary>
     public sealed class SessionPoolOptions
     {
+        /// <summary>
+        /// Constructs a new <see cref="SessionPoolOptions"/>.
+        /// </summary>
+        public SessionPoolOptions()
+        {
+            var retry = SpannerSettings.GetDefault().CommitSettings.Timing.Retry;
+            // ReSharper disable once PossibleInvalidOperationException
+            Timeout = (int)(retry?.TotalExpiration.Timeout).Value.TotalSeconds;
+        }
+
         /// <summary>
         /// Maximum number of active sessions that can be in use by the application at any one time.
         /// </summary>
@@ -56,7 +67,7 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// The total time in seconds allowed for a network call to the Cloud Spanner server, including retries.
         /// </summary>
-        public int Timeout { get; set; } = 60;
+        public int Timeout { get; set; }
 
         /// <summary>
         /// The maximum number of session create operations allowed to occur simultaneously.


### PR DESCRIPTION
Caught when reviewing a default timeout change from the spanner team.
We need to be pulling the default timeout directly from generated code instead of having a hard coded value.
Also added a test that will fail if the generated settings change in an incompatible way.