### PR TITLE
Fix Visual Studio build with long filenames

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,9 @@
+<Project>
+  <!-- See https://github.com/Microsoft/msbuild/issues/1786 for details -->
+  <Target Name="WorkaroundAppConfigPathTooLong"
+          BeforeTargets="GenerateBindingRedirects">
+    <PropertyGroup>
+      <_GenerateBindingRedirectsIntermediateAppConfig>$(IntermediateOutputPath)$(TargetFileName).config</_GenerateBindingRedirectsIntermediateAppConfig>
+    </PropertyGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
Massive thanks to @tmat and @nguerrera for this workaround.