### PR TITLE
Increase the page size for the logs polling in integration tests.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Logging/LogEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Logging/LogEntryPolling.cs
@@ -16,7 +16,6 @@ using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Cloud.Logging.V2;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Xml;
 
 namespace Google.Cloud.Diagnostics.Common.IntegrationTests
@@ -51,7 +50,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
                 {
                     ResourceNames = { $"projects/{_projectId}" },
                     Filter = $"timestamp >= \"{time}\" AND textPayload:{testId}",
-                    PageSize = 250,
+                    PageSize = 1000,
                 };
                 return _client.ListLogEntries(request);
             });


### PR DESCRIPTION
I occasionally still seeing a failure that looks similar to the previous failures (missing entries due to too small poll size).