### PR TITLE
Fix Google.Cloud.VideoIntelligence.V1Beta2 snippets.

### DIFF
--- a/apis/Google.Cloud.VideoIntelligence.V1Beta2/Google.Cloud.VideoIntelligence.V1Beta2.Snippets/VideoIntelligenceServiceClientSnippets.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1Beta2/Google.Cloud.VideoIntelligence.V1Beta2.Snippets/VideoIntelligenceServiceClientSnippets.cs
@@ -24,7 +24,7 @@ namespace Google.Cloud.VideoIntelligence.V1Beta2.Snippets
         public void AnnotateVideo()
         {
             // Sample: AnnotateVideo
-            // Additional: AnnotateVideo(string,IEnumerable<Feature>,VideoContext,string,string,CallSettings)
+            // Additional: AnnotateVideo(string,IEnumerable<Feature>,ByteString,VideoContext,string,string,CallSettings)
             VideoIntelligenceServiceClient client = VideoIntelligenceServiceClient.Create();
             AnnotateVideoRequest request = new AnnotateVideoRequest
             {


### PR DESCRIPTION
Looks like the API changed from beta1 to beta2.  This caused our build docs Jenkins job to fail.
