### PR TITLE
Added the ability to configure credentials using a JSON file

### DIFF
--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/Log4NetTest.cs
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/Log4NetTest.cs
@@ -188,6 +188,7 @@ namespace Google.Cloud.Logging.Log4Net.Tests
                 Assert.Throws<InvalidOperationException>(() => appender.AddResourceLabel(new GoogleStackdriverAppender.Label { Key = "a", Value = "b" }));
                 Assert.Throws<InvalidOperationException>(() => appender.ProjectId = "");
                 Assert.Throws<InvalidOperationException>(() => appender.LogId = "");
+                Assert.Throws<InvalidOperationException>(() => appender.CredentialFile = "");
                 Assert.Throws<InvalidOperationException>(() => appender.MaxUploadBatchSize = 0);
                 Assert.Throws<InvalidOperationException>(() => appender.LocalQueueType = LocalQueueType.Memory);
                 Assert.Throws<InvalidOperationException>(() => appender.MaxMemorySize = 0);
@@ -212,6 +213,7 @@ namespace Google.Cloud.Logging.Log4Net.Tests
             appender.AddResourceLabel(new GoogleStackdriverAppender.Label { Key = "a", Value = "b" });
             appender.ProjectId = "";
             appender.LogId = "";
+            appender.CredentialFile = "";
             appender.MaxUploadBatchSize = 0;
             appender.LocalQueueType = LocalQueueType.Memory;
             appender.MaxMemorySize = 0;

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender.cs
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender.cs
@@ -15,6 +15,7 @@
 using Google.Api;
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Apis.Auth.OAuth2;
 using Google.Cloud.DevTools.Source.V1;
 using Google.Cloud.Logging.Type;
 using Google.Cloud.Logging.V2;
@@ -23,6 +24,7 @@ using log4net.Appender;
 using log4net.Core;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Security;
 using System.Threading;
@@ -67,6 +69,11 @@ namespace Google.Cloud.Logging.Log4Net
         internal const string s_logsLostWarningMessage = "Logs lost due to insufficient process-local storage: {0} -> {1}";
         internal const string s_lostDateTimeFmt = "yyyy-MM-dd' 'HH:mm:ss'Z'";
         internal const string s_mismatchedProjectIdMessage = "Detected project ID does not match configured project ID; using detected project ID.";
+
+        internal static readonly string[] s_oAuthScopes = new string[]
+        {
+            "https://www.googleapis.com/auth/logging.write"
+        };
 
         /// <summary>
         /// Construct a Google Stackdriver appender.
@@ -134,7 +141,7 @@ namespace Google.Cloud.Logging.Log4Net
             base.ActivateOptions();
 
             // Initialise services if not already initialised for testing
-            _client = _client ?? LoggingServiceV2Client.Create();
+            _client = _client ?? BuildLoggingServiceClient();
             _scheduler = _scheduler ?? SystemScheduler.Instance;
             _clock = _clock ?? SystemClock.Instance;
             _platform = _platform ?? Platform.Instance();
@@ -192,6 +199,38 @@ namespace Google.Cloud.Logging.Log4Net
                 _logQ, logsLostWarningEntry, MaxUploadBatchSize,
                 serverErrorBackoffSettings);
             _isActivated = true;
+        }
+
+        private LoggingServiceV2Client BuildLoggingServiceClient()
+        {
+            GoogleCredential credential;
+            if(!TryGetCredentialFromFile(out credential))
+            {
+                return LoggingServiceV2Client.Create();
+            }
+            
+            return LoggingServiceV2Client.Create(new Grpc.Core.Channel(LoggingServiceV2Client.DefaultEndpoint.Host, LoggingServiceV2Client.DefaultEndpoint.Port, Grpc.Auth.GoogleGrpcCredentials.ToChannelCredentials(credential)));
+        }
+
+        private bool TryGetCredentialFromFile(out GoogleCredential credential)
+        {
+            credential = null;
+            if(string.IsNullOrWhiteSpace(CredentialFile))
+            {
+                return false;
+            }
+            
+            using (FileStream credStream = File.OpenRead(CredentialFile))
+            {
+                credential = GoogleCredential.FromStream(credStream);
+            }
+            
+            if (credential.IsCreateScopedRequired)
+            {
+                credential = credential.CreateScoped(s_oAuthScopes);
+            }
+
+            return true;
         }
 
         private void ActivateLogIdAndResource()

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender_Configuration.cs
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender_Configuration.cs
@@ -231,6 +231,17 @@ namespace Google.Cloud.Logging.Log4Net
             set => _maxMemoryCount = ThrowIfActivated(value, nameof(MaxMemoryCount));
         }
 
+        private string _credentialFile;
+        /// <summary>
+        /// The file path of a service account JSON file to use for authenitication.
+        /// Not necessary if running on GCE or GAE or if the GOOGLE_APPLICATION_CREDENTIALS environment variable has been set.
+        /// </summary>
+        public string CredentialFile
+        {
+            get => _credentialFile;
+            set => _credentialFile = ThrowIfActivated(value, nameof(CredentialFile));
+        }
+
         /// <summary>
         /// Specify custom labels for all log entries.
         /// </summary>


### PR DESCRIPTION
Added property that allows configuration of credentials using a JSON file instead of using the default credentials. This is necessary to support GCP instances where the configured service account cannot be granted the logging.logWriter role.