### PR TITLE
Implement Datastore transaction options in DatastoreDb.

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDb.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDb.cs
@@ -238,6 +238,28 @@ namespace Google.Cloud.Datastore.V1
         }
 
         /// <summary>
+        /// Begins a transaction, returning a <see cref="DatastoreTransaction"/> which can be used to operate on the transaction.
+        /// </summary>
+        /// <param name="options">The options for the new transaction. May be null, for default options.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A new <see cref="DatastoreTransaction"/> for this object's project.</returns>
+        public virtual DatastoreTransaction BeginTransactionWithOptions(TransactionOptions options, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Begins a transaction asynchronously, returning a <see cref="DatastoreTransaction"/> which can be used to operate on the transaction.
+        /// </summary>
+        /// <param name="options">The options for the new transaction. May be null, for default options.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A new <see cref="DatastoreTransaction"/> for this object's project.</returns>
+        public virtual Task<DatastoreTransaction> BeginTransactionWithOptionsAsync(TransactionOptions options, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Allocates an ID for a single incomplete key.
         /// </summary>
         /// <remarks>This method simply delegates to <see cref="AllocateIds(IEnumerable{Key},CallSettings)"/>.</remarks>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDbImpl.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDbImpl.cs
@@ -146,7 +146,23 @@ namespace Google.Cloud.Datastore.V1
         {
             var response = await Client.BeginTransactionAsync(ProjectId, callSettings).ConfigureAwait(false);
             return DatastoreTransaction.Create(Client, ProjectId, NamespaceId, response.Transaction);
-        }                
+        }
+
+        /// <inheritdoc/>
+        public override DatastoreTransaction BeginTransactionWithOptions(TransactionOptions options, CallSettings callSettings = null)
+        {
+            var request = new BeginTransactionRequest { ProjectId = ProjectId, TransactionOptions = options };
+            var response = Client.BeginTransaction(request, callSettings);
+            return DatastoreTransaction.Create(Client, ProjectId, NamespaceId, response.Transaction);
+        }
+
+        /// <inheritdoc/>
+        public async override Task<DatastoreTransaction> BeginTransactionWithOptionsAsync(TransactionOptions options, CallSettings callSettings = null)
+        {
+            var request = new BeginTransactionRequest { ProjectId = ProjectId, TransactionOptions = options };
+            var response = await Client.BeginTransactionAsync(request, callSettings).ConfigureAwait(false);
+            return DatastoreTransaction.Create(Client, ProjectId, NamespaceId, response.Transaction);
+        }
 
         /// <inheritdoc/>
         public override IReadOnlyList<Key> AllocateIds(IEnumerable<Key> keys, CallSettings callSettings = null)


### PR DESCRIPTION
These have been available in the generated code (so in
BeginTransactionRequest) for a while, but not exposed in DatastoreDb.

Unfortunately we can't just overload BeginTransaction, as that would
change the meaning of db.BeginTransaction(null).

(I haven't implemented this in terms of delegation, but could do. We'd need to be very careful about what delegated to what, given the existing release. I think it's simpler not to.)