### PR TITLE
Adds ability to specify a json credential file in the connection string of spanner.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
@@ -24,4 +24,9 @@
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="SpannerEF-8dfc036f6000.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerEF-8dfc036f6000.json
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerEF-8dfc036f6000.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "spanneref",
+  "private_key_id": "8dfc036f60007347e40de53590451b0061120b47",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDsdgZkLn/dUxjb\nE+Xhq+ygbFdAO9mlXC9PJq1PHMly357Rut/xLteCncgmkeHKNz+xggu+XS/A5atN\nXNPA5VrKSfPMmkhPZHOgV+VR8o83OVIhy8P+3i5+IFx86aZ1S3HFFloy2IlpQMeY\nsWIg5pLapMRsDyjvOjYRZ4UNsR6PZwg3Hy4uiTMb3iL0aGlUVcIdoNmY6r01Cuab\nou5o6MkbU33PbN/Ciw0dfLPPjDSni+RUOUCuW5H2arn2J1iFu726rnNaBk4Kzm1r\nztXileDcRWTSrut8/dWUHNdVqsK3BCkpHnuagGEsYFmn9zPOFLlSfaU0GxxEAUgc\nJFOKOUzDAgMBAAECggEADSS3HW5wPdWJz8BlY/I+4hPjlBByyPw8xo64NDa90Jxm\nPL/BOHi834FbR+zBh8OJm//ftm8blM9I6ReJAnNwZOCDcRLKUVw2CR2ZnSdF/ddt\nanxKPEQOG+vUkdgZU1lXZsSwf5vScRh55h55MKotIE+0RoVfmYLuanBxahEESXHH\nUXa3DObnyfoK7/h/kK4pA+eJCFIJ1ZjJQcCuVDXpyDRtPNaHuanUGL9dHN5lLvhm\n4AKzqfBdTjAh/HHHjCCs/F8OWKcFiTNjYwffmEW1sm19PEIqzQCvrqglNvMihCbX\njxCb5UXCJo+M+EJInee29Rprnl/bPQrRD49HKJRC0QKBgQD2dX/gdHiwX48s3YEa\nQh0821kJK4lVaZpGBQlj266eocEzCK7pRJFnmqdZ1JwClsF10HcmP6/lm6h4MsRv\npsSBsfb6dh05utH8irDUW7p3RIbJsyxzER9MTjxxhVslc7JvlXgX6SplfcPFWyNT\nY9sFRNFjBGlh2iS2689+XleHJQKBgQD1nXEqrBGWJ2uY/MXHIawv/vlZTmJLSdYS\nylrn5jw/IKwUjBBtRbrWRRz1ReL65tK8LrK/9OUgosnkAMutVwl78HuTONHY1/mI\nSzqpnaWq96+QAlhX0MsB9+H7HVYsZO2Pci/dh+XHixK7RjfNn8CLNT1XTCaNruV/\nu+cuLbGTxwKBgQCXxj5M1I0qWH7Ma1BBAmwM+Su4iPYXAmR+MEXbGANOL2DR88v7\nXT2KJuReXp8AvSRAUHO/u0KwTI6QDvuHopSrJhRpo2lWDuWX9zT0YdTP9ARpnAyI\nhAfZLujsI+rAgqJlMw/08aMpQyzXkcuMZBcSBJJJvwLCvtsTRt7N/H08fQKBgQDc\nHJiKUWIBWpqGpCDqcDbLXIlBi4lzR1xdwpLtN9vOBw2v7EXcZ50k4RMui876Y1l/\n46m1dVbRhJHBjyT41wNc2wsjyMvmtMafaivMTcdmDEp9mFxrdmY4AVm3nXbYmip7\nXy2eLmeyB+RliGwCDqSTHMc4MLpsRszNSCvJqpF1iQKBgD2KQ1qpJekOR4I2IPDp\nXLtdDQkH9Np/ocwjhmxeNIlWY6xy4zNafmh/LBMvt91a05CxHLiX2G8XuUr6benp\nDStZoetv+KODLPjWBwjUHL2oAnktU/kSYPvMoEINYWbFEcj15f32H/wdr7/4KeB+\n7yQ6pvxq2t5RBOeSTMLv8qS8\n-----END PRIVATE KEY-----\n",
+  "client_email": "serviceaccountname@spanneref.iam.gserviceaccount.com",
+  "client_id": "111481446626682450003",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/serviceaccountname%40spanneref.iam.gserviceaccount.com"
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/ErrorCode.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/ErrorCode.cs
@@ -56,14 +56,14 @@ namespace Google.Cloud.Spanner.Data
         AlreadyExists = StatusCode.AlreadyExists,
 
         /// <summary>
-        /// The supplied credential from <see cref="SpannerConnectionStringBuilder.Credential"/>
+        /// The supplied credential from <see cref="SpannerConnectionStringBuilder.CredentialFile"/>
         /// or from default application credentials does not have sufficient permission for the request.
         /// </summary>
         PermissionDenied = StatusCode.PermissionDenied,
 
         /// <summary>
         /// There is no supplied credential either through default application credentials or
-        /// directly through <see cref="SpannerConnectionStringBuilder.Credential"/>
+        /// directly through <see cref="SpannerConnectionStringBuilder.CredentialFile"/>
         /// </summary>
         Unauthenticated = StatusCode.Unauthenticated,
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -88,7 +88,7 @@ namespace Google.Cloud.Spanner.Data
         {
             get => _connectionStringBuilder?.ToString();
             set => TrySetNewConnectionInfo(
-                new SpannerConnectionStringBuilder(value, _connectionStringBuilder?.Credential));
+                new SpannerConnectionStringBuilder(value, _connectionStringBuilder?.CredentialOverride));
         }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Google.Cloud.Spanner.Data
         /// If credentials are not specified, then application default credentials are used instead.
         /// See gcloud documentation on how to set up application default credentials.
         /// </summary>
-        public ITokenAccess Credential => _connectionStringBuilder?.Credential;
+        public ITokenAccess GetCredential() => _connectionStringBuilder?.GetCredential();
 
         /// <inheritdoc />
         public override string Database => _connectionStringBuilder?.SpannerDatabase;
@@ -294,7 +294,7 @@ namespace Google.Cloud.Spanner.Data
             {
                 ClientPool.Default.ReleaseClient(
                     client,
-                    _connectionStringBuilder.Credential,
+                    _connectionStringBuilder.GetCredential(),
                     _connectionStringBuilder.EndPoint,
                     _connectionStringBuilder);
             }
@@ -442,7 +442,7 @@ namespace Google.Cloud.Spanner.Data
                     try
                     {
                         localClient = await ClientPool.Default.AcquireClientAsync(
-                                _connectionStringBuilder.Credential,
+                                _connectionStringBuilder.GetCredential(),
                                 _connectionStringBuilder.EndPoint,
                                 _connectionStringBuilder)
                             .ConfigureAwait(false);


### PR DESCRIPTION
via CredentialFile=<json_file>
Can be a full path or relative to the application folder retrieved via AppDomain.CurrentDomain.BaseDirectory (AppContext for netcore < 2).
