### PR TITLE
Implement Datastore transaction options in DatastoreDb.

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDb.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDb.cs
@@ -238,6 +238,28 @@ namespace Google.Cloud.Datastore.V1
         }
 
         /// <summary>
+        /// Begins a transaction, returning a <see cref="DatastoreTransaction"/> which can be used to operate on the transaction.
+        /// </summary>
+        /// <param name="options">The options for the new transaction. May be null, for default options.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A new <see cref="DatastoreTransaction"/> for this object's project.</returns>
+        public virtual DatastoreTransaction BeginTransaction(TransactionOptions options, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Begins a transaction asynchronously, returning a <see cref="DatastoreTransaction"/> which can be used to operate on the transaction.
+        /// </summary>
+        /// <param name="options">The options for the new transaction. May be null, for default options.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A new <see cref="DatastoreTransaction"/> for this object's project.</returns>
+        public virtual Task<DatastoreTransaction> BeginTransactionAsync(TransactionOptions options, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Allocates an ID for a single incomplete key.
         /// </summary>
         /// <remarks>This method simply delegates to <see cref="AllocateIds(IEnumerable{Key},CallSettings)"/>.</remarks>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDbImpl.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDbImpl.cs
@@ -146,7 +146,23 @@ namespace Google.Cloud.Datastore.V1
         {
             var response = await Client.BeginTransactionAsync(ProjectId, callSettings).ConfigureAwait(false);
             return DatastoreTransaction.Create(Client, ProjectId, NamespaceId, response.Transaction);
-        }                
+        }
+
+        /// <inheritdoc/>
+        public override DatastoreTransaction BeginTransaction(TransactionOptions options, CallSettings callSettings = null)
+        {
+            var request = new BeginTransactionRequest { ProjectId = ProjectId, TransactionOptions = options };
+            var response = Client.BeginTransaction(request, callSettings);
+            return DatastoreTransaction.Create(Client, ProjectId, NamespaceId, response.Transaction);
+        }
+
+        /// <inheritdoc/>
+        public async override Task<DatastoreTransaction> BeginTransactionAsync(TransactionOptions options, CallSettings callSettings = null)
+        {
+            var request = new BeginTransactionRequest { ProjectId = ProjectId, TransactionOptions = options };
+            var response = await Client.BeginTransactionAsync(request, callSettings).ConfigureAwait(false);
+            return DatastoreTransaction.Create(Client, ProjectId, NamespaceId, response.Transaction);
+        }
 
         /// <inheritdoc/>
         public override IReadOnlyList<Key> AllocateIds(IEnumerable<Key> keys, CallSettings callSettings = null)

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/TransactionOptionsPartial.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/TransactionOptionsPartial.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Protobuf;
+
+namespace Google.Cloud.Datastore.V1
+{
+    // Factory methods to create new instances. We have to create a new instance each time as the class is mutable.
+    public partial class TransactionOptions
+    {
+        /// <summary>
+        /// Creates options for a read-only transaction.
+        /// </summary>
+        /// <returns>A <see cref="TransactionOptions"/> for a read-only transaction.</returns>
+        public static TransactionOptions CreateReadOnly() => new TransactionOptions { ReadOnly = new Types.ReadOnly() };
+
+        /// <summary>
+        /// Creates options for a transaction that will retry a previous one, identified by <paramref name="previousTransactionId"/>.
+        /// </summary>
+        /// <param name="previousTransactionId">The ID of the transaction being retried.</param>
+        /// <returns>A <see cref="TransactionOptions"/> for a transaction to retry.</returns>
+        public static TransactionOptions CreateForRetry(ByteString previousTransactionId) =>
+            new TransactionOptions { ReadWrite = new Types.ReadWrite { PreviousTransaction = previousTransactionId } };
+
+        /// <summary>
+        /// Creates options for a read-write transaction. (This is equivalent to not specifying transaction options at all.)
+        /// </summary>
+        /// <returns>A <see cref="TransactionOptions"/> for a read-write transaction.</returns>
+        public static TransactionOptions CreateReadWrite() => new TransactionOptions { ReadWrite = new Types.ReadWrite() };
+    }
+}


### PR DESCRIPTION
These have been available in the generated code (so in
BeginTransactionRequest) for a while, but not exposed in DatastoreDb.

I don't propose to merge this until we can test it directly in whitelisted projects. (I've tested using a test environment.)