### PR TITLE
Index BigQuery schema fields for more efficient access

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryPageTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryPageTest.cs
@@ -42,7 +42,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
         {
             var nextPageToken = "token";
             var schema = new TableSchema();
-            var row = new BigQueryRow(new TableRow(), schema);
+            var row = new BigQueryRow(new TableRow(), schema, schema.IndexFieldNames());
             var rawPage = new Page<BigQueryRow>(new List<BigQueryRow> { row }, nextPageToken);
             var jobReference = new JobReference { ProjectId = "project", JobId = "job" };
             var tableReference = new TableReference { ProjectId = "project", DatasetId = "dataset", TableId = "table" };

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
@@ -55,7 +55,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     new TableCell { V = new JObject { ["f"] = new JArray {new JObject { ["v"] = "100" }, new JObject { ["v"] = "xyz" } } } }
                 }
             };
-            var row = new BigQueryRow(rawRow, schema);
+            var row = CreateRow(rawRow, schema);
             Assert.Equal(10, (long)row["integer"]);
             Assert.Equal(true, (bool)row["bool"]);
             Assert.Equal(new byte[] { 1, 2 }, (byte[])row["bytes"]);
@@ -103,7 +103,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     } }
                 }
             };
-            var row = new BigQueryRow(rawRow, schema);
+            var row = CreateRow(rawRow, schema);
             Assert.Equal(new[] { 10L, 20L }, (long[])row["integer"]);
             Assert.Equal(new[] { true, false }, (bool[])row["bool"]);
             Assert.Equal(new[] { new byte[] { 1, 2 }, new byte[] { 1, 3 } }, (byte[][])row["bytes"]);
@@ -138,7 +138,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     new TableCell { V = null }
                 }
             };
-            var row = new BigQueryRow(rawRow, schema);
+            var row = CreateRow(rawRow, schema);
             Assert.Null(row["text"]);
         }
 
@@ -157,12 +157,14 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     new TableCell { V = new JObject { ["f"] = new JArray {new JObject { ["v"] = "100" } } } }
                 }
             };
-            var row = new BigQueryRow(rawRow, schema);
+            var row = CreateRow(rawRow, schema);
             Assert.Throws<InvalidOperationException>(() => row["struct"]);
         }
 
         private JArray CreateArray(params string[] values) => new JArray(values.Select(CreateObject));
 
         private JObject CreateObject(string value) => new JObject { ["v"] = value };
+
+        private BigQueryRow CreateRow(TableRow rawRow, TableSchema schema) => new BigQueryRow(rawRow, schema, schema.IndexFieldNames());
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/TableSchemaExtensionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/TableSchemaExtensionsTest.cs
@@ -21,7 +21,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
     public class TableSchemaExtensionsTest
     {
         [Fact]
-        public void GetFieldIndex()
+        public void IndexFieldNames()
         {
             var schema = new TableSchema
             {
@@ -31,8 +31,15 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     new TableFieldSchema { Name = "bar" }
                 }
             };
-            Assert.Equal(1, schema.GetFieldIndex("bar"));
-            Assert.Throws<KeyNotFoundException>(() => schema.GetFieldIndex("qux"));
+            var expected = new Dictionary<string, int> { { "foo", 0 }, { "bar", 1 } };
+            Assert.Equal(expected, schema.IndexFieldNames());
+        }
+
+        [Fact]
+        public void IndexFieldNames_EmptySchema()
+        {
+            var schema = new TableSchema();
+            Assert.Empty(schema.IndexFieldNames());
         }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
@@ -30,15 +30,17 @@ namespace Google.Cloud.BigQuery.V2
         {
             private readonly BigQueryClient _client;
             private readonly TableSchema _schema;
+            private readonly Dictionary<string, int> _fieldNameToIndexMap;
 
             internal TableRowPageManager(BigQueryClient client, TableSchema schema)
             {
                 _client = client;
                 _schema = schema;
+                _fieldNameToIndexMap = schema.IndexFieldNames();                
             }
 
             public string GetNextPageToken(TableDataList response) => response.PageToken;
-            public IEnumerable<BigQueryRow> GetResources(TableDataList response) => response.Rows?.Select(row => new BigQueryRow(row, _schema));
+            public IEnumerable<BigQueryRow> GetResources(TableDataList response) => response.Rows?.Select(row => new BigQueryRow(row, _schema, _fieldNameToIndexMap));
             public void SetPageSize(TabledataResource.ListRequest request, int pageSize) => request.MaxResults = pageSize;
             public void SetPageToken(TabledataResource.ListRequest request, string pageToken)
             {

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
@@ -35,10 +35,13 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         public TableSchema Schema { get; }
 
-        internal BigQueryRow(TableRow rawRow, TableSchema schema)
+        private readonly IDictionary<string, int> _fieldNameIndexMap;
+
+        internal BigQueryRow(TableRow rawRow, TableSchema schema, IDictionary<string, int> fieldNameIndexMap)
         {
             Schema = schema;
             RawRow = rawRow;
+            _fieldNameIndexMap = fieldNameIndexMap;
         }
 
         private static readonly Func<string, string> StringConverter = v => v;
@@ -62,7 +65,7 @@ namespace Google.Cloud.BigQuery.V2
         /// <summary>
         /// Retrieves a cell value by field name.
         /// </summary>
-        public object this[string name] => this[Schema.GetFieldIndex(name)];
+        public object this[string name] => this[_fieldNameIndexMap[name]];
 
         /// <summary>
         /// Retrieves a cell value by index.

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/TableSchemaExtensions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/TableSchemaExtensions.cs
@@ -15,30 +15,30 @@
 using System.Collections.Generic;
 using Google.Api.Gax;
 using Google.Apis.Bigquery.v2.Data;
+using System;
 
 namespace Google.Cloud.BigQuery.V2
 {
     /// <summary>
     /// Extension methods over table schemas.
     /// </summary>
-    public static class TableSchemaExtensions
+    internal static class TableSchemaExtensions
     {
-        /// <summary>
-        /// Retrieves the index of a field given its name.
-        /// </summary>
-        public static int GetFieldIndex(this TableSchema schema, string fieldName)
+        internal static Dictionary<string, int> IndexFieldNames(this TableSchema schema)
         {
-            GaxPreconditions.CheckNotNull(schema, nameof(schema));
-            GaxPreconditions.CheckNotNull(fieldName, nameof(fieldName));
-
-            for (int i = 0; i < schema.Fields.Count; i++)
+            // Could use LINQ, but there's no overload for ToDictionary that gives us the index,
+            // using Select to get it feels annoying.
+            // While Fields is unlikely to be null in realistic use cases, it does no harm to handle it.
+            var fields = schema.Fields ?? new TableFieldSchema[0];
+            var ret = new Dictionary<string, int>(fields.Count, StringComparer.Ordinal);
+            for (int i = 0; i < fields.Count; i++)
             {
-                if (schema.Fields[i].Name == fieldName)
-                {
-                    return i;
-                }
+                // This will throw on duplicate field names. This should never happen in real life,
+                // and if it does, it's better to have an exception than silently start returning
+                // unexpected data.
+                ret.Add(fields[i].Name, i);
             }
-            throw new KeyNotFoundException($"No such field: '{fieldName}'");
+            return ret;
         }
     }
 }


### PR DESCRIPTION
Fixes #1440.

Breaking change: the public GetFieldIndex extension method on TableSchema
has been removed. We now don't provide any public equivalent, but we
could make the new extension method public if we wanted to.

cc @benwulfe as this will need a merge into the ADO branch.