### PR TITLE
Public dependency analyzer

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.Dlp.V2Beta1/Google.Cloud.Dlp.V2Beta1/Google.Cloud.Dlp.V2Beta1.csproj
+++ b/apis/Google.Cloud.Dlp.V2Beta1/Google.Cloud.Dlp.V2Beta1/Google.Cloud.Dlp.V2Beta1.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.csproj
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental.csproj
+++ b/apis/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.VideoIntelligence.V1Beta2/Google.Cloud.VideoIntelligence.V1Beta2/Google.Cloud.VideoIntelligence.V1Beta2.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1Beta2/Google.Cloud.VideoIntelligence.V1Beta2/Google.Cloud.VideoIntelligence.V1Beta2.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
@@ -21,6 +21,7 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />

--- a/grpc.ruleset
+++ b/grpc.ruleset
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="gRPC Rules" Description=" " ToolsVersion="15.0">
+  <Rules AnalyzerId="Google.Cloud.Tools.Analyzers" RuleNamespace="Google.Cloud.Tools.Analyzers">
+    <Rule Id="GCP0003" Action="Warning" />
+  </Rules>
+</RuleSet>

--- a/tools/Google.Cloud.Tools.Analyzers.Tests/PublicDependencyForbiddenAnalyzerTest.cs
+++ b/tools/Google.Cloud.Tools.Analyzers.Tests/PublicDependencyForbiddenAnalyzerTest.cs
@@ -1,0 +1,271 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using TestHelper;
+using Xunit;
+
+namespace Google.Cloud.Tools.Analyzers.Test
+{
+    public class PublicDependencyForbiddenAnalyzerTest : CodeFixVerifier
+    {
+        [Fact]
+        public void ConstructorCheck()
+        {
+            var test = @"
+using Google.Apis.Foo;
+using System;
+
+public class A
+{
+    public A () {}
+    public A (B b) {}
+    internal A (B b) {}
+}
+
+namespace Google.Apis.Foo
+{
+    public class B
+    {
+        public B() {}
+    }
+}";
+            var expected = CreateDiagnostic("Google.Apis.Foo.B", "Google.Apis.Foo", 8, 15);
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
+        [Fact]
+        public void CustomEventCheck()
+        {
+            var test = @"
+using Google.Apis.Foo;
+using System;
+
+public class A
+{
+    public event EventHandler<EventArgs> GoodEvent { add {} remove {} }
+    public event EventHandler<GoogleEventArgs> BadEvent { add {} remove {} }
+    internal event EventHandler<GoogleEventArgs> InternalEvent { add {} remove {} }
+}
+
+namespace Google.Apis.Foo
+{
+    public class GoogleEventArgs : EventArgs
+    {
+    }
+
+    public class OtherType
+    {
+        public event EventHandler<GoogleEventArgs> NotChecked { add {} remove {} }
+    }
+}";
+            var expected = CreateDiagnostic("System.EventHandler<Google.Apis.Foo.GoogleEventArgs>", "Google.Apis.Foo", 8, 18);
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
+        [Fact]
+        public void EventCheck()
+        {
+            var test = @"
+using Google.Apis.Foo;
+using System;
+
+public class A
+{
+    public event EventHandler<EventArgs> GoodEvent;
+    public event EventHandler<GoogleEventArgs> BadEvent;
+    internal event EventHandler<GoogleEventArgs> InternalEvent;
+}
+
+namespace Google.Apis.Foo
+{
+    public class GoogleEventArgs : EventArgs
+    {
+    }
+
+    public class OtherType
+    {
+        public event EventHandler<GoogleEventArgs> NotChecked;
+    }
+}";
+            var expected = CreateDiagnostic("System.EventHandler<Google.Apis.Foo.GoogleEventArgs>", "Google.Apis.Foo", 8, 18);
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
+        [Fact]
+        public void FieldCheck()
+        {
+            var test = @"
+using Google.Apis.Foo;
+
+public class A
+{
+    public A _good_field;
+    public B _bad_field;
+    internal B _internal_field;
+}
+
+namespace Google.Apis.Foo
+{
+    public class B
+    {
+    }
+
+    public class OtherType
+    {
+        public B _not_checked;
+    }
+}";
+            var expected = CreateDiagnostic("Google.Apis.Foo.B", "Google.Apis.Foo", 7, 12);
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
+        [Fact]
+        public void MethodParameterCheck()
+        {
+            var test = @"
+using Google.Apis.Foo;
+
+public class A
+{
+    public void GoodMethod(A a) { }
+    public void BadMethod(B b) { }
+    internal void InternalMethod(B b) { }
+}
+
+namespace Google.Apis.Foo
+{
+    public class B
+    {
+    }
+
+    public class OtherType
+    {
+        public void NotChecked(B b) { }
+    }
+}";
+            var expected = CreateDiagnostic("Google.Apis.Foo.B", "Google.Apis.Foo", 7, 27);
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
+        [Fact]
+        public void MethodReturnTypeCheck()
+        {
+            var test = @"
+using Google.Apis.Foo;
+
+public class A
+{
+    public A GoodMethod() { return default(A); }
+    public B BadMethod() { return default(B); }
+    internal B InternalMethod() { return default(B); }
+}
+
+namespace Google.Apis.Foo
+{
+    public class B
+    {
+    }
+
+    public class OtherType
+    {
+        public B NotChecked() { return default(B); }
+    }
+}";
+            var expected = CreateDiagnostic("Google.Apis.Foo.B", "Google.Apis.Foo", 7, 12);
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
+        [Fact]
+        public void PropertyCheck()
+        {
+            var test = @"
+using Google.Apis.Foo;
+
+public class A
+{
+    public A GoodProperty { get; set; }
+    public B BadProperty { get; set; }
+    internal B InternalProperty { get; set; }
+}
+
+namespace Google.Apis.Foo
+{
+    public class B
+    {
+    }
+
+    public class OtherType
+    {
+        public B NotChecked { get; set; }
+    }
+}";
+            var expected = CreateDiagnostic("Google.Apis.Foo.B", "Google.Apis.Foo", 7, 12);
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
+        [Fact]
+        public void TypeBaseCheck()
+        {
+            var test = @"
+using Google.Apis.Foo;
+
+public class A : B { }
+
+namespace Google.Apis.Foo
+{
+    public class B { }
+
+    public class OtherType : B { }
+}";
+            var expected = CreateDiagnostic("A", "Google.Apis.Foo", 4, 16);
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
+        [Fact]
+        public void TypeInterfaceCheck()
+        {
+            var test = @"
+using Google.Apis.Foo;
+using System;
+
+public class A : IComparable<B> { }
+
+namespace Google.Apis.Foo
+{
+    public class B { }
+
+    public class OtherType : IComparable<B> { }
+}";
+            var expected = CreateDiagnostic("A", "Google.Apis.Foo", 5, 16);
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
+        private DiagnosticResult CreateDiagnostic(
+            string typeName, string namespaceName, int line, int column) =>
+                new DiagnosticResult
+                {
+                    Id = PublicDependencyForbiddenAnalyzer.DiagnosticId,
+                    Message = $"The type '{typeName}' directly or indirectly depends on the forbidden namespace '{namespaceName}'",
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", line, column) }
+                };
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new PublicDependencyForbiddenAnalyzer();
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.Analyzers.Tests/PublicDependencyForbiddenAnalyzerTest.cs
+++ b/tools/Google.Cloud.Tools.Analyzers.Tests/PublicDependencyForbiddenAnalyzerTest.cs
@@ -259,7 +259,7 @@ namespace Google.Apis.Foo
                 {
                     Id = PublicDependencyForbiddenAnalyzer.DiagnosticId,
                     Message = $"The type '{typeName}' directly or indirectly depends on the forbidden namespace '{namespaceName}'",
-                    Severity = DiagnosticSeverity.Warning,
+                    Severity = DiagnosticSeverity.Hidden,
                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", line, column) }
                 };
 

--- a/tools/Google.Cloud.Tools.Analyzers/Google.Cloud.Tools.Analyzers.csproj
+++ b/tools/Google.Cloud.Tools.Analyzers/Google.Cloud.Tools.Analyzers.csproj
@@ -4,6 +4,9 @@
     <Version>1.0.0</Version>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.3|AnyCPU'">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.1" />

--- a/tools/Google.Cloud.Tools.Analyzers/PublicDependencyForbiddenAnalyzer.cs
+++ b/tools/Google.Cloud.Tools.Analyzers/PublicDependencyForbiddenAnalyzer.cs
@@ -1,0 +1,280 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Semantics;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Google.Cloud.Tools.Analyzers
+{
+    /// <summary>
+    /// Warns about deriving from or exposing types from namespaces which are not to be exposed as dependencies.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class PublicDependencyForbiddenAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly ImmutableArray<string> ForbiddenNamespacePrefixes = ImmutableArray.Create("Google.Apis.");
+
+        public const string DiagnosticId = "GCP0003";
+        private const string Category = "Usage";
+
+        private static readonly LocalizableString Title = "Publicly dependency to forbidden namespace";
+        private static readonly LocalizableString MessageFormat = "The type '{0}' directly or indirectly depends on the forbidden namespace '{1}'";
+        private static readonly LocalizableString Description = "Dependencies on certain namespaces should not be exposed publicly.";
+        private static DiagnosticDescriptor Rule =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Hidden, isEnabledByDefault: true, description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.RegisterSymbolAction(AnalyzeEvent, SymbolKind.Event);
+            context.RegisterSymbolAction(AnalyzeField, SymbolKind.Field);
+            context.RegisterSymbolAction(AnalyzeMethod, SymbolKind.Method);
+            context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+            context.RegisterSymbolAction(AnalyzeProperty, SymbolKind.Property);
+        }
+
+        private static void AnalyzeEvent(SymbolAnalysisContext context)
+        {
+            var eventSymbol = (IEventSymbol)context.Symbol;
+            var declNode = context.Symbol.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken);
+            if (declNode.IsKind(SyntaxKind.EventDeclaration))
+            {
+                CheckType<EventDeclarationSyntax>(
+                    context,
+                    eventSymbol.Type,
+                    eventNode => eventNode.Type.GetLocation());
+            }
+            else
+            {
+                CheckType<VariableDeclaratorSyntax>(
+                    context,
+                    eventSymbol.Type,
+                    variableDeclaratorNode => (variableDeclaratorNode.Parent as VariableDeclarationSyntax)?.Type.GetLocation());
+            }
+        }
+
+        private static void AnalyzeField(SymbolAnalysisContext context)
+        {
+            var fieldSymbol = (IFieldSymbol)context.Symbol;
+            CheckType<VariableDeclaratorSyntax>(
+                context,
+                fieldSymbol.Type,
+                variableDeclaratorNode => (variableDeclaratorNode.Parent as VariableDeclarationSyntax)?.Type.GetLocation());
+        }
+
+        private static void AnalyzeMethod(SymbolAnalysisContext context)
+        {
+            var methodKind = ((IMethodSymbol)context.Symbol).MethodKind;
+            switch (methodKind)
+            {
+                case MethodKind.AnonymousFunction:
+                case MethodKind.DelegateInvoke:
+                case MethodKind.Destructor:
+                case MethodKind.EventAdd:
+                case MethodKind.EventRaise:
+                case MethodKind.EventRemove:
+                case MethodKind.ExplicitInterfaceImplementation:
+                case MethodKind.PropertyGet:
+                case MethodKind.PropertySet:
+                case MethodKind.StaticConstructor:
+                case MethodKind.LocalFunction:
+                    return;
+            }
+
+            var methodSymbol = (IMethodSymbol)context.Symbol;
+            if (methodKind != MethodKind.Constructor)
+            {
+                CheckType<MethodDeclarationSyntax>(
+                    context,
+                    methodSymbol.ReturnType,
+                    methodNode => methodNode.ReturnType.GetLocation());
+            }
+
+            for (int i = 0; i < methodSymbol.Parameters.Length; ++i)
+            {
+                if (methodKind == MethodKind.Constructor)
+                {
+                    CheckType<ConstructorDeclarationSyntax>(
+                       context,
+                       methodSymbol.Parameters[i].Type,
+                       constructorNode => constructorNode.ParameterList.Parameters[i].Type.GetLocation());
+                }
+                else
+                {
+                    CheckType<MethodDeclarationSyntax>(
+                       context,
+                       methodSymbol.Parameters[i].Type,
+                       methodNode => methodNode.ParameterList.Parameters[i].Type.GetLocation());
+                }
+            }
+        }
+
+        private static void AnalyzeNamedType(SymbolAnalysisContext context)
+        {
+            var typeSymbol = (INamedTypeSymbol)context.Symbol;
+            CheckType<TypeDeclarationSyntax>(
+                context,
+                typeSymbol,
+                methodNode => methodNode.BaseList.GetLocation());
+        }
+
+        private static void AnalyzeProperty(SymbolAnalysisContext context)
+        {
+            var propertySymbol = (IPropertySymbol)context.Symbol;
+            CheckType<PropertyDeclarationSyntax>(
+                context,
+                propertySymbol.Type,
+                propertyNode => propertyNode.Type.GetLocation());
+
+            for (int i = 0; i < propertySymbol.Parameters.Length; ++i)
+            {
+                CheckType<IndexerDeclarationSyntax>(
+                    context,
+                    propertySymbol.Parameters[i].Type,
+                    propertyNode => propertyNode.ParameterList.Parameters[i].Type.GetLocation());
+            }
+        }
+
+        private static void CheckType<T>(SymbolAnalysisContext context, ITypeSymbol type, Func<T, Location> getErrorLocation)
+            where T : CSharpSyntaxNode
+        {
+            if (!context.Symbol.IsExternallyVisible())
+            {
+                return;
+            }
+
+            if (ForbiddenNamespacePrefixes.Any(context.Symbol.ContainingSymbol.ToDisplayString().StartsWith))
+            {
+                // If a symbol is actually defined in a forbidden namespace, don't add an error to it.
+                return;
+            }
+
+            var checkedTypes = new Dictionary<ITypeSymbol, TypeCheckResult>();
+            var result = CheckType(type, checkedTypes);
+            if (!result.IsTypeForbidden)
+            {
+                return;
+            }
+
+            if (context.Symbol.DeclaringSyntaxReferences.IsEmpty)
+            {
+                return;
+            }
+
+            T declaringNode = (T)context.Symbol.DeclaringSyntaxReferences.FirstOrDefault().GetSyntax(context.CancellationToken);
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    Rule,
+                    getErrorLocation(declaringNode),
+                    type.ToDisplayString(),
+                    result.ForbiddenNamespace));
+        }
+
+        private static TypeCheckResult CheckType(ITypeSymbol type, Dictionary<ITypeSymbol, TypeCheckResult> checkedTypes)
+        {
+            if (!checkedTypes.TryGetValue(type, out var result))
+            {
+                // Add a placeholder before we do anything else to prevent recursion issues.
+                checkedTypes.Add(type, TypeCheckResult.Allowed);
+
+                result = CheckTypeImpl(type);
+                checkedTypes[type] = result;
+            }
+            return result;
+
+            TypeCheckResult CheckTypeImpl(ITypeSymbol currentType)
+            {
+                if (currentType.TypeKind == TypeKind.Array)
+                {
+                    return CheckType(((IArrayTypeSymbol)currentType).ElementType, checkedTypes);
+                }
+
+                if (currentType is INamedTypeSymbol namedType)
+                {
+                    if (namedType.TypeKind == TypeKind.Delegate)
+                    {
+                        var delegateResult = CheckType(namedType.DelegateInvokeMethod.ReturnType, checkedTypes);
+                        if (!delegateResult.IsTypeForbidden) {
+                            delegateResult =
+                                    namedType.DelegateInvokeMethod.Parameters.
+                                        Select(p => CheckType(p.Type, checkedTypes)).
+                                        FirstOrDefault(c => c.IsTypeForbidden);
+                        }
+
+                        if (delegateResult?.IsTypeForbidden == true)
+                        {
+                            return TypeCheckResult.Forbidden(delegateResult.ForbiddenNamespace);
+                        }
+                    }
+                    else
+                    {
+                        if (ForbiddenNamespacePrefixes.Any(namedType.ContainingNamespace.ToDisplayString().StartsWith))
+                        {
+                            return TypeCheckResult.Forbidden(namedType.ContainingNamespace.ToDisplayString());
+                        }
+
+                        var dependentTypeResult =
+                            namedType.BaseType == null ? null : CheckType(namedType.BaseType, checkedTypes);
+
+                        if (dependentTypeResult?.IsTypeForbidden != true)
+                        {
+                            dependentTypeResult =
+                                namedType.Interfaces.Select(i => CheckType(i, checkedTypes)).FirstOrDefault(c => c.IsTypeForbidden);
+                        }
+
+                        if (dependentTypeResult?.IsTypeForbidden != true)
+                        {
+                            dependentTypeResult =
+                                namedType.TypeArguments.Select(p => CheckType(p, checkedTypes)).FirstOrDefault(c => c.IsTypeForbidden);
+                        }
+
+                        if (dependentTypeResult?.IsTypeForbidden == true)
+                        {
+                            return TypeCheckResult.Forbidden(dependentTypeResult.ForbiddenNamespace);
+                        }
+                    }
+                }
+
+                return TypeCheckResult.Allowed;
+            }
+        }
+
+        private class TypeCheckResult
+        {
+            public static readonly TypeCheckResult Allowed = new TypeCheckResult();
+
+            public static TypeCheckResult Forbidden(string forbiddenNamespace) =>
+                new TypeCheckResult
+                {
+                    IsTypeForbidden = true,
+                    ForbiddenNamespace = forbiddenNamespace
+                };
+
+            private TypeCheckResult() { }
+
+            public bool IsTypeForbidden { get; private set; }
+            public string ForbiddenNamespace { get; private set; }
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
+++ b/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
@@ -313,6 +313,10 @@ TODO: Add snippet references here.
                 new XElement("RepositoryType", "git"),
                 new XElement("RepositoryUrl", "https://github.com/GoogleCloudPlatform/google-cloud-dotnet")
             );
+            if (api.Type == "grpc")
+            {
+                propertyGroup.Add(new XElement("CodeAnalysisRuleSet", "..\\..\\..\\grpc.ruleset"));
+            }
             var packingElement = new XElement("ItemGroup",
                 new XAttribute("Label", DotnetPackInstructionsLabel),
                 targetFrameworks.Split(';').Select(tfm => new XElement("Content",


### PR DESCRIPTION
This analyzer is disabled by default and needs to be opted into. I added a ruleset file to do just that for the gRPC projects. I'm having trouble building everything locally due to #1455 (not sure if that's just a problem on my machine or something wrong with that PR), but I'm creating this PR to see what the build machines do.