### PR TITLE
Use Protobuf 3.4.1 for Google.LongRunning

### DIFF
--- a/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.1.0-beta02" />
+    <PackageReference Include="Google.Protobuf" Version="3.4.1" />
     <PackageReference Include="Grpc.Core" Version="1.4.0" PrivateAssets="None" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.1.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -458,6 +458,9 @@
     "type": "grpc",
     "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",
     "tags": [ "LongRunning" ],
+    "dependencies": {
+      "Google.Protobuf": "3.4.1"
+    },
     "testDependencies": {
       "Google.Api.Gax.Testing": "default"
     }


### PR DESCRIPTION
3.4.0 introduced Any.TryUnpack, which means we don't need to
implement it ourselves - and we can refer to it in the docs.