### PR TITLE
Update Google.Cloud.Logging.Log4Net versions

### DIFF
--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0-alpha00</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -24,9 +24,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0-beta4" PrivateAssets="All" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.1.0" />
     <PackageReference Include="Google.Cloud.DevTools.Common" Version="1.0.0" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="2.0.0" />
-    <PackageReference Include="Grpc.Core" Version="1.4.0" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="1.6.1" PrivateAssets="None" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.1.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -238,7 +238,7 @@
 
   {
     "id": "Google.Cloud.Logging.Log4Net",
-    "version": "2.1.0",
+    "version": "2.2.0-alpha00",
     "type": "other",
     "targetFrameworks": "netstandard1.5;net45",
     "testTargetFrameworks": "netcoreapp1.0;net452",
@@ -246,9 +246,10 @@
     "tags": [ "Log4Net", "Logging", "Stackdriver" ],
     "dependencies": {
       "log4net": "2.0.8",
+      "Google.Api.Gax.Grpc": "2.1.0",
       "Google.Cloud.Logging.V2": "2.0.0",
       "Google.Cloud.DevTools.Common": "1.0.0",
-      "Grpc.Core": "1.4.0"
+      "Grpc.Core": "1.6.1"
     },
     "testDependencies": {
       "Google.Api.Gax.Testing": "2.0.0"


### PR DESCRIPTION
This explicitly depends on Google.Api.Gax.Grpc 2.1.0 to bring in the
dependency on Google.Apis.Auth 1.29.1, allowing for credentials to
be loaded from a file easily.