### PR TITLE
Update Google.LongRunning to 1.0

### DIFF
--- a/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta11</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -472,15 +472,17 @@
 
   {
     "id": "Google.LongRunning",
-    "version": "1.0.0-beta11",
+    "version": "1.0.0",
     "type": "grpc",
     "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",
     "tags": [ "LongRunning" ],
     "dependencies": {
-      "Google.Protobuf": "3.4.1"
+      "Google.Api.Gax.Grpc": "2.1.0",
+      "Google.Protobuf": "3.4.1",
+      "Grpc.Core": "1.6.1"
     },
     "testDependencies": {
-      "Google.Api.Gax.Testing": "default"
+      "Google.Api.Gax.Testing": "2.1.0"
     }
   }
 ]


### PR DESCRIPTION
(When this is released, packages that depend on Google.LongRunning
can be updated to use the GA version.)