### PR TITLE
Update versions for release

### DIFF
--- a/apis/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental.csproj
+++ b/apis/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental/Google.Cloud.Language.V1.Experimental.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta10</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta12</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1/Google.Cloud.VideoIntelligence.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha04</Version>
+    <Version>1.0.0-alpha05</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.VideoIntelligence.V1Beta2/Google.Cloud.VideoIntelligence.V1Beta2/Google.Cloud.VideoIntelligence.V1Beta2.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1Beta2/Google.Cloud.VideoIntelligence.V1Beta2/Google.Cloud.VideoIntelligence.V1Beta2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha00</Version>
+    <Version>1.0.0-alpha01</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -217,17 +217,21 @@
     "id": "Google.Cloud.Language.V1",
     "productName": "Google Cloud Natural Language",
     "productUrl": "https://cloud.google.com/natural-language",
-    "version": "1.0.0-beta10",
+    "version": "1.0.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Natural Language API, which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.",
     "tags": [ "Language" ],
+    "dependencies": {
+      "Google.Api.Gax.Grpc": "2.1.0",
+      "Grpc.Core": "1.6.1"
+    },
   },
 
   {
     "id": "Google.Cloud.Language.V1.Experimental",
     "productName": "Google Cloud Natural Language",
     "productUrl": "https://cloud.google.com/natural-language",
-    "version": "1.0.0-beta04",
+    "version": "1.0.0-beta05",
     "type": "grpc",
     "description": "Experimental library for the Google Cloud Natural Language API, containing features which may still change before final release.",
     "tags": [ "Language", "Experimental" ],
@@ -385,12 +389,14 @@
     "id": "Google.Cloud.Speech.V1",
     "productName": "Google Cloud Speech",
     "productUrl": "https://cloud.google.com/speech",
-    "version": "1.0.0-beta12",
+    "version": "1.0.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.",
     "tags": [ "Speech" ],
     "dependencies": {
-      "Google.LongRunning": "1.0.0"
+      "Google.Api.Gax.Grpc": "2.1.0",
+      "Google.LongRunning": "1.0.0",
+      "Grpc.Core": "1.6.1"
     },
   },
 
@@ -438,7 +444,7 @@
     "id": "Google.Cloud.VideoIntelligence.V1Beta1",
     "productName": "Google Cloud Video Intelligence",
     "productUrl": "https://cloud.google.com/video-intelligence",
-    "version": "1.0.0-alpha04",
+    "version": "1.0.0-alpha05",
     "type": "grpc",
     "description": "Recommended Google client library to access the v1beta1 Google Cloud Video Intelligence API.",
     "tags": [ "VideoIntelligence" ],
@@ -451,7 +457,7 @@
     "id": "Google.Cloud.VideoIntelligence.V1Beta2",
     "productName": "Google Cloud Video Intelligence",
     "productUrl": "https://cloud.google.com/video-intelligence",
-    "version": "1.0.0-alpha00",
+    "version": "1.0.0-alpha01",
     "type": "grpc",
     "description": "Recommended Google client library to access the v1beta2 Google Cloud Video Intelligence API.",
     "tags": [ "VideoIntelligence" ],
@@ -464,10 +470,14 @@
     "id": "Google.Cloud.Vision.V1",
     "productName": "Google Cloud Vision",
     "productUrl": "https://cloud.google.com/vision",
-    "version": "1.0.0-beta05",
+    "version": "1.0.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Vision API, which integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.",
     "tags": [ "Vision" ],
+    "dependencies": {
+      "Google.Api.Gax.Grpc": "2.1.0",
+      "Grpc.Core": "1.6.1"
+    },
   },
 
   {


### PR DESCRIPTION
Releases to GA:
- Language to 1.0.0
- Speech to1.0.0
- Vision to 1.0.0

Prereleases:
- Language.Experimental to 1.0.0-beta05
- VideoIntelligence.V1Beta1 to 1.0.0-alpha05 (possibly last release of this package)
- VideoIntelligence.V1Beta2 to 1.0.0-alpha01

Spanner libraries to be updated later with LongRunning 1.0.0 dependency