### PR TITLE
Extra ETag tests for BigQuery

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/DatasetsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/DatasetsTest.cs
@@ -117,7 +117,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Equal(fetched.Resource.ETag, updated.Resource.ETag);
         }
 
-        [Fact(Skip = "Known etag issue tracked internally")]
+        [Fact]
         public void UpdateDataset_Conflict()
         {
             var client = BigQueryClient.Create(_fixture.ProjectId);
@@ -227,7 +227,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Equal(fetched.Resource.ETag, updated.Resource.ETag);
         }
 
-        [Fact(Skip = "Known etag issue tracked internally")]
+        [Fact]
         public async Task UpdateDatasetAsync_Conflict()
         {
             var client = BigQueryClient.Create(_fixture.ProjectId);

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/DatasetsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/DatasetsTest.cs
@@ -103,6 +103,8 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var fetched = client.GetDataset(id);
             Assert.Equal("Description2", fetched.Resource.Description);
             Assert.Equal("FriendlyName2", fetched.Resource.FriendlyName);
+            Assert.NotEqual(original.Resource.ETag, updated.Resource.ETag);
+            Assert.Equal(fetched.Resource.ETag, updated.Resource.ETag);
         }
 
         [Fact(Skip = "Known etag issue tracked internally")]
@@ -143,6 +145,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var fetched = client.GetDataset(id);
             Assert.Equal("Description2", fetched.Resource.Description);
             Assert.Equal("FriendlyName1", fetched.Resource.FriendlyName);
+            Assert.Equal(fetched.Resource.ETag, patched.Resource.ETag);
         }
 
         [Fact]
@@ -217,6 +220,8 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var fetched = await client.GetDatasetAsync(id);
             Assert.Equal("Description2", fetched.Resource.Description);
             Assert.Equal("FriendlyName2", fetched.Resource.FriendlyName);
+            Assert.NotEqual(original.Resource.ETag, updated.Resource.ETag);
+            Assert.Equal(fetched.Resource.ETag, updated.Resource.ETag);
         }
 
         [Fact(Skip = "Known etag issue tracked internally")]
@@ -257,6 +262,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var fetched = await client.GetDatasetAsync(id);
             Assert.Equal("Description2", fetched.Resource.Description);
             Assert.Equal("FriendlyName1", fetched.Resource.FriendlyName);
+            Assert.Equal(fetched.Resource.ETag, patched.Resource.ETag);
         }
 
         [Fact]

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/DatasetsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/DatasetsTest.cs
@@ -79,6 +79,19 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
         }
 
+        // Regression test against issue where the etag returned on create wasn't the same as
+        // for the initial fetch.
+        [Fact]
+        public void CreateDataset_InitialEtag()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var id = _fixture.CreateDatasetId();
+
+            var created = client.CreateDataset(id, new CreateDatasetOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+            var fetched = client.GetDataset(id);
+            Assert.Equal(created.Resource.ETag, fetched.Resource.ETag);
+        }
+
         [Fact]
         public void UpdateDataset()
         {
@@ -90,9 +103,6 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             // Modify locally...
             original.Resource.Description = "Description2";
             original.Resource.FriendlyName = "FriendlyName2";
-
-            // FIXME: I shouldn't need to do this.
-            original.Resource.ETag = client.GetDataset(id).Resource.ETag;
 
             // Check the results of the update
             var updated = original.Update();
@@ -155,8 +165,6 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var id = _fixture.CreateDatasetId();
 
             var original = client.CreateDataset(id, new CreateDatasetOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
-            // FIXME: I shouldn't need to do this.
-            original.Resource.ETag = client.GetDataset(id).Resource.ETag;
 
             // Modify on the server, which will change the etag
             var sneaky = client.GetDataset(id);
@@ -175,8 +183,6 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var id = _fixture.CreateDatasetId();
 
             var original = client.CreateDataset(id, new CreateDatasetOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
-            // FIXME: I shouldn't need to do this.
-            original.Resource.ETag = client.GetDataset(id).Resource.ETag;
 
             // Modify on the server, which will change the etag
             var sneaky = client.GetDataset(id);
@@ -207,9 +213,6 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             // Modify locally...
             original.Resource.Description = "Description2";
             original.Resource.FriendlyName = "FriendlyName2";
-
-            // FIXME: I shouldn't need to do this.
-            original.Resource.ETag = client.GetDataset(id).Resource.ETag;
 
             // Check the results of the update
             var updated = await original.UpdateAsync();
@@ -272,8 +275,6 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var id = _fixture.CreateDatasetId();
 
             var original = await client.CreateDatasetAsync(id, new CreateDatasetOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
-            // FIXME: I shouldn't need to do this.
-            original.Resource.ETag = client.GetDataset(id).Resource.ETag;
 
             // Modify on the server, which will change the etag
             var sneaky = await client.GetDatasetAsync(id);
@@ -292,8 +293,6 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var id = _fixture.CreateDatasetId();
 
             var original = await client.CreateDatasetAsync(id, new CreateDatasetOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
-            // FIXME: I shouldn't need to do this.
-            original.Resource.ETag = client.GetDataset(id).Resource.ETag;
 
             // Modify on the server, which will change the etag
             var sneaky = await client.GetDatasetAsync(id);

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/TablesTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/TablesTest.cs
@@ -34,6 +34,20 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             _fixture = fixture;
         }
 
+        // Regression test against issue where the etag returned on create wasn't the same as
+        // for the initial fetch.
+        [Fact]
+        public void CreateTable_InitialEtag()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            var tableId = _fixture.CreateTableId();
+            var created = client.CreateTable(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
+
+            var fetched = client.GetTable(datasetId, tableId);
+            Assert.Equal(created.Resource.ETag, fetched.Resource.ETag);
+        }
+
         [Fact]
         public void UpdateTable()
         {
@@ -46,9 +60,6 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             // Modify locally...
             original.Resource.Description = "Description2";
             original.Resource.FriendlyName = "FriendlyName2";
-
-            // FIXME: I shouldn't need to do this.
-            original.Resource.ETag = client.GetTable(datasetId, tableId).Resource.ETag;
 
             // Check the results of the update
             var updated = original.Update();
@@ -114,8 +125,6 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var tableId = _fixture.CreateTableId();
 
             var original = client.CreateTable(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
-            // FIXME: I shouldn't need to do this.
-            original.Resource.ETag = client.GetTable(datasetId, tableId).Resource.ETag;
 
             // Modify on the server, which will change the etag
             var sneaky = client.GetTable(datasetId, tableId);
@@ -135,8 +144,6 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var tableId = _fixture.CreateTableId();
 
             var original = client.CreateTable(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
-            // FIXME: I shouldn't need to do this.
-            original.Resource.ETag = client.GetTable(datasetId, tableId).Resource.ETag;
 
             // Modify on the server, which will change the etag
             var sneaky = client.GetTable(datasetId, tableId);
@@ -168,9 +175,6 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             // Modify locally...
             original.Resource.Description = "Description2";
             original.Resource.FriendlyName = "FriendlyName2";
-
-            // FIXME: I shouldn't need to do this.
-            original.Resource.ETag = client.GetTable(datasetId, tableId).Resource.ETag;
 
             // Check the results of the update
             var updated = await original.UpdateAsync();
@@ -236,8 +240,6 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var tableId = _fixture.CreateTableId();
 
             var original = await client.CreateTableAsync(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
-            // FIXME: I shouldn't need to do this.
-            original.Resource.ETag = client.GetTable(datasetId, tableId).Resource.ETag;
 
             // Modify on the server, which will change the etag
             var sneaky = await client.GetTableAsync(datasetId, tableId);
@@ -257,8 +259,6 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var tableId = _fixture.CreateTableId();
 
             var original = await client.CreateTableAsync(datasetId, tableId, new TableSchema(), new CreateTableOptions { Description = "Description1", FriendlyName = "FriendlyName1" });
-            // FIXME: I shouldn't need to do this.
-            original.Resource.ETag = client.GetTable(datasetId, tableId).Resource.ETag;
 
             // Modify on the server, which will change the etag
             var sneaky = await client.GetTableAsync(datasetId, tableId);

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/TablesTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/TablesTest.cs
@@ -59,6 +59,8 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var fetched = client.GetTable(datasetId, tableId);
             Assert.Equal("Description2", fetched.Resource.Description);
             Assert.Equal("FriendlyName2", fetched.Resource.FriendlyName);
+            Assert.NotEqual(original.Resource.ETag, updated.Resource.ETag);
+            Assert.Equal(fetched.Resource.ETag, updated.Resource.ETag);
         }
 
         [Fact]
@@ -101,6 +103,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var fetched = client.GetTable(datasetId, tableId);
             Assert.Equal("Description2", fetched.Resource.Description);
             Assert.Equal("FriendlyName1", fetched.Resource.FriendlyName);
+            Assert.Equal(fetched.Resource.ETag, patched.Resource.ETag);
         }
 
         [Fact]
@@ -178,6 +181,8 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var fetched = await client.GetTableAsync(datasetId, tableId);
             Assert.Equal("Description2", fetched.Resource.Description);
             Assert.Equal("FriendlyName2", fetched.Resource.FriendlyName);
+            Assert.NotEqual(original.Resource.ETag, updated.Resource.ETag);
+            Assert.Equal(fetched.Resource.ETag, updated.Resource.ETag);
         }
 
         [Fact]
@@ -220,6 +225,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var fetched = await client.GetTableAsync(datasetId, tableId);
             Assert.Equal("Description2", fetched.Resource.Description);
             Assert.Equal("FriendlyName1", fetched.Resource.FriendlyName);
+            Assert.Equal(fetched.Resource.ETag, patched.Resource.ETag);
         }
 
         [Fact]


### PR DESCRIPTION
This is:

- New ETag issues being spotted then fixed (so regression tests against them)
- Old ETag issues we were working around being fixed
- New-but-skipped ETag issues now not being skipped