### PR TITLE
Expose the creation of the GoogleLoggerProvider

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.sln
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Diagnostics.Co
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{5C7831EE-28C4-4971-BDAD-422C6B92A60D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Diagnostics.AspNetCore2.Snippets", "Google.Cloud.Diagnostics.AspNetCore2.Snippets\Google.Cloud.Diagnostics.AspNetCore2.Snippets.csproj", "{9CD48E8B-43C9-46EC-ADA7-9B0F203F6B2B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -180,6 +182,18 @@ Global
 		{5C7831EE-28C4-4971-BDAD-422C6B92A60D}.Release|x64.Build.0 = Release|Any CPU
 		{5C7831EE-28C4-4971-BDAD-422C6B92A60D}.Release|x86.ActiveCfg = Release|Any CPU
 		{5C7831EE-28C4-4971-BDAD-422C6B92A60D}.Release|x86.Build.0 = Release|Any CPU
+		{9CD48E8B-43C9-46EC-ADA7-9B0F203F6B2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9CD48E8B-43C9-46EC-ADA7-9B0F203F6B2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9CD48E8B-43C9-46EC-ADA7-9B0F203F6B2B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9CD48E8B-43C9-46EC-ADA7-9B0F203F6B2B}.Debug|x64.Build.0 = Debug|Any CPU
+		{9CD48E8B-43C9-46EC-ADA7-9B0F203F6B2B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9CD48E8B-43C9-46EC-ADA7-9B0F203F6B2B}.Debug|x86.Build.0 = Debug|Any CPU
+		{9CD48E8B-43C9-46EC-ADA7-9B0F203F6B2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9CD48E8B-43C9-46EC-ADA7-9B0F203F6B2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9CD48E8B-43C9-46EC-ADA7-9B0F203F6B2B}.Release|x64.ActiveCfg = Release|Any CPU
+		{9CD48E8B-43C9-46EC-ADA7-9B0F203F6B2B}.Release|x64.Build.0 = Release|Any CPU
+		{9CD48E8B-43C9-46EC-ADA7-9B0F203F6B2B}.Release|x86.ActiveCfg = Release|Any CPU
+		{9CD48E8B-43C9-46EC-ADA7-9B0F203F6B2B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerFactoryExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerFactoryExtensions.cs
@@ -53,6 +53,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         public static ILoggerFactory AddGoogle(this ILoggerFactory factory, string projectId = null,
             LoggerOptions options = null, LoggingServiceV2Client client = null)
         {
+            GaxPreconditions.CheckNotNull(factory, nameof(factory));
             projectId = Project.GetAndCheckProjectId(projectId, options.MonitoredResource);
             return factory.AddGoogle(LogTarget.ForProject(projectId), options, client);
         }
@@ -67,6 +68,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         public static ILoggerFactory AddGoogle(this ILoggerFactory factory, LogTarget logTarget,
             LoggerOptions options = null, LoggingServiceV2Client client = null)
         {
+            GaxPreconditions.CheckNotNull(factory, nameof(factory));
             factory.AddProvider(GoogleLoggerProvider.Create(logTarget, options, client));
             return factory;
         }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerFactoryExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerFactoryExtensions.cs
@@ -53,7 +53,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         public static ILoggerFactory AddGoogle(this ILoggerFactory factory, string projectId = null,
             LoggerOptions options = null, LoggingServiceV2Client client = null)
         {
-            options = options ?? LoggerOptions.Create();
             projectId = Project.GetAndCheckProjectId(projectId, options.MonitoredResource);
             return factory.AddGoogle(LogTarget.ForProject(projectId), options, client);
         }
@@ -68,16 +67,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         public static ILoggerFactory AddGoogle(this ILoggerFactory factory, LogTarget logTarget,
             LoggerOptions options = null, LoggingServiceV2Client client = null)
         {
-            // Check params and set defaults if unset.
-            GaxPreconditions.CheckNotNull(factory, nameof(factory));
-            GaxPreconditions.CheckNotNull(logTarget, nameof(logTarget));
-            client = client ?? LoggingServiceV2Client.Create();
-            options = options ?? LoggerOptions.Create();
-
-            // Get the proper consumer from the options and add a logger provider.
-            IConsumer<LogEntry> consumer = LogConsumer.Create(client, options.BufferOptions, options.RetryOptions);
-            GoogleLoggerProvider provider = new GoogleLoggerProvider(consumer, logTarget, options);
-            factory.AddProvider(provider);
+            factory.AddProvider(GoogleLoggerProvider.Create(logTarget, options, client));
             return factory;
         }
     }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore2.Snippets/AspNetCoreSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore2.Snippets/AspNetCoreSnippets.cs
@@ -1,0 +1,41 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.ClientTesting;
+using Google.Cloud.Diagnostics.AspNetCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Google.Cloud.Diagnostics.AspNetCore2.Snippets
+{
+    [SnippetOutputCollector]
+    public class AspNetCoreSnippets
+    {
+        private class Startup { }
+        
+        public void Configure()
+        {
+            // Sample: RegisterGoogleLogger
+            string projectId = "[Google Cloud Platform project ID]";
+            var webHost = new WebHostBuilder()
+                .ConfigureLogging((hostingContext, logging) =>
+                {
+                    logging.AddProvider(GoogleLoggerProvider.Create(projectId));
+                })
+                .UseStartup<Startup>()
+                .Build();
+            // End sample
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore2.Snippets/AspNetCoreSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore2.Snippets/AspNetCoreSnippets.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,9 +30,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore2.Snippets
             string projectId = "[Google Cloud Platform project ID]";
             var webHost = new WebHostBuilder()
                 .ConfigureLogging((hostingContext, logging) =>
-                {
-                    logging.AddProvider(GoogleLoggerProvider.Create(projectId));
-                })
+                    logging.AddProvider(GoogleLoggerProvider.Create(projectId)))
                 .UseStartup<Startup>()
                 .Build();
             // End sample

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore2.Snippets/Google.Cloud.Diagnostics.AspNetCore2.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore2.Snippets/Google.Cloud.Diagnostics.AspNetCore2.Snippets.csproj
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Features>IOperation</Features>
+    <IsPackable>false</IsPackable>
+    <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Google.Api.Gax.Testing" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.3.0-beta5-build3769" />
+    <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
+    <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore\Google.Cloud.Diagnostics.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />
+    <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.Tests\Google.Cloud.Diagnostics.Common.Tests.csproj" />
+    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
+    <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
+    <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore2.Snippets/coverage.xml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f netcoreapp2.0 -c Release</TargetArguments>
+  <Filters>
+    <IncludeFilters>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Diagnostics.AspNetCore</ModuleMask>
+      </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Diagnostics.Common</ModuleMask>
+      </FilterEntry>
+    </IncludeFilters>
+  </Filters>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Diagnostics.AspNetCore2.Snippets.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
@@ -24,6 +24,10 @@ and Stackdriver Trace.
 
 [!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNetCore.AspNetCore.txt#RegisterGoogleLogger)]
 
+## Initializing Logging (AspNetCore 2.0)
+
+[!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNetCore2.AspNetCore.txt#RegisterGoogleLogger)]
+
 ## Log
 
 [!code-cs[](obj/snippets/Google.Cloud.Diagnostics.AspNetCore.AspNetCore.txt#UseGoogleLogger)]


### PR DESCRIPTION
This will allow ASP.NET Core 2.0 apps to use the new way of setting up logging.

This also adds a snippet for a 2.0.

Fixes #1425

Note:  All of this setup is tested by the integration tests.