### PR TITLE
Update codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,12 @@
 coverage:
   status:
+    # For overall status
     project:
+      default:
+        # Allow coverage to drop by 2% before complaining
+        threshold: 2
+    # For pull requests
+    patch:
       default:
         # Allow coverage to drop by 2% before complaining
         threshold: 2


### PR DESCRIPTION
I'm hoping that the reason it's still marking pull requests as
failing is because they use the "patch" part of the configuration.