### PR TITLE
Rename BigQueryParameter.ArrayType to ArrayElementType

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/ExhaustiveTypesTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/ExhaustiveTypesTest.cs
@@ -126,13 +126,13 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             // Date/DateTime/Timestamp arrays need to be given the types explicitly.
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array,
                 new[] { new DateTime(2017, 2, 14), new DateTime(2017, 2, 15) })
-                { ArrayType = BigQueryDbType.Date });
+                { ArrayElementType = BigQueryDbType.Date });
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array,
                 new[] { new DateTime(2017, 2, 14, 17, 25, 30, DateTimeKind.Unspecified), new DateTime(2017, 2, 15, 17, 25, 30, DateTimeKind.Unspecified) })
-                { ArrayType = BigQueryDbType.DateTime });
+                { ArrayElementType = BigQueryDbType.DateTime });
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array,
                 new[] { new DateTime(2017, 2, 14, 17, 25, 30, DateTimeKind.Utc), new DateTime(2017, 2, 15, 17, 25, 30, DateTimeKind.Utc) })
-                { ArrayType = BigQueryDbType.Timestamp });
+                { ArrayElementType = BigQueryDbType.Timestamp });
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array,
                 new[] { new TimeSpan(0, 1, 2, 3, 456), new TimeSpan(0, 23, 59, 59, 987) }));
         }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryParameterTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryParameterTest.cs
@@ -251,7 +251,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
         public void ExplicitlyTypedArrayType()
         {
             var parameter = new BigQueryParameter(BigQueryDbType.Array, new[] { new DateTimeOffset(new DateTime(2016, 10, 31), new TimeSpan(8, 30, 0)) });
-            parameter.ArrayType = BigQueryDbType.DateTime;
+            parameter.ArrayElementType = BigQueryDbType.DateTime;
             string actualJson = JsonConvert.SerializeObject(parameter.ToQueryParameter(BigQueryParameterMode.Positional));
 
             var expectedResult = new QueryParameter

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameter.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameter.cs
@@ -129,14 +129,24 @@ namespace Google.Cloud.BigQuery.V2
             set { _type = value == null ? default : GaxPreconditions.CheckEnumValue(value.Value, nameof(value)); }
         }
 
-        private BigQueryDbType? _arrayType;
+        private BigQueryDbType? _arrayElementType;
         /// <summary>
         /// The type of the nested elements, for array parameters. If this is null, the type is inferred from the value.
         /// </summary>
+        public BigQueryDbType? ArrayElementType
+        {
+            get { return _arrayElementType; }
+            set { _arrayElementType = value == null ? default : GaxPreconditions.CheckEnumValue(value.Value, nameof(value)); }
+        }
+
+        /// <summary>
+        /// The type of the nested elements, for array parameters. If this is null, the type is inferred from the value.
+        /// </summary>
+        [Obsolete("This property has been renamed to ArrayElementType. Please migrate your code to use that.")]
         public BigQueryDbType? ArrayType
         {
-            get { return _arrayType; }
-            set { _arrayType = value == null ? default : GaxPreconditions.CheckEnumValue(value.Value, nameof(value)); }
+            get => ArrayElementType;
+            set => ArrayElementType = value;
         }
 
         private object _value;
@@ -240,7 +250,7 @@ namespace Google.Cloud.BigQuery.V2
             switch (type)
             {
                 case BigQueryDbType.Array:
-                    return PopulateArrayParameter(parameter, value, ArrayType);
+                    return PopulateArrayParameter(parameter, value, ArrayElementType);
                 case BigQueryDbType.Bool:
                     return parameter.PopulateScalar<bool>(value, x => x ? "TRUE" : "FALSE")
                         ?? parameter.PopulateScalar<string>(value, x => x)


### PR DESCRIPTION
This is consistent with reflection and clearer.

I haven't renamed Type to BigQueryDbType as suggested in #1403, as
we're no longer trying to make this library feel like ADO.NET - and
Type is a considerably shorter name than BigQueryDbType with no loss
of clarity IMO.

Fixes #1403.