### PR TITLE
Switch from ITokenAccess to ChannelCredentials

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
@@ -21,6 +21,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Google.Apis.Auth.OAuth2;
 using Google.Cloud.Spanner.V1;
+using Grpc.Auth;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -422,7 +423,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                             using (var connection =
                                 new SpannerConnection(
                                     $"{_testFixture.ConnectionString};{nameof(SpannerSettings.AllowImmediateTimeouts)}=true",
-                                    new CredentialWrapper(appDefaultCredentials)))
+                                    new CredentialWrapper(appDefaultCredentials).ToChannelCredentials()))
                             {
                                 var cmd =
                                     connection.CreateSelectCommand("SELECT 1");

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
@@ -46,7 +46,7 @@ namespace Google.Cloud.Spanner.Data.Snippets
         [Fact]
         public void CreateConnection()
         {
-            // Snippet: #ctor(string, ITokenAccess)
+            // Snippet: #ctor(string, ChannelCredentials)
             string connectionString = "Data Source=projects/my-project/instances/my-instance/databases/my-db";
             SpannerConnection connection = new SpannerConnection(connectionString);
             Console.WriteLine(connection.Project);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/ConnectionStringBuilderTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/ConnectionStringBuilderTests.cs
@@ -133,7 +133,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             Assert.True(File.Exists(jsonFile));
             using (var connection = new SpannerConnection($"CredentialFile={jsonFile}"))
             {
-                Assert.NotNull(connection.GetCredential());
+                Assert.NotNull(connection.GetCredentials());
             }
         }
 
@@ -142,7 +142,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         {
             using (var connection = new SpannerConnection("CredentialFile=SpannerEF-8dfc036f6000.json"))
             {
-                Assert.NotNull(connection.GetCredential());
+                Assert.NotNull(connection.GetCredentials());
             }
         }
 
@@ -151,7 +151,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         {
             using (var connection = new SpannerConnection("CredentialFile=SpannerEF-8dfc036f6000.p12"))
             {
-                Assert.Throws<InvalidOperationException>(() => connection.GetCredential());
+                Assert.Throws<InvalidOperationException>(() => connection.GetCredentials());
             }
         }
 
@@ -160,7 +160,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         {
             using (var connection = new SpannerConnection("CredentialFile=..\\BadFilePath.json"))
             {
-                Assert.Throws<FileNotFoundException>(() => connection.GetCredential());
+                Assert.Throws<FileNotFoundException>(() => connection.GetCredentials());
             }
         }
     }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/MockClientFactory.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/MockClientFactory.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using Google.Api.Gax.Grpc;
 using Google.Apis.Auth.OAuth2;
 using Google.Cloud.Spanner.V1;
+using Grpc.Core;
 using Moq;
 
 namespace Google.Cloud.Spanner.Data.Tests
@@ -29,7 +30,7 @@ namespace Google.Cloud.Spanner.Data.Tests
 
         public MockClientFactory(SpannerClient firstClient) => _currentClient = firstClient;
 
-        public Task<SpannerClient> CreateClientAsync(ServiceEndpoint endpoint, ITokenAccess credential, IDictionary additionalOptions)
+        public Task<SpannerClient> CreateClientAsync(ServiceEndpoint endpoint, ChannelCredentials credentials, IDictionary additionalOptions)
         {
             Invocations++;
             var result = _currentClient;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -20,11 +20,11 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Google.Api.Gax;
-using Google.Apis.Auth.OAuth2;
 using Google.Cloud.Spanner.V1;
 using Google.Cloud.Spanner.V1.Internal;
 using Google.Cloud.Spanner.V1.Internal.Logging;
 using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
 
 #if !NETSTANDARD1_5
 using Transaction = System.Transactions.Transaction;
@@ -96,7 +96,7 @@ namespace Google.Cloud.Spanner.Data
         /// If credentials are not specified, then application default credentials are used instead.
         /// See gcloud documentation on how to set up application default credentials.
         /// </summary>
-        public ITokenAccess GetCredential() => _connectionStringBuilder?.GetCredential();
+        public ChannelCredentials GetCredentials() => _connectionStringBuilder?.GetCredentials();
 
         /// <inheritdoc />
         public override string Database => _connectionStringBuilder?.SpannerDatabase;
@@ -142,9 +142,9 @@ namespace Google.Cloud.Spanner.Data
         /// A Spanner formatted connection string. This is usually of the form
         /// `Data Source=projects/{project}/instances/{instance}/databases/{database};[Host={hostname};][Port={portnumber}]`
         /// </param>
-        /// <param name="credential">An optional credential for operations to be performed on the Spanner database.  May be null.</param>
-        public SpannerConnection(string connectionString, ITokenAccess credential = null)
-            : this(new SpannerConnectionStringBuilder(connectionString, credential)) { }
+        /// <param name="credentials">An optional credential for operations to be performed on the Spanner database.  May be null.</param>
+        public SpannerConnection(string connectionString, ChannelCredentials credentials = null)
+            : this(new SpannerConnectionStringBuilder(connectionString, credentials)) { }
 
         /// <summary>
         /// Creates a SpannerConnection with a datasource contained in connectionString.
@@ -294,7 +294,7 @@ namespace Google.Cloud.Spanner.Data
             {
                 ClientPool.Default.ReleaseClient(
                     client,
-                    _connectionStringBuilder.GetCredential(),
+                    _connectionStringBuilder.GetCredentials(),
                     _connectionStringBuilder.EndPoint,
                     _connectionStringBuilder);
             }
@@ -442,7 +442,7 @@ namespace Google.Cloud.Spanner.Data
                     try
                     {
                         localClient = await ClientPool.Default.AcquireClientAsync(
-                                _connectionStringBuilder.GetCredential(),
+                                _connectionStringBuilder.GetCredentials(),
                                 _connectionStringBuilder.EndPoint,
                                 _connectionStringBuilder)
                             .ConfigureAwait(false);


### PR DESCRIPTION
Preferred method will be for the user to use a json file specified in the connectionstring (if not using default app creds).  But we'll keep this mechanism open in case the user has any custom requirement for specifying the creds.
