### PR TITLE
For now, pass None into gRPC MoveNext and document the limitation.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
@@ -69,6 +69,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             {
                 var cmd = connection.CreateSelectCommand(sql);
                 var result = await cmd.ExecuteScalarAsync<T>();
+
+                //ensure the synchronous method returns the same as the async.
+                Assert.Equal(await cmd.ExecuteScalarAsync<object>(),
+                    cmd.ExecuteScalar());
+
                 return result;
             }
         }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReader.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReader.cs
@@ -226,7 +226,13 @@ namespace Google.Cloud.Spanner.Data
         /// <inheritdoc />
         public override bool Read() => ReadAsync(CancellationToken.None).ResultWithUnwrappedExceptions();
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Reads the next row of values from Cloud Spanner.
+        /// Important: Cloud Spanner supports limited cancellation of this task.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to cancel the read. Cloud Spanner currently
+        /// supports limited cancellation while advancing the read to the next row.</param>
+        /// <returns>True if another row was read.</returns>
         public override Task<bool> ReadAsync(CancellationToken cancellationToken)
         {
             return ExecuteHelper.WithErrorTranslationAndProfiling(

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ReliableStreamReader.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ReliableStreamReader.cs
@@ -92,6 +92,19 @@ namespace Google.Cloud.Spanner.V1 {
         }
 
         /// <summary>
+        /// This helper ensures we invalidate the _currentCall state if we want to throw canceled.
+        /// </summary>
+        private void ThrowIfCancellationRequested(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _currentCall?.Dispose();
+                _currentCall = null;
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+
+        /// <summary>
         ///     Connects or reconnects to Spanner, fast forwarding to where we left off based on
         ///     our _resumeToken and _resumeSkipCount.
         /// </summary>
@@ -99,11 +112,11 @@ namespace Google.Cloud.Spanner.V1 {
         private async Task<bool> ReliableConnectAsync(CancellationToken cancellationToken) {
             if (_currentCall == null) {
                 await ConnectAsync().ConfigureAwait(false);
-
                 Debug.Assert(_currentCall != null, "_currentCall != null");
-                cancellationToken.ThrowIfCancellationRequested();
 
                 for (int i = 0; i <= _resumeSkipCount; i++) {
+                    ThrowIfCancellationRequested(cancellationToken);
+
                     //This calls a simple movenext on purpose.  If we get an error here, we'll fail out.
                     //TODO(benwu): Fix cancel on MoveNext in a subsequent change targeting spanner GA
                     _isReading = await _currentCall.ResponseStream.MoveNext(CancellationToken.None).WithSessionChecking(() => _session).ConfigureAwait(false);
@@ -123,30 +136,58 @@ namespace Google.Cloud.Spanner.V1 {
         private async Task<bool> ReliableMoveNextAsync(CancellationToken cancellationToken) {
             try {
                 Logger.LogPerformanceCounterFn("StreamReader.MoveNextCount", x => x + 1);
-                //we increment our skip count before calling MoveNext so that a reconnect operation
-                //will fast forward to the proper place.
-                _resumeSkipCount++;
-                //TODO(benwu): Fix cancel on MoveNext in a subsequent change targeting spanner GA
                 _isReading = await _currentCall.ResponseStream.MoveNext(CancellationToken.None)
                     .WithSessionChecking(() => _session).ConfigureAwait(false);
+
+                //we only increment our skip count after we know the MoveNext has succeeded
+                _resumeSkipCount++;
             }
-            catch (Exception e) 
+            catch (Exception e)
             {
-                _currentCall = null;
-
-                //reconnect on failure which will call reliableconnect and respect resumetoken and resumeskip
-                cancellationToken.ThrowIfCancellationRequested();
-
-                Logger.Warn(
-                    () =>
-                            $"An error occurred attemping to iterate through the sql query.  Attempting to recover. Exception:{e}");
-
-                //when we reconnect, we purposely do not do a *reliable*movenext.  If we fail to fast forward on the reconnect
-                //we bail out completely and surface the error.
-                return await ReliableConnectAsync(cancellationToken).ConfigureAwait(false);
+                // execution here means the movenext failed and _resumeSkipCount has not yet been increased.
+                await TryRecoverOnFailureAsync(cancellationToken, e).ConfigureAwait(false);
             }
             RecordResumeToken();
             return _isReading;
+        }
+
+        private async Task TryRecoverOnFailureAsync(CancellationToken cancellationToken, Exception exception)
+        {
+            _currentCall?.Dispose();
+            _currentCall = null;
+
+            //reconnect on failure which will call reliableconnect and respect resumetoken and resumeskip
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Logger.Warn(
+                () =>
+                    $"An error occurred attemping to iterate through the sql query.  Attempting to recover. Exception:{exception}");
+
+            //when we reconnect, we purposely do not do a *reliable*movenext.  If we fail to fast forward on the reconnect
+            //we bail out completely and surface the error.
+            _isReading = await ReliableConnectAsync(cancellationToken).ConfigureAwait(false);
+            if (_isReading)
+            {
+                // we try one more time to advance. Note that we should have done an exponential backoff retry
+                // on the initial connect -- but MoveNext is not idempotent, so all we can do if it fails is start
+                // from scratch.  But in case something is going horribly awry, we don't want to spin indefinitely,
+                // so we bail if the recovery isn't successful in moving to the next item.
+                try
+                {
+                    _isReading = await _currentCall.ResponseStream.MoveNext(CancellationToken.None)
+                        .WithSessionChecking(() => _session).ConfigureAwait(false);
+                    _resumeSkipCount++;
+                }
+                catch (Exception e)
+                {
+                    Logger.Warn(() => $"An error occurred attemping to recover. Exception:{e}");
+                    //At this point, we give up, rethrowing and setting state such that it will
+                    //need to reconnect if the user calls MoveNext again.
+                    _currentCall?.Dispose();
+                    _currentCall = null;
+                    throw;
+                }
+            }
         }
 
         private void RecordResumeToken() {


### PR DESCRIPTION
In the future, we may alter the design to support better cancellation of MoveNext.