### PR TITLE
Support string-keyed dictionaries with non-object values

### DIFF
--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/SerializationHelpersTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/SerializationHelpersTest.cs
@@ -11,11 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Dynamic;
 using Xunit;
-
 using BclType = System.Type;
 
 namespace Google.Cloud.Firestore.Data.Tests
@@ -24,6 +24,7 @@ namespace Google.Cloud.Firestore.Data.Tests
     {
         [Theory]
         [InlineData(typeof(Dictionary<string, int>), typeof(int))]
+        [InlineData(typeof(IDictionary<string, int>), typeof(int))]
         [InlineData(typeof(Dictionary<string, string>), typeof(string))]
         [InlineData(typeof(ConcurrentDictionary<string, string>), typeof(string))]
         [InlineData(typeof(ExpandoObject), typeof(object))]

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/SerializationHelpersTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/SerializationHelpersTest.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Dynamic;
+using Xunit;
+
+using BclType = System.Type;
+
+namespace Google.Cloud.Firestore.Data.Tests
+{
+    public class SerializationHelpersTest
+    {
+        [Theory]
+        [InlineData(typeof(Dictionary<string, int>), typeof(int))]
+        [InlineData(typeof(Dictionary<string, string>), typeof(string))]
+        [InlineData(typeof(ConcurrentDictionary<string, string>), typeof(string))]
+        [InlineData(typeof(ExpandoObject), typeof(object))]
+        [InlineData(typeof(Dictionary<object, int>), null)]
+        [InlineData(typeof(Dictionary<,>), null)]
+        [InlineData(typeof(IDictionary<,>), null)]
+        [InlineData(typeof(int), null)]
+        [InlineData(typeof(string), null)]
+        [InlineData(typeof(List<string>), null)]
+        public void TryGetStringDictionaryValueType(BclType input, BclType expectedElementType)
+        {
+            var actual = SerializationHelpers.TryGetStringDictionaryValueType(input, out var actualElementType);
+            Assert.Equal(expectedElementType != null, actual);
+            Assert.Equal(expectedElementType, actualElementType);
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/SerializationTestData.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/SerializationTestData.cs
@@ -106,6 +106,8 @@ namespace Google.Cloud.Firestore.Data.Tests
             // Map values (that can be deserialized again): dictionaries, attributed types, expandos (which are just dictionaries)
             { new Dictionary<string, object> { { "name", "Jon" }, { "score", 10L } },
                 new Value { MapValue = new MapValue { Fields = { { "name", new Value { StringValue = "Jon" } }, { "score", new Value { IntegerValue = 10L } } } } } },
+            { new Dictionary<string, int> { { "A", 10 }, { "B", 20 } },
+                new Value { MapValue = new MapValue { Fields = { { "A", new Value { IntegerValue = 10L } }, { "B", new Value { IntegerValue = 20L } } } } } },
             { new GameResult { Name = "Jon", Score = 10 },
                 new Value { MapValue = new MapValue { Fields = { { "name", new Value { StringValue = "Jon" } }, { "Score", new Value { IntegerValue = 10L } } } } } },
             { () => { dynamic d = new ExpandoObject(); d.name = "Jon"; d.score = 10L; return d; },

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/ValueDeserializerTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/ValueDeserializerTest.cs
@@ -79,6 +79,7 @@ namespace Google.Cloud.Firestore.Data.Tests
             { new Value { IntegerValue = 10L }, typeof(string) },
             { new Value { ArrayValue = new ArrayValue() }, typeof(string) },
             { new Value { MapValue = new MapValue() }, typeof(string) },
+            { new Value { MapValue = new MapValue() }, typeof(IUnsupportedDictionary) }, // See below
             // Invalid original value
             { new Value(), typeof(object) },
             { ValueSerializer.Serialize(new { Missing = "Surprise!" }), typeof(SerializationTestData.GameResult) },
@@ -111,10 +112,15 @@ namespace Google.Cloud.Firestore.Data.Tests
         {
             var value = new Value { NullValue = wkt::NullValue.NullValue };
             Assert.Null(DeserializeDefault(value, targetType));
-        }        
+        }
 
         // Just a convenience method to avoid having to specify all of this on each call.
         private static object DeserializeDefault(Value value, BclType targetType) =>
             ValueDeserializer.Default.Deserialize(SerializationTestData.Database, value, targetType);
+
+        /// <summary>
+        /// An interface that we can't deserialize to, because Dictionary{,} doesn't implement it.
+        /// </summary>
+        public interface IUnsupportedDictionary : IDictionary<string, string> { }
     }
 }


### PR DESCRIPTION
This has to use reflection to invoke helper methods at the moment.
It's all pretty ugly and inefficient, but it's a start.

We could use the same technique to support any ICollection<T>
implementation instead of requiring IList<T> - I'll do that in a
follow-up PR if it's desired.