### PR TITLE
Automatically add a resource prefix header to gRPC calls

### DIFF
--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Tests/FirebaseClientImplTest.cs
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Tests/FirebaseClientImplTest.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Xunit;
+
+namespace Google.Cloud.Firestore.V1Beta1.Tests
+{
+    public class FirebaseClientImplTest
+    {
+        [Theory]
+        [InlineData("projects/proj/databases/database", "projects/proj/databases/database")]
+        [InlineData("projects/proj/databases/database/", "projects/proj/databases/database")]
+        [InlineData("projects/proj/databases/database/documents", "projects/proj/databases/database")]
+        [InlineData("projects/proj/databases/database/documents/col1/doc", "projects/proj/databases/database")]
+        [InlineData("projects/proj_id/databases/(default)/foo", "projects/proj_id/databases/(default)")]
+        public void GetDatabaseResourceName_Valid(string resourceName, string expectedDatabaseName)
+        {
+            Assert.Equal(expectedDatabaseName, FirestoreClientImpl.GetDatabaseResourceName(resourceName));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("projects//databases/(default)/foo")]
+        [InlineData("not_projects/project/databases/(default)/foo")]
+        [InlineData("projects/proj/not_databases/database")]
+        [InlineData("projects/")]
+        [InlineData("projects/proj/")]
+        [InlineData("projects/proj/databases")]
+        [InlineData("projects/proj/databases/")]
+        [InlineData("projects/proj/databases//other")]
+        public void GetDatabaseResourceName_Invalid(string resourceName)
+        {
+            Assert.Throws<ArgumentException>(() => FirestoreClientImpl.GetDatabaseResourceName(resourceName));
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Tests/Google.Cloud.Firestore.V1Beta1.Tests.csproj
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Tests/Google.Cloud.Firestore.V1Beta1.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Features>IOperation</Features>
+    <IsPackable>false</IsPackable>
+    <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
+    <ProjectReference Include="..\Google.Cloud.Firestore.V1Beta1\Google.Cloud.Firestore.V1Beta1.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
+    <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
+    <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Tests/coverage.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <Filters>
+    <IncludeFilters>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Firestore.V1Beta1</ModuleMask>
+      </FilterEntry>
+    </IncludeFilters>
+  </Filters>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Firestore.V1Beta1.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.sln
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.V1Be
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{BC7E6B2C-8980-46EE-A93D-51B1B450876F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.V1Beta1.Tests", "Google.Cloud.Firestore.V1Beta1.Tests\Google.Cloud.Firestore.V1Beta1.Tests.csproj", "{84F1AADB-C360-403D-8002-2849881A8E69}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -58,5 +60,17 @@ Global
 		{BC7E6B2C-8980-46EE-A93D-51B1B450876F}.Release|x64.Build.0 = Release|x64
 		{BC7E6B2C-8980-46EE-A93D-51B1B450876F}.Release|x86.ActiveCfg = Release|x86
 		{BC7E6B2C-8980-46EE-A93D-51B1B450876F}.Release|x86.Build.0 = Release|x86
+		{84F1AADB-C360-403D-8002-2849881A8E69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84F1AADB-C360-403D-8002-2849881A8E69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84F1AADB-C360-403D-8002-2849881A8E69}.Debug|x64.ActiveCfg = Debug|x64
+		{84F1AADB-C360-403D-8002-2849881A8E69}.Debug|x64.Build.0 = Debug|x64
+		{84F1AADB-C360-403D-8002-2849881A8E69}.Debug|x86.ActiveCfg = Debug|x86
+		{84F1AADB-C360-403D-8002-2849881A8E69}.Debug|x86.Build.0 = Debug|x86
+		{84F1AADB-C360-403D-8002-2849881A8E69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84F1AADB-C360-403D-8002-2849881A8E69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{84F1AADB-C360-403D-8002-2849881A8E69}.Release|x64.ActiveCfg = Release|x64
+		{84F1AADB-C360-403D-8002-2849881A8E69}.Release|x64.Build.0 = Release|x64
+		{84F1AADB-C360-403D-8002-2849881A8E69}.Release|x86.ActiveCfg = Release|x86
+		{84F1AADB-C360-403D-8002-2849881A8E69}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 EndGlobal

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/AssemblyInfo.cs
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Google.Cloud.Firestore.V1Beta1.Tests, PublicKey="
+    + "0024000004800000940000000602000000240000525341310004000001000100afab79952ee222"
+    + "15f12b4e09337e65509c943fbc22d7006bc371d581d0f0ebf0da5d8039aab2607fb68a138a5d80"
+    + "a71bc02b7ebf586dbe1f2493c0ab20423ababfd15ce74d2264a6b37745f3658f016abaad662182"
+    + "aaef634a60f1346fcc45343acab5b6781535a3134818e13fac895a6c106c0480e34bbb06cb123e"
+    + "5583d8d2"
+)]

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/FirestoreClientPartial.cs
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/FirestoreClientPartial.cs
@@ -1,0 +1,115 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Grpc;
+using System;
+
+namespace Google.Cloud.Firestore.V1Beta1
+{
+    public partial class FirestoreClientImpl
+    {
+        private const string ResourcePrefixHeader = "google-cloud-resource-prefix";
+
+        partial void Modify_BatchGetDocumentsRequest(ref BatchGetDocumentsRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeader(ref settings, request.Database);
+
+        partial void Modify_BeginTransactionRequest(ref BeginTransactionRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeader(ref settings, request.Database);
+
+        partial void Modify_CommitRequest(ref CommitRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeader(ref settings, request.Database);
+
+        partial void Modify_CreateDocumentRequest(ref CreateDocumentRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeader(ref settings, request.Parent);
+
+        partial void Modify_DeleteDocumentRequest(ref DeleteDocumentRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeader(ref settings, request.Name);
+
+        partial void Modify_GetDocumentRequest(ref GetDocumentRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeader(ref settings, request.Name);
+
+        partial void Modify_ListCollectionIdsRequest(ref ListCollectionIdsRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeader(ref settings, request.Parent);
+
+        partial void Modify_ListDocumentsRequest(ref ListDocumentsRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeader(ref settings, request.Parent);
+
+        partial void Modify_RollbackRequest(ref RollbackRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeader(ref settings, request.Database);
+
+        partial void Modify_RunQueryRequest(ref RunQueryRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeader(ref settings, request.Parent);
+
+        partial void Modify_UpdateDocumentRequest(ref UpdateDocumentRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeader(ref settings, request.Document?.Name);
+
+        // TODO: Consider Write and Listen, where the settings and the requests are separate.
+
+        private static void ApplyResourcePrefixHeader(ref CallSettings settings, string resource)
+        {
+            // If we haven't been given a resource name, just let the request as it is.
+            if (string.IsNullOrEmpty(resource))
+            {
+                return;
+            }
+            string database = GetDatabaseResourceName(resource);
+            settings = settings.WithHeader(ResourcePrefixHeader, database);
+        }
+        
+        // Visible for testing
+
+        /// <summary>
+        /// Retrieves the database resource name from a full resource name.
+        /// Validation is performed as far as the database ID but no further; the database ID is deemed to end at the first slash.
+        /// </summary>
+        /// <param name="resource">The resource name, which must start with projects/{project_id}/databases/{database_id}</param>
+        /// <returns>The database resource name</returns>
+        internal static string GetDatabaseResourceName(string resource)
+        {
+            const string projectsPrefix = "projects/";
+            const string databasesPrefix = "databases/";
+            if (string.CompareOrdinal(resource, 0, projectsPrefix, 0, projectsPrefix.Length) != 0)
+            {
+                // "projects/" doesn't match
+                ThrowInvalidResource();
+            }
+            int endOfProjectId = resource.IndexOf('/', projectsPrefix.Length);
+            if (endOfProjectId == -1 || endOfProjectId == projectsPrefix.Length)
+            {
+                // Empty project ID or no slash at the end of it
+                ThrowInvalidResource();
+            }
+            if (string.CompareOrdinal(resource, endOfProjectId + 1, databasesPrefix, 0, databasesPrefix.Length) != 0)
+            {
+                // "databases/" doesn't match
+                ThrowInvalidResource();
+            }
+            int startOfDatabaseId = endOfProjectId + 1 + databasesPrefix.Length;
+            if (startOfDatabaseId == resource.Length)
+            {
+                // No database ID
+                ThrowInvalidResource();
+            }
+            int endOfDatabaseId = resource.IndexOf('/', startOfDatabaseId);
+            // It's valid for the whole resource name to be the database name
+            if (endOfDatabaseId == startOfDatabaseId)
+            {
+                ThrowInvalidResource();
+            }
+            return endOfDatabaseId == -1 ? resource : resource.Substring(0, endOfDatabaseId);
+
+            void ThrowInvalidResource() => throw new ArgumentException($"{resource} is not a valid Firestore resource name", nameof(resource));
+        }
+    }
+}


### PR DESCRIPTION
This does not affect Listen/Write as they are client-streaming calls.

We reduce the resource name down to just the project ID and database
portion.