### PR TITLE
Introduce WriteBatch

### DIFF
--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.cs
@@ -1,0 +1,100 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Firestore.V1Beta1;
+using Moq;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using wkt = Google.Protobuf.WellKnownTypes;
+
+namespace Google.Cloud.Firestore.Data.Tests
+{
+    public class WriteBatchTest
+    {
+        [Fact]
+        public void Create()
+        {
+            var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
+            var batch = db.CreateWriteBatch();
+            var doc = db.Document("col/doc");
+            batch.Create(doc, new { Name = "Test", Score = 20 });
+
+            var expectedWrite = new Write
+            {
+                CurrentDocument = new V1Beta1.Precondition { Exists = false },
+                Update = new Document
+                {
+                    Name = doc.Path,
+                    Fields =
+                    {
+                        { "Name", new Value { StringValue = "Test" } },
+                        { "Score", new Value { IntegerValue = 20L } }
+                    }
+                }
+            };
+            AssertWrites(batch, expectedWrite);
+        }
+
+        [Fact]
+        public async Task CommitAsync()
+        {
+            var mock = new Mock<FirestoreClient> { CallBase = true };
+            var write1 = new Write { Update = new Document { Name = "irrelevant1" } };
+            var write2 = new Write { Update = new Document { Name = "irrelevant2" } };
+            var request = new CommitRequest
+            {
+                Database = "projects/proj/databases/db",
+                Writes = { write1, write2 }
+            };
+            var response = new CommitResponse
+            {
+                CommitTime = CreateProtoTimestamp(10, 500),
+                WriteResults =
+                {
+                    new V1Beta1.WriteResult { UpdateTime = CreateProtoTimestamp(10, 0) },
+                    // Deliberately no UpdateTime; result should default to CommitTime
+                    new V1Beta1.WriteResult {  }
+                }
+            };
+
+            mock.Setup(c => c.CommitAsync(request, It.IsAny<CallSettings>())).ReturnsAsync(response);
+            var db = FirestoreDb.Create("proj", "db", mock.Object);
+            var reference = db.Document("col/doc");
+            var batch = db.CreateWriteBatch();
+            batch.Writes.AddRange(new[] { write1, write2 });
+            var actualTimestamps = (await batch.CommitAsync()).Select(x => x.UpdateTime);
+            var expectedTimestamps = new[] { new Timestamp(10, 0), new Timestamp(10, 500) };
+            Assert.Equal(expectedTimestamps, actualTimestamps);
+            mock.VerifyAll();
+        }
+
+        [Fact]
+        public void IsEmpty()
+        {
+            var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
+            var batch = db.CreateWriteBatch();
+            Assert.True(batch.IsEmpty);
+            batch.Create(db.Document("col/doc"), new { Name = "Test" });
+            Assert.False(batch.IsEmpty);
+        }
+
+        private void AssertWrites(WriteBatch batch, params Write[] writes) =>
+            Assert.Equal(writes, batch.Writes);
+
+        private static wkt::Timestamp CreateProtoTimestamp(long seconds, int nanos) =>
+            new wkt.Timestamp { Seconds = seconds, Nanos = nanos };
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/FirestoreDb.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/FirestoreDb.cs
@@ -130,7 +130,13 @@ namespace Google.Cloud.Firestore.Data
                 documentRef = new DocumentReference(this, collectionRef, elements[i + 1]);
             }
             return documentRef;
-        }        
+        }
+
+        /// <summary>
+        /// Creates a write batch, which can be used to commit multiple mutations atomically.
+        /// </summary>
+        /// <returns>A write batch for this database.</returns>
+        public WriteBatch CreateWriteBatch() => new WriteBatch(this);
 
         internal DocumentReference GetDocumentReferenceFromResourceName(string referenceValue)
         {

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/WriteBatch.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/WriteBatch.cs
@@ -1,0 +1,86 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.using System;
+
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Firestore.V1Beta1;
+using Google.Protobuf;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Firestore.Data
+{
+    // TODO: Sentinel fields on all operations
+
+    /// <summary>
+    /// A batch of write operations, to be applied in a single commit.
+    /// </summary>
+    public sealed class WriteBatch
+    {
+        private readonly FirestoreDb _db;
+
+        internal bool IsEmpty => Writes.Count == 0;
+
+        // Visible for testing; should not be used elsewhere in the production code.
+        internal List<Write> Writes = new List<Write>();
+
+        internal WriteBatch(FirestoreDb firestoreDb)
+        {
+            _db = firestoreDb;
+        }
+
+        /// <summary>
+        /// Adds a write operation which will create the specified document with a precondition
+        /// that it doesn't exist already.
+        /// </summary>
+        /// <param name="documentReference">A document reference indicating the path of the document to create. Must not be null.</param>
+        /// <param name="documentData">The data for the document. Must not be null.</param>
+        /// <returns>This batch, for the purpose of method chaining</returns>
+        public WriteBatch Create(DocumentReference documentReference, object documentData)
+        {
+            GaxPreconditions.CheckNotNull(documentReference, nameof(documentReference));
+            GaxPreconditions.CheckNotNull(documentData, nameof(documentData));
+            var write = new Write
+            {
+                CurrentDocument = Precondition.MustNotExist.Proto,
+                Update = new Document
+                {
+                    Fields = { ValueSerializer.SerializeMap(documentData) },
+                    Name = documentReference.Path
+                }
+            };
+            Writes.Add(write);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Commits the batch on the server.
+        /// </summary>
+        /// <returns>The write results from the commit.</returns>
+        public Task<IList<WriteResult>> CommitAsync(CancellationToken cancellationToken = default) =>
+            CommitAsync(ByteString.Empty, cancellationToken);
+
+        internal async Task<IList<WriteResult>> CommitAsync(ByteString transactionId, CancellationToken cancellationToken)
+        {
+            var request = new CommitRequest { Database = _db.RootPath, Writes = { Writes }, Transaction = transactionId };
+            var response = await _db.Client.CommitAsync(request, CallSettings.FromCancellationToken(cancellationToken)).ConfigureAwait(false);
+            return response.WriteResults.Select(wr => WriteResult.FromProto(wr, response.CommitTime)).ToList();
+        }
+    }
+}


### PR DESCRIPTION
WriteBatch is at the heart of all mutations. Create is just the first operation - we'll also have Set and Update.
I expect WriteBatch to be thoroughly unit tested, but other integration points (soon to be added, such as
DocumentReference.Create) to be less thoroughly unit tested, with integration tests instead. (Most of those
will be convenience methods calling into WriteBatch, so the testing should stlil be good overall.)