### PR TITLE
Firestore: fetch snapshots, convenience methods, integration tests

### DIFF
--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/DocumentCreationTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/DocumentCreationTest.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Grpc.Core;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Firestore.Data.IntegrationTests
+{
+    [Collection(nameof(FirestoreFixture))]
+    public class DocumentCreationTest
+    {
+        private readonly FirestoreFixture _fixture;
+
+        public DocumentCreationTest(FirestoreFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public async Task Create_Success()
+        {
+            var collection = _fixture.NonQueryCollection;
+            var reference = await collection.AddAsync(new { Name = "Test" });
+
+            // Make sure we can fetch it again too...
+            var snapshot = await reference.SnapshotAsync();
+            Assert.True(snapshot.Exists);
+            var dictionary = snapshot.ToDictionary();
+            Assert.Equal("Test", dictionary["Name"]);
+        }
+
+        [Fact]
+        public async Task Create_AlreadyExists()
+        {
+            var collection = _fixture.NonQueryCollection;
+            var reference = await collection.AddAsync(new { Name = "Test" });
+
+            // TODO: Should we have a more specific exception here?
+            // See also https://github.com/googleapis/toolkit/issues/1357
+            await Assert.ThrowsAsync<RpcException>(() => reference.CreateAsync(new { Name = "Other" }));
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/FirestoreFixture.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/FirestoreFixture.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Xunit;
+
+namespace Google.Cloud.Firestore.Data.IntegrationTests
+{
+    [CollectionDefinition(nameof(FirestoreFixture))]
+    public class FirestoreFixture : IDisposable, ICollectionFixture<FirestoreFixture>
+    {
+        // This is not the test project environment variable used by other integration tests,
+        // as Datastore and Firestore can't both be active in the same project.
+        private const string ProjectEnvironmentVariable = "FIRESTORE_TEST_PROJECT";
+        public FirestoreDb FirestoreDb { get; }
+
+        /// <summary>
+        /// A randomly generated prefix for collections.
+        /// </summary>
+        public string CollectionPrefix { get; }
+
+        /// <summary>
+        /// A collection intended for tests to create and fetch documents in. Don't query in tests!
+        /// </summary>
+        public CollectionReference NonQueryCollection { get; }
+
+        public FirestoreFixture()
+        {
+            string projectId = Environment.GetEnvironmentVariable(ProjectEnvironmentVariable);
+            if (string.IsNullOrEmpty(projectId))
+            {
+                throw new InvalidOperationException(
+                    $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
+            }
+
+            // Currently, only the default database is supported... so we create all our collections with a randomly-generated prefix.
+            // When multiple databases are supported, we'll create a new one per test run.
+            CollectionPrefix = Guid.NewGuid().ToString();
+            FirestoreDb = FirestoreDb.Create(projectId);
+            NonQueryCollection = FirestoreDb.Collection(CollectionPrefix + "-non-query");
+        }        
+
+        public void Dispose()
+        {
+            // No-op for now. With multiple-database support, we'll create a database
+            // on construction and delete it here.
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/DocumentSnapshotTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/DocumentSnapshotTest.cs
@@ -16,7 +16,7 @@ using Google.Cloud.Firestore.V1Beta1;
 using System;
 using System.Collections.Generic;
 using Xunit;
-using wkt = Google.Protobuf.WellKnownTypes;
+using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
 
 namespace Google.Cloud.Firestore.Data.Tests
 {
@@ -51,8 +51,8 @@ namespace Google.Cloud.Firestore.Data.Tests
             var readTime = new Timestamp(10, 2);
             var proto = new Document
             {
-                CreateTime = new wkt::Timestamp { Seconds = 1, Nanos = 10 },
-                UpdateTime = new wkt::Timestamp { Seconds = 2, Nanos = 20 },
+                CreateTime = CreateProtoTimestamp(1, 10),
+                UpdateTime = CreateProtoTimestamp(2, 20),
                 Name = "projects/proj/databases/db/documents/col1/doc1/col2/doc2"                
             };
             var document = DocumentSnapshot.ForDocument(db, proto, readTime);
@@ -130,8 +130,8 @@ namespace Google.Cloud.Firestore.Data.Tests
             var readTime = new Timestamp(10, 2);
             var proto = new Document
             {
-                CreateTime = new wkt::Timestamp { Seconds = 1, Nanos = 10 },
-                UpdateTime = new wkt::Timestamp { Seconds = 2, Nanos = 20 },
+                CreateTime = CreateProtoTimestamp(1, 10),
+                UpdateTime = CreateProtoTimestamp(2, 20),
                 Name = "projects/proj/databases/db/documents/col1/doc1/col2/doc2",
                 Fields = { ValueSerializer.SerializeMap(poco) }
             };

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/FirestoreDbTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/FirestoreDbTest.cs
@@ -14,15 +14,15 @@
 
 using Google.Api.Gax.Grpc;
 using Google.Cloud.Firestore.V1Beta1;
+using Google.Protobuf;
 using Moq;
 using System;
-using System.Threading.Tasks;
-using Xunit;
-using static Google.Cloud.Firestore.V1Beta1.FirestoreClient;
 using System.Collections.Generic;
 using System.Linq;
-using Google.Protobuf;
-using wkt = Google.Protobuf.WellKnownTypes;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
+using static Google.Cloud.Firestore.V1Beta1.FirestoreClient;
 
 namespace Google.Cloud.Firestore.Data.Tests
 {
@@ -234,8 +234,5 @@ namespace Google.Cloud.Firestore.Data.Tests
             public override IAsyncEnumerator<BatchGetDocumentsResponse> ResponseStream =>
                 _responses.ToAsyncEnumerable().GetEnumerator();
         }
-
-        private static wkt::Timestamp CreateProtoTimestamp(long seconds, int nanos) =>
-            new wkt.Timestamp { Seconds = seconds, Nanos = nanos };
     }
 }

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/FirestoreDbTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/FirestoreDbTest.cs
@@ -12,9 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Firestore.V1Beta1;
+using Moq;
 using System;
 using System.Threading.Tasks;
 using Xunit;
+using static Google.Cloud.Firestore.V1Beta1.FirestoreClient;
+using System.Collections.Generic;
+using System.Linq;
+using Google.Protobuf;
+using wkt = Google.Protobuf.WellKnownTypes;
 
 namespace Google.Cloud.Firestore.Data.Tests
 {
@@ -127,5 +135,107 @@ namespace Google.Cloud.Firestore.Data.Tests
             var db = FirestoreDb.Create("proj", "db", new FakeFirestoreClient());
             Assert.Throws<ArgumentException>(() => db.GetDocumentReferenceFromResourceName(path));
         }
+
+        [Fact]
+        public async Task GetDocumentSnapshotsAsync()
+        {
+            string docName1 = "projects/proj/databases/db/documents/col1/doc1";
+            string docName2 = "projects/proj/databases/db/documents/col2/doc2";
+            var mock = new Mock<FirestoreClient> { CallBase = true };
+            var request = new BatchGetDocumentsRequest
+            {
+                Database = "projects/proj/databases/db",
+                Documents = { docName1, docName2 }
+            };
+            var responses = new[]
+            {
+                // Deliberately not in the requested order
+                new BatchGetDocumentsResponse
+                {
+                    Found = new Document
+                    {
+                        Name = docName2, CreateTime = CreateProtoTimestamp(0, 1), UpdateTime = CreateProtoTimestamp(0, 2),
+                        Fields = { { "Name", new Value { StringValue = "Test" } } }
+                    },
+                    ReadTime = CreateProtoTimestamp(1, 3)
+                },
+                new BatchGetDocumentsResponse { Missing = docName1, ReadTime = CreateProtoTimestamp(1, 2) },
+            };
+            mock.Setup(c => c.BatchGetDocuments(request, It.IsAny<CallSettings>())).Returns(new FakeDocumentStream(responses));
+            var db = FirestoreDb.Create("proj", "db", mock.Object);
+            var docRef1 = db.Document("col1/doc1");
+            var docRef2 = db.Document("col2/doc2");
+            var results = await db.GetDocumentSnapshotsAsync(new[] { docRef1, docRef2 }, null, default);
+            Assert.Equal(2, results.Count);
+            // Note that this is the second result, not the first - we get them back in response order, not request order.
+            // (If we need to ensure request order, that can be done as a separate method layered on this one.)
+            var snapshot1 = results[1];
+            Assert.False(snapshot1.Exists);
+            Assert.Equal(new Timestamp(1, 2), snapshot1.ReadTime);
+            Assert.Equal(docRef1, snapshot1.Reference);
+
+            var snapshot2 = results[0];
+            Assert.True(snapshot2.Exists);
+            Assert.Equal(new Timestamp(0, 1), snapshot2.CreateTime);
+            Assert.Equal(new Timestamp(0, 2), snapshot2.UpdateTime);
+            Assert.Equal(new Timestamp(1, 3), snapshot2.ReadTime);
+            Assert.Equal(docRef2, snapshot2.Reference);
+            Assert.Equal("Test", snapshot2.GetField<string>("Name"));
+            mock.VerifyAll();
+        }
+
+        [Fact]
+        public async Task GetDocumentSnapshotsAsync_WithTransaction()
+        {
+            // This test is about checking the transaction is copied...
+            var transactionId = ByteString.CopyFrom(1, 2, 3, 4);
+            string docName = "projects/proj/databases/db/documents/col1/doc1";
+            var mock = new Mock<FirestoreClient> { CallBase = true };
+            var request = new BatchGetDocumentsRequest
+            {
+                Database = "projects/proj/databases/db",
+                Documents = { docName },
+                Transaction = transactionId
+            };
+            var responses = new[]
+            {
+                new BatchGetDocumentsResponse { Missing = docName, ReadTime = CreateProtoTimestamp(1, 2) },
+            };
+            mock.Setup(c => c.BatchGetDocuments(request, It.IsAny<CallSettings>())).Returns(new FakeDocumentStream(responses));
+            var db = FirestoreDb.Create("proj", "db", mock.Object);
+            var results = await db.GetDocumentSnapshotsAsync(new[] { db.Document("col1/doc1") }, transactionId, default);
+            mock.VerifyAll();
+        }
+
+        [Fact]
+        public async Task GetDocumentSnapshotsAsync_UnknownResponseCase()
+        {
+            string docName = "projects/proj/databases/db/documents/col1/doc1";
+            var mock = new Mock<FirestoreClient> { CallBase = true };
+            var request = new BatchGetDocumentsRequest
+            {
+                Database = "projects/proj/databases/db",
+                Documents = { docName },
+            };
+            var responses = new[] { new BatchGetDocumentsResponse { ReadTime = CreateProtoTimestamp(1, 2) } };
+            mock.Setup(c => c.BatchGetDocuments(request, It.IsAny<CallSettings>())).Returns(new FakeDocumentStream(responses));
+            var db = FirestoreDb.Create("proj", "db", mock.Object);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => db.GetDocumentSnapshotsAsync(new[] { db.Document("col1/doc1") }, null, default));
+            mock.VerifyAll();
+        }
+
+        private class FakeDocumentStream : BatchGetDocumentsStream
+        {
+            private readonly IEnumerable<BatchGetDocumentsResponse> _responses;
+
+            internal FakeDocumentStream(IEnumerable<BatchGetDocumentsResponse> responses) =>
+                _responses = responses;
+
+            public override IAsyncEnumerator<BatchGetDocumentsResponse> ResponseStream =>
+                _responses.ToAsyncEnumerable().GetEnumerator();
+        }
+
+        private static wkt::Timestamp CreateProtoTimestamp(long seconds, int nanos) =>
+            new wkt.Timestamp { Seconds = seconds, Nanos = nanos };
     }
 }

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/PreconditionTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/PreconditionTest.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using Xunit;
-using wkt = Google.Protobuf.WellKnownTypes;
+using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
 
 namespace Google.Cloud.Firestore.Data.Tests
 {
@@ -53,7 +53,7 @@ namespace Google.Cloud.Firestore.Data.Tests
             var precondition = Precondition.LastUpdated(timestamp);
             Assert.Null(precondition.Exists);
             Assert.Equal(timestamp, precondition.LastUpdateTime);
-            Assert.Equal(new V1Beta1.Precondition { UpdateTime = new wkt::Timestamp { Seconds = 1, Nanos = 5 } }, precondition.Proto);
+            Assert.Equal(new V1Beta1.Precondition { UpdateTime = CreateProtoTimestamp(1, 5) }, precondition.Proto);
         }
     }
 }

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/ProtoHelpers.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/ProtoHelpers.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using wkt = Google.Protobuf.WellKnownTypes;
+
+namespace Google.Cloud.Firestore.Data.Tests
+{
+    /// <summary>
+    /// Helper methods to create protos in a more convenient fashion.
+    /// Initially just timestamps, but potentially CreateValue with multiple overloads, too.
+    /// </summary>
+    internal static class ProtoHelpers
+    {
+        internal static wkt::Timestamp CreateProtoTimestamp(long seconds, int nanos) =>
+            new wkt::Timestamp { Seconds = seconds, Nanos = nanos };
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/SerializationTestData.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/SerializationTestData.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using wkt = Google.Protobuf.WellKnownTypes;
+using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
 
 namespace Google.Cloud.Firestore.Data.Tests
 {
@@ -71,14 +72,14 @@ namespace Google.Cloud.Firestore.Data.Tests
             
             // Timestamps
             { new Timestamp(1, 500),
-                new Value { TimestampValue = new wkt::Timestamp { Seconds = 1, Nanos = 500 } } },
+                new Value { TimestampValue = CreateProtoTimestamp(1, 500) } },
             { new DateTime(1970, 1, 1, 0, 0, 1, DateTimeKind.Utc).AddTicks(5),
-                new Value { TimestampValue = new wkt::Timestamp { Seconds = 1, Nanos = 500 } } },
+                new Value { TimestampValue = CreateProtoTimestamp(1, 500) } },
             // If the local time is 1 hour ahead of UTC, the timestamp is an hour before the Unix epoch
             { new DateTimeOffset(1970, 1, 1, 0, 0, 1, TimeSpan.FromHours(1)).AddTicks(5),
-                new Value { TimestampValue = new wkt::Timestamp { Seconds = 1 - 3600, Nanos = 500 } } },
-            { new wkt::Timestamp { Seconds = 1, Nanos = 500 },
-                new Value { TimestampValue = new wkt::Timestamp { Seconds = 1, Nanos = 500 } } },
+                new Value { TimestampValue = CreateProtoTimestamp(1 - 3600, 500) } },
+            { CreateProtoTimestamp(1, 500),
+                new Value { TimestampValue = CreateProtoTimestamp(1, 500) } },
 
             // Blobs
             { new byte[] { 1, 2, 3, 4 },
@@ -119,7 +120,7 @@ namespace Google.Cloud.Firestore.Data.Tests
                 } } },
             // Nullable type handling
             { new NullableContainer { NullableValue = null },
-                new Value { MapValue = new MapValue { Fields = { { "NullableValue", new Value { NullValue = wkt.NullValue.NullValue } } } } } },
+                new Value { MapValue = new MapValue { Fields = { { "NullableValue", new Value { NullValue = wkt::NullValue.NullValue } } } } } },
             { new NullableContainer { NullableValue = 10 },
                 new Value { MapValue = new MapValue { Fields = { { "NullableValue", new Value { IntegerValue = 10L } } } } } },
 

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/TimestampTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/TimestampTest.cs
@@ -14,7 +14,7 @@
 
 using System;
 using Xunit;
-using wkt = Google.Protobuf.WellKnownTypes;
+using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
 
 namespace Google.Cloud.Firestore.Data.Tests
 {
@@ -73,7 +73,7 @@ namespace Google.Cloud.Firestore.Data.Tests
         public void FromProto()
         {
             var direct = new Timestamp(1, 100);
-            var fromProto = Timestamp.FromProto(new wkt::Timestamp { Seconds = 1, Nanos = 100 });
+            var fromProto = Timestamp.FromProto(CreateProtoTimestamp(1, 100));
             Assert.Equal(direct, fromProto);
         }
 
@@ -81,7 +81,7 @@ namespace Google.Cloud.Firestore.Data.Tests
         public void ToProto()
         {
             var timestamp = new Timestamp(1, 100);
-            var proto = new wkt::Timestamp { Seconds = 1, Nanos = 100 };
+            var proto = CreateProtoTimestamp(1, 100);
             Assert.Equal(proto, timestamp.ToProto());
         }
 
@@ -151,7 +151,7 @@ namespace Google.Cloud.Firestore.Data.Tests
         [Fact]
         public void FromProtoOrNull_NonNull()
         {
-            var proto = new wkt::Timestamp { Seconds = 1, Nanos = 100 };
+            var proto = CreateProtoTimestamp(1, 100);
             var timestamp = Timestamp.FromProtoOrNull(proto).Value;
             var expected = new Timestamp(1, 100);
             Assert.Equal(expected, timestamp);

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.cs
@@ -18,7 +18,7 @@ using Moq;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
-using wkt = Google.Protobuf.WellKnownTypes;
+using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
 
 namespace Google.Cloud.Firestore.Data.Tests
 {
@@ -93,8 +93,5 @@ namespace Google.Cloud.Firestore.Data.Tests
 
         private void AssertWrites(WriteBatch batch, params Write[] writes) =>
             Assert.Equal(writes, batch.Writes);
-
-        private static wkt::Timestamp CreateProtoTimestamp(long seconds, int nanos) =>
-            new wkt.Timestamp { Seconds = seconds, Nanos = nanos };
     }
 }

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteResultTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteResultTest.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using Xunit;
-using wkt = Google.Protobuf.WellKnownTypes;
+using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
 
 namespace Google.Cloud.Firestore.Data.Tests
 {
@@ -22,8 +22,8 @@ namespace Google.Cloud.Firestore.Data.Tests
         [Fact]
         public void FromProto_TimestampInProto()
         {
-            var commitTime = new wkt.Timestamp { Seconds = 20, Nanos = 30 };
-            var proto = new V1Beta1.WriteResult { UpdateTime = new wkt.Timestamp { Seconds = 10, Nanos = 20 } };
+            var commitTime = CreateProtoTimestamp(20, 30);
+            var proto = new V1Beta1.WriteResult { UpdateTime = CreateProtoTimestamp(10, 20) };
             var result = WriteResult.FromProto(proto, commitTime);
             Assert.Equal(new Timestamp(10, 20), result.UpdateTime);
         }
@@ -31,7 +31,7 @@ namespace Google.Cloud.Firestore.Data.Tests
         [Fact]
         public void FromProto_TimestampNotInProto()
         {
-            var commitTime = new wkt.Timestamp { Seconds = 20, Nanos = 30 };
+            var commitTime = CreateProtoTimestamp(20, 30);
             var proto = new V1Beta1.WriteResult();
             var result = WriteResult.FromProto(proto, commitTime);
             Assert.Equal(new Timestamp(20, 30), result.UpdateTime);

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/CollectionReference.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/CollectionReference.cs
@@ -16,6 +16,8 @@
 using Google.Api.Gax;
 using Google.Cloud.Firestore.V1Beta1;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Google.Cloud.Firestore.Data
 {
@@ -64,7 +66,24 @@ namespace Google.Cloud.Firestore.Data
         /// <returns>A <see cref="CollectionReference"/> for the specified collection.</returns>
         public DocumentReference Document(string documentId) =>
             new DocumentReference(Database, this,
-                documentId == null ? PathUtilities.GenerateId() : PathUtilities.ValidateId(documentId, nameof(documentId)));        
+                documentId == null ? PathUtilities.GenerateId() : PathUtilities.ValidateId(documentId, nameof(documentId)));
+
+        /// <summary>
+        /// Asynchronously creates a document with the given data in this collection. The document has a randomly generated ID.
+        /// </summary>
+        /// <remarks>
+        /// If the <see cref="WriteResult"/> for the operation is required, use <see cref="DocumentReference.CreateAsync(object, CancellationToken)"/>
+        /// instead of this method.
+        /// </remarks>
+        /// <param name="documentData">The data for the document. Must not be null.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
+        /// <returns>The reference for the newly-created document.</returns>
+        public async Task<DocumentReference> AddAsync(object documentData, CancellationToken cancellationToken = default)
+        {
+            var docRef = Document(null);
+            var result = await docRef.CreateAsync(documentData, cancellationToken).ConfigureAwait(false);
+            return docRef;
+        }
 
         /// <inheritdoc />
         public override int GetHashCode() => Path.GetHashCode();


### PR DESCRIPTION
Definitely worth reviewing one commit at a time:

- Introducing FirestoreDb.GetDocumentSnapshotsAsync, with unit tests
- Test refactoring to make it easier to create timestamps
- Methods in DocumentReference and CollectionReference to fetch/create documents, with corresponding *integration* tests