### PR TITLE
Implement document deletion for Firestore

### DIFF
--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/DocumentDeletionTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/DocumentDeletionTest.cs
@@ -1,0 +1,79 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Grpc.Core;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Firestore.Data.IntegrationTests
+{
+    [Collection(nameof(FirestoreFixture))]
+    public class DocumentDeletionTest
+    {
+        private readonly FirestoreFixture _fixture;
+
+        public DocumentDeletionTest(FirestoreFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public async Task Delete_Unconditional_DoesntExist()
+        {
+            var doc = _fixture.NonQueryCollection.Document(null);
+            var result = await doc.DeleteAsync();
+            var afterDelete = await doc.SnapshotAsync();
+            Assert.False(afterDelete.Exists);
+        }
+
+        [Fact]
+        public async Task Delete_Unconditional_Existed()
+        {
+            var doc = _fixture.NonQueryCollection.Document(null);
+            var createResult = await doc.CreateAsync(new { Name = "Delete me" });
+            var deleteResult = await doc.DeleteAsync();
+            var afterDelete = await doc.SnapshotAsync();
+            Assert.False(afterDelete.Exists);
+        }
+
+        [Fact]
+        public async Task Delete_Precondition_Success()
+        {
+            var doc = _fixture.NonQueryCollection.Document(null);
+            var createResult = await doc.CreateAsync(new { Name = "Delete me" });
+            var deleteResult = await doc.DeleteAsync(Precondition.LastUpdated(createResult.UpdateTime));
+            var afterDelete = await doc.SnapshotAsync();
+            Assert.False(afterDelete.Exists);
+        }
+
+        [Fact]
+        public async Task Delete_Precondition_Failed()
+        {
+            var doc = _fixture.NonQueryCollection.Document(null);
+            var createResult = await doc.CreateAsync(new { Name = "Don't delete me" });
+            var otherTimestamp = Timestamp.FromDateTimeOffset(createResult.UpdateTime.ToDateTimeOffset().AddSeconds(-1));
+            var exception = await Assert.ThrowsAsync<RpcException>(() => doc.DeleteAsync(Precondition.LastUpdated(otherTimestamp)));
+            Assert.Equal(StatusCode.FailedPrecondition, exception.Status.StatusCode);
+            var afterDelete = await doc.SnapshotAsync();
+            Assert.True(afterDelete.Exists);
+        }
+
+        [Fact]
+        public async Task Delete_Precondition_DoesntExist()
+        {
+            var doc = _fixture.NonQueryCollection.Document(null);
+            var exception = await Assert.ThrowsAsync<RpcException>(() => doc.DeleteAsync(Precondition.LastUpdated(new Timestamp(1, 0))));
+            Assert.Equal(StatusCode.FailedPrecondition, exception.Status.StatusCode);
+            var afterDelete = await doc.SnapshotAsync();
+            Assert.False(afterDelete.Exists);
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.cs
@@ -49,6 +49,34 @@ namespace Google.Cloud.Firestore.Data.Tests
         }
 
         [Fact]
+        public void Delete_NoPrecondition()
+        {
+            var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
+            var batch = db.CreateWriteBatch();
+            var doc = db.Document("col/doc");
+            batch.Delete(doc);
+
+            var expectedWrite = new Write { Delete = doc.Path };
+            AssertWrites(batch, expectedWrite);
+        }
+
+        [Fact]
+        public void Delete_WithPrecondition()
+        {
+            var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
+            var batch = db.CreateWriteBatch();
+            var doc = db.Document("col/doc");
+            batch.Delete(doc, Precondition.LastUpdated(new Timestamp(1 ,2)));
+
+            var expectedWrite = new Write
+            {
+                Delete = doc.Path,
+                CurrentDocument = new V1Beta1.Precondition { UpdateTime = CreateProtoTimestamp(1, 2) }
+            };
+            AssertWrites(batch, expectedWrite);
+        }
+
+        [Fact]
         public async Task CommitAsync()
         {
             var mock = new Mock<FirestoreClient> { CallBase = true };

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/DocumentReference.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/DocumentReference.cs
@@ -14,6 +14,7 @@
 
 using Google.Api.Gax;
 using Google.Protobuf;
+using Grpc.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -88,6 +89,24 @@ namespace Google.Cloud.Firestore.Data
             var batch = Database.CreateWriteBatch();
             var results = await batch.Create(this, documentData).CommitAsync(cancellationToken).ConfigureAwait(false);
             return results.Single();
+        }
+
+        /// <summary>
+        /// Asynchronously deletes the document referred to by this path, with an optional precondition.
+        /// </summary>
+        /// <remarks>
+        /// If no precondition is specified and the document doesn't exist, this returned task will succeed. If a precondition
+        /// is specified and not met, the returned task will fail with an <see cref="RpcException"/>.
+        /// </remarks>
+        /// <param name="precondition">Optional precondition for deletion. May be null, in which case the deletion is unconditional.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public async Task<WriteResult> DeleteAsync(Precondition precondition = null, CancellationToken cancellationToken = default)
+        {
+            var batch = Database.CreateWriteBatch();
+            batch.Delete(this, precondition);
+            var results = await batch.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return results[0];
         }
 
         // TODO: Check naming. Other languages just have "get", but that feels a bit odd in .NET.

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/WriteBatch.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/WriteBatch.cs
@@ -70,6 +70,24 @@ namespace Google.Cloud.Firestore.Data
         }
 
         /// <summary>
+        /// Adds a write operation that deletes the specified document, with an optional precondition.
+        /// </summary>
+        /// <param name="documentReference">A document reference indicating the path of the document to delete. Must not be null.</param>
+        /// <param name="precondition">Optional precondition for deletion. May be null, in which case the deletion is unconditional.</param>
+        /// <returns>This batch, for the purposes of method chaining.</returns>
+        public WriteBatch Delete(DocumentReference documentReference, Precondition precondition = null)
+        {
+            GaxPreconditions.CheckNotNull(documentReference, nameof(documentReference));
+            var write = new Write
+            {
+                CurrentDocument = precondition?.Proto,
+                Delete = documentReference.Path
+            };
+            Writes.Add(write);
+            return this;
+        }
+
+        /// <summary>
         /// Commits the batch on the server.
         /// </summary>
         /// <returns>The write results from the commit.</returns>


### PR DESCRIPTION
I haven't documented that if the precondition is "bad" (e.g.
specifying a timestamp that is in the future) the RpcException has
an InvalidArgument status code instead of FailedPrecondition, but I
don't want to get too confusing.