### PR TITLE
Add extra time to the error reporting integration tests.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/BaseEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/BaseEntryPolling.cs
@@ -24,11 +24,27 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
     /// </summary>
     internal abstract class BaseEntryPolling<T>
     {
+        /// <summary>Default total time to spend sleeping when looking for entries.</summary>
+        private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(10);
+
+        /// <summary>Default time to sleep between checks for entries.</summary>
+        private static readonly TimeSpan _defaultSleepInterval = TimeSpan.FromSeconds(5);
+
         /// <summary>Total time to spend sleeping when looking for entries.</summary>
-        private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(10);
+        private readonly TimeSpan _timeout;
 
         /// <summary>Time to sleep between checks for entries.</summary>
-        private static readonly TimeSpan _sleepInterval = TimeSpan.FromSeconds(5);
+        private readonly TimeSpan _sleepInterval;
+
+        /// <param name="timeout">Optional, total time to spend sleeping when looking for entries.
+        ///     Defaults to <see cref="_defaultTimeout"/>.</param>
+        /// <param name="sleepInterval">Optional, time to sleep between checks for entries.
+        ///     Defaults to <see cref="_defaultSleepInterval"/></param>
+        protected BaseEntryPolling(TimeSpan timeout = default, TimeSpan sleepInterval = default)
+        {
+            _timeout = timeout == default ? _defaultTimeout : timeout;
+            _sleepInterval = sleepInterval == default ?  _defaultSleepInterval : sleepInterval;
+        }
 
         /// <summary>
         /// Polls for entries of type <see cref="T"/>.  Will continue to poll until

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryPolling.cs
@@ -35,6 +35,9 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         /// <summary>Project to run the test on.</summary>
         private readonly ProjectName _projectName = new ProjectName(Utils.GetProjectIdFromEnvironment());
 
+        // Give the error reporting events a little extra time to be processed.
+        internal ErrorEventEntryPolling() : base(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(10)) { }
+
         /// <summary>
         /// Gets error events that contain the passed in testId in the message.  Will poll
         /// and wait for the entries to appear.


### PR DESCRIPTION
The tests started failing a few days ago, it looks like they are taking a little longer to get processed.