### PR TITLE
Add query support for Firestore

### DIFF
--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/Models/HighScore.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/Models/HighScore.cs
@@ -1,0 +1,67 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Google.Cloud.Firestore.Data.IntegrationTests.Models
+{
+    [FirestoreData]
+    public class HighScore : IEquatable<HighScore>
+    {
+        // Note: keep ordered by name, so we don't need to do that explicitly in tests.
+        // The levels and names should be unique for the sake of testing; there can be multiple
+        // high scores with the same score though.
+        public static HighScore[] Data = new[]
+        {
+            new HighScore("Alice", 20, 100),
+            new HighScore("Bob", 10, 90),
+            new HighScore("Carol", 15, 110),
+            new HighScore("Dalip", 25, 200),
+            new HighScore("Erin", 30, 200)
+        };
+
+        /// <summary>
+        /// Needed for deserialization.
+        /// </summary>
+        public HighScore()
+        {
+        }
+
+        public HighScore(string name, int level, int score)
+        {
+            Name = name;
+            Level = level;
+            Score = score;
+        }
+
+        [FirestoreProperty]
+        public string Name { get; set; }
+
+        [FirestoreProperty]
+        public int Level { get; set; }
+
+        [FirestoreProperty]
+        public int Score { get; set; }
+
+        public override int GetHashCode() => (Name?.GetHashCode() ?? 0) ^ Level.GetHashCode() ^ Score.GetHashCode();
+
+        public override bool Equals(object obj) => Equals(obj as HighScore);
+
+        public bool Equals(HighScore other) =>
+            other != null &&
+            Name == other.Name &&
+            Level == other.Level &&
+            Score == other.Score;
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/QueryTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/QueryTest.cs
@@ -1,0 +1,169 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Firestore.Data.IntegrationTests.Models;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Firestore.Data.IntegrationTests
+{
+    [Collection(nameof(FirestoreFixture))]
+    public class QueryTest
+    {
+        private readonly FirestoreFixture _fixture;
+
+        public QueryTest(FirestoreFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public async Task EmptyQuery()
+        {
+            var query = _fixture.HighScoreCollection;
+            var snapshot = await query.SnapshotAsync();
+            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            Assert.Equal(HighScore.Data, items.OrderBy(x => x.Name));
+        }
+
+        [Fact]
+        public async Task WhereGreaterThan()
+        {
+            var query = _fixture.HighScoreCollection.Where("Score", QueryOperator.GreaterThan, 100);
+            var snapshot = await query.SnapshotAsync();
+            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            Assert.Equal(HighScore.Data.Where(x => x.Score > 100), items.OrderBy(x => x.Name));
+        }
+
+        [Fact]
+        public async Task OrderBy()
+        {
+            var query = _fixture.HighScoreCollection.OrderBy("Level");
+            var snapshot = await query.SnapshotAsync();
+            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            Assert.Equal(HighScore.Data.OrderBy(x => x.Level), items);
+        }
+
+        [Fact]
+        public async Task OrderByDocumentId()
+        {
+            var query = _fixture.HighScoreCollection.Select("Name").OrderBy(FieldPath.DocumentId);
+            var snapshot = await query.SnapshotAsync();
+
+            // Check that we got the documents we expected
+            var names = snapshot.Documents.Select(doc => doc.GetField<string>("Name")).OrderBy(x => x);
+            Assert.Equal(HighScore.Data.Select(x => x.Name), names);
+
+            // Check that the ordering is actually by document reference
+            var orderedByReference = snapshot.Documents.OrderBy(doc => doc.Reference.Path);
+            Assert.Equal(orderedByReference, snapshot.Documents);
+        }
+
+        [Fact(Skip = "Requires CreateIndex support")]
+        public async Task OrderBySecondaryAscending()
+        {
+            var query = _fixture.HighScoreCollection.OrderBy("Score").OrderBy("Level");
+            var snapshot = await query.SnapshotAsync();
+            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            Assert.Equal(HighScore.Data.OrderBy(x => x.Score).ThenBy(x => x.Level), items);
+        }
+
+        [Fact(Skip = "Requires CreateIndex support")]
+        public async Task OrderBySecondaryDescending()
+        {
+            var query = _fixture.HighScoreCollection.OrderBy("Score").OrderByDescending("Level");
+            var snapshot = await query.SnapshotAsync();
+            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            Assert.Equal(HighScore.Data.OrderBy(x => x.Score).ThenByDescending(x => x.Level), items);
+        }
+
+        [Fact]
+        public async Task Select()
+        {
+            var query = _fixture.HighScoreCollection.Select("Name", "Score");
+            var snapshot = await query.SnapshotAsync();
+            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            Assert.Equal(
+                // Create the equivalent results by creating new objects
+                HighScore.Data.Select(x => new HighScore { Name = x.Name, Score = x.Score }),
+                items.OrderBy(x => x.Name));
+        }
+
+        [Fact]
+        public async Task SelectDocumentId()
+        {
+            var query = _fixture.HighScoreCollection.Select(FieldPath.DocumentId);
+            var snapshot = await query.SnapshotAsync();
+
+            Assert.Equal(snapshot.Documents.Count, HighScore.Data.Length);
+
+            // Check that all the documents are empty - all we're getting is the doc reference
+            Assert.All(snapshot.Documents, doc => Assert.Empty(doc.ToDictionary()));
+        }
+
+        [Fact]
+        public async Task Limit()
+        {
+            var query = _fixture.HighScoreCollection.OrderBy("Level").Limit(3);
+            var snapshot = await query.SnapshotAsync();
+            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            Assert.Equal(HighScore.Data.OrderBy(x => x.Level).Take(3), items);
+        }
+
+        [Fact]
+        public async Task Offset()
+        {
+            var query = _fixture.HighScoreCollection.OrderBy("Level").Offset(2);
+            var snapshot = await query.SnapshotAsync();
+            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            Assert.Equal(HighScore.Data.OrderBy(x => x.Level).Skip(2), items);
+        }
+
+        [Fact]
+        public async Task StartAt()
+        {
+            var query = _fixture.HighScoreCollection.OrderBy("Level").StartAt(20);
+            var snapshot = await query.SnapshotAsync();
+            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            Assert.Equal(HighScore.Data.Where(x => x.Level >= 20).OrderBy(x => x.Score), items);
+        }
+
+        [Fact]
+        public async Task StartAfter()
+        {
+            var query = _fixture.HighScoreCollection.OrderBy("Level").StartAfter(20);
+            var snapshot = await query.SnapshotAsync();
+            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            Assert.Equal(HighScore.Data.Where(x => x.Level > 20).OrderBy(x => x.Level), items);
+        }
+
+        [Fact]
+        public async Task EndAt()
+        {
+            var query = _fixture.HighScoreCollection.OrderBy("Level").EndAt(20);
+            var snapshot = await query.SnapshotAsync();
+            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            Assert.Equal(HighScore.Data.Where(x => x.Level <= 20).OrderBy(x => x.Level), items);
+        }
+
+        [Fact]
+        public async Task EndBefore()
+        {
+            var query = _fixture.HighScoreCollection.OrderBy("Level").EndBefore(20);
+            var snapshot = await query.SnapshotAsync();
+            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            Assert.Equal(HighScore.Data.Where(x => x.Level < 20).OrderBy(x => x.Level), items);
+        }
+
+        // TODO: Filtering by DocumentId.
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/QueryTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/QueryTest.cs
@@ -1,0 +1,559 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Firestore.V1Beta1;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Cloud.Firestore.V1Beta1.FirestoreClient;
+using static Google.Cloud.Firestore.V1Beta1.StructuredQuery.Types;
+using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
+using Google.Protobuf;
+using System.Threading;
+
+namespace Google.Cloud.Firestore.Data.Tests
+{
+    public class QueryTest
+    {
+        private static Query GetEmptyQuery()
+        {
+            var db = FirestoreDb.Create("proj", "db", new FakeFirestoreClient());
+            return db.Collection("col");
+        }
+
+        [Fact]
+        public void Select()
+        {
+            var query = GetEmptyQuery().Select("a.b", "c");
+            var expected = new StructuredQuery
+            {
+                Select = new Projection { Fields = { Field("a.b"), Field("c") } },
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Fact]
+        public void Where_SingleFieldFilter()
+        {
+            var query = GetEmptyQuery().Where("a.b", QueryOperator.LessThan, "x");
+            var expected = new StructuredQuery
+            {
+                Where = Filter(new FieldFilter { Field = Field("a.b"), Op = FieldFilter.Types.Operator.LessThan, Value = new Value { StringValue = "x" } }),
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Theory]
+        [InlineData(double.NaN)]
+        [InlineData(float.NaN)]
+        public void Where_SingleNaNFilter(object value)
+        {
+            var query = GetEmptyQuery().Where("a.b", QueryOperator.Equal, value);
+            var expected = new StructuredQuery
+            {
+                Where = Filter(new UnaryFilter { Field = Field("a.b"), Op = UnaryFilter.Types.Operator.IsNan }),
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Fact]
+        public void Where_SingleNullFilter()
+        {
+            var query = GetEmptyQuery().Where("a.b", QueryOperator.Equal, null);
+            var expected = new StructuredQuery
+            {
+                Where = Filter(new UnaryFilter { Field = Field("a.b"), Op = UnaryFilter.Types.Operator.IsNull }),
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Fact]
+        public void Where_CompositeFilter()
+        {
+            var query = GetEmptyQuery()
+                .Where("a", QueryOperator.GreaterThanOrEqual, "x")
+                .Where("b", QueryOperator.Equal, "y")
+                .Where("c", QueryOperator.Equal, "z");
+            var expected = new StructuredQuery
+            {
+                Where = CompositeFilter(
+                    Filter(new FieldFilter { Field = Field("a"), Op = FieldFilter.Types.Operator.GreaterThanOrEqual, Value = new Value { StringValue = "x" } }),
+                    Filter(new FieldFilter { Field = Field("b"), Op = FieldFilter.Types.Operator.Equal, Value = new Value { StringValue = "y" } }),
+                    Filter(new FieldFilter { Field = Field("c"), Op = FieldFilter.Types.Operator.Equal, Value = new Value { StringValue = "z" } })
+                ),
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Theory]
+        [InlineData(QueryOperator.LessThan, null)]
+        [InlineData(QueryOperator.GreaterThan, double.NaN)]
+        [InlineData(QueryOperator.LessThanOrEqual, float.NaN)]
+        [InlineData((QueryOperator) 100, 10)]
+        public void Where_Invalid(QueryOperator op, object value)
+        {
+            var query = GetEmptyQuery();
+            Assert.Throws<ArgumentException>(() => query.Where("x", op, value));
+        }
+
+        // Test for methods which replace previous values
+        [Fact]
+        public void ReplacementCalls()
+        {
+            var query = GetEmptyQuery()
+                .Select("ignored")
+                .Select("x")
+                .OrderBy("foo") // Required for start/end
+                .StartAt("ignored")
+                .StartAfter("a")
+                .EndAt("ignored")
+                .EndBefore("b")
+                .Offset(100)
+                .Offset(5)
+                .Limit(100)
+                .Limit(10);
+            var expected = new StructuredQuery
+            {
+                Select = new Projection { Fields = { Field("x") } },
+                OrderBy = { new Order { Field = Field("foo"), Direction = Direction.Ascending } },
+                StartAt = new Cursor { Before = false, Values = { new Value { StringValue = "a" } } },
+                EndAt = new Cursor { Before = true, Values = { new Value { StringValue = "b" } } },
+                Offset = 5,
+                Limit = 10,
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Fact]
+        public void OrderBy_String()
+        {
+            var query = GetEmptyQuery().OrderBy("foo");
+            var expected = new StructuredQuery
+            {
+                OrderBy = { new Order { Field = Field("foo"), Direction = Direction.Ascending } },
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Fact]
+        public void OrderBy_FieldPath()
+        {
+            var query = GetEmptyQuery().OrderBy(new FieldPath("foo"));
+            var expected = new StructuredQuery
+            {
+                OrderBy = { new Order { Field = Field("foo"), Direction = Direction.Ascending } },
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Fact]
+        public void OrderByDescending_String()
+        {
+            var query = GetEmptyQuery().OrderByDescending("foo");
+            var expected = new StructuredQuery
+            {
+                OrderBy = { new Order { Field = Field("foo"), Direction = Direction.Descending } },
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Fact]
+        public void OrderByDescending_FieldPath()
+        {
+            var query = GetEmptyQuery().OrderByDescending(new FieldPath("foo"));
+            var expected = new StructuredQuery
+            {
+                OrderBy = { new Order { Field = Field("foo"), Direction = Direction.Descending } },
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Fact]
+        public void OrderAfterCursor()
+        {
+            var query = GetEmptyQuery().OrderBy("foo").StartAt("x");
+            Assert.Throws<InvalidOperationException>(() => query.OrderBy("bar"));
+            Assert.Throws<InvalidOperationException>(() => query.OrderByDescending("bar"));
+            Assert.Throws<InvalidOperationException>(() => query.OrderBy(new FieldPath("bar")));
+            Assert.Throws<InvalidOperationException>(() => query.OrderByDescending(new FieldPath("bar")));
+        }
+
+        [Fact]
+        public void StartAt()
+        {
+            var query = GetEmptyQuery().OrderBy("foo").OrderBy("bar").OrderBy("baz").StartAt(1, "x");
+            var expected = new StructuredQuery
+            {
+                OrderBy =
+                {
+                    new Order { Field = Field("foo"), Direction = Direction.Ascending },
+                    new Order { Field = Field("bar"), Direction = Direction.Ascending },
+                    new Order { Field = Field("baz"), Direction = Direction.Ascending },
+                },
+                StartAt = new Cursor { Before = true, Values = { new Value { IntegerValue = 1 }, new Value { StringValue = "x" } } },
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Fact]
+        public void StartAfter()
+        {
+            var query = GetEmptyQuery().OrderBy("foo").OrderBy("bar").OrderBy("baz").StartAfter(1, "x");
+            var expected = new StructuredQuery
+            {
+                OrderBy =
+                {
+                    new Order { Field = Field("foo"), Direction = Direction.Ascending },
+                    new Order { Field = Field("bar"), Direction = Direction.Ascending },
+                    new Order { Field = Field("baz"), Direction = Direction.Ascending },
+                },
+                StartAt = new Cursor { Before = false, Values = { new Value { IntegerValue = 1 }, new Value { StringValue = "x" } } },
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Fact]
+        public void EndAt()
+        {
+            var query = GetEmptyQuery().OrderBy("foo").OrderBy("bar").OrderBy("baz").EndAt(1, "x");
+            var expected = new StructuredQuery
+            {
+                OrderBy =
+                {
+                    new Order { Field = Field("foo"), Direction = Direction.Ascending },
+                    new Order { Field = Field("bar"), Direction = Direction.Ascending },
+                    new Order { Field = Field("baz"), Direction = Direction.Ascending },
+                },
+                EndAt = new Cursor { Before = false, Values = { new Value { IntegerValue = 1 }, new Value { StringValue = "x" } } },
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Fact]
+        public void EndBefore()
+        {
+            var query = GetEmptyQuery().OrderBy("foo").OrderBy("bar").OrderBy("baz").EndBefore(1, "x");
+            var expected = new StructuredQuery
+            {
+                OrderBy =
+                {
+                    new Order { Field = Field("foo"), Direction = Direction.Ascending },
+                    new Order { Field = Field("bar"), Direction = Direction.Ascending },
+                    new Order { Field = Field("baz"), Direction = Direction.Ascending },
+                },
+                EndAt = new Cursor { Before = true, Values = { new Value { IntegerValue = 1 }, new Value { StringValue = "x" } } },
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Theory]
+        [InlineData(new object[0])]
+        [InlineData("x", "y")]
+        public void InvalidCursor(params object[] values)
+        {
+            var query = GetEmptyQuery().OrderBy("foo");
+
+            Assert.Throws<ArgumentException>(() => query.StartAt(values));
+            Assert.Throws<ArgumentException>(() => query.StartAfter(values));
+            Assert.Throws<ArgumentException>(() => query.EndAt(values));
+            Assert.Throws<ArgumentException>(() => query.EndBefore(values));
+        }
+
+        [Fact]
+        public void LimitValidation()
+        {
+            var query = GetEmptyQuery();
+            query.Limit(0);
+            Assert.Throws<ArgumentOutOfRangeException>(() => query.Limit(-1));
+        }
+
+        [Fact]
+        public void InvalidOffset()
+        {
+            var query = GetEmptyQuery();
+            query.Offset(0);
+            Assert.Throws<ArgumentOutOfRangeException>(() => query.Offset(-1));
+        }
+
+        [Fact]
+        public void KitchenSink()
+        {
+            var query = GetEmptyQuery()
+                .Select("a.b", "c.d")
+                .Where("a", QueryOperator.Equal, null)
+                .Where("b", QueryOperator.GreaterThan, 10)
+                .OrderBy("foo")
+                .OrderByDescending("bar")
+                .StartAt("x", 10)
+                .EndAt("y")
+                .Offset(3)
+                .Limit(2);
+
+            var expected = new StructuredQuery
+            {
+                Select = new Projection { Fields = { Field("a.b"), Field("c.d") } },
+                Where = CompositeFilter(
+                    Filter(new UnaryFilter { Field = Field("a"), Op = UnaryFilter.Types.Operator.IsNull }),
+                    Filter(new FieldFilter { Field = Field("b"), Op = FieldFilter.Types.Operator.GreaterThan, Value = new Value { IntegerValue = 10L } })
+                ),
+                OrderBy =
+                {
+                    new Order { Field = Field("foo"), Direction = Direction.Ascending },
+                    new Order { Field = Field("bar"), Direction = Direction.Descending }
+                },
+                StartAt = new Cursor { Before = true, Values = { new Value { StringValue = "x" }, new Value { IntegerValue = 10 } } },
+                EndAt = new Cursor { Before = false, Values = { new Value { StringValue = "y" } } },
+                Offset = 3,
+                Limit = 2,
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.QueryProto);
+        }
+
+        [Fact]
+        public async Task SnapshotAsync_NoDocuments()
+        {
+            var mock = new Mock<FirestoreClient> { CallBase = true };
+            var request = new RunQueryRequest
+            {
+                Parent = "projects/proj/databases/db/documents",
+                StructuredQuery = new StructuredQuery
+                {
+                    Select = new Projection { Fields = { Field("Name") } },
+                    From = { new CollectionSelector { CollectionId = "col" } }
+                }
+            };
+            var responses = new[]
+            {
+                new RunQueryResponse { ReadTime = CreateProtoTimestamp(1, 2) }
+            };
+            mock.Setup(c => c.RunQuery(request, It.IsAny<CallSettings>())).Returns(new FakeQueryStream(responses));
+            var db = FirestoreDb.Create("proj", "db", mock.Object);
+            var query = db.Collection("col").Select("Name");
+            var snapshot = await query.SnapshotAsync();
+            Assert.Empty(snapshot.Documents);
+            Assert.Same(query, snapshot.Query);
+            Assert.Equal(new Timestamp(1, 2), snapshot.ReadTime);
+
+            mock.VerifyAll();
+        }
+
+        [Fact]
+        public async Task SnapshotAsync_WithDocuments()
+        {
+            var mock = new Mock<FirestoreClient> { CallBase = true };
+            var request = new RunQueryRequest
+            {
+                Parent = "projects/proj/databases/db/documents",
+                StructuredQuery = new StructuredQuery
+                {
+                    Select = new Projection { Fields = { Field("Name") } },
+                    From = { new CollectionSelector { CollectionId = "col" } },
+                    Offset = 3
+                }
+            };
+            var responses = new[]
+            {
+                new RunQueryResponse { SkippedResults = 3 },
+                new RunQueryResponse
+                {
+                    ReadTime = CreateProtoTimestamp(1, 2),
+                    Document = new Document
+                    {
+                        CreateTime = CreateProtoTimestamp(0, 1),
+                        UpdateTime = CreateProtoTimestamp(0, 2),
+                        Name = "projects/proj/databases/db/documents/col/doc1",
+                        Fields = { { "Name", new Value { StringValue = "x" } } }
+                    }                    
+                },
+                new RunQueryResponse
+                {
+                    ReadTime = CreateProtoTimestamp(1, 3),
+                    Document = new Document
+                    {
+                        CreateTime = CreateProtoTimestamp(0, 3),
+                        UpdateTime = CreateProtoTimestamp(0, 4),
+                        Name = "projects/proj/databases/db/documents/col/doc2",
+                        Fields = { { "Name", new Value { StringValue = "y" } } }
+                    }
+                }
+            };
+            mock.Setup(c => c.RunQuery(request, It.IsAny<CallSettings>())).Returns(new FakeQueryStream(responses));
+            var db = FirestoreDb.Create("proj", "db", mock.Object);
+            var query = db.Collection("col").Select("Name").Offset(3);
+            var snapshot = await query.SnapshotAsync();
+            Assert.Equal(2, snapshot.Documents.Count);
+            Assert.Same(query, snapshot.Query);
+            Assert.Equal(new Timestamp(1, 2), snapshot.ReadTime); // From first document
+
+            var doc1 = snapshot.Documents[0];
+            Assert.Equal(db.Document("col/doc1"), doc1.Reference);
+            Assert.Equal(new Timestamp(1, 2), doc1.ReadTime);
+            Assert.Equal(new Timestamp(0, 1), doc1.CreateTime);
+            Assert.Equal(new Timestamp(0, 2), doc1.UpdateTime);
+            Assert.Equal("x", doc1.GetField<string>("Name"));
+
+            var doc2 = snapshot.Documents[1];
+            Assert.Equal(db.Document("col/doc2"), doc2.Reference);
+            Assert.Equal(new Timestamp(1, 3), doc2.ReadTime);
+            Assert.Equal(new Timestamp(0, 3), doc2.CreateTime);
+            Assert.Equal(new Timestamp(0, 4), doc2.UpdateTime);
+            Assert.Equal("x", doc1.GetField<string>("Name"));
+            mock.VerifyAll();
+        }
+
+        [Fact]
+        public async Task SnapshotAsync_NoResponses()
+        {
+            var mock = new Mock<FirestoreClient> { CallBase = true };
+            var request = new RunQueryRequest
+            {
+                Parent = "projects/proj/databases/db/documents",
+                StructuredQuery = new StructuredQuery
+                {
+                    Select = new Projection { Fields = { Field("Name") } },
+                    From = { new CollectionSelector { CollectionId = "col" } }
+                }
+            };
+            var responses = new RunQueryResponse[0];
+            mock.Setup(c => c.RunQuery(request, It.IsAny<CallSettings>())).Returns(new FakeQueryStream(responses));
+            var db = FirestoreDb.Create("proj", "db", mock.Object);
+            var query = db.Collection("col").Select("Name");
+            // This shouldn't happen, of course - but let's check that we do what we expect.
+            await Assert.ThrowsAsync<InvalidOperationException>(() => query.SnapshotAsync());
+            mock.VerifyAll();
+        }
+
+        [Fact]
+        public async Task StreamAsync_WithDocuments()
+        {
+            var mock = new Mock<FirestoreClient> { CallBase = true };
+            var request = new RunQueryRequest
+            {
+                Parent = "projects/proj/databases/db/documents",
+                StructuredQuery = new StructuredQuery
+                {
+                    Select = new Projection { Fields = { Field("Name") } },
+                    From = { new CollectionSelector { CollectionId = "col" } },
+                    Offset = 3
+                },
+                Transaction = ByteString.CopyFrom(1, 2, 3, 4)
+            };
+            var responses = new[]
+            {
+                new RunQueryResponse { SkippedResults = 3 },
+                new RunQueryResponse
+                {
+                    ReadTime = CreateProtoTimestamp(1, 2),
+                    Document = new Document
+                    {
+                        CreateTime = CreateProtoTimestamp(0, 1),
+                        UpdateTime = CreateProtoTimestamp(0, 2),
+                        Name = "projects/proj/databases/db/documents/col/doc1",
+                        Fields = { { "Name", new Value { StringValue = "x" } } }
+                    }
+                },
+                new RunQueryResponse
+                {
+                    ReadTime = CreateProtoTimestamp(1, 3),
+                    Document = new Document
+                    {
+                        CreateTime = CreateProtoTimestamp(0, 3),
+                        UpdateTime = CreateProtoTimestamp(0, 4),
+                        Name = "projects/proj/databases/db/documents/col/doc2",
+                        Fields = { { "Name", new Value { StringValue = "y" } } }
+                    }
+                }
+            };
+            mock.Setup(c => c.RunQuery(request, It.IsAny<CallSettings>())).Returns(new FakeQueryStream(responses));
+            var db = FirestoreDb.Create("proj", "db", mock.Object);
+            var query = db.Collection("col").Select("Name").Offset(3);
+            // Just for variety, we'll provide a transaction ID this time...
+            var documents = await query.StreamAsync(ByteString.CopyFrom(1, 2, 3, 4), CancellationToken.None).ToList();
+            Assert.Equal(2, documents.Count);
+
+            var doc1 = documents[0];
+            Assert.Equal(db.Document("col/doc1"), doc1.Reference);
+            Assert.Equal(new Timestamp(1, 2), doc1.ReadTime);
+            Assert.Equal(new Timestamp(0, 1), doc1.CreateTime);
+            Assert.Equal(new Timestamp(0, 2), doc1.UpdateTime);
+            Assert.Equal("x", doc1.GetField<string>("Name"));
+
+            var doc2 = documents[1];
+            Assert.Equal(db.Document("col/doc2"), doc2.Reference);
+            Assert.Equal(new Timestamp(1, 3), doc2.ReadTime);
+            Assert.Equal(new Timestamp(0, 3), doc2.CreateTime);
+            Assert.Equal(new Timestamp(0, 4), doc2.UpdateTime);
+            Assert.Equal("x", doc1.GetField<string>("Name"));
+            mock.VerifyAll();
+        }
+
+        [Fact]
+        public async Task StreamAsync_NoResponses()
+        {
+            var mock = new Mock<FirestoreClient> { CallBase = true };
+            var request = new RunQueryRequest
+            {
+                Parent = "projects/proj/databases/db/documents",
+                StructuredQuery = new StructuredQuery
+                {
+                    Select = new Projection { Fields = { Field("Name") } },
+                    From = { new CollectionSelector { CollectionId = "col" } }
+                }
+            };
+            var responses = new RunQueryResponse[0];
+            mock.Setup(c => c.RunQuery(request, It.IsAny<CallSettings>())).Returns(new FakeQueryStream(responses));
+            var db = FirestoreDb.Create("proj", "db", mock.Object);
+            var query = db.Collection("col").Select("Name");
+            var documents = await query.StreamAsync().ToList();
+            Assert.Empty(documents);
+            mock.VerifyAll();
+        }
+
+        private static FieldReference Field(string path) => new FieldReference { FieldPath = path };
+        private static Filter Filter(UnaryFilter filter) => new Filter { UnaryFilter = filter };
+        private static Filter Filter(FieldFilter filter) => new Filter { FieldFilter = filter };
+        private static Filter CompositeFilter(params Filter[] filters) =>
+            new Filter { CompositeFilter = new CompositeFilter { Op = StructuredQuery.Types.CompositeFilter.Types.Operator.And, Filters = { filters } } };
+
+        private class FakeQueryStream : RunQueryStream
+        {
+            private readonly IEnumerable<RunQueryResponse> _responses;
+
+            internal FakeQueryStream(IEnumerable<RunQueryResponse> responses) =>
+                _responses = responses;
+
+            public override IAsyncEnumerator<RunQueryResponse> ResponseStream =>
+                _responses.ToAsyncEnumerable().GetEnumerator();
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/FieldPath.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/FieldPath.cs
@@ -16,6 +16,7 @@ using Google.Api.Gax;
 using System;
 using System.Linq;
 using System.Text;
+using static Google.Cloud.Firestore.V1Beta1.StructuredQuery.Types;
 
 namespace Google.Cloud.Firestore.Data
 {
@@ -159,5 +160,10 @@ namespace Google.Cloud.Firestore.Data
 
         /// <inheritdoc />
         public bool Equals(FieldPath other) => EncodedPath == other?.EncodedPath;
+
+        /// <summary>
+        /// Conversion from FieldPath to FieldReference.
+        /// </summary>
+        internal FieldReference ToFieldReference() => new FieldReference { FieldPath = EncodedPath };
     }
 }

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/GrpcWorkaround.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/GrpcWorkaround.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Firestore.Data
+{
+    /// <summary>
+    /// Workaround for https://github.com/grpc/grpc/issues/12355
+    /// </summary>
+    internal static class GrpcWorkaround
+    {
+        internal static IAsyncEnumerator<T> CreateCancellationWrapper<T>(Func<CancellationToken, IAsyncEnumerator<T>> call, CancellationToken cancellationToken)
+        {
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var enumerator = call(cts.Token);
+            Func<CancellationToken, Task<bool>> moveNext = async token =>
+            {
+                using (token.Register(() => cts.Cancel()))
+                {
+                    return await enumerator.MoveNext(CancellationToken.None).ConfigureAwait(false);
+                }
+            };
+            return AsyncEnumerable.CreateEnumerator(moveNext, () => enumerator.Current, () => enumerator.Dispose());
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/Query.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/Query.cs
@@ -12,8 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
 using Google.Cloud.Firestore.V1Beta1;
+using Google.Protobuf;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using static Google.Cloud.Firestore.V1Beta1.StructuredQuery.Types;
+using FieldOp = Google.Cloud.Firestore.V1Beta1.StructuredQuery.Types.FieldFilter.Types.Operator;
 
 namespace Google.Cloud.Firestore.Data
 {
@@ -31,15 +40,418 @@ namespace Google.Cloud.Firestore.Data
         /// </summary>
         public FirestoreDb Database { get; }
 
-        internal string ParentPath { get; }
+        // Visible for testing
+        internal StructuredQuery QueryProto { get; }
 
-        private readonly StructuredQuery _query;
+        internal string ParentPath { get; }
 
         internal Query(FirestoreDb database, StructuredQuery query, string parentPath)
         {
             Database = database;
-            _query = query;
+            QueryProto = query;
             ParentPath = parentPath;
+        }
+
+        /// <summary>
+        /// Specifies the field paths to return in the results.
+        /// </summary>
+        /// <remarks>
+        /// This call replaces any previously-specified projections in the query.
+        /// </remarks>
+        /// <param name="fieldPaths">The dot-separated field paths to select. Must not be null or empty, or contain null or empty
+        /// elements.</param>
+        /// <returns>A new query based on the current one, but with the specified projection applied.</returns>
+        public Query Select(params string[] fieldPaths)
+        {
+            return Select(ConvertFieldPaths(fieldPaths));
+        }
+
+        /// <summary>
+        /// Specifies the field paths to return in the results.
+        /// </summary>
+        /// <remarks>
+        /// This call replaces any previously-specified projections in the query.
+        /// </remarks>
+        /// <param name="fieldPaths">The field paths to select. Must not be null or empty, or contain null elements.</param>
+        /// <returns>A new query based on the current one, but with the specified projection applied.</returns>
+        public Query Select(params FieldPath[] fieldPaths)
+        {
+            GaxPreconditions.CheckNotNull(fieldPaths, nameof(fieldPaths));
+            GaxPreconditions.CheckArgument(fieldPaths.Length != 0, nameof(fieldPaths), "Projection must specify at least one field");
+            GaxPreconditions.CheckArgument(!fieldPaths.Contains(null), nameof(fieldPaths), "Field paths must not contain a null element");
+            var query = QueryProto.Clone();
+            query.Select = new Projection { Fields = { fieldPaths.Select(fp => fp.ToFieldReference()) } };
+            return WithQuery(query);
+        }
+
+        // TODO: Choices...
+        // - Use an enum instead of strings?
+        // - Rename the "op" parameter? (operator is a keyword, but we could make it @operator maybe)
+        // - Rename "Where" to "AddFilter"?
+        // - Reimplement as individual methods, two per filter operator (accepting string or FieldPath),
+        //   e.g. WhereEqual, WhereLess than etc
+
+        /// <summary>
+        /// Add a filter for the given field path.
+        /// </summary>
+        /// <remarks>
+        /// This call adds additional filters to any previously-specified ones.
+        /// </remarks>
+        /// <param name="fieldPath">The dot-separated field path to filter on. Must not be null or empty.</param>
+        /// <param name="op">The filter operator. Must not be null.</param>
+        /// <param name="value">The value to compare in the filter.</param>
+        /// <returns>A new query based on the current one, but with the additional specified filter applied.</returns>
+        public Query Where(string fieldPath, QueryOperator op, object value)
+        {
+            GaxPreconditions.CheckNotNullOrEmpty(fieldPath, nameof(fieldPath));
+            return Where(FieldPath.FromDotSeparatedString(fieldPath), op, value);
+        }
+
+        /// <summary>
+        /// Add a filter for the given field path.
+        /// </summary>
+        /// <remarks>
+        /// This call adds additional filters to any previously-specified ones.
+        /// </remarks>
+        /// <param name="fieldPath">The field path to filter on. Must not be null.</param>
+        /// <param name="op">The filter operator.</param>
+        /// <param name="value">The value to compare in the filter.</param>
+        /// <returns>A new query based on the current one, but with the additional specified filter applied.</returns>
+        public Query Where(FieldPath fieldPath, QueryOperator op, object value)
+        {
+            FieldOp queryOp = GetOperator(op);
+            var unaryOperator = GetUnaryOperator(value);
+            Filter filter;
+            if (unaryOperator != UnaryFilter.Types.Operator.Unspecified)
+            {
+                if (queryOp == FieldOp.Equal)
+                {
+                    filter = new Filter { UnaryFilter = new UnaryFilter { Field = fieldPath.ToFieldReference(), Op = unaryOperator } };
+                }
+                else
+                {
+                    throw new ArgumentException(nameof(value), "null and NaN values can only be used with the Equal operator");
+                }
+            }
+            else
+            {
+                var convertedValue = ValueSerializer.Serialize(value);
+                filter = new Filter { FieldFilter = new FieldFilter { Field = fieldPath.ToFieldReference(), Op = queryOp, Value = convertedValue } };
+            }
+            return WithFilter(filter);
+        }
+
+        private FieldOp GetOperator(QueryOperator op
+)
+        {
+            switch (op)
+            {
+                case QueryOperator.Equal: return FieldOp.Equal;
+                case QueryOperator.LessThan: return FieldOp.LessThan;
+                case QueryOperator.LessThanOrEqual: return FieldOp.LessThanOrEqual;
+                case QueryOperator.GreaterThan: return FieldOp.GreaterThan;
+                case QueryOperator.GreaterThanOrEqual: return FieldOp.GreaterThanOrEqual;
+                default:
+                    throw new ArgumentException($"No operator for {op}", nameof(op));
+            }
+        }
+
+        private static UnaryFilter.Types.Operator GetUnaryOperator(object value)
+        {
+            switch (value)
+            {
+                case null:
+                    return UnaryFilter.Types.Operator.IsNull;
+                case double d when double.IsNaN(d):
+                case float f when float.IsNaN(f):
+                    return UnaryFilter.Types.Operator.IsNan;
+                default:
+                    return UnaryFilter.Types.Operator.Unspecified;
+            }
+        }
+
+        /// <summary>
+        /// Adds an additional ascending ordering by the specified path.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Unlike LINQ's OrderBy method, this call adds additional subordinate orderings to any
+        /// additionally specified. So <c>query.OrderBy("foo").OrderBy("bar")</c> is similar
+        /// to a LINQ <c>query.OrderBy(x => x.Foo).ThenBy(x => x.Bar)</c>.
+        /// </para>
+        /// <para>
+        /// This method cannot be called after a start/end cursor has been specified with
+        /// <see cref="StartAt"/>, <see cref="StartAfter(object[])"/>, <see cref="EndAt(object[])"/> or <see cref="EndBefore(object[])"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="fieldPath">The dot-separated field path to order by. Must not be null or empty.</param>
+        /// <returns>A new query based on the current one, but with the additional specified ordering applied.</returns>
+        public Query OrderBy(string fieldPath) => OrderBy(fieldPath, Direction.Ascending);
+
+        /// <summary>
+        /// Adds an additional descending ordering by the specified path.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Unlike LINQ's OrderBy method, this call adds additional subordinate orderings to any
+        /// additionally specified. So <c>query.OrderBy("foo").OrderByDescending("bar")</c> is similar
+        /// to a LINQ <c>query.OrderBy(x => x.Foo).ThenByDescending(x => x.Bar)</c>.
+        /// </para>
+        /// <para>
+        /// This method cannot be called after a start/end cursor has been specified with
+        /// <see cref="StartAt"/>, <see cref="StartAfter(object[])"/>, <see cref="EndAt(object[])"/> or <see cref="EndBefore(object[])"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="fieldPath">The dot-separated field path to order by. Must not be null or empty.</param>
+        /// <returns>A new query based on the current one, but with the additional specified ordering applied.</returns>
+        public Query OrderByDescending(string fieldPath) => OrderBy(fieldPath, Direction.Descending);
+
+        /// <summary>
+        /// Adds an additional ascending ordering by the specified path.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Unlike LINQ's OrderBy method, this call adds additional subordinate orderings to any
+        /// additionally specified. So <c>query.OrderBy("foo").OrderBy("bar")</c> is similar
+        /// to a LINQ <c>query.OrderBy(x => x.Foo).ThenBy(x => x.Bar)</c>.
+        /// </para>
+        /// <para>
+        /// This method cannot be called after a start/end cursor has been specified with
+        /// <see cref="StartAt"/>, <see cref="StartAfter(object[])"/>, <see cref="EndAt(object[])"/> or <see cref="EndBefore(object[])"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="fieldPath">The field path to order by. Must not be null.</param>
+        /// <returns>A new query based on the current one, but with the additional specified ordering applied.</returns>
+        public Query OrderBy(FieldPath fieldPath) => OrderBy(GaxPreconditions.CheckNotNull(fieldPath, nameof(fieldPath)), Direction.Ascending);
+
+        /// <summary>
+        /// Adds an additional descending ordering by the specified path.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Unlike LINQ's OrderBy method, this call adds additional subordinate orderings to any
+        /// additionally specified. So <c>query.OrderBy("foo").OrderByDescending("bar")</c> is similar
+        /// to a LINQ <c>query.OrderBy(x => x.Foo).ThenByDescending(x => x.Bar)</c>.
+        /// </para>
+        /// <para>
+        /// This method cannot be called after a start/end cursor has been specified with
+        /// <see cref="StartAt"/>, <see cref="StartAfter(object[])"/>, <see cref="EndAt(object[])"/> or <see cref="EndBefore(object[])"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="fieldPath">The field path to order by. Must not be null.</param>
+        /// <returns>A new query based on the current one, but with the additional specified ordering applied.</returns>
+        public Query OrderByDescending(FieldPath fieldPath) => OrderBy(GaxPreconditions.CheckNotNull(fieldPath, nameof(fieldPath)), Direction.Descending);
+
+        private Query OrderBy(string fieldPath, Direction direction)
+        {
+            GaxPreconditions.CheckNotNullOrEmpty(fieldPath, nameof(fieldPath));
+            return OrderBy(FieldPath.FromDotSeparatedString(fieldPath), direction);
+        }
+
+        private Query OrderBy(FieldPath fieldPath, Direction direction)
+        {
+            GaxPreconditions.CheckState(QueryProto.StartAt == null && QueryProto.EndAt == null,
+                "All orderings must be specified before StartAt, StartAfter, EndBefore or EndAt are called.");
+            var query = QueryProto.Clone();
+            query.OrderBy.Add(new Order { Field = fieldPath.ToFieldReference(), Direction = direction });
+            return WithQuery(query);
+        }
+
+        /// <summary>
+        /// Specifies the maximum number of results to return.
+        /// </summary>
+        /// <remarks>
+        /// This call replaces any previously-specified limit in the query.
+        /// </remarks>
+        /// <param name="limit">The maximum number of results to return. Must be greater than or equal to 0.</param>
+        /// <returns>A new query based on the current one, but with the specified limit applied.</returns>
+        public Query Limit(int limit)
+        {
+            GaxPreconditions.CheckArgumentRange(limit, nameof(limit), 0, int.MaxValue);
+            var query = QueryProto.Clone();
+            query.Limit = limit;
+            return WithQuery(query);
+        }
+
+        /// <summary>
+        /// Specifies a number of results to skip.
+        /// </summary>
+        /// <remarks>
+        /// This call replaces any previously-specified offset in the query.
+        /// </remarks>
+        /// <param name="offset">The number of results to skip. Must be greater than or equal to 0.</param>
+        /// <returns>A new query based on the current one, but with the specified offset applied.</returns>
+        public Query Offset(int offset)
+        {
+            GaxPreconditions.CheckArgumentRange(offset, nameof(offset), 0, int.MaxValue);
+            var query = QueryProto.Clone();
+            query.Offset = offset;
+            return WithQuery(query);
+        }
+
+        /// <summary>
+        /// Creates and returns a new query that starts at the provided fields relative to the order of the
+        /// query. The order of the field values must match the order of the order-by clauses of the query.
+        /// </summary>
+        /// <remarks>
+        /// This call replaces any previously specified start position in the query.
+        /// </remarks>
+        /// <param name="fieldValues">The field values. Must not be null or empty, or have more values than query has orderings.</param>
+        /// <returns>A new query based on the current one, but with the specified start position.</returns>
+        public Query StartAt(params object[] fieldValues)
+        {
+            var query = QueryProto.Clone();
+            query.StartAt = CreateCursor(fieldValues, true);
+            return WithQuery(query);
+        }
+
+        /// <summary>
+        /// Creates and returns a new query that starts after the provided fields relative to the order of the
+        /// query. The order of the field values must match the order of the order-by clauses of the query.
+        /// </summary>
+        /// <remarks>
+        /// This call replaces any previously specified start position in the query.
+        /// </remarks>
+        /// <param name="fieldValues">The field values. Must not be null or empty, or have more values than query has orderings.</param>
+        /// <returns>A new query based on the current one, but with the specified start position.</returns>
+        public Query StartAfter(params object[] fieldValues)
+        {
+            var query = QueryProto.Clone();
+            query.StartAt = CreateCursor(fieldValues, false);
+            return WithQuery(query);
+        }
+
+        /// <summary>
+        /// Creates and returns a new query that ends before the provided fields relative to the order of the
+        /// query. The order of the field values must match the order of the order-by clauses of the query.
+        /// </summary>
+        /// <remarks>
+        /// This call replaces any previously specified end position in the query.
+        /// </remarks>
+        /// <param name="fieldValues">The field values. Must not be null or empty, or have more values than query has orderings.</param>
+        /// <returns>A new query based on the current one, but with the specified end position.</returns>
+        public Query EndBefore(params object[] fieldValues)
+        {
+            var query = QueryProto.Clone();
+            query.EndAt = CreateCursor(fieldValues, true);
+            return WithQuery(query);
+        }
+
+        /// <summary>
+        /// Creates and returns a new query that ends at the provided fields relative to the order of the
+        /// query. The order of the field values must match the order of the order-by clauses of the query.
+        /// </summary>
+        /// <remarks>
+        /// This call replaces any previously specified end position in the query.
+        /// </remarks>
+        /// <param name="fieldValues">The field values. Must not be null or empty, or have more values than query has orderings.</param>
+        /// <returns>A new query based on the current one, but with the specified end position.</returns>
+        public Query EndAt(params object[] fieldValues)
+        {
+            var query = QueryProto.Clone();
+            query.EndAt = CreateCursor(fieldValues, false);
+            return WithQuery(query);
+        }
+
+        private Cursor CreateCursor(object[] fieldValues, bool before)
+        {
+            GaxPreconditions.CheckNotNull(fieldValues, nameof(fieldValues));
+            GaxPreconditions.CheckArgument(fieldValues.Length != 0, nameof(fieldValues), "Cannot specify an empty set of values for a start/end query cursor.");
+            GaxPreconditions.CheckArgument(
+                fieldValues.Length <= QueryProto.OrderBy.Count,
+                nameof(fieldValues),
+                "Too many cursor values specified. The specified values must match the ordering constraints of the query. {0} specified for a query with {1} ordering constraints.",
+                fieldValues.Length, QueryProto.OrderBy.Count);
+
+            return new Cursor { Before = before, Values = { fieldValues.Select(ValueSerializer.Serialize) } };
+        }
+
+        private static FieldPath[] ConvertFieldPaths(string[] fieldPaths)
+        {
+            GaxPreconditions.CheckNotNull(fieldPaths, nameof(fieldPaths));
+            // Note: if a null or empty element is passed in, we'll currently throw an exception from FieldPath.FromDotSeparatedString.
+            // Not sure whether it's worth reimplementing the checks - and we wouldn't want to do *all* validation...
+            return fieldPaths.Select(FieldPath.FromDotSeparatedString).ToArray();
+        }
+
+        private Query WithFilter(Filter filter)
+        {
+            var query = QueryProto.Clone();
+            if (query.Where == null)
+            {
+                query.Where = filter;
+            }
+            else if (query.Where.FilterTypeCase == Filter.FilterTypeOneofCase.CompositeFilter)
+            {
+                query.Where.CompositeFilter.Filters.Add(filter);
+            }
+            else
+            {
+                query.Where = new Filter { CompositeFilter = new CompositeFilter { Op = CompositeFilter.Types.Operator.And, Filters = { query.Where, filter } } };
+            }
+            return WithQuery(query);
+        }
+
+        private Query WithQuery(StructuredQuery query) => new Query(Database, query, ParentPath);
+
+        /// <summary>
+        /// Asynchronously takes a snapshot of all documents matching the query.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token for the operation.</param>
+        /// <returns>A snapshot of documents matching the query.</returns>
+        public Task<QuerySnapshot> SnapshotAsync(CancellationToken cancellationToken = default) => SnapshotAsync(null, cancellationToken);
+
+        internal async Task<QuerySnapshot> SnapshotAsync(ByteString transactionId, CancellationToken cancellationToken)
+        {
+            var responses = StreamResponsesAsync(transactionId, cancellationToken);
+            Timestamp? readTime = null;
+            List<DocumentSnapshot> snapshots = new List<DocumentSnapshot>();
+            await responses.ForEachAsync(response =>
+            {
+                if (response.Document != null)
+                {
+                    snapshots.Add(DocumentSnapshot.ForDocument(Database, response.Document, Timestamp.FromProto(response.ReadTime)));
+                }
+                if (readTime == null && response.ReadTime != null)
+                {
+                    readTime = Timestamp.FromProto(response.ReadTime);
+                }
+            }, cancellationToken).ConfigureAwait(false);
+
+            GaxPreconditions.CheckState(readTime != null, "The stream returned from RunQuery did not provide a read timestamp.");
+
+            return new QuerySnapshot(this, snapshots.AsReadOnly(), readTime.Value);
+        }
+
+        /// <summary>
+        /// Returns an asynchronous sequence of snapshots matching the query.
+        /// </summary>
+        /// <remarks>
+        /// Each time you iterate over the sequence, a new query will be performed.
+        /// </remarks>
+        /// <param name="cancellationToken">A cancellation token for the operation.</param>
+        /// <returns>An asynchronous sequence of document snapshots matching the query.</returns>
+        public IAsyncEnumerable<DocumentSnapshot> StreamAsync(CancellationToken cancellationToken = default) => StreamAsync(null, cancellationToken);
+
+        internal IAsyncEnumerable<DocumentSnapshot> StreamAsync(ByteString transactionId, CancellationToken cancellationToken) =>
+             StreamResponsesAsync(transactionId, cancellationToken)
+                .Where(resp => resp.Document != null)
+                .Select(resp => DocumentSnapshot.ForDocument(Database, resp.Document, Timestamp.FromProto(resp.ReadTime)));
+
+        private IAsyncEnumerable<RunQueryResponse> StreamResponsesAsync(ByteString transactionId, CancellationToken cancellationToken)
+        {
+            var request = new RunQueryRequest { StructuredQuery = QueryProto, Parent = ParentPath };
+            if (transactionId != null)
+            {
+                request.Transaction = transactionId;
+            }
+            Func<CancellationToken, IAsyncEnumerator<RunQueryResponse>> streamProvider = token =>
+            {
+                var settings = CallSettings.FromCancellationToken(cancellationToken);
+                return Database.Client.RunQuery(request, settings).ResponseStream;
+            };
+            return AsyncEnumerable
+                .CreateEnumerable(() => GrpcWorkaround.CreateCancellationWrapper(streamProvider, cancellationToken));
         }
     }
 }

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/QueryOperator.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/QueryOperator.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Firestore.Data
+{
+    /// <summary>
+    /// Operators for use in queries.
+    /// </summary>
+    public enum QueryOperator
+    {
+        /// <summary>
+        /// Requires that the specified field has a value equal to the one in the filter.
+        /// </summary>
+        Equal,
+
+        /// <summary>
+        /// Requires that the specified field has a value less than the one in the filter.
+        /// </summary>
+        LessThan,
+
+        /// <summary>
+        /// Requires that the specified field has a value less than or equal to the one in the filter.
+        /// </summary>
+        LessThanOrEqual,
+
+        /// <summary>
+        /// Requires that the specified field has a value greater than the one in the filter.
+        /// </summary>
+        GreaterThan,
+
+        /// <summary>
+        /// Requires that the specified field has a value greater than or equal to the one in the filter.
+        /// </summary>
+        GreaterThanOrEqual
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/QuerySnapshot.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/QuerySnapshot.cs
@@ -1,0 +1,45 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System.Collections.Generic;
+
+namespace Google.Cloud.Firestore.Data
+{
+    /// <summary>
+    /// An immutable snapshot of complete query results.
+    /// </summary>
+    public class QuerySnapshot
+    {
+        internal QuerySnapshot(Query query, IReadOnlyList<DocumentSnapshot> documents, Timestamp readTime)
+        {
+            Query = query;
+            Documents = documents;
+            ReadTime = readTime;
+        }
+
+        /// <summary>
+        /// The query producing this snapshot.
+        /// </summary>
+        public Query Query { get; }
+
+        /// <summary>
+        /// The time at which the snapshot was read.
+        /// </summary>
+        public Timestamp ReadTime { get; }
+
+        /// <summary>
+        /// The documents in the snapshot.
+        /// </summary>
+        public IReadOnlyList<DocumentSnapshot> Documents { get; }
+    }
+}


### PR DESCRIPTION
The unit tests give 100% coverage, but it's crucial to have
integration tests too.

Note that unlike Java, we *don't* default Select() to __name__,
but it's easy to call Select(FieldPath.DocumentId).

I haven't investigated filtering by DocumentId yet - have added a
TODO in the integration tests for that.