### PR TITLE
BigtableByteString wrapper type

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableByteStringTest.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableByteStringTest.cs
@@ -39,7 +39,9 @@ namespace Google.Cloud.Bigtable.V2.Tests
             var unequal = new[]
             {
                 new BigtableByteString(0),
-                new BigtableByteString(0L)
+                new BigtableByteString(0L),
+                new BigtableByteString("a"),
+                new BigtableByteString(ByteString.CopyFrom(1, 2, 3))
             };
             ComparisonTester.AssertEqual(control, equal, unequal);
             ComparisonTester.AssertEqualityOperators(control, equal, unequal);
@@ -144,13 +146,13 @@ namespace Google.Cloud.Bigtable.V2.Tests
         }
 
         [Theory]
-        [InlineData("BigtableByteString: Length=0; UTF-8 String=")]
+        [InlineData("BigtableByteString: Length=0; Hex=")]
         [InlineData("BigtableByteString: Length=6; Hex=00 01 02 03 0A 10", 0, 1, 2, 3, 10, 16)]
         [InlineData("BigtableByteString: Length=32; Hex=00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14 15 16 17 18 19 1A 1B 1C 1D 1E 1F",
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31)]
         [InlineData("BigtableByteString: Length=33; Hex (first 32 bytes only)=00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14 15 16 17 18 19 1A 1B 1C 1D 1E 1F",
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32)]
-        [InlineData("BigtableByteString: Length=8; UTF-8 String=Bigtable", 66, 105, 103, 116, 97, 98, 108, 101)]
+        [InlineData("BigtableByteString: Length=8; Hex=42 69 67 74 61 62 6C 65", 66, 105, 103, 116, 97, 98, 108, 101)]
         public void Formatting(string expectedText, params int[] data)
         {
             // xUnit isn't happy if the parameter type is actually byte[].

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableByteStringTest.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableByteStringTest.cs
@@ -1,0 +1,161 @@
+﻿// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Protobuf;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Google.Cloud.Bigtable.V2.Tests
+{
+    public class BigtableByteStringTest
+    {
+        [Fact]
+        public void EmptyString()
+        {
+            BigtableByteString control = default;
+            var equal = new[]
+            {
+                new BigtableByteString((string)null),
+                new BigtableByteString((byte[])null),
+                new BigtableByteString((ByteString)null),
+                new BigtableByteString(""),
+                new BigtableByteString(new byte[0]),
+                new BigtableByteString(ByteString.Empty)
+            };
+            var unequal = new[]
+            {
+                new BigtableByteString(0),
+                new BigtableByteString(0L)
+            };
+            ComparisonTester.AssertEqual(control, equal, unequal);
+            ComparisonTester.AssertEqualityOperators(control, equal, unequal);
+        }
+
+        [Fact]
+        public void Comparisons()
+        {
+            var control = new BigtableByteString(128);
+            var less = new[]
+            {
+                new BigtableByteString(),
+                new BigtableByteString(0),
+                new BigtableByteString(127),
+                new BigtableByteString(127, 1)
+            };
+            var equal = new[]
+            {
+                new BigtableByteString(128)
+            };
+            var greater = new[]
+            {
+                new BigtableByteString(128, 1),
+                new BigtableByteString(129)
+            };
+            ComparisonTester.AssertCompare(control, less, equal, greater);
+            ComparisonTester.AssertCompareOperators(control, less, equal, greater);
+        }
+
+        [Fact]
+        public void Properties()
+        {
+            var byteString = new BigtableByteString(1, 2, 3, 4, 5);
+            Assert.Equal(ByteString.CopyFrom(1, 2, 3, 4, 5), byteString.Value);
+            Assert.Equal(5, byteString.Length);
+            Assert.Equal(2, byteString[1]);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(new byte[0])]
+        [InlineData(new byte[] { 1, 2, 3 }, 1, 2, 3)]
+        public void ConversionsBytes(byte[] value, params int[] data)
+        {
+            BigtableByteString byteString = value;
+
+            var expected = new BigtableByteString(data.Select(x => (byte)x).ToArray());
+            Assert.Equal(expected, byteString);
+
+            var roundTrip = (byte[])byteString;
+            Assert.Equal(value ?? new byte[0], roundTrip);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(new byte[0])]
+        [InlineData(new byte[] { 1, 2, 3 }, 1, 2, 3)]
+        public void ConversionsByteString(byte[] bytes, params int[] data)
+        {
+            var value = bytes == null ? null : ByteString.CopyFrom(bytes);
+            BigtableByteString byteString = value;
+
+            var expected = new BigtableByteString(data.Select(x => (byte)x).ToArray());
+            Assert.Equal(expected, byteString);
+
+            ByteString roundTrip = byteString;
+            Assert.Equal(value ?? ByteString.Empty, roundTrip);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("abc", 97, 98, 99)]
+        [InlineData("\t\0\n", 9, 0, 10)]
+        public void ConversionsString(string value, params int[] data)
+        {
+            BigtableByteString byteString = value;
+
+            var expected = new BigtableByteString(data.Select(x => (byte)x).ToArray());
+            Assert.Equal(expected, byteString);
+
+            var roundTrip = (string)byteString;
+            Assert.Equal(value ?? "", roundTrip);
+        }
+
+        [Theory]
+        [InlineData(0,
+            0, 0, 0, 0, 0, 0, 0, 0)]
+        [InlineData(1,
+            0, 0, 0, 0, 0, 0, 0, 1)]
+        [InlineData(0x01_23_45_67_89_AB_CD_EF,
+            0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF)]
+        public void ConversionsLong(long value, params int[] data)
+        {
+            BigtableByteString byteString = value;
+
+            var expected = new BigtableByteString(data.Select(x => (byte)x).ToArray());
+            Assert.Equal(expected, byteString);
+
+            var roundTrip = (long)byteString;
+            Assert.Equal(value, roundTrip);
+        }
+
+        [Theory]
+        [InlineData("BigtableByteString: Length=0; UTF-8 String=")]
+        [InlineData("BigtableByteString: Length=6; Hex=00 01 02 03 0A 10", 0, 1, 2, 3, 10, 16)]
+        [InlineData("BigtableByteString: Length=32; Hex=00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14 15 16 17 18 19 1A 1B 1C 1D 1E 1F",
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31)]
+        [InlineData("BigtableByteString: Length=33; Hex (first 32 bytes only)=00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14 15 16 17 18 19 1A 1B 1C 1D 1E 1F",
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32)]
+        [InlineData("BigtableByteString: Length=8; UTF-8 String=Bigtable", 66, 105, 103, 116, 97, 98, 108, 101)]
+        public void Formatting(string expectedText, params int[] data)
+        {
+            // xUnit isn't happy if the parameter type is actually byte[].
+            var byteString = new BigtableByteString(data.Select(x => (byte)x).ToArray());
+            Assert.Equal(expectedText, byteString.ToString());
+        }
+    }
+}

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/ComparisonTester.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/ComparisonTester.cs
@@ -1,0 +1,176 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Google.Cloud.Bigtable.V2.Tests
+{
+    internal static class ComparisonTester
+    {
+        internal static void AssertEqual<T>(T control, T[] equal, T[] unequal) where T : IEquatable<T>
+        {
+            foreach (var candidate in new[] { control }.Concat(equal)) // Check that control equals itself too
+            {
+                Assert.True(control.Equals(candidate));
+                Assert.True(candidate.Equals(control));
+                Assert.True(control.Equals((object) candidate));
+                Assert.True(candidate.Equals((object) control));
+                Assert.Equal(control.GetHashCode(), candidate.GetHashCode());
+            }
+
+            foreach (var candidate in unequal)
+            {
+                Assert.False(control.Equals(candidate));
+                Assert.False(candidate.Equals(control));
+                Assert.False(control.Equals((object) candidate));
+                Assert.False(candidate.Equals((object) control));
+                // While this isn't actually required, if it fails it would usually be due to a bug.
+                Assert.NotEqual(control.GetHashCode(), candidate.GetHashCode());
+            }
+
+            Assert.False(control.Equals(null));
+
+            if (default(T) == null)
+            {
+                Assert.False(control.Equals(default(T)));
+            }
+        }
+
+        internal static void AssertEqualityOperators<T>(T control, T[] equal, T[] unequal)
+        {
+            var typeInfo = typeof(T).GetTypeInfo();
+            var equalityMethodInfo = typeInfo.GetMethod("op_Equality", new[] { typeof(T), typeof(T) });
+            var inequalityMethodInfo = typeInfo.GetMethod("op_Inequality", new[] { typeof(T), typeof(T) });
+
+            Func<T, T, bool> equality = (lhs, rhs) => (bool) equalityMethodInfo.Invoke(null, new object[] { lhs, rhs });
+            Func<T, T, bool> inequality = (lhs, rhs) => (bool) inequalityMethodInfo.Invoke(null, new object[] { lhs, rhs });
+
+            foreach (var candidate in new[] { control }.Concat(equal)) // Check that control equals itself too
+            {
+                Assert.True(equality(control, candidate));
+                Assert.True(equality(candidate, control));
+                Assert.False(inequality(control, candidate));
+                Assert.False(inequality(candidate, control));
+            }
+
+            foreach (var candidate in unequal)
+            {
+                Assert.False(equality(control, candidate));
+                Assert.False(equality(candidate, control));
+                Assert.True(inequality(control, candidate));
+                Assert.True(inequality(candidate, control));
+            }
+        }
+
+        internal static void AssertCompare<T>(
+            T control, T[] less, T[] equal, T[] greater) where T : IComparable, IComparable<T>
+        {
+            foreach (var candidate in new[] { control }.Concat(equal)) // Check that control equals itself too
+            {
+                Assert.Equal(0, control.CompareTo(candidate));
+                Assert.Equal(0, candidate.CompareTo(control));
+                Assert.Equal(0, control.CompareTo((object) candidate));
+                Assert.Equal(0, candidate.CompareTo((object) control));
+            }
+
+            foreach (var candidate in less)
+            {
+                Assert.True(control.CompareTo(candidate) > 0);
+                Assert.True(candidate.CompareTo(control) < 0);
+                Assert.True(control.CompareTo((object)candidate) > 0);
+                Assert.True(candidate.CompareTo((object)control) < 0);
+            }
+
+            foreach (var candidate in greater)
+            {
+                Assert.True(control.CompareTo(candidate) < 0);
+                Assert.True(candidate.CompareTo(control) > 0);
+                Assert.True(control.CompareTo((object)candidate) < 0);
+                Assert.True(candidate.CompareTo((object)control) > 0);
+            }
+
+            Assert.Throws<ArgumentException>(() => control.CompareTo(null));
+        }
+
+        internal static void AssertCompareOperators<T>(
+            T control, T[] less, T[] equal, T[] greater)
+        {
+            var typeInfo = typeof(T).GetTypeInfo();
+            var lessThanMethodInfo = typeInfo.GetMethod("op_LessThan", new[] { typeof(T), typeof(T) });
+            var lessThanOrEqualMethodInfo = typeInfo.GetMethod("op_LessThanOrEqual", new[] { typeof(T), typeof(T) });
+            var equalityMethodInfo = typeInfo.GetMethod("op_Equality", new[] { typeof(T), typeof(T) });
+            var inequalityMethodInfo = typeInfo.GetMethod("op_Inequality", new[] { typeof(T), typeof(T) });
+            var greaterThanOrEqualMethodInfo = typeInfo.GetMethod("op_GreaterThanOrEqual", new[] { typeof(T), typeof(T) });
+            var greaterThanMethodInfo = typeInfo.GetMethod("op_GreaterThan", new[] { typeof(T), typeof(T) });
+
+            Func<T, T, bool> lessThan = (lhs, rhs) => (bool)lessThanMethodInfo.Invoke(null, new object[] { lhs, rhs });
+            Func<T, T, bool> lessThanOrEqual = (lhs, rhs) => (bool)lessThanOrEqualMethodInfo.Invoke(null, new object[] { lhs, rhs });
+            Func<T, T, bool> equality = (lhs, rhs) => (bool) equalityMethodInfo.Invoke(null, new object[] { lhs, rhs });
+            Func<T, T, bool> inequality = (lhs, rhs) => (bool) inequalityMethodInfo.Invoke(null, new object[] { lhs, rhs });
+            Func<T, T, bool> greaterThanOrEqual = (lhs, rhs) => (bool)greaterThanOrEqualMethodInfo.Invoke(null, new object[] { lhs, rhs });
+            Func<T, T, bool> greaterThan = (lhs, rhs) => (bool)greaterThanMethodInfo.Invoke(null, new object[] { lhs, rhs });
+
+            foreach (var candidate in less)
+            {
+                Assert.False(lessThan(control, candidate));
+                Assert.True(lessThan(candidate, control));
+                Assert.False(lessThanOrEqual(control, candidate));
+                Assert.True(lessThanOrEqual(candidate, control));
+                Assert.False(equality(control, candidate));
+                Assert.False(equality(candidate, control));
+                Assert.True(inequality(control, candidate));
+                Assert.True(inequality(candidate, control));
+                Assert.True(greaterThanOrEqual(control, candidate));
+                Assert.False(greaterThanOrEqual(candidate, control));
+                Assert.True(greaterThan(control, candidate));
+                Assert.False(greaterThan(candidate, control));
+            }
+
+            foreach (var candidate in new[] { control }.Concat(equal)) // Check that control equals itself too
+            {
+                Assert.False(lessThan(control, candidate));
+                Assert.False(lessThan(candidate, control));
+                Assert.True(lessThanOrEqual(control, candidate));
+                Assert.True(lessThanOrEqual(candidate, control));
+                Assert.True(equality(control, candidate));
+                Assert.True(equality(candidate, control));
+                Assert.False(inequality(control, candidate));
+                Assert.False(inequality(candidate, control));
+                Assert.True(greaterThanOrEqual(control, candidate));
+                Assert.True(greaterThanOrEqual(candidate, control));
+                Assert.False(greaterThan(control, candidate));
+                Assert.False(greaterThan(candidate, control));
+            }
+
+            foreach (var candidate in greater)
+            {
+                Assert.True(lessThan(control, candidate));
+                Assert.False(lessThan(candidate, control));
+                Assert.True(lessThanOrEqual(control, candidate));
+                Assert.False(lessThanOrEqual(candidate, control));
+                Assert.False(equality(control, candidate));
+                Assert.False(equality(candidate, control));
+                Assert.True(inequality(control, candidate));
+                Assert.True(inequality(candidate, control));
+                Assert.False(greaterThanOrEqual(control, candidate));
+                Assert.True(greaterThanOrEqual(candidate, control));
+                Assert.False(greaterThan(control, candidate));
+                Assert.True(greaterThan(candidate, control));
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Google.Cloud.Bigtable.V2.Tests.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Google.Cloud.Bigtable.V2.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Features>IOperation</Features>
+    <IsPackable>false</IsPackable>
+    <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="2.1.0" />
+    <ProjectReference Include="..\Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj" />
+    <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="xunit" Version="2.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
+    <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/coverage.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -f net452 -c Release</TargetArguments>
+  <Filters>
+    <IncludeFilters>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Bigtable.V2</ModuleMask>
+      </FilterEntry>
+    </IncludeFilters>
+  </Filters>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Bigtable.V2.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.sln
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.sln
@@ -1,12 +1,14 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.14
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Bigtable.V2", "Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj", "{4D4B5FB5-FC91-4E89-9A6F-4577671BE53E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Bigtable.V2.Snippets", "Google.Cloud.Bigtable.V2.Snippets\Google.Cloud.Bigtable.V2.Snippets.csproj", "{EBEEF3F2-005D-43DE-B676-BBDC8682FE79}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{59850771-DC4D-4523-AA6E-4575764855CB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Bigtable.V2.Tests", "Google.Cloud.Bigtable.V2.Tests\Google.Cloud.Bigtable.V2.Tests.csproj", "{C15DE6EB-CC28-4E20-B04B-290D17A789E2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -54,8 +56,23 @@ Global
 		{59850771-DC4D-4523-AA6E-4575764855CB}.Release|x64.Build.0 = Release|Any CPU
 		{59850771-DC4D-4523-AA6E-4575764855CB}.Release|x86.ActiveCfg = Release|Any CPU
 		{59850771-DC4D-4523-AA6E-4575764855CB}.Release|x86.Build.0 = Release|Any CPU
+		{C15DE6EB-CC28-4E20-B04B-290D17A789E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C15DE6EB-CC28-4E20-B04B-290D17A789E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C15DE6EB-CC28-4E20-B04B-290D17A789E2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C15DE6EB-CC28-4E20-B04B-290D17A789E2}.Debug|x64.Build.0 = Debug|Any CPU
+		{C15DE6EB-CC28-4E20-B04B-290D17A789E2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C15DE6EB-CC28-4E20-B04B-290D17A789E2}.Debug|x86.Build.0 = Debug|Any CPU
+		{C15DE6EB-CC28-4E20-B04B-290D17A789E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C15DE6EB-CC28-4E20-B04B-290D17A789E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C15DE6EB-CC28-4E20-B04B-290D17A789E2}.Release|x64.ActiveCfg = Release|Any CPU
+		{C15DE6EB-CC28-4E20-B04B-290D17A789E2}.Release|x64.Build.0 = Release|Any CPU
+		{C15DE6EB-CC28-4E20-B04B-290D17A789E2}.Release|x86.ActiveCfg = Release|Any CPU
+		{C15DE6EB-CC28-4E20-B04B-290D17A789E2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {90F53F76-F60C-4B8E-802B-694BCDF16973}
 	EndGlobalSection
 EndGlobal

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableByteString.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableByteString.cs
@@ -1,0 +1,301 @@
+﻿// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Protobuf;
+using System;
+using System.Text;
+
+namespace Google.Cloud.Bigtable.V2
+{
+    /// <summary>
+    /// The bytes string which can be used for a row key, column qualifier, or cell value.
+    /// </summary>
+    public struct BigtableByteString : IComparable, IComparable<BigtableByteString>, IEquatable<BigtableByteString>
+    {
+        private readonly ByteString _value;
+
+        /// <summary>
+        /// Creates a <see cref="BigtableByteString"/> value from the UTF-8 encoding of a string.
+        /// </summary>
+        /// <param name="valueAsUtf8">
+        /// The value whose UTF-8 representation should be used to initialize the byte string.
+        /// May be null in which case the empty byte string is used.
+        /// </param>
+        public BigtableByteString(string valueAsUtf8)
+        {
+            _value = valueAsUtf8 != null ? ByteString.CopyFromUtf8(valueAsUtf8) : ByteString.Empty;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="BigtableByteString"/> value from the big-endian encoding of a signed 64-bit value.
+        /// </summary>
+        /// <param name="value">The 64-bit value which should be used to initialize the byte string.</param>
+        public BigtableByteString(long value)
+        {
+            var bytes = BitConverter.GetBytes(value);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
+            _value = ByteString.CopyFrom(bytes);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="BigtableByteString"/> value from an array of bytes.
+        /// </summary>
+        /// <param name="value">
+        /// The bytes making up the byte string. May be null in which case the empty byte string is used.
+        /// </param>
+        public BigtableByteString(params byte[] value)
+        {
+            _value = value != null ? ByteString.CopyFrom(value) : ByteString.Empty;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="BigtableByteString"/> value from a byte string.
+        /// </summary>
+        /// <param name="value">
+        /// The byte string making up the value. May be null in which case the empty byte string is used.
+        /// </param>
+        public BigtableByteString(ByteString value)
+        {
+            _value = value ?? ByteString.Empty;
+        }
+
+        /// <summary>
+        /// Gets the number of bytes in the byte string.
+        /// </summary>
+        public int Length => Value.Length;
+
+        /// <summary>
+        /// Gets the underlying byte string.
+        /// </summary>
+        public ByteString Value => _value ?? ByteString.Empty;
+
+        /// <summary>
+        /// Returns the byte at index <paramref name="index"/>.
+        /// </summary>
+        /// <param name="index">
+        /// The index in the byte string to return. Must be greater than or equal to 0, and less than <see cref="Length"/>.
+        /// </param>
+        /// <returns>The byte at index <paramref name="index"/>.</returns>
+        public byte this[int index] => Value[index];
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => obj is BigtableByteString other && Equals(other);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => Value.GetHashCode();
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            var value = Value;
+            var builder = new StringBuilder($"{nameof(BigtableByteString)}: Length={value.Length}; ");
+            int initialLength = builder.Length;
+
+            // For short byte strings which can be interpreted as simple strings, display them that way.
+            if (value.Length <= 32)
+            {
+                // TODO: See if there's something better we can do here
+                builder.Append($"UTF-8 String=");
+                for (int i = 0; i < Math.Min(value.Length, 32); i++)
+                {
+                    byte b = value[i];
+                    if (b < 32 || 127 < b)
+                    {
+                        builder.Length = initialLength;
+                        break;
+                    }
+
+                    builder.Append((char)b);
+                }
+            }
+
+            if (builder.Length == initialLength)
+            {
+                builder.Append(value.Length > 32 ? "Hex (first 32 bytes only)=" : "Hex=");
+                for (int i = 0; i < Math.Min(value.Length, 32); i++)
+                {
+                    if (i != 0)
+                    {
+                        builder.Append(" ");
+                    }
+                    builder.Append(value[i].ToString("X2"));
+                }
+            }
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Compares two <see cref="BigtableByteString"/> values lexicographically.
+        /// </summary>
+        /// <param name="x">Left value to compare</param>
+        /// <param name="y">Right value to compare</param>
+        /// <returns>true if <paramref name="x"/> is less than <paramref name="y"/>; otherwise false.</returns>
+        public static int Compare(BigtableByteString x, BigtableByteString y)
+        {
+            ByteString xVal = x.Value;
+            ByteString yVal = y.Value;
+            for (int i = 0, length = Math.Min(xVal.Length, yVal.Length); i < length; ++i)
+            {
+                int result = xVal[i].CompareTo(yVal[i]);
+                if (result != 0)
+                {
+                    return result;
+                }
+            }
+
+            return xVal.Length.CompareTo(yVal.Length);
+        }
+
+        /// <inheritdoc />
+        public int CompareTo(object obj)
+        {
+            if (obj is BigtableByteString other)
+            {
+                return CompareTo(other);
+            }
+            throw new ArgumentException($"The specified object cannot be compared with {nameof(BigtableByteString)}", nameof(obj));
+        }
+
+        /// <inheritdoc />
+        public int CompareTo(BigtableByteString other) => Compare(this, other);
+
+        /// <inheritdoc />
+        public bool Equals(BigtableByteString other) => Length == other.Length && Compare(this, other) == 0;
+
+        /// <summary>
+        /// Operator overload to compare two <see cref="BigtableByteString"/> values.
+        /// </summary>
+        /// <param name="x">Left value to compare</param>
+        /// <param name="y">Right value to compare</param>
+        /// <returns>true if <paramref name="x"/> is less than <paramref name="y"/>; otherwise false.</returns>
+        public static bool operator <(BigtableByteString x, BigtableByteString y) => Compare(x, y) < 0;
+
+        /// <summary>
+        /// Operator overload to compare two <see cref="BigtableByteString"/> values.
+        /// </summary>
+        /// <param name="x">Left value to compare</param>
+        /// <param name="y">Right value to compare</param>
+        /// <returns>true if <paramref name="x"/> is less than or equal <paramref name="y"/>; otherwise false.</returns>
+        public static bool operator <=(BigtableByteString x, BigtableByteString y) => Compare(x, y) <= 0;
+
+        /// <summary>
+        /// Operator overload to compare two <see cref="BigtableByteString"/> values for equality.
+        /// </summary>
+        /// <param name="x">Left value to compare</param>
+        /// <param name="y">Right value to compare</param>
+        /// <returns>true if <paramref name="x"/> is equal to <paramref name="y"/>; otherwise false.</returns>
+        public static bool operator ==(BigtableByteString x, BigtableByteString y) => x.Equals(y);
+
+        /// <summary>
+        /// Operator overload to compare two <see cref="BigtableByteString"/> values for inequality.
+        /// </summary>
+        /// <param name="x">Left value to compare</param>
+        /// <param name="y">Right value to compare</param>
+        /// <returns>true if <paramref name="x"/> is not equal to <paramref name="y"/>; otherwise false.</returns>
+        public static bool operator !=(BigtableByteString x, BigtableByteString y) => !x.Equals(y);
+
+        /// <summary>
+        /// Operator overload to compare two <see cref="BigtableByteString"/> values.
+        /// </summary>
+        /// <param name="x">Left value to compare</param>
+        /// <param name="y">Right value to compare</param>
+        /// <returns>true if <paramref name="x"/> is greater than or equal <paramref name="y"/>; otherwise false.</returns>
+        public static bool operator >=(BigtableByteString x, BigtableByteString y) => Compare(x, y) >= 0;
+
+        /// <summary>
+        /// Operator overload to compare two <see cref="BigtableByteString"/> values.
+        /// </summary>
+        /// <param name="x">Left value to compare</param>
+        /// <param name="y">Right value to compare</param>
+        /// <returns>true if <paramref name="x"/> is greater than <paramref name="y"/>; otherwise false.</returns>
+        public static bool operator >(BigtableByteString x, BigtableByteString y) => Compare(x, y) > 0;
+
+        /// <summary>
+        /// Converts the UTF-8 encoding of a string to a <see cref="BigtableByteString"/> value.
+        /// </summary>
+        /// <param name="valueAsUtf8">
+        /// The value whose UTF-8 representation should be used to initialize the byte string.
+        /// May be null in which case the empty byte string is used.
+        /// </param>
+        public static implicit operator BigtableByteString(string valueAsUtf8) => new BigtableByteString(valueAsUtf8);
+
+        /// <summary>
+        /// Converts the <see cref="BigtableByteString"/> value to a string assuming it is UTF-8 encoded.
+        /// </summary>
+        /// <param name="value">
+        /// The BigtableByteString value to convert.
+        /// </param>
+        public static explicit operator string(BigtableByteString value) => value.Value.ToStringUtf8();
+
+        /// <summary>
+        /// Converts the big-endian encoding of a signed 64-bit value to a <see cref="BigtableByteString"/> value.
+        /// </summary>
+        /// <param name="value">
+        /// The 64-bit value which should be used to initialize the byte string.
+        /// </param>
+        public static implicit operator BigtableByteString(long value) => new BigtableByteString(value);
+
+        /// <summary>
+        /// Converts the <see cref="BigtableByteString"/> value to its a signed 64-bit value assuming it is big-endian encoded.
+        /// </summary>
+        /// <param name="value">
+        /// The BigtableByteString value to convert.
+        /// </param>
+        public static explicit operator long(BigtableByteString value)
+        {
+            var bytes = value.Value.ToByteArray();
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
+            return BitConverter.ToInt64(bytes, 0);
+        }
+
+        /// <summary>
+        /// Converts a byte array to a <see cref="BigtableByteString"/> value.
+        /// </summary>
+        /// <param name="value">
+        /// The bytes making up the byte string. May be null in which case the empty byte string is used.
+        /// </param>
+        public static implicit operator BigtableByteString(byte[] value) => new BigtableByteString(value);
+
+        /// <summary>
+        /// Converts the <see cref="BigtableByteString"/> value to its underlying byte array.
+        /// </summary>
+        /// <param name="value">
+        /// The BigtableByteString value to convert.
+        /// </param>
+        public static explicit operator byte[] (BigtableByteString value) => value.Value.ToByteArray();
+
+        /// <summary>
+        /// Converts a byte string to a <see cref="BigtableByteString"/> value.
+        /// </summary>
+        /// <param name="value">
+        /// The byte string making up the value. May be null in which case the empty byte string is used.
+        /// </param>
+        public static implicit operator BigtableByteString(ByteString value) => new BigtableByteString(value);
+
+        /// <summary>
+        /// Converts the <see cref="BigtableByteString"/> value to its underlying byte string.
+        /// </summary>
+        /// <param name="value">
+        /// The BigtableByteString value to convert.
+        /// </param>
+        public static implicit operator ByteString(BigtableByteString value) => value.Value;
+    }
+}

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableByteString.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableByteString.cs
@@ -20,7 +20,7 @@ using System.Text;
 namespace Google.Cloud.Bigtable.V2
 {
     /// <summary>
-    /// The bytes string which can be used for a row key, column qualifier, or cell value.
+    /// A sequence of bytes which can be used for a row key, column qualifier, or cell value.
     /// </summary>
     public struct BigtableByteString : IComparable, IComparable<BigtableByteString>, IEquatable<BigtableByteString>
     {
@@ -103,38 +103,19 @@ namespace Google.Cloud.Bigtable.V2
         public override string ToString()
         {
             var value = Value;
-            var builder = new StringBuilder($"{nameof(BigtableByteString)}: Length={value.Length}; ");
-            int initialLength = builder.Length;
-
-            // For short byte strings which can be interpreted as simple strings, display them that way.
-            if (value.Length <= 32)
-            {
-                // TODO: See if there's something better we can do here
-                builder.Append($"UTF-8 String=");
-                for (int i = 0; i < Math.Min(value.Length, 32); i++)
-                {
-                    byte b = value[i];
-                    if (b < 32 || 127 < b)
-                    {
-                        builder.Length = initialLength;
-                        break;
-                    }
-
-                    builder.Append((char)b);
-                }
+            var x = BitConverter.ToString(value.ToByteArray());
+            var builder = new StringBuilder($"{nameof(BigtableByteString)}: Length={value.Length}; Hex");
+            if (value.Length > 32) {
+                builder.Append(" (first 32 bytes only)");
             }
-
-            if (builder.Length == initialLength)
+            builder.Append('=');
+            for (int i = 0; i < Math.Min(value.Length, 32); i++)
             {
-                builder.Append(value.Length > 32 ? "Hex (first 32 bytes only)=" : "Hex=");
-                for (int i = 0; i < Math.Min(value.Length, 32); i++)
+                if (i != 0)
                 {
-                    if (i != 0)
-                    {
-                        builder.Append(" ");
-                    }
-                    builder.Append(value[i].ToString("X2"));
+                    builder.Append(" ");
                 }
+                builder.Append(value[i].ToString("X2"));
             }
             return builder.ToString();
         }


### PR DESCRIPTION
This has a few changes from #1506:
- Added a Length property
- Added an indexer
- Made the conversion from BigtableByteString to ByteString implicit (so now both directions are implicit).

@jskeet I copied your EqualityTester from Firebase to make the ComparisonTester, but on line 47 there's a test for `default(T) == null`. I believe that should be `default(T) != null`, right? I left it as you had it for now just incase I'm missing something. But if it should be changed, I'll update both places.