### PR TITLE
Add Set functionality for Firestore

### DIFF
--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/DocumentMutationTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/DocumentMutationTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -63,8 +64,106 @@ namespace Google.Cloud.Firestore.Data.IntegrationTests
             AssertSerialized(snapshot, new { Name = "Changed again", Level = 2, Score = new { CustomTime = timestamp, Value = 40 } });
         }
 
+        [Fact]
+        public async Task Set()
+        {
+            var doc = await _fixture.NonQueryCollection.AddAsync(new { Name = "Original" });
+            // Add a field
+            await doc.SetAsync(new { Score = 20 }, SetOptions.MergeAll);
+            var snapshot = await doc.SnapshotAsync();
+            AssertSerialized(snapshot, new { Name = "Original", Score = 20 });
+
+            // Update one field with "MergeAll"
+            await doc.SetAsync(new { Score = 30 }, SetOptions.MergeAll);
+            snapshot = await doc.SnapshotAsync();
+            AssertSerialized(snapshot, new { Name = "Original", Score = 30 });
+
+            // Update one field with "MergeFields"
+            await doc.SetAsync(new { Name = "Ignored", Score = 30 }, SetOptions.MergeFields("Score"));
+            snapshot = await doc.SnapshotAsync();
+            AssertSerialized(snapshot, new { Name = "Original", Score = 30 });
+
+            // Overwrite
+            await doc.SetAsync(new { Text = "Different" });
+            snapshot = await doc.SnapshotAsync();
+            AssertSerialized(snapshot, new { Text = "Different" });
+        }
+
+        /// <summary>
+        /// Execute a sequence of operations as per the specification, validating the result at each step.
+        /// </summary>
+        [Fact]
+        public async Task SpecSequence()
+        {
+            var collection = _fixture.NonQueryCollection;
+            var docRef = collection.Document(null);
+
+            // Step 1: Create
+            await docRef.CreateAsync(Map(("a.b", Map("c.d", 1)), ("e", 1)));
+            var snapshot = await docRef.SnapshotAsync();
+            AssertSerialized(snapshot, Map(("a.b", Map("c.d", 1L)), ("e", 1L)));
+
+            // Step 2: Set (overwrite)
+            await docRef.SetAsync(Map(("a.b", Map("f.g", 2)), ("h", Map("g", 2))));
+            snapshot = await docRef.SnapshotAsync();
+            AssertSerialized(snapshot, Map(("a.b", Map("f.g", 2L)), ("h", Map("g", 2L))));
+
+            // Step 3: Set (merge)
+            await docRef.SetAsync(Map("h", Map(("g", 3), ("f", 3))), SetOptions.MergeAll);
+            snapshot = await docRef.SnapshotAsync();
+            AssertSerialized(snapshot, Map(("a.b", Map("f.g", 2L)), ("h", Map(("g", 3L), ("f", 3L)))));
+
+            // Step 4: Set (update path specified; only h.g is updated, not h.f)
+            await docRef.SetAsync(Map("h", Map(("g", 4), ("f", 4))), SetOptions.MergeFields("h.g"));
+            snapshot = await docRef.SnapshotAsync();
+            AssertSerialized(snapshot, Map(("a.b", Map("f.g", 2L)), ("h", Map(("g", 4L), ("f", 3L)))));
+
+            // Step 5: Set (update path specified; all of h is overwritten)
+            await docRef.SetAsync(Map("h", Map(("g", 5), ("f", 5))), SetOptions.MergeFields("h"));
+            snapshot = await docRef.SnapshotAsync();
+            AssertSerialized(snapshot, Map(("a.b", Map("f.g", 2L)), ("h", Map(("g", 5L), ("f", 5L)))));
+
+            // Step 6: Update
+            await docRef.UpdateAsync(new Dictionary<FieldPath, object>
+            {
+                { new FieldPath("h", "g"), Map("j.k", 6) },
+            });
+            snapshot = await docRef.SnapshotAsync();
+            AssertSerialized(snapshot, Map(("a.b", Map("f.g", 2L)), ("h", Map(("g", Map("j.k", 6L)), ("f", 5L)))));
+
+            // Step 7: Update (varargs in Java)
+            await docRef.UpdateAsync(new Dictionary<FieldPath, object>
+            {
+                { new FieldPath("a.b", "f.g"), 7 },
+                { new FieldPath("h", "m"), Map("n.o", 7) }
+            });
+            snapshot = await docRef.SnapshotAsync();
+            AssertSerialized(snapshot, Map(("a.b", Map("f.g", 7L)), ("h", Map(("g", Map("j.k", 6L)), ("f", 5L), ("m", Map("n.o", 7L))))));
+
+            // Step 8: Update (varargs in Java)
+            await docRef.UpdateAsync(new Dictionary<FieldPath, object>
+            {
+                { new FieldPath("a.b"), 8 },
+                { new FieldPath("h"), 8 },
+            });
+            snapshot = await docRef.SnapshotAsync();
+            AssertSerialized(snapshot, Map(("a.b", 8L), ("h", 8L)));
+
+            // Step 9: Delete
+            await docRef.DeleteAsync();
+            var doc = await docRef.SnapshotAsync();
+            Assert.False(doc.Exists);
+        }
+
+        // Helpers to avoid "new Dictionary<string, object>" everywhere...
+        private Dictionary<string, object> Map(string name, object value) => new Dictionary<string, object> { { name, value } };
+        private Dictionary<string, object> Map(params (string name, object value)[] fields) =>
+            fields.ToDictionary(field => field.name, field => field.value);
+
         /// <summary>
         /// Asserts that the document in snapshot is the serialized form of the expected value.
+        /// Note that the actual snapshot is the first parameter, somewhat unconventionally, as the expected value
+        /// is usually wordier in code, and works better as the final argument.
         /// </summary>
         private void AssertSerialized(DocumentSnapshot snapshot, object expectedValue)
         {

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.ApplyFieldMask.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.ApplyFieldMask.cs
@@ -1,0 +1,101 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Firestore.V1Beta1;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
+
+namespace Google.Cloud.Firestore.Data.Tests
+{
+    // Just tests for WriteBatch.ApplyFieldMask
+    public partial class WriteBatchTest
+    {
+        [Fact]
+        public void ApplyFieldMask_Simple()
+        {
+            var fields = new Dictionary<string, Value>
+            {
+                { "a", CreateValue(10) },
+                { "b", CreateValue("kept") },
+                { "c", CreateValue("removed") }
+            };
+            var mask = CreateMask("a", "b");
+            var expected = new Dictionary<FieldPath, Value>
+            {
+                { new FieldPath("a"), CreateValue(10) },
+                { new FieldPath("b"), CreateValue("kept") },
+            };
+            var actual = WriteBatch.ApplyFieldMask(fields, mask);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ApplyFieldMask_WholeMapIncluded()
+        {
+            var fields = new Dictionary<string, Value>
+            {
+                { "a", CreateMap(("b", CreateValue(10)), ("c", CreateValue("kept"))) },
+                { "d", CreateValue("removed") }
+            };
+            var mask = CreateMask("a");
+            var expected = new Dictionary<FieldPath, Value>
+            {
+                { new FieldPath("a"), CreateMap(("b", CreateValue(10)), ("c", CreateValue("kept"))) },
+            };
+            var actual = WriteBatch.ApplyFieldMask(fields, mask);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ApplyFieldMask_WholeMapAndMapField()
+        {
+            var fields = new Dictionary<string, Value>
+            {
+                { "a", CreateMap(("b", CreateValue(10)), ("c", CreateValue("kept"))) },
+                { "d", CreateValue("removed") }
+            };
+            // The a.b value is effectively redundant here, because we've already got "a".
+            var mask = CreateMask("a", "a.b");
+            var expected = new Dictionary<FieldPath, Value>
+            {
+                { new FieldPath("a"), CreateMap(("b", CreateValue(10)), ("c", CreateValue("kept"))) },
+            };
+            var actual = WriteBatch.ApplyFieldMask(fields, mask);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ApplyFieldMask_MapFieldsIncluded()
+        {
+            var fields = new Dictionary<string, Value>
+            {
+                { "a", CreateMap(("b", CreateValue(10)), ("c", CreateValue("kept")), ("d", CreateValue("removed"))) },
+                { "e", CreateValue("removed") }
+            };
+            var mask = CreateMask("a.b", "a.c");
+            var expected = new Dictionary<FieldPath, Value>
+            {
+                { new FieldPath("a", "b"), CreateValue(10) },
+                { new FieldPath("a", "c"), CreateValue("kept") },
+            };
+            var actual = WriteBatch.ApplyFieldMask(fields, mask);
+            Assert.Equal(expected, actual);
+        }
+
+        private static IEnumerable<FieldPath> CreateMask(params string[] paths) =>
+            paths.Select(FieldPath.FromDotSeparatedString);
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.ExpandObject.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.ExpandObject.cs
@@ -22,6 +22,7 @@ using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
 
 namespace Google.Cloud.Firestore.Data.Tests
 {
+    // Just tests for WriteBatch.ExpandObject
     public partial class WriteBatchTest
     {
         [Fact]
@@ -148,9 +149,6 @@ namespace Google.Cloud.Firestore.Data.Tests
             Assert.Throws<InvalidOperationException>(() => WriteBatch.ExpandObject(input));
             Assert.Throws<InvalidOperationException>(() => WriteBatch.ExpandObject(input.InReverseOrder()));
         }
-
-        private void AssertWrites(WriteBatch batch, params Write[] writes) =>
-            Assert.Equal(writes, batch.Writes);
 
         /// <summary>
         /// Dictionary that preserves insertion order. Far from production ready, but it allows us to test more robustly here.

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.ExtractDocumentMask.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.ExtractDocumentMask.cs
@@ -1,0 +1,100 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Firestore.V1Beta1;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
+
+namespace Google.Cloud.Firestore.Data.Tests
+{
+    // Just tests for WriteBatch.ExtractDocumentMask
+    public partial class WriteBatchTest
+    {
+        [Fact]
+        public void ExtractDocumentMask_Simple()
+        {
+            var fields = new Dictionary<string, Value>
+            {
+                { "a", CreateValue(10) },
+                { "b", CreateValue("text") },
+                { "c", CreateNullValue() }
+            };
+            var mask = WriteBatch.ExtractDocumentMask(fields);
+
+            AssertFieldMask(mask, "a", "b", "c");
+        }
+
+        [Fact]
+        public void ExtractDocumentMask_DottedFields()
+        {
+            var fields = new Dictionary<string, Value>
+            {
+                { "a.b", CreateValue(10) },
+                { "c.d", CreateValue("text") },
+            };
+            var mask = WriteBatch.ExtractDocumentMask(fields);
+
+            AssertFieldMask(mask, "`a.b`", "`c.d`");
+        }
+
+        [Fact]
+        public void ExtractDocumentMask_Map()
+        {
+            var fields = new Dictionary<string, Value>
+            {
+                { "a", CreateMap(("b", CreateValue(10)), ("c", CreateValue("text"))) },
+                { "d", CreateValue(10) },
+            };
+            var mask = WriteBatch.ExtractDocumentMask(fields);
+
+            AssertFieldMask(mask, "a.b", "a.c", "d");
+        }
+
+        [Fact]
+        public void ExtractDocumentMask_NestedMap()
+        {
+            var fields = new Dictionary<string, Value>
+            {
+                { "a", CreateMap(("b", CreateValue(10)), ("c", CreateMap("d", CreateValue(10)))) },
+                { "e", CreateValue(10) },
+            };
+            var mask = WriteBatch.ExtractDocumentMask(fields);
+
+            AssertFieldMask(mask, "a.b", "a.c.d", "e");
+        }
+
+        [Fact]
+        public void ExtractDocumentMask_EmptyMap()
+        {
+            var fields = new Dictionary<string, Value>
+            {
+                { "a", CreateMap(("b", CreateValue(10)), ("c", CreateMap())) },
+                { "d", CreateMap() },
+                { "e", CreateValue(10) },
+            };
+            var mask = WriteBatch.ExtractDocumentMask(fields);
+
+            AssertFieldMask(mask, "a.b", "e");
+        }
+
+        private static void AssertFieldMask(IReadOnlyList<FieldPath> mask, params string[] expectedEncodedPaths)
+        {
+            var actualEncodedPaths = mask.Select(fp => fp.EncodedPath).OrderBy(x => x, StringComparer.Ordinal).ToList();
+            Assert.Equal(expectedEncodedPaths.OrderBy(x => x, StringComparer.Ordinal), actualEncodedPaths);
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/DocumentReference.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/DocumentReference.cs
@@ -124,6 +124,21 @@ namespace Google.Cloud.Firestore.Data
             return results[0];
         }
 
+        /// <summary>
+        /// Asynchronously sets data in the document, either replacing it completely or merging fields.
+        /// </summary>
+        /// <param name="documentData">The data to store in the document. Must not be null.</param>
+        /// <param name="options">The options to use when updating the document. May be null, which is equivalent to <see cref="SetOptions.Overwrite"/>.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public async Task<WriteResult> SetAsync(object documentData, SetOptions options = null, CancellationToken cancellationToken = default)
+        {
+            var batch = Database.CreateWriteBatch();
+            batch.Set(this, documentData, options);
+            var results = await batch.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return results[0];
+        }
+
         // TODO: Check naming. Other languages just have "get", but that feels a bit odd in .NET.
         // Options:
         // - Get


### PR DESCRIPTION
Set is more complex than Update, as there are three modes:

- Overwrite (the default)
- Merge all
- Merge specific fields

Overwrite is simple, but merging involves creating an appropriate
field mask if it's not been specified, and *applying* a field mask
if one has been specified (to avoid passing on redundant data).