### PR TITLE
Adds a public way to clear out Cloud Spanner pooled resources

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/SpannerStressTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/SpannerStressTests.cs
@@ -134,7 +134,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         {
             // Clear current session pool to eliminate the chance of a previous
             // test altering the pool state (which is validated at end)
-            Task.Run(SessionPool.Default.ReleaseAll).Wait(SessionPool.Default.ShutDownTimeout);
+            Task.Run(SessionPool.Default.ReleaseAllAsync).Wait(SessionPool.Default.ShutDownTimeout);
 
             //prewarm
             // The maximum roundtrip time for spanner (and mysql) is about 200ms per

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TestDatabaseFixture.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TestDatabaseFixture.cs
@@ -65,6 +65,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 var dropCommand = connection.CreateDdlCommand("DROP DATABASE " + DatabaseName);
                 dropCommand.ExecuteNonQueryAsync().ResultWithUnwrappedExceptions();
             }
+            SpannerConnection.ClearPooledResourcesAsync().WaitWithUnwrappedExceptions();
         }
 
         public async Task<SpannerConnection> GetTestDatabaseConnectionAsync()

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SessionPoolTests.cs
@@ -210,6 +210,19 @@ namespace Google.Cloud.Spanner.Data.Tests
         }
 
         [Fact]
+        public async Task CanClearResources()
+        {
+            var client1 = CreateMockClient();
+            var session = await SessionPool.Default.CreateSessionFromPoolAsync(
+                        client1.Object, s_defaultName.ProjectId,
+                        s_defaultName.InstanceId, s_defaultName.DatabaseId, null, CancellationToken.None)
+                    .ConfigureAwait(false);
+            SessionPool.Default.ReleaseToPool(client1.Object, session);
+            await SpannerConnection.ClearPooledResourcesAsync();
+            Assert.Equal(0, SessionPool.Default.CurrentPooledSessions);
+        }
+
+        [Fact]
         public async Task DatabasesHaveDifferentPools()
         {
             using (var pool = new SessionPool())

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -83,6 +83,11 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         public static SpannerOptions SpannerOptions => SpannerOptions.Instance;
 
+        /// <summary>
+        /// Releases all pooled Cloud Spanner sessions.
+        /// </summary>
+        public static Task ClearPooledResourcesAsync() => SessionPool.Default.ReleaseAllAsync();
+
         /// <inheritdoc />
         public override string ConnectionString
         {

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.cs
@@ -369,11 +369,10 @@ namespace Google.Cloud.Spanner.V1
         /// Releases all pooled sessions and frees resources on the server.
         /// </summary>
         /// <returns></returns>
-        public Task ReleaseAll()
+        public Task ReleaseAllAsync()
         {
             var entries = _poolByClientAndDatabase.Values;
-            _poolByClientAndDatabase.Clear();
-                // ReleaseAll should not be called while other operations are starting.
+            // ReleaseAll can be called while other operations are starting.
             return Task.WhenAll(entries.Select(sessionpool => sessionpool.ReleaseAllImpl()));
         }
 
@@ -404,7 +403,7 @@ namespace Google.Cloud.Spanner.V1
         /// <inheritdoc />
         public void Dispose()
         {
-            Task.Run(ReleaseAll).Wait(ShutDownTimeout);
+            Task.Run(ReleaseAllAsync).Wait(ShutDownTimeout);
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPoolImpl.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPoolImpl.cs
@@ -79,6 +79,8 @@ namespace Google.Cloud.Spanner.V1
             {
                 entries = _sessionMruStack.ToArray();
             }
+            // *Try* to evict the sessions. If a session has been acquired and is no longer in the pool
+            // by the time evict runs, it will result in a no-op.
             return Task.WhenAll(entries.Select(sessionpoolentry => EvictImmediatelyAsync(sessionpoolentry.Session, CancellationToken.None)).ToArray());
         }
 


### PR DESCRIPTION
Adds a public way to clear out resources as a fallback for possible race conditions with grpc Environment shutdown event callbacks.