### PR TITLE
Remove NuGet instructions from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,15 +76,6 @@
                         <h1>google-cloud</h1>
                         <p>Google Cloud Client Libraries for .NET provide an idiomatic, intuitive, and natural way for .NET developers to integrate with Google Cloud Platform services, like Cloud Datastore and Cloud Storage.</p>
                     </div><!-- end of .col.col-left -->
-                    <div class="col col-right">
-                        <!-- TODO: Use nuget buttons as per https://github.com/prabirshrestha/nuget-button ? -->
-                        <h2>Add NuGet pre-release packages to your project:</h2>
-			<pre class="package-list"><a href="docs/Google.Cloud.BigQuery.V2/index.html">Google.Cloud.BigQuery.V2</a>
-<a href="docs/Google.Cloud.Datastore.V1/index.html">Google.Cloud.Datastore.V1</a>
-<a href="docs/Google.Cloud.Logging.V2/index.html">Google.Cloud.Logging.V2</a>
-<a href="docs/Google.Cloud.PubSub.V1/index.html">Google.Cloud.PubSub.V1</a>
-<a href="docs/Google.Cloud.Storage.V1/index.html">Google.Cloud.Storage.V1</a></pre>
-                    </div><!-- end of .col.col-right -->
                 </div><!-- end of .container -->
             </section><!-- end of .hero-banner -->
 


### PR DESCRIPTION
- Only 5 APIs were listed; we definitely don't want to list all of
  them
- They were listed as pre-release when they're all GA

I think it's better for each API to have its own instructions (as
they already do).