### PR TITLE
First pass at transaction support

### DIFF
--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/FakeDocumentStream.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/FakeDocumentStream.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Firestore.V1Beta1;
+using System.Collections.Generic;
+using System.Linq;
+using static Google.Cloud.Firestore.V1Beta1.FirestoreClient;
+
+namespace Google.Cloud.Firestore.Data.Tests
+{
+    /// <summary>
+    /// A document stream that simply returns the responses provided at construction time.
+    /// </summary>
+    internal class FakeDocumentStream : BatchGetDocumentsStream
+    {
+        private readonly IEnumerable<BatchGetDocumentsResponse> _responses;
+
+        internal FakeDocumentStream(IEnumerable<BatchGetDocumentsResponse> responses) =>
+            _responses = responses;
+
+        public override IAsyncEnumerator<BatchGetDocumentsResponse> ResponseStream =>
+            _responses.ToAsyncEnumerable().GetEnumerator();
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/FakeQueryStream.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/FakeQueryStream.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Firestore.V1Beta1;
+using System.Collections.Generic;
+using System.Linq;
+using static Google.Cloud.Firestore.V1Beta1.FirestoreClient;
+
+namespace Google.Cloud.Firestore.Data.Tests
+{
+    /// <summary>
+    ///  A query stream that simply returns the responses provided at construction time.
+    /// </summary>
+    internal class FakeQueryStream : RunQueryStream
+    {
+        private readonly IEnumerable<RunQueryResponse> _responses;
+
+        internal FakeQueryStream(IEnumerable<RunQueryResponse> responses) =>
+            _responses = responses;
+
+        public override IAsyncEnumerator<RunQueryResponse> ResponseStream =>
+            _responses.ToAsyncEnumerable().GetEnumerator();
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/FirestoreDbTest.RunTransactionAsync.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/FirestoreDbTest.RunTransactionAsync.cs
@@ -1,0 +1,227 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Firestore.V1Beta1;
+using Google.Protobuf;
+using Grpc.Core;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
+
+namespace Google.Cloud.Firestore.Data.Tests
+{
+    public partial class FirestoreDbTest
+    {
+        // Just check the basics of each overload...
+        [Fact]
+        public async Task RunTransactionAsync_CommitSuccess_Sync_NoResult()
+        {
+            var client = new TransactionTestingClient();
+            var db = FirestoreDb.Create("proj", "db", client);
+            await db.RunTransactionAsync(transaction =>
+            {
+                transaction.Create(db.Document("col/doc1"), new { Name = "Test" });
+                transaction.Delete(db.Document("col/doc2"));
+            });
+            Assert.Equal(new[] { CreateCommitRequest("transaction 1") }, client.CommitRequests);
+            Assert.Empty(client.RollbackRequests);
+        }
+
+        [Fact]
+        public async Task RunTransactionAsync_CommitSuccess_Async_NoResult()
+        {
+            var client = new TransactionTestingClient();
+            var db = FirestoreDb.Create("proj", "db", client);
+            await db.RunTransactionAsync(async transaction =>
+            {
+                await transaction.GetDocumentSnapshotAsync(db.Document("col/x"));
+                transaction.Create(db.Document("col/doc1"), new { Name = "Test" });
+                transaction.Delete(db.Document("col/doc2"));
+            });
+            Assert.Equal(new[] { CreateCommitRequest("transaction 1") }, client.CommitRequests);
+            Assert.Empty(client.RollbackRequests);
+        }
+
+        [Fact]
+        public async Task RunTransactionAsync_CommitSuccess_Sync_WithResult()
+        {
+            var client = new TransactionTestingClient();
+            var db = FirestoreDb.Create("proj", "db", client);
+            var result = await db.RunTransactionAsync(transaction =>
+            {
+                transaction.Create(db.Document("col/doc1"), new { Name = "Test" });
+                transaction.Delete(db.Document("col/doc2"));
+                return "test";
+            });
+            Assert.Equal("test", result);
+            Assert.Equal(new[] { CreateCommitRequest("transaction 1") }, client.CommitRequests);
+            Assert.Empty(client.RollbackRequests);
+        }
+
+        [Fact]
+        public async Task RunTransactionAsync_CommitSuccess_Async_WithResult()
+        {
+            var client = new TransactionTestingClient();
+            var db = FirestoreDb.Create("proj", "db", client);
+            var result = await db.RunTransactionAsync(CreateCountingCallback());
+            Assert.Equal(1, result);
+            Assert.Equal(new[] { CreateCommitRequest("transaction 1") }, client.CommitRequests);
+            Assert.Empty(client.RollbackRequests);
+        }
+
+        // In-depth testing is only performed for the main work method
+        [Fact]
+        public async Task RunTransactionAsync_RollbackAndRetry()
+        {
+            var client = new TransactionTestingClient(2, CreateRpcException(StatusCode.Aborted));
+            var db = FirestoreDb.Create("proj", "db", client);
+            var result = await db.RunTransactionAsync(CreateCountingCallback());
+            // Two failures were retries, so our callback executed 3 times.
+            Assert.Equal(3, result);
+
+            var expectedCommitRequests = new[]
+            {
+                CreateCommitRequest("transaction 1"),
+                CreateCommitRequest("transaction 2; retrying transaction 1"),
+                CreateCommitRequest("transaction 3; retrying transaction 2")
+            };
+            var expectedRollbackRequests = new[]
+            {
+                CreateRollbackRequest("transaction 1"),
+                CreateRollbackRequest("transaction 2; retrying transaction 1"),
+            };
+            Assert.Equal(expectedCommitRequests, client.CommitRequests);
+            Assert.Equal(expectedRollbackRequests, client.RollbackRequests);
+        }
+
+        [Theory]
+        [InlineData(StatusCode.DeadlineExceeded)]
+        [InlineData(StatusCode.Cancelled)]
+        public async Task RunTransactionAsync_RollbackNoRetryOnCommitFailure(StatusCode code)
+        {
+            var client = new TransactionTestingClient(1, CreateRpcException(code));
+            var db = FirestoreDb.Create("proj", "db", client);
+            await Assert.ThrowsAsync<RpcException>(() => db.RunTransactionAsync(CreateCountingCallback()));
+            Assert.Equal(new[] { CreateCommitRequest("transaction 1") }, client.CommitRequests);
+            Assert.Equal(new[] { CreateRollbackRequest("transaction 1") }, client.RollbackRequests);
+        }
+
+        [Theory]
+        [InlineData(StatusCode.FailedPrecondition)]
+        [InlineData(StatusCode.Internal)]
+        [InlineData(StatusCode.PermissionDenied)]
+        public async Task RunTransactionAsync_NoRollbackOnCommitFailure(StatusCode code)
+        {
+            var client = new TransactionTestingClient(1, CreateRpcException(code));
+            var db = FirestoreDb.Create("proj", "db", client);
+            await Assert.ThrowsAsync<RpcException>(() => db.RunTransactionAsync(CreateCountingCallback()));
+            Assert.Equal(new[] { CreateCommitRequest("transaction 1") }, client.CommitRequests);
+            Assert.Empty(client.RollbackRequests);
+        }
+
+        [Fact]
+        public async Task RunTransactionAsync_RollbackOnlyOnCallbackFailure()
+        {
+            var client = new TransactionTestingClient(2, CreateRpcException(StatusCode.Aborted));
+            var db = FirestoreDb.Create("proj", "db", client);
+
+            var exception = await Assert.ThrowsAsync<IOException>(() => db.RunTransactionAsync<int>(
+                async transaction =>
+                {
+                    await transaction.GetDocumentSnapshotAsync(db.Document("col/x"));
+                    throw new IOException("Bang!");
+                }));
+            Assert.Equal("Bang!", exception.Message);
+
+            Assert.Empty(client.CommitRequests);
+            Assert.Equal(new[] { CreateRollbackRequest("transaction 1") }, client.RollbackRequests);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(2)]
+        [InlineData(10)]
+        public async Task RunTransactionAsync_TooManyRetries(int? userSpecifiedAttempts)
+        {
+            int actualAttempts = userSpecifiedAttempts ?? TransactionOptions.Default.MaxAttempts;
+            var options = userSpecifiedAttempts == null ? null : TransactionOptions.Create(userSpecifiedAttempts.Value);
+
+            var client = new TransactionTestingClient(actualAttempts, CreateRpcException(StatusCode.Aborted));
+            var db = FirestoreDb.Create("proj", "db", client);
+            var exception = await Assert.ThrowsAsync<RpcException>(() => db.RunTransactionAsync(CreateCountingCallback(), options));
+            Assert.Equal(StatusCode.Aborted, exception.Status.StatusCode);
+            // We should have made as many attempts as we were allowed, and all should have been rolled back.
+            Assert.Equal(actualAttempts, client.CommitRequests.Count);
+            Assert.Equal(actualAttempts, client.RollbackRequests.Count);
+        }
+
+        /// <summary>
+        /// Creates a request that creates projects/proj/databases/db/documents/col/doc1 and
+        /// deletes projects/proj/databases/db/documents/col/doc2 - the operations performed in
+        /// our RunTransactionAsync tests.
+        /// </summary>
+        private static CommitRequest CreateCommitRequest(string transactionId) =>
+            new CommitRequest
+            {
+                Database = "projects/proj/databases/db",
+                Transaction = ByteString.CopyFromUtf8(transactionId),
+                Writes =
+                {
+                        // Create
+                        new Write
+                        {
+                            CurrentDocument = new V1Beta1.Precondition { Exists = false },
+                            Update = new Document
+                            {
+                                Name = "projects/proj/databases/db/documents/col/doc1",
+                                Fields = { { "Name", CreateValue("Test") } }
+                            }
+                        },
+                        // Delete
+                        new Write { Delete = "projects/proj/databases/db/documents/col/doc2" },
+                }
+            };
+
+        /// <summary>
+        /// Creates a callback that returns how many times it's executed so far.
+        /// In each iteration, it fetches a document, creates another, and deletes a third.
+        /// The commit from this callback should be the same as returned by <see cref="CreateCommitRequest(string)"/>.
+        /// </summary>
+        private Func<Transaction, Task<int>> CreateCountingCallback()
+        {
+            int callbackCount = 0;
+            return async transaction =>
+            {
+                var db = transaction.Database;
+                callbackCount++;
+                await transaction.GetDocumentSnapshotAsync(db.Document("col/x"));
+                transaction.Create(db.Document("col/doc1"), new { Name = "Test" });
+                transaction.Delete(db.Document("col/doc2"));
+                return callbackCount;
+            };
+        }
+
+
+        private static RollbackRequest CreateRollbackRequest(string transactionId) =>
+            new RollbackRequest
+            {
+                Database = "projects/proj/databases/db",
+                Transaction = ByteString.CopyFromUtf8(transactionId)
+            };
+
+        private static RpcException CreateRpcException(StatusCode code) => new RpcException(new Status(code, "Bang"));
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/FirestoreDbTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/FirestoreDbTest.cs
@@ -17,16 +17,13 @@ using Google.Cloud.Firestore.V1Beta1;
 using Google.Protobuf;
 using Moq;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
-using static Google.Cloud.Firestore.V1Beta1.FirestoreClient;
 
 namespace Google.Cloud.Firestore.Data.Tests
 {
-    public class FirestoreDbTest
+    public partial class FirestoreDbTest
     {
         [Fact]
         public void Create()
@@ -222,17 +219,6 @@ namespace Google.Cloud.Firestore.Data.Tests
             var db = FirestoreDb.Create("proj", "db", mock.Object);
             await Assert.ThrowsAsync<InvalidOperationException>(() => db.GetDocumentSnapshotsAsync(new[] { db.Document("col1/doc1") }, null, default));
             mock.VerifyAll();
-        }
-
-        private class FakeDocumentStream : BatchGetDocumentsStream
-        {
-            private readonly IEnumerable<BatchGetDocumentsResponse> _responses;
-
-            internal FakeDocumentStream(IEnumerable<BatchGetDocumentsResponse> responses) =>
-                _responses = responses;
-
-            public override IAsyncEnumerator<BatchGetDocumentsResponse> ResponseStream =>
-                _responses.ToAsyncEnumerable().GetEnumerator();
         }
     }
 }

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/Google.Cloud.Firestore.Data.Tests.csproj
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/Google.Cloud.Firestore.Data.Tests.csproj
@@ -28,5 +28,8 @@
     <Compile Update="WriteBatchTest.*.cs">
       <DependentUpon>WriteBatchTest.cs</DependentUpon>
     </Compile>
+    <Compile Update="FirestoreDbTest.*.cs">
+      <DependentUpon>FirestoreDbTest.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/QueryTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/QueryTest.cs
@@ -544,16 +544,5 @@ namespace Google.Cloud.Firestore.Data.Tests
         private static Filter Filter(FieldFilter filter) => new Filter { FieldFilter = filter };
         private static Filter CompositeFilter(params Filter[] filters) =>
             new Filter { CompositeFilter = new CompositeFilter { Op = StructuredQuery.Types.CompositeFilter.Types.Operator.And, Filters = { filters } } };
-
-        private class FakeQueryStream : RunQueryStream
-        {
-            private readonly IEnumerable<RunQueryResponse> _responses;
-
-            internal FakeQueryStream(IEnumerable<RunQueryResponse> responses) =>
-                _responses = responses;
-
-            public override IAsyncEnumerator<RunQueryResponse> ResponseStream =>
-                _responses.ToAsyncEnumerable().GetEnumerator();
-        }
     }
 }

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/TransactionTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/TransactionTest.cs
@@ -1,0 +1,155 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Firestore.V1Beta1;
+using Google.Protobuf;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
+
+namespace Google.Cloud.Firestore.Data.Tests
+{
+    public class TransactionTest
+    {
+        [Fact]
+        public async Task BeginTransaction_Properties()
+        {
+            var cancellationToken = new CancellationTokenSource().Token;
+            var db = CreateFirestoreDbExpectingNoCommits();
+            var transaction = await Transaction.BeginAsync(db, null, cancellationToken);
+            Assert.Equal("transaction 1", transaction.TransactionId.ToStringUtf8());
+            Assert.Equal(cancellationToken, transaction.CancellationToken);
+            Assert.Same(db, transaction.Database);
+        }
+
+        [Fact]
+        public async Task NoCommitsBeforeCommitCall()
+        {
+            var db = CreateFirestoreDbExpectingNoCommits();
+            var transaction = await Transaction.BeginAsync(db, null, default);
+            Assert.Equal("transaction 1", transaction.TransactionId.ToStringUtf8());
+
+            var doc = db.Document("col/doc");
+            var snapshot = await transaction.GetDocumentSnapshotAsync(doc);
+            Assert.Equal("transaction 1", snapshot.GetField<string>("transaction"));
+            var query = await transaction.GetQuerySnapshotAsync(db.Collection("col"));
+            Assert.Empty(query.Documents);
+
+            transaction.Create(doc, new { Name = "Test" });
+            transaction.Update(doc, new Dictionary<FieldPath, object> { { new FieldPath("Name"), "Test2" } });
+            transaction.Set(doc, new { Name = "Test3" });
+            transaction.Delete(doc);
+        }
+
+        [Fact]
+        public async Task GetDocumentSnapshotAsync_FailsAfterWrite()
+        {
+            var db = CreateFirestoreDbExpectingNoCommits();
+            var transaction = await Transaction.BeginAsync(db, null, default);
+            var doc = db.Document("col/doc");
+            transaction.Delete(doc);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => transaction.GetDocumentSnapshotAsync(doc));
+        }
+
+        [Fact]
+        public async Task GetQuerySnaphotAsync_FailsAfterWrite()
+        {
+            var db = CreateFirestoreDbExpectingNoCommits();
+            var transaction = await Transaction.BeginAsync(db, null, default);
+            var doc = db.Document("col/doc");
+            transaction.Delete(doc);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => transaction.GetQuerySnapshotAsync(doc.Parent));
+        }
+
+        [Fact]
+        public async Task CommitAsync()
+        {
+            var client = new TransactionTestingClient();
+            var db = FirestoreDb.Create("proj", "db", client);
+            var transaction = await Transaction.BeginAsync(db, null, default);
+            var doc = db.Document("col/doc");
+            // A simple write of each kind, just to check they're all passed along as expected.
+            transaction.Create(doc, new { Name = "Test" });
+            transaction.Update(doc, new Dictionary<FieldPath, object> { { new FieldPath("Name"), "Test2" } });
+            transaction.Set(doc, new { Name = "Test3" });
+            transaction.Delete(doc);
+            await transaction.CommitAsync();
+
+            var expectedRequest = new CommitRequest
+            {
+                Database = "projects/proj/databases/db",                
+                Transaction = ByteString.CopyFromUtf8("transaction 1"),
+                Writes =
+                {
+                    // Create
+                    new Write
+                    {
+                        CurrentDocument = new V1Beta1.Precondition { Exists = false },
+                        Update = new Document
+                        {
+                            Name = doc.Path,
+                            Fields = { { "Name", CreateValue("Test") } }
+                        }
+                    },
+                    // Update
+                    new Write
+                    {
+                        CurrentDocument = new V1Beta1.Precondition { Exists = true },
+                        Update = new Document
+                        {
+                            Name = doc.Path,
+                            Fields = { { "Name", CreateValue("Test2") } }
+                        },
+                        UpdateMask = new DocumentMask { FieldPaths = { "Name" } }
+                    },
+                    // Set
+                    new Write
+                    {
+                        Update = new Document
+                        {
+                            Name = doc.Path,
+                            Fields = { { "Name", CreateValue("Test3") } }
+                        },
+                    },
+                    // Delete
+                    new Write { Delete = doc.Path }
+                }
+            };
+            Assert.Equal(new[] { expectedRequest }, client.CommitRequests);
+            Assert.Empty(client.RollbackRequests);
+        }
+
+        [Fact]
+        public async Task RollbackAsync()
+        {
+            var client = new TransactionTestingClient();
+            var db = FirestoreDb.Create("proj", "db", client);
+            var transaction = await Transaction.BeginAsync(db, null, default);
+            await transaction.RollbackAsync();
+            var expectedRequest = new RollbackRequest
+            {
+                Database = "projects/proj/databases/db",
+                Transaction = ByteString.CopyFromUtf8("transaction 1")
+            };
+            Assert.Empty(client.CommitRequests);
+            Assert.Equal(new[] { expectedRequest }, client.RollbackRequests);
+        }
+
+        private FirestoreDb CreateFirestoreDbExpectingNoCommits() =>
+            FirestoreDb.Create("proj", "db", new TransactionTestingClient(int.MaxValue, new NotSupportedException()));
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/TransactionTestingClient.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/TransactionTestingClient.cs
@@ -1,0 +1,149 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Firestore.V1Beta1;
+using Google.Protobuf;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
+using wkt = Google.Protobuf.WellKnownTypes;
+
+namespace Google.Cloud.Firestore.Data.Tests
+{
+    /// <summary>
+    /// Fake FirestoreClient to allow testing of the RPCs required for transactions.
+    /// This client doesn't really emulate Firestore in any meaningful way, but it allows
+    /// failure injection and request recording.
+    /// </summary>
+    internal class TransactionTestingClient : FirestoreClient
+    {
+        private int _nanos = 0;
+        private int _transactions = 0;
+        private int _failures;
+        private readonly Exception _exception;
+
+        /// <summary>
+        /// The list of commit requests we've received.
+        /// </summary>
+        public List<CommitRequest> CommitRequests { get; } = new List<CommitRequest>();
+
+        /// <summary>
+        /// The list of commit requests we've received.
+        /// </summary>
+        public List<RollbackRequest> RollbackRequests { get; } = new List<RollbackRequest>();
+
+        /// <summary>
+        /// Creates a testing client which will make all commits succeed.
+        /// </summary>
+        public TransactionTestingClient() : this(0, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a client which will respond to the first <paramref name="failures"/> commit calls with <paramref name="exception"/>.
+        /// </summary>
+        public TransactionTestingClient(int failures, Exception exception)
+        {
+            _failures = failures;
+            _exception = exception;
+        }
+
+        // Async wrappers for the synchronous implementations.
+        // Using Task.Run instead of Task.FromResult to allow exceptions to be propagated as faulted tasks.
+        public override Task<BeginTransactionResponse> BeginTransactionAsync(BeginTransactionRequest request, CallSettings callSettings = null) =>
+            Task.Run(() => BeginTransaction(request, callSettings));
+
+        public override Task<CommitResponse> CommitAsync(CommitRequest request, CallSettings callSettings = null) =>
+            Task.Run(() => Commit(request, callSettings));
+
+        public override Task RollbackAsync(RollbackRequest request, CallSettings callSettings = null) =>
+            Task.Run(() => Rollback(request, callSettings));
+
+        public override RunQueryStream RunQuery(RunQueryRequest request, CallSettings callSettings = null)
+        {
+            // Don't return any documents, but a response that lets us check the transaction was propagated.
+            var response = new RunQueryResponse { ReadTime = GetNextTimestamp() };
+            if (request.ConsistencySelectorCase == RunQueryRequest.ConsistencySelectorOneofCase.Transaction)
+            {
+                response.Transaction = request.Transaction;
+            }
+            return new FakeQueryStream(new[] { response });
+        }
+
+        public override BatchGetDocumentsStream BatchGetDocuments(BatchGetDocumentsRequest request, CallSettings callSettings = null)
+        {
+            string transaction = request.ConsistencySelectorCase == BatchGetDocumentsRequest.ConsistencySelectorOneofCase.Transaction ?
+                request.Transaction.ToStringUtf8() : "no transaction";
+            // Fake documents that show which transaction was being used.
+            var responses = request.Documents.Select(path => new BatchGetDocumentsResponse
+            {
+                Found = new Document
+                {
+                    Name = path,
+                    CreateTime = CreateProtoTimestamp(0, 0),
+                    UpdateTime = CreateProtoTimestamp(0, 0),
+                    Fields = { { "transaction", CreateValue(transaction) } }
+                },
+                ReadTime = GetNextTimestamp()
+            });
+            return new FakeDocumentStream(responses);
+        }
+
+        public override BeginTransactionResponse BeginTransaction(BeginTransactionRequest request, CallSettings callSettings = null)
+        {
+            int id = Interlocked.Increment(ref _transactions);
+            string text = $"transaction {id}";
+            ByteString retry = request.Options?.ReadWrite?.RetryTransaction;
+            if (retry != null)
+            {
+                // We don't want to chain "transaction 5; retrying transaction 4; retrying transaction 3" etc.
+                string retryText = retry.ToStringUtf8().Split(';')[0];
+                text += $"; retrying {retryText}";
+            }
+            return new BeginTransactionResponse { Transaction = ByteString.CopyFromUtf8(text) };
+        }
+
+        public override CommitResponse Commit(CommitRequest request, CallSettings callSettings = null)
+        {
+            lock (CommitRequests)
+            {
+                CommitRequests.Add(request);
+            }
+            if (Interlocked.Decrement(ref _failures) >= 0)
+            {
+                throw _exception;
+            }
+            var commitTime = GetNextTimestamp();
+            return new CommitResponse
+            {
+                CommitTime = commitTime,
+                WriteResults = { request.Writes.Select(write => new V1Beta1.WriteResult { UpdateTime = commitTime }) }
+            };
+        }
+
+        public override void Rollback(RollbackRequest request, CallSettings callSettings = null)
+        {
+            lock (RollbackRequests)
+            {
+                RollbackRequests.Add(request);
+            }
+        }
+
+        private wkt::Timestamp GetNextTimestamp() => CreateProtoTimestamp(0, Interlocked.Increment(ref _nanos));
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/DocumentReference.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/DocumentReference.cs
@@ -150,9 +150,16 @@ namespace Google.Cloud.Firestore.Data
         /// Asynchronously fetches a snapshot of the document.
         /// </summary>
         /// <returns>A snapshot of the document. The snapshot may represent a missing document.</returns>
-        public async Task<DocumentSnapshot> SnapshotAsync(CancellationToken cancellationToken = default)
+        public Task<DocumentSnapshot> SnapshotAsync(CancellationToken cancellationToken = default) =>
+            SnapshotAsync(null, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously fetches a snapshot of the document.
+        /// </summary>
+        /// <returns>A snapshot of the document. The snapshot may represent a missing document.</returns>
+        internal async Task<DocumentSnapshot> SnapshotAsync(ByteString transactionId, CancellationToken cancellationToken)
         {
-            var multiple = await Database.GetDocumentSnapshotsAsync(new[] { this }, null, cancellationToken).ConfigureAwait(false);
+            var multiple = await Database.GetDocumentSnapshotsAsync(new[] { this }, transactionId, cancellationToken).ConfigureAwait(false);
             return multiple.Single();
         }
 

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/Transaction.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/Transaction.cs
@@ -1,0 +1,169 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.using System;
+
+
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Firestore.V1Beta1;
+using Google.Protobuf;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using static Google.Cloud.Firestore.V1Beta1.TransactionOptions.Types;
+
+namespace Google.Cloud.Firestore.Data
+{
+    /// <summary>
+    /// A transaction, as created by
+    /// <see cref="FirestoreDb.RunTransactionAsync{T}(System.Func{Transaction, Task{T}}, TransactionOptions, CancellationToken)"/>
+    /// (and overloads) and passed to user code.
+    /// </summary>
+    public class Transaction
+    {
+        /// <summary>
+        /// The cancellation token for this transaction
+        /// </summary>
+        public CancellationToken CancellationToken { get; }
+
+        /// <summary>
+        /// The database for this transaction.
+        /// </summary>
+        public FirestoreDb Database { get; }
+
+        private readonly WriteBatch _writes;
+
+        internal ByteString TransactionId { get; }
+
+        internal Transaction(FirestoreDb db, ByteString transactionId, CancellationToken overallCancellationToken)
+        {
+            Database = db;
+            TransactionId = transactionId;
+            CancellationToken = overallCancellationToken;
+            _writes = new WriteBatch(db);
+        }
+
+        internal static async Task<Transaction> BeginAsync(FirestoreDb db, ByteString previousTransactionId, CancellationToken cancellationToken)
+        {
+            var request = new BeginTransactionRequest
+            {
+                Database = db.RootPath,
+                Options = previousTransactionId == null ? null : new V1Beta1.TransactionOptions { ReadWrite = new ReadWrite { RetryTransaction = previousTransactionId } }
+            };
+            var response = await db.Client.BeginTransactionAsync(request, CallSettings.FromCancellationToken(cancellationToken)).ConfigureAwait(false);
+            return new Transaction(db, response.Transaction, cancellationToken);
+        }
+
+        // TODO: Consider names of GetDocumentSnapshotAsync/GetQuerySnapshotAsync.
+        // Perhaps just SnapshotDocumentAsync and SnapshotQueryAsync?
+        // Just using SnapshotAsync overloads feels like a bad idea as they do quite different things.
+
+        /// <summary>
+        /// Fetch a snapshot of the document specified by <paramref name="documentReference"/>, with respect to this transaction.
+        /// This method cannot be called after any write operations have been created.
+        /// </summary>
+        /// <param name="documentReference">The document reference to fetch. Must not be null.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
+        /// <returns>A snapshot of the given document with respect to this transaction.</returns>
+        public Task<DocumentSnapshot> GetDocumentSnapshotAsync(DocumentReference documentReference, CancellationToken cancellationToken = default)
+        {
+            GaxPreconditions.CheckNotNull(documentReference, nameof(documentReference));
+            GaxPreconditions.CheckState(_writes.IsEmpty, "Firestore transactions require all reads to be executed before all writes.");
+            CancellationToken effectiveToken = GetEffectiveCancellationToken(cancellationToken);
+            return documentReference.SnapshotAsync(TransactionId, effectiveToken);
+        }
+
+        /// <summary>
+        /// Performs a query and returned a snapshot of the the results, with respect to this transaction.
+        /// This method cannot be called after any write operations have been created.
+        /// </summary>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
+        /// <returns>A snapshot of results of the given query with respect to this transaction.</returns>
+        public Task<QuerySnapshot> GetQuerySnapshotAsync(Query query, CancellationToken cancellationToken = default)
+        {
+            GaxPreconditions.CheckNotNull(query, nameof(query));
+            CancellationToken effectiveToken = GetEffectiveCancellationToken(cancellationToken);
+            GaxPreconditions.CheckState(_writes.IsEmpty, "Firestore transactions require all reads to be executed before all writes.");
+            return query.SnapshotAsync(TransactionId, cancellationToken);
+        }
+
+        /// <summary>
+        /// Adds an operation to create a document in this transaction.
+        /// </summary>
+        /// <param name="documentReference">The document reference to create. Must not be null.</param>
+        /// <param name="documentData">The data for the document. Must not be null.</param>
+        public void Create(DocumentReference documentReference, object documentData)
+        {
+            // Preconditions are validated by WriteBatch.
+            _writes.Create(documentReference, documentData);
+        }
+
+        /// <summary>
+        /// Adds an operation to set a document's data in this transaction.
+        /// </summary>
+        /// <param name="documentReference">The document in which to set the data. Must not be null.</param>
+        /// <param name="documentData">The data for the document. Must not be null.</param>
+        /// <param name="options">The options to use when updating the document. May be null, which is equivalent to <see cref="SetOptions.Overwrite"/>.</param>
+        public void Set(DocumentReference documentReference, object documentData, SetOptions options = null)
+        {
+            // Preconditions are validated by WriteBatch.
+            _writes.Set(documentReference, documentData, options);
+        }
+
+        /// <summary>
+        /// Adds an operation to update a document's data in this transaction.
+        /// </summary>
+        /// <param name="documentReference">The document to update. Must not be null.</param>
+        /// <param name="updates">The updates to perform on the document, keyed by the field path to update. Fields not present in this dictionary are not updated. Must not be null.</param>
+        /// <param name="precondition">Optional precondition for updating the document. May be null, which is equivalent to <see cref="Precondition.MustExist"/>.</param>
+        public void Update(DocumentReference documentReference, Dictionary<FieldPath, object> updates, Precondition precondition = null)
+        {
+            // Preconditions are validated by WriteBatch.
+            _writes.Update(documentReference, updates, precondition);
+        }
+
+        /// <summary>
+        /// Adds an operation to delete a document's data in this transaction.
+        /// </summary>
+        /// <param name="documentReference">The document to delete. Must not be null.</param>
+        /// <param name="precondition">Optional precondition for deletion. May be null, in which case the deletion is unconditional.</param>
+        public void Delete(DocumentReference documentReference, Precondition precondition = null)
+        {
+            // Preconditions are validated by WriteBatch.
+            _writes.Delete(documentReference, precondition);
+        }
+
+        // TODO: The specification has some rules around retrying the commit operation. Rather than implement them
+        // here, it would be good to hook into the GAX retry mechanism - we don't want to build too many layers of
+        // retry (each with backoff) on top of each other.
+
+        /// <summary>
+        /// Asynchronously commits the transaction, using the same cancellation token as was used to begin the transaction.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        internal Task CommitAsync() => _writes.CommitAsync(TransactionId, CancellationToken);
+
+        /// <summary>
+        /// Asynchronously rolls back the transaction, using the same cancellation token as was used to begin the transaction.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        internal Task RollbackAsync() =>
+            Database.Client.RollbackAsync(Database.RootPath, TransactionId, CancellationToken);
+
+        private CancellationToken GetEffectiveCancellationToken(CancellationToken other) =>
+            !CancellationToken.CanBeCanceled ? other
+            : !other.CanBeCanceled ? CancellationToken
+            : CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, other).Token;
+    }
+}


### PR DESCRIPTION
No integration tests yet, as I'm trying to find out how to reliably force a retriable failure.
The rules about when to roll back and which commits can be retried are slightly up in the air, but
we can change them later. Right now:

- We roll back if we haven't even tried to commit
- We roll back if we tried to commit and it failed with abort/cancellation/deadline
- We retry the whole transaction if commit failed with abort