### PR TITLE
Implement sentinel values for Firestore

### DIFF
--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.SentinelValues.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.SentinelValues.cs
@@ -1,0 +1,155 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Firestore.V1Beta1;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using static Google.Cloud.Firestore.Data.Tests.ProtoHelpers;
+using static Google.Cloud.Firestore.V1Beta1.DocumentTransform.Types;
+
+namespace Google.Cloud.Firestore.Data.Tests
+{
+    // Just tests for the handling of sentinel values. These use
+    // WriteBatch.Set as it lets us check the update mask handling too.
+    public partial class WriteBatchTest
+    {
+        public static IEnumerable<object[]> SentinelValuesInArraysData { get; } = new List<object>
+        {
+            // Single check that ServerTimestamp counts as a sentinel value. For the rest of the
+            // test data, we'll just use Delete
+            new { Values = new[] { SentinelValue.ServerTimestamp } },
+
+            // Directly in an array
+            new { Values = new[] { SentinelValue.Delete } },
+
+            // In a field in an array
+            new { Values = new[] { new { DeleteMe = SentinelValue.Delete } } },
+
+            // In a nested array
+            new { Values = new[] { new { DeleteMe = new[] { SentinelValue.Delete } } } },
+
+            // An array within a map
+            new { Foo = new { Score = 10, Values = new[] { SentinelValue.Delete } } }
+        }
+        .Select(x => new[] { x }).ToList();
+
+        public static IEnumerable<object[]> NoSentinelValuesInArraysData { get; } = new List<object>
+        {
+            // Each object has a sentinel value in a valid position.
+            new { Values = new[] { 1, 2 }, DeleteMe = SentinelValue.Delete },
+            new { Values = new[] { new { Fields = new { NestedArray = new[] { 1, 2 }, Text = "Foo" } } }, DeleteMe = SentinelValue.Delete }
+        }
+        .Select(x => new[] { x }).ToList();
+
+        /// <summary>
+        /// Array values cannot contain sentinel values (delete/server-timestamp) anywhere,
+        /// including via recursion.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(SentinelValuesInArraysData))]
+        public void SentinelValuesInArrays(object documentData)
+        {
+            var db = FirestoreDb.Create("proj", "db", new FakeFirestoreClient());
+            var batch = db.CreateWriteBatch();
+            var doc = db.Document("col/doc");
+            Assert.Throws<ArgumentException>(() => batch.Set(doc, documentData));
+        }
+
+        [Theory]
+        [MemberData(nameof(NoSentinelValuesInArraysData))]
+        public void NoSentinelValuesInArrays(object documentData)
+        {
+            var db = FirestoreDb.Create("proj", "db", new FakeFirestoreClient());
+            var batch = db.CreateWriteBatch();
+            var doc = db.Document("col/doc");
+            // Don't check the result, just that it doesn't throw.
+            batch.Set(doc, documentData);
+        }
+
+        [Fact]
+        public void SentinelValues_Simple()
+        {
+            var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
+            var batch = db.CreateWriteBatch();
+            var doc = db.Document("col/doc");
+            var data = new { Name = "Test", DeleteMe = SentinelValue.Delete, Timestamp = SentinelValue.ServerTimestamp };
+            batch.Set(doc, data, SetOptions.MergeAll);
+
+            var expectedUpdate = new Write
+            {
+                Update = new Document
+                {
+                    Name = doc.Path,
+                    Fields = { { "Name", CreateValue("Test") } }
+                },
+                UpdateMask = new DocumentMask { FieldPaths = { "Name", "DeleteMe", "Timestamp" } }
+            };
+            var expectedTransform = new Write
+            {
+                Transform = new DocumentTransform
+                {
+                    Document = doc.Path,
+                    FieldTransforms = { ServerTimestampTransform("Timestamp") }
+                }
+            };
+            AssertWrites(batch, new[] { expectedUpdate, expectedTransform });
+        }
+
+        [Fact]
+        public void SentinelValues_NestedSentinels()
+        {
+            var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
+            var batch = db.CreateWriteBatch();
+            var doc = db.Document("col/doc");
+            var data = new
+            {
+                ValueA = new { Name = "Test", TimestampA = SentinelValue.ServerTimestamp, DeleteMeA = SentinelValue.Delete },
+                ValueB = new { TimestampB = SentinelValue.ServerTimestamp, DeleteMeB = SentinelValue.Delete },
+            };
+            batch.Set(doc, data, SetOptions.MergeAll);
+
+            var expectedUpdate = new Write
+            {
+                Update = new Document
+                {
+                    Name = doc.Path,
+                    Fields =
+                    {
+                        { "ValueA", CreateMap(("Name", CreateValue("Test"))) },
+                        // The presence of this empty map is slightly annoying, but sometimes it's value for an empty
+                        // map to be in a set of fields, and it's hard to detect whether that's deliberate or not at this stage.
+                        // TODO: Validate this decision with the Firestore team.
+                        { "ValueB", CreateMap() }
+                    }
+                },
+                UpdateMask = new DocumentMask { FieldPaths = { "ValueA.Name", "ValueA.DeleteMeA", "ValueA.TimestampA", "ValueB.DeleteMeB", "ValueB.TimestampB" } }
+            };
+            var expectedTransform = new Write
+            {
+                Transform = new DocumentTransform
+                {
+                    Document = doc.Path,
+                    FieldTransforms = { ServerTimestampTransform("ValueA.TimestampA"), ServerTimestampTransform("ValueB.TimestampB") }
+                }
+            };
+            AssertWrites(batch, new[] { expectedUpdate, expectedTransform });
+        }
+
+        private static FieldTransform ServerTimestampTransform(string fieldPath) =>
+            new FieldTransform { FieldPath = fieldPath, SetToServerValue = FieldTransform.Types.ServerValue.RequestTime };
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.Tests/WriteBatchTest.cs
@@ -260,7 +260,10 @@ namespace Google.Cloud.Firestore.Data.Tests
         }
 
         private static void AssertWrites(WriteBatch batch, params Write[] writes) =>
-            Assert.Equal(writes, batch.Writes.Select(CanonicalizeWrite));
+            // The ToList calls aren't strictly necessary, but make the failure output easier to read.
+            Assert.Equal(
+                writes.Select(CanonicalizeWrite).ToList(),
+                batch.Writes.Select(CanonicalizeWrite).ToList());
 
         /// <summary>
         /// Creates a canonical representation of a Write just by ordering lists predictably.
@@ -272,6 +275,11 @@ namespace Google.Cloud.Firestore.Data.Tests
             {
                 clone.UpdateMask.FieldPaths.Clear();
                 clone.UpdateMask.FieldPaths.AddRange(input.UpdateMask.FieldPaths.OrderBy(x => x, StringComparer.Ordinal));
+            }
+            if (clone.Transform != null)
+            {
+                clone.Transform.FieldTransforms.Clear();
+                clone.Transform.FieldTransforms.AddRange(input.Transform.FieldTransforms.OrderBy(ft => ft.FieldPath, StringComparer.Ordinal));
             }
             return clone;
         }

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/FirestorePropertyAttribute.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/FirestorePropertyAttribute.cs
@@ -29,6 +29,12 @@ namespace Google.Cloud.Firestore.Data
         public string Name { get; set; }
 
         /// <summary>
+        /// The sentinel value for this property, defaulting to <see cref="SentinelValue.None"/>
+        /// indicating a regular value to be serialized.
+        /// </summary>
+        public SentinelValue SentinelValue { get; set; }
+
+        /// <summary>
         /// Creates an instance with no specified name.
         /// </summary>
         public FirestorePropertyAttribute()
@@ -43,5 +49,7 @@ namespace Google.Cloud.Firestore.Data
         {
             Name = name;
         }
+
+        // TODO: Constructor overloads with SentinelValue?
     }
 }

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/SentinelValue.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/SentinelValue.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Firestore.Data
+{
+    /// <summary>
+    /// Sentinel values are special values where the client-side value is not part of the
+    /// document modification sent to the server. A property decorated with
+    /// <see cref="FirestorePropertyAttribute"/> can specify the sentinel value in the attribute
+    /// using <see cref="FirestorePropertyAttribute.SentinelValue"/>, or the sentinel values in this enum
+    /// can be used directly as values to be serialized (for example, in anonymous types), and they will be handled
+    /// directly by the serialization mechanism.
+    /// </summary>
+    public enum SentinelValue
+    {
+        /// <summary>
+        /// Only present to allow <see cref="FirestorePropertyAttribute"/> to indicate that
+        /// a property is not a sentinel value; this value cannot be serialized.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The value should be ignored on creation and modification operations,
+        /// using the server time for the commit that modifies the document.
+        /// </summary>
+        ServerTimestamp = 1,
+
+        /// <summary>
+        /// The value should be ignored, and the document field deleted.
+        /// </summary>
+        Delete = 2
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/SentinelValues.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/SentinelValues.cs
@@ -1,0 +1,66 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Firestore.V1Beta1;
+using System;
+using wkt = Google.Protobuf.WellKnownTypes;
+
+namespace Google.Cloud.Firestore.Data
+{
+    /// <summary>
+    /// Internal helpers for sentinel values.
+    /// </summary>
+    internal static class SentinelValues
+    {
+        // These sentinel values are invalid "null" values - the NullValue enum only has a single entry (0), but we're
+        // using the fact that there enums are just named numbers to hide extra information there.
+        // This is deeply unpleasant, but:
+        // - It's extensible to future later sentinel values, so long as they don't require user-specified data (which I don't think they will)
+        // - It's "clone-safe" - when you clone a sentinel value, you get the equivalent value. (We clone in a few places,
+        //   which means we can't use reference identity to distinguish sentinel values.)
+        // - The values are only ever in memory temporarily; they're not exposed to users or included in an RPC.
+
+        private const wkt::NullValue ServerTimestampSentinelNullValue = (wkt::NullValue) SentinelValue.ServerTimestamp;
+        private const wkt::NullValue DeleteSentinelNullValue = (wkt::NullValue) SentinelValue.Delete;
+
+        /// <summary>
+        /// Sentinel value used to represent server timestamps. This value must not be modified. Visible for testing.
+        /// </summary>
+        internal static Value ServerTimestampSentinel { get; } = new Value { NullValue = ServerTimestampSentinelNullValue };
+
+        /// <summary>
+        /// Sentinel value used to represent a deleted field. This value must not be modified. Visible for testing.
+        /// </summary>
+        internal static Value DeleteSentinel { get; } = new Value { NullValue = DeleteSentinelNullValue };
+
+        internal static Value ToProtoValue(this SentinelValue value)
+        {
+            switch (value)
+            {
+                case SentinelValue.ServerTimestamp:
+                    return ServerTimestampSentinel;
+                case SentinelValue.Delete:
+                    return DeleteSentinel;
+                default:
+                    throw new ArgumentException($"Unable to convert {nameof(SentinelValue)} value {value}");
+            }
+        }
+
+        internal static bool IsServerTimestampSentinel(this Value value) =>
+            value.ValueTypeCase == Value.ValueTypeOneofCase.NullValue && value.NullValue == ServerTimestampSentinelNullValue;
+
+        internal static bool IsDeleteSentinel(this Value value) =>
+            value.ValueTypeCase == Value.ValueTypeOneofCase.NullValue && value.NullValue == DeleteSentinelNullValue;
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/ValueSerializer.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data/ValueSerializer.cs
@@ -85,6 +85,8 @@ namespace Google.Cloud.Firestore.Data
             }
             switch (value)
             {
+                case SentinelValue sentinel:
+                    return sentinel.ToProtoValue();
                 // Shortcut to avoid reflection for a common case
                 case IDictionary<string, object> map:
                     return ExtractDictionary(map);
@@ -149,7 +151,9 @@ namespace Google.Cloud.Firestore.Data
                 var attribute = property.GetCustomAttribute<FirestorePropertyAttribute>();
                 if (attribute != null)
                 {
-                    ret[attribute.Name ?? property.Name] = Serialize(property.GetValue(value));
+                    var sentinel = attribute.SentinelValue;
+                    Value protoValue = sentinel == SentinelValue.None ? Serialize(property.GetValue(value)) : sentinel.ToProtoValue();
+                    ret[attribute.Name ?? property.Name] = protoValue;
                 }
             }
             return ret;


### PR DESCRIPTION
The internal representation of sentinel values is ghastly: we use
the fact that NullValue is a single-value enum, but that protos can
store undefined enums. So the temporary Value representations of
sentinel values are highly unusual null values... but fortunately
they'll never be visible to the user, or transmitted on the wire.

Everything else about this is *reasonably* straightforward. There's
an odd situation where a field has a map value, but all the
sub-values are sentinel values; we end up transmitting an empty map,
which *may* not be what's desired. Will check that with the
Firestore team, but I don't think it should block this PR.