### PR TITLE
Integration tests for transactions

### DIFF
--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/DocumentMutationTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/DocumentMutationTest.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using static Google.Cloud.Firestore.Data.IntegrationTests.FirestoreAssert;
 
 namespace Google.Cloud.Firestore.Data.IntegrationTests
 {
@@ -159,16 +160,5 @@ namespace Google.Cloud.Firestore.Data.IntegrationTests
         private Dictionary<string, object> Map(string name, object value) => new Dictionary<string, object> { { name, value } };
         private Dictionary<string, object> Map(params (string name, object value)[] fields) =>
             fields.ToDictionary(field => field.name, field => field.value);
-
-        /// <summary>
-        /// Asserts that the document in snapshot is the serialized form of the expected value.
-        /// Note that the actual snapshot is the first parameter, somewhat unconventionally, as the expected value
-        /// is usually wordier in code, and works better as the final argument.
-        /// </summary>
-        private void AssertSerialized(DocumentSnapshot snapshot, object expectedValue)
-        {
-            var serialized = ValueSerializer.SerializeMap(expectedValue);
-            Assert.Equal(serialized, snapshot.Document.Fields);
-        }
     }
 }

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/FirestoreAssert.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/FirestoreAssert.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Google.Cloud.Firestore.Data.IntegrationTests
+{
+    /// <summary>
+    /// Firestore-specific assertions.
+    /// </summary>
+    internal static class FirestoreAssert
+    {
+        /// <summary>
+        /// Asserts that the document in snapshot is the serialized form of the expected value.
+        /// Note that the actual snapshot is the first parameter, somewhat unconventionally, as the expected value
+        /// is usually wordier in code, and works better as the final argument.
+        /// </summary>
+        internal static void AssertSerialized(DocumentSnapshot snapshot, object expectedValue)
+        {
+            var serialized = ValueSerializer.SerializeMap(expectedValue);
+            Assert.Equal(serialized, snapshot.Document.Fields);
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/RunInTransactionTest.cs
+++ b/apis/Google.Cloud.Firestore.Data/Google.Cloud.Firestore.Data.IntegrationTests/RunInTransactionTest.cs
@@ -1,0 +1,130 @@
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Grpc.Core;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Cloud.Firestore.Data.IntegrationTests.FirestoreAssert;
+
+namespace Google.Cloud.Firestore.Data.IntegrationTests
+{
+    [Collection(nameof(FirestoreFixture))]
+    public class RunInTransactionTest
+    {
+        private readonly FirestoreFixture _fixture;
+
+        public RunInTransactionTest(FirestoreFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public async Task SimpleTransaction()
+        {
+            var db = _fixture.FirestoreDb;
+            var doc1 = _fixture.NonQueryCollection.Document(null);
+            var doc2 = _fixture.NonQueryCollection.Document(null);
+
+            await db.RunTransactionAsync(transaction =>
+            {
+                transaction.Create(doc1, new { Name = "test1" });
+                transaction.Create(doc2, new { Name = "test2" });
+            });
+            var snapshot1 = await doc1.SnapshotAsync();
+            var snapshot2 = await doc2.SnapshotAsync();
+            AssertSerialized(snapshot1, new { Name = "test1" });
+            AssertSerialized(snapshot2, new { Name = "test2" });
+        }
+
+        /// <summary>
+        /// Provoking a retry is tricky. This method has two transactions, each just incrementing a counter.
+        /// A CountdownEvent is used to ensure that they've both read the same document before they then both
+        /// try to commit. One will "win", and the other will be retries.
+        /// </summary>
+        [Fact]
+        public async Task TransactionWithRetry()
+        {
+            int attempts = 0;
+            var db = _fixture.FirestoreDb;
+            var doc = await _fixture.NonQueryCollection.AddAsync(new { Count = 0 });
+            var latch = new CountdownEvent(2);
+
+            var t1 = db.RunTransactionAsync(IncrementCounter);
+            var t2 = db.RunTransactionAsync(IncrementCounter);
+            await Task.WhenAll(t1, t2);
+
+            // We only had two increment transactions, but one needed to retry
+            Assert.Equal(3, attempts);
+            var result = await doc.SnapshotAsync();
+            Assert.Equal(2, result.GetField<int>("Count"));
+
+            async Task IncrementCounter(Transaction transaction)
+            {
+                var snapshot = await transaction.GetDocumentSnapshotAsync(doc);
+                Interlocked.Increment(ref attempts);
+                // We wouldn't want to signal again when retrying. Nothing is going
+                // to *increment* CurrentCount, so this should be safe.
+                if (latch.CurrentCount != 0)
+                {
+                    latch.Signal();
+                }
+                if (!latch.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    throw new TimeoutException();
+                }
+                transaction.Set(doc, new { Count = snapshot.GetField<int>("Count") + 1 });
+            }
+        }
+
+        /// <summary>
+        /// As TransactionWithRetry, but preventing retries from happening. We expect one transaction
+        /// to succeed, and the other to fail - it would have retried (as above) but the options prevent that.
+        /// </summary>
+        [Fact]
+        public async Task TransactionNeedingRetryWithOnlyOneAttempt()
+        {
+            int attempts = 0;
+            var db = _fixture.FirestoreDb;
+            var doc = await _fixture.NonQueryCollection.AddAsync(new { Count = 0 });
+            var latch = new CountdownEvent(2);
+
+            var t1 = db.RunTransactionAsync(IncrementCounter, TransactionOptions.Create(1));
+            var t2 = db.RunTransactionAsync(IncrementCounter, TransactionOptions.Create(1));
+            await Assert.ThrowsAsync<RpcException>(() => Task.WhenAll(t1, t2));
+
+            // Exactly one of the transactions should be faulted.
+            Assert.True(t1.IsFaulted ^ t2.IsFaulted);
+
+            Assert.Equal(2, attempts);
+            var result = await doc.SnapshotAsync();
+            Assert.Equal(1, result.GetField<int>("Count"));
+
+            async Task IncrementCounter(Transaction transaction)
+            {
+                var snapshot = await transaction.GetDocumentSnapshotAsync(doc);
+                Interlocked.Increment(ref attempts);
+                // We wouldn't want to signal again when retrying. Nothing is going
+                // to *increment* CurrentCount, so this should be safe.
+                if (latch.CurrentCount != 0)
+                {
+                    latch.Signal();
+                }
+                if (!latch.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    throw new TimeoutException();
+                }
+                transaction.Set(doc, new { Count = snapshot.GetField<int>("Count") + 1 });
+            }
+        }
+    }
+}


### PR DESCRIPTION
I can't quite get my head round how to force more than one retry, so
the "exhausted retry" test just forces the transactions into "0
retries available" mode.