### PR TITLE
Allow unauthenticated access for StorageClient

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UnauthenticatedAccessTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UnauthenticatedAccessTest.cs
@@ -1,0 +1,67 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Google.Cloud.Storage.V1.IntegrationTests
+{
+    [Collection(nameof(StorageFixture))]
+    public class UnauthenticatedAccessTest
+    {
+        // See https://cloud.google.com/storage/docs/public-datasets/landsat
+        // We pick one particular prefix/directory and a small file to test.
+        private const string LandsatBucket = "gcp-public-data-landsat";
+        private const string LandsatPrefix = "LC08/PRE/044/034/LC80440342016259LGN00/";
+        private const string LandsatObject = LandsatPrefix + "LC80440342016259LGN00_MTL.txt";
+
+        private readonly StorageFixture _fixture;
+
+        public UnauthenticatedAccessTest(StorageFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public void DownloadPublicData()
+        {
+            var client = StorageClient.CreateUnauthenticated();
+            MemoryStream stream = new MemoryStream();
+            client.DownloadObject(LandsatBucket, LandsatObject, stream);
+            Assert.Equal(7903, stream.Length);
+        }
+
+        [Fact]
+        public void ListPublicData()
+        {
+            var client = StorageClient.CreateUnauthenticated();
+            var objects = client.ListObjects(LandsatBucket, LandsatPrefix).ToList();
+            Assert.Equal(13, objects.Count);
+        }
+
+        [Fact]
+        public void DownloadInRegularBucket_Fails()
+        {
+            var client = StorageClient.CreateUnauthenticated();
+            Assert.Throws<GoogleApiException>(() => client.DownloadObject(
+                _fixture.ReadBucket, _fixture.SmallObject, new MemoryStream()));
+        }
+
+        [Fact]
+        public void UploadInRegularBucket_Fails()
+        {
+            var client = StorageClient.CreateUnauthenticated();
+            Assert.Throws<GoogleApiException>(() => client.UploadObject(
+                _fixture.SingleVersionBucket, "foo.txt", "application/text", new MemoryStream(new byte[10])));
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.cs
@@ -93,6 +93,15 @@ namespace Google.Cloud.Storage.V1
             return CreateImpl(scopedCredentials, encryptionKey);
         }
 
+        /// <summary>
+        /// Creates a <see cref="StorageClient"/> with no credentials. This can only be used in limited
+        /// situations (where authentication isn't required), primarily downloading public data.
+        /// </summary>
+        /// <returns>The created <see cref="StorageClient"/>.</returns>
+        public static StorageClient CreateUnauthenticated()
+        {
+            return CreateImpl(null, null);
+        }
 
         private static StorageClient CreateImpl(GoogleCredential scopedCredentials, EncryptionKey encryptionKey)
         {


### PR DESCRIPTION
This makes it simple to work with public datasets.

(I won't be merging this immediately; I want it to get wider review first.)