### PR TITLE
Allow for more flexible translations for some of the translate integration tests.

### DIFF
--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/AdvancedTranslationClientTest.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/AdvancedTranslationClientTest.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Translation.V2.IntegrationTests
         {
             var client = AdvancedTranslationClient.Create();
             var translation = client.TranslateText(LargeText, LanguageCodes.French);
-            Assert.StartsWith("Lorsque, au cours d", translation.TranslatedText);
+            Assert.Contains("au cours d", translation.TranslatedText);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/TranslationClientTest.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/TranslationClientTest.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.Translation.V2.IntegrationTests
         {
             var client = TranslationClient.Create();
             var translation = client.TranslateText(LargeText, LanguageCodes.French);
-            Assert.StartsWith("Lorsque, au cours d", translation.TranslatedText);
+            Assert.Contains("au cours d", translation.TranslatedText);
             Assert.Equal(LargeText, translation.OriginalText);
             Assert.Equal(LanguageCodes.French, translation.TargetLanguage);
             Assert.Equal(LanguageCodes.English, translation.DetectedSourceLanguage);


### PR DESCRIPTION
Some of these tests keep failing as the transtaltion has changed between starting with "Lorsque, au cours d" and Quand, au cours d"