### PR TITLE
Type conversion prepping.

### DIFF
--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerComplexTypeMapping.cs
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerComplexTypeMapping.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Data.Common;
+using Google.Cloud.Spanner.Data;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
+{
+    /// <summary>
+    /// Represents a complex spanner type mapping. This class is used for setting up type conversions.
+    /// </summary>
+    internal class SpannerComplexTypeMapping : RelationalTypeMapping
+    {
+        private readonly SpannerDbType _complexType;
+
+        public SpannerComplexTypeMapping(SpannerDbType complexType) 
+            : base(complexType.ToString(), complexType.DefaultClrType, complexType.DbType)
+        {
+            _complexType = complexType;
+        }
+
+        public override RelationalTypeMapping Clone(string storeType, int? size)
+        {
+            return new SpannerComplexTypeMapping(_complexType);
+        }
+
+        protected override void ConfigureParameter(DbParameter parameter)
+        {
+            // This key step will configure our SpannerParameter with this complex type, which will result in
+            // the proper type conversions when the requests go out.
+            ((SpannerParameter) parameter).SpannerDbType = _complexType;
+            base.ConfigureParameter(parameter);
+        }
+    }
+}

--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerTypeMapper.cs
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerTypeMapper.cs
@@ -25,40 +25,44 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
     /// </summary>
     public class SpannerTypeMapper : RelationalTypeMapper
     {
-        private static readonly BoolTypeMapping s_bool = new BoolTypeMapping(SpannerDbType.Bool.DatabaseTypeName);
-        private static readonly DateTimeTypeMapping s_date =
-            new DateTimeTypeMapping(SpannerDbType.Date.DatabaseTypeName, DbType.Date);
-        private static readonly DateTimeTypeMapping s_datetime =
-            new DateTimeTypeMapping(SpannerDbType.Timestamp.DatabaseTypeName, DbType.DateTime);
+        private static readonly BoolTypeMapping s_bool
+            = new BoolTypeMapping(SpannerDbType.Bool.ToString());
+        private static readonly DateTimeTypeMapping s_date
+            = new DateTimeTypeMapping(SpannerDbType.Date.ToString(), DbType.DateTime);
+        private static readonly DateTimeTypeMapping s_datetime
+            = new DateTimeTypeMapping(SpannerDbType.Timestamp.ToString(), DbType.DateTime);
         private static readonly StringTypeMapping s_defaultString
-            = new StringTypeMapping(SpannerDbType.String.DatabaseTypeName, DbType.String, true);
-        private static readonly DoubleTypeMapping s_double = new DoubleTypeMapping(SpannerDbType.Float64.DatabaseTypeName);
-        private static readonly LongTypeMapping s_long =
-            new LongTypeMapping(SpannerDbType.Int64.DatabaseTypeName, DbType.Int64);
+            = new StringTypeMapping(SpannerDbType.String.ToString(), DbType.String, true);
+        private static readonly DoubleTypeMapping s_double
+            = new DoubleTypeMapping(SpannerDbType.Float64.ToString());
+        private static readonly LongTypeMapping s_long 
+            = new LongTypeMapping(SpannerDbType.Int64.ToString(), DbType.Int64);
 
-        private static readonly Dictionary<string, RelationalTypeMapping> s_storeTypeMappings 
-            = new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase)
-        {
-            {s_long.StoreType, s_long},
-            {s_bool.StoreType, s_bool},
-            {s_date.StoreType, s_date},
-            {s_datetime.StoreType, s_datetime},
-            {s_double.StoreType, s_double},
-            {s_defaultString.StoreType, s_defaultString}
-        };
+        private static readonly Dictionary<SpannerDbType, RelationalTypeMapping> s_dbTypeMappings
+            = new Dictionary<SpannerDbType, RelationalTypeMapping>
+            {
+                { SpannerDbType.Bool, s_bool },
+                { SpannerDbType.Bytes, null },
+                { SpannerDbType.Date, s_date },
+                { SpannerDbType.Float64, s_double },
+                { SpannerDbType.Int64, s_long },
+                { SpannerDbType.Timestamp, s_datetime },
+                { SpannerDbType.String, s_defaultString },
+                { SpannerDbType.Unspecified, null },
+            };
 
         private static readonly Dictionary<System.Type, RelationalTypeMapping> s_clrTypeMappings
             = new Dictionary<System.Type, RelationalTypeMapping>
-            {
-                {typeof(int), s_long},
-                {typeof(long), s_long},
-                {typeof(uint), s_long},
-                {typeof(bool), s_long},
-                {typeof(DateTime), s_long},
-                {typeof(float), s_double},
-                {typeof(double), s_double},
-                {typeof(string), s_defaultString}
-            };
+        {
+            {typeof(int), s_long },
+            {typeof(long), s_long },
+            {typeof(uint), s_long},
+            {typeof(bool), s_bool},
+            {typeof(DateTime), s_datetime},
+            {typeof(float), s_double},
+            {typeof(double), s_double},
+            {typeof(string), s_defaultString}
+        };
 
         /// <summary>
         /// </summary>
@@ -77,6 +81,26 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
 
         /// <inheritdoc />
         protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetStoreTypeMappings()
-            => s_storeTypeMappings;
+            => null;
+
+        /// <inheritdoc />
+        protected override RelationalTypeMapping CreateMappingFromStoreType(string storeType)
+        {
+            if (SpannerDbType.TryParse(storeType, out SpannerDbType parsedType))
+            {
+                if (!parsedType.Size.HasValue
+                    && s_dbTypeMappings.TryGetValue(parsedType, out RelationalTypeMapping mapping))
+                {
+                    return mapping;
+                }
+                if (parsedType.DbType == DbType.String)
+                {
+                    // return a sized string.
+                    return new StringTypeMapping(storeType, parsedType.DbType, true, parsedType.Size);
+                }
+                return new SpannerComplexTypeMapping(parsedType);
+            }
+            return null;
+        }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerDbTypeTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerDbTypeTests.cs
@@ -53,5 +53,137 @@ namespace Google.Cloud.Spanner.Data.Tests
             Assert.Equal(spannerType1.GetHashCode(), spannerType2.GetHashCode());
             Assert.True(spannerType1.Equals(spannerType2));
         }
+
+        public static IEnumerable<object[]> GetSpannerStringConversions()
+        {
+            yield return new object[] { "STRING", SpannerDbType.String };
+            yield return new object[] { "STRING(MAX)", SpannerDbType.String };
+            yield return new object[] { "BOOL", SpannerDbType.Bool };
+            yield return new object[] { "BYTES", SpannerDbType.Bytes };
+            yield return new object[] { "DATE", SpannerDbType.Date };
+            yield return new object[] { "FLOAT64", SpannerDbType.Float64 };
+            yield return new object[] { "INT64", SpannerDbType.Int64 };
+            yield return new object[] { "TIMESTAMP", SpannerDbType.Timestamp };
+
+            yield return new object[] { " STRING  ", SpannerDbType.String };
+            yield return new object[] { "  BOOL  ", SpannerDbType.Bool };
+            yield return new object[] { "  BYTES  ", SpannerDbType.Bytes };
+            yield return new object[] { "  DATE  ", SpannerDbType.Date };
+            yield return new object[] { "  FLOAT64  ", SpannerDbType.Float64 };
+            yield return new object[] { "  INT64  ", SpannerDbType.Int64 };
+            yield return new object[] { "  TIMESTAMP  ", SpannerDbType.Timestamp };
+
+            yield return new object[] { "STRING(2)", SpannerDbType.String.WithSize(2) };
+            yield return new object[] { "STRING(100)", SpannerDbType.String.WithSize(100) };
+            yield return new object[] { " STRING ( 100  )  ", SpannerDbType.String.WithSize(100) };
+            yield return new object[] { "STRING (  MAX )", SpannerDbType.String };
+            yield return new object[] { "STRING(100)", SpannerDbType.String, false };
+            yield return new object[] { "BYTES(100)", SpannerDbType.Bytes.WithSize(100) };
+            yield return new object[] { "BYTES(100)", SpannerDbType.Bytes, false };
+            yield return new object[] { " BYTES ( 100  )  ", SpannerDbType.Bytes.WithSize(100) };
+
+            //some common array types.
+            yield return new object[] { "ARRAY<STRING>", SpannerDbType.ArrayOf(SpannerDbType.String) };
+            yield return new object[] { "ARRAY<STRING(MAX)>", SpannerDbType.ArrayOf(SpannerDbType.String) };
+            yield return new object[] { "ARRAY<STRING(5)>", SpannerDbType.ArrayOf(SpannerDbType.String.WithSize(5)) };
+            yield return new object[] { "ARRAY<STRING>", SpannerDbType.ArrayOf(SpannerDbType.String) };
+            yield return new object[] { "ARRAY<BOOL>", SpannerDbType.ArrayOf(SpannerDbType.Bool) };
+            yield return new object[] { "ARRAY<BYTES>", SpannerDbType.ArrayOf(SpannerDbType.Bytes) };
+            yield return new object[] { "ARRAY<BYTES(100)>", SpannerDbType.ArrayOf(SpannerDbType.Bytes.WithSize(100)) };
+            yield return new object[] { "ARRAY<DATE>", SpannerDbType.ArrayOf(SpannerDbType.Date) };
+            yield return new object[] { "ARRAY<FLOAT64>", SpannerDbType.ArrayOf(SpannerDbType.Float64) };
+            yield return new object[] { "ARRAY<INT64>", SpannerDbType.ArrayOf(SpannerDbType.Int64) };
+            yield return new object[] { "ARRAY<TIMESTAMP>", SpannerDbType.ArrayOf(SpannerDbType.Timestamp) };
+
+            yield return new object[] { "ARRAY<STRING(5)>", SpannerDbType.ArrayOf(SpannerDbType.String), false };
+            yield return new object[] { "ARRAY<BYTES(5)>", SpannerDbType.ArrayOf(SpannerDbType.Bytes), false };
+
+            yield return new object[] { "ARRAY <  STRING (   5 )>", SpannerDbType.ArrayOf(SpannerDbType.String.WithSize(5)) };
+            yield return new object[] { "ARRAY<  STRING (   5 )  > ", SpannerDbType.ArrayOf(SpannerDbType.String.WithSize(5)) };
+
+            //simple structs
+            yield return new object[] { "STRUCT<F1:STRING,F2:INT64>", SpannerDbType.StructOf(
+                new Dictionary<string, SpannerDbType>
+                {
+                    { "F1", SpannerDbType.String },
+                    { "F2", SpannerDbType.Int64 },
+                }) };
+
+            yield return new object[] { "STRUCT< F1 : STRING , F2  : INT64 >", SpannerDbType.StructOf(
+                new Dictionary<string, SpannerDbType>
+                {
+                    { "F1", SpannerDbType.String },
+                    { "F2", SpannerDbType.Int64 },
+                }) };
+
+            yield return new object[] { "STRUCT<F1:STRING,F2:INT64,F3:BOOL,F4:BYTES,F5:DATE,F6:FLOAT64,F7:TIMESTAMP>",
+                SpannerDbType.StructOf( new Dictionary<string, SpannerDbType>
+                {
+                    { "F1", SpannerDbType.String },
+                    { "F2", SpannerDbType.Int64 },
+                    { "F3", SpannerDbType.Bool },
+                    { "F4", SpannerDbType.Bytes },
+                    { "F5", SpannerDbType.Date },
+                    { "F6", SpannerDbType.Float64 },
+                    { "F7", SpannerDbType.Timestamp },
+                }) };
+
+            yield return new object[] { "STRUCT<F1: STRING(100), F2: BYTES(200)>" ,
+                SpannerDbType.StructOf( new Dictionary<string, SpannerDbType>
+                {
+                    { "F1", SpannerDbType.String.WithSize(100) },
+                    { "F2", SpannerDbType.Bytes.WithSize(200) }
+                }) };
+
+            //struct of struct
+            yield return new object[] { "STRUCT<F1:STRUCT<F2:INT64>>", SpannerDbType.StructOf(
+                new Dictionary<string, SpannerDbType>
+                {
+                    { "F1", SpannerDbType.StructOf(
+                            new Dictionary<string, SpannerDbType>
+                            {
+                                { "F2", SpannerDbType.Int64 },
+                            }
+                        ) },
+                }) };
+
+            //struct of array
+            yield return new object[] { "STRUCT<F1:ARRAY<INT64>>", SpannerDbType.StructOf(
+                new Dictionary<string, SpannerDbType>
+                {
+                    { "F1", SpannerDbType.ArrayOf(SpannerDbType.Int64) }
+                }) };
+
+            //array of struct
+            yield return new object[]
+            {
+                "ARRAY<STRUCT<F1:INT64>>", SpannerDbType.ArrayOf(
+                    SpannerDbType.StructOf(
+                        new Dictionary<string, SpannerDbType>
+                        {
+                            {"F1", SpannerDbType.Int64}
+                        }))
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetSpannerStringConversions))]
+        public void StringConversions(string stringFormat, SpannerDbType spannerType, bool shouldEqual = true)
+        {
+            Assert.True(SpannerDbType.TryParse(stringFormat, out SpannerDbType result));
+            if (shouldEqual)
+            {
+                Assert.Equal(spannerType, result);
+            }
+            else
+            {
+                Assert.NotEqual(spannerType, result);
+            }
+
+            //roundtrip test.
+            Assert.True(SpannerDbType.TryParse(result.ToString(), out SpannerDbType result2));
+            Assert.Equal(result, result2);
+        }
+
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/TypeTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/TypeTests.cs
@@ -439,7 +439,7 @@ namespace Google.Cloud.Spanner.Data.Tests
                 try
                 {
                     string expected = expectedJsonValue;
-                    var jsonValue = ValueConversion.ToValue(clrValue, spannerDbType);
+                    var jsonValue = spannerDbType.ToProtobufValue(clrValue);
                     string actual = jsonValue.ToString();
                     if (expected != actual)
                     {
@@ -483,7 +483,7 @@ namespace Google.Cloud.Spanner.Data.Tests
                 {
                     var wireValue = JsonParser.Default.Parse<Value>(inputJson);
                     var targetClrType = expected?.GetType() ?? typeof(object);
-                    var actual = wireValue.ConvertToClrType(spannerDbType.ToProtobufType(), targetClrType);
+                    var actual = spannerDbType.ConvertToClrType(wireValue, targetClrType);
                     Assert.Equal(expected, actual);
                 }
                 catch (Exception e)
@@ -510,7 +510,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             var exceptionCaught = false;
             try
             {
-                ValueConversion.ToValue(value, type);
+                type.ToProtobufValue(value);
             }
             catch (Exception e) when (e is OverflowException || e is InvalidCastException || e is FormatException)
             {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
@@ -418,7 +418,7 @@ namespace Google.Cloud.Spanner.Data
                         {
                             Values =
                             {
-                                Parameters.Select(x => ValueConversion.ToValue(x.GetValidatedValue(), x.SpannerDbType))
+                                Parameters.Select(x => x.SpannerDbType.ToProtobufValue(x.GetValidatedValue()))
                             }
                         }
                     }
@@ -453,7 +453,7 @@ namespace Google.Cloud.Spanner.Data
                                     Values =
                                     {
                                         Parameters.Select(
-                                            x => ValueConversion.ToValue(x.GetValidatedValue(), x.SpannerDbType))
+                                            x => x.SpannerDbType.ToProtobufValue(x.GetValidatedValue()))
                                     }
                                 }
                             }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReader.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReader.cs
@@ -80,7 +80,7 @@ namespace Google.Cloud.Spanner.Data
         public override bool IsClosed => _resultSet.IsClosed;
 
         /// <inheritdoc />
-        public override object this[int i] => _innerList[i].ConvertToClrType(GetSpannerFieldType(i));
+        public override object this[int i] => GetSpannerFieldType(i).ConvertToClrType(_innerList[i]);
 
         /// <inheritdoc />
         public override object this[string name] => this[
@@ -90,33 +90,33 @@ namespace Google.Cloud.Spanner.Data
         public override int RecordsAffected => -1;
 
         /// <inheritdoc />
-        public override bool GetBoolean(int i) => _innerList[i].ConvertToClrType<bool>(GetSpannerFieldType(i));
+        public override bool GetBoolean(int i) => GetSpannerFieldType(i).ConvertToClrType<bool>(_innerList[i]);
 
         /// <inheritdoc />
-        public override byte GetByte(int i) => _innerList[i].ConvertToClrType<byte>(GetSpannerFieldType(i));
+        public override byte GetByte(int i) => GetSpannerFieldType(i).ConvertToClrType<byte>(_innerList[i]);
 
         /// <inheritdoc />
         public override long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferoffset, int length) => throw
             new NotSupportedException("Spanner does not support conversion to byte arrays.");
 
         /// <inheritdoc />
-        public override char GetChar(int i) => _innerList[i].ConvertToClrType<char>(GetSpannerFieldType(i));
+        public override char GetChar(int i) => GetSpannerFieldType(i).ConvertToClrType<char>(_innerList[i]);
 
         /// <inheritdoc />
         public override long GetChars(int i, long fieldoffset, char[] buffer, int bufferoffset, int length) => throw
             new NotSupportedException("Spanner does not support conversion to char arrays.");
 
         /// <inheritdoc />
-        public override string GetDataTypeName(int i) => GetSpannerFieldType(i).Code.ToString();
+        public override string GetDataTypeName(int i) => GetSpannerFieldType(i).ToString();
 
         /// <inheritdoc />
-        public override DateTime GetDateTime(int i) => _innerList[i].ConvertToClrType<DateTime>(GetSpannerFieldType(i));
+        public override DateTime GetDateTime(int i) => GetSpannerFieldType(i).ConvertToClrType<DateTime>(_innerList[i]);
 
         /// <inheritdoc />
-        public override decimal GetDecimal(int i) => _innerList[i].ConvertToClrType<decimal>(GetSpannerFieldType(i));
+        public override decimal GetDecimal(int i) => GetSpannerFieldType(i).ConvertToClrType<decimal>(_innerList[i]);
 
         /// <inheritdoc />
-        public override double GetDouble(int i) => _innerList[i].ConvertToClrType<double>(GetSpannerFieldType(i));
+        public override double GetDouble(int i) => GetSpannerFieldType(i).ConvertToClrType<double>(_innerList[i]);
 
         /// <inheritdoc />
         public override IEnumerator GetEnumerator()
@@ -133,12 +133,12 @@ namespace Google.Cloud.Spanner.Data
         {
             var fieldMetadata = PopulateMetadataAsync(CancellationToken.None).ResultWithUnwrappedExceptions().RowType
                 .Fields[i];
-            return fieldMetadata.Type.Code.GetDefaultClrTypeFromSpannerType();
+            return SpannerDbType.FromProtobufType(fieldMetadata.Type).DefaultClrType;
         }
 
         /// <inheritdoc />
-        public override T GetFieldValue<T>(int ordinal) => (T) _innerList[ordinal]
-            .ConvertToClrType(GetSpannerFieldType(ordinal), typeof(T));
+        public override T GetFieldValue<T>(int ordinal) => (T)GetSpannerFieldType(ordinal).ConvertToClrType(
+            _innerList[ordinal], typeof(T));
 
         /// <summary>
         /// Gets the value of the specified column as type T.
@@ -158,23 +158,23 @@ namespace Google.Cloud.Spanner.Data
             {
                 throw new ArgumentException($"{columnName} is not a valid column", nameof(columnName));
             }
-            return (T)_innerList[ordinal].ConvertToClrType(GetSpannerFieldType(ordinal), typeof(T));
+            return (T)GetSpannerFieldType(ordinal).ConvertToClrType(_innerList[ordinal], typeof(T));
         }
 
         /// <inheritdoc />
-        public override float GetFloat(int i) => _innerList[i].ConvertToClrType<float>(GetSpannerFieldType(i));
+        public override float GetFloat(int i) => GetSpannerFieldType(i).ConvertToClrType<float>(_innerList[i]);
 
         /// <inheritdoc />
-        public override Guid GetGuid(int i) => _innerList[i].ConvertToClrType<Guid>(GetSpannerFieldType(i));
+        public override Guid GetGuid(int i) => GetSpannerFieldType(i).ConvertToClrType<Guid>(_innerList[i]);
 
         /// <inheritdoc />
-        public override short GetInt16(int i) => _innerList[i].ConvertToClrType<short>(GetSpannerFieldType(i));
+        public override short GetInt16(int i) => GetSpannerFieldType(i).ConvertToClrType<short>(_innerList[i]);
 
         /// <inheritdoc />
-        public override int GetInt32(int i) => _innerList[i].ConvertToClrType<int>(GetSpannerFieldType(i));
+        public override int GetInt32(int i) => GetSpannerFieldType(i).ConvertToClrType<int>(_innerList[i]);
 
         /// <inheritdoc />
-        public override long GetInt64(int i) => _innerList[i].ConvertToClrType<long>(GetSpannerFieldType(i));
+        public override long GetInt64(int i) => GetSpannerFieldType(i).ConvertToClrType<long>(_innerList[i]);
 
         /// <summary>
         /// Gets the value of the specified column as a pure Protobuf type.
@@ -193,14 +193,14 @@ namespace Google.Cloud.Spanner.Data
             => GetFieldIndexAsync(name, CancellationToken.None).ResultWithUnwrappedExceptions();
 
         /// <inheritdoc />
-        public override string GetString(int i) => _innerList[i].ConvertToClrType<string>(GetSpannerFieldType(i));
+        public override string GetString(int i) => GetSpannerFieldType(i).ConvertToClrType<string>(_innerList[i]);
 
         /// <summary>
         /// Gets the value of the specified column as type <see cref="Timestamp"/>.
         /// </summary>
         /// <param name="i">The index of the column to retrieve.</param>
         /// <returns></returns>
-        public Timestamp GetTimestamp(int i) => _innerList[i].ConvertToClrType<Timestamp>(GetSpannerFieldType(i));
+        public Timestamp GetTimestamp(int i) => GetSpannerFieldType(i).ConvertToClrType<Timestamp>(_innerList[i]);
 
         /// <inheritdoc />
         public override object GetValue(int i) => this[i];
@@ -303,11 +303,11 @@ namespace Google.Cloud.Spanner.Data
                         .ConfigureAwait(false)), "SpannerDataReader.GetMetadata", Logger);
         }
 
-        private V1.Type GetSpannerFieldType(int i)
+        private SpannerDbType GetSpannerFieldType(int i)
         {
             var fieldMetadata = PopulateMetadataAsync(CancellationToken.None).ResultWithUnwrappedExceptions().RowType
                 .Fields[i];
-            return fieldMetadata.Type;
+            return SpannerDbType.FromProtobufType(fieldMetadata.Type);
         }
 
 #if !NETSTANDARD1_5

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.StringParsing.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.StringParsing.cs
@@ -1,0 +1,189 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Google.Cloud.Spanner.V1;
+using TypeCode = Google.Cloud.Spanner.V1.TypeCode;
+
+namespace Google.Cloud.Spanner.Data
+{
+    public sealed partial class SpannerDbType
+    {
+        /// <summary>
+        /// Given a string representation, returns an instance of <see cref="SpannerDbType"/>.
+        /// </summary>
+        /// <param name="spannerType">A string representation of a SpannerDbType. See <see cref="ToString"/></param>
+        /// <param name="spannerDbType">If parsing was successful, then an instance of <see cref="SpannerDbType"/>.
+        ///  Otherwise null.</param>
+        /// <returns></returns>
+        public static bool TryParse(string spannerType, out SpannerDbType spannerDbType)
+        {
+            spannerDbType = null;
+            if (!TryParsePartial(spannerType, out TypeCode code, out int? size, out string remainder))
+            {
+                return false;
+            }
+            switch (code)
+            {
+                case TypeCode.Unspecified:
+                case TypeCode.Bool:
+                case TypeCode.Int64:
+                case TypeCode.Float64:
+                case TypeCode.Timestamp:
+                case TypeCode.Date:
+                case TypeCode.String:
+                case TypeCode.Bytes:
+                    if (!string.IsNullOrEmpty(remainder))
+                    {
+                        //unexepected inner remainder on simple type
+                        return false;
+                    }
+                    spannerDbType = !size.HasValue ? FromTypeCode(code) : new SpannerDbType(code, size.Value);
+                    return true;
+                case TypeCode.Array:
+                    if (!TryParse(remainder, out SpannerDbType elementType))
+                    {
+                        return false;
+                    }
+                    spannerDbType = new SpannerDbType(code, elementType);
+                    return true;
+                case TypeCode.Struct:
+                    //there could be nested structs, so we need to be careful about parsing the inner string.
+                    List<Tuple<string, SpannerDbType>> fields = new List<Tuple<string, SpannerDbType>>();
+                    int currentIndex = 0;
+                    while (currentIndex < remainder.Length)
+                    {
+                        int midfieldIndex = NonNestedIndexOf(remainder, currentIndex, ':');
+                        if (midfieldIndex == -1)
+                        {
+                            return false;
+                        }
+                        int endFieldIndex = NonNestedIndexOf(remainder, currentIndex, ',');
+                        if (endFieldIndex == -1)
+                        {
+                            //we reached the last field.
+                            endFieldIndex = remainder.Length;
+                        }
+
+                        string fieldName = remainder.Substring(currentIndex, midfieldIndex - currentIndex).Trim();
+                        if (!TryParse(remainder.Substring(midfieldIndex + 1, endFieldIndex - midfieldIndex - 1),
+                            out SpannerDbType fieldDbType))
+                        {
+                            return false;
+                        }
+                        fields.Add(new Tuple<string, SpannerDbType>(fieldName, fieldDbType));
+                        currentIndex = endFieldIndex + 1;
+                    }
+                    spannerDbType = new SpannerDbType(code, fields);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns the first index of 'c' within typeString at nesting level '0' where the nesting level is defined
+        /// by brackets &lt; and &gt;
+        /// </summary>
+        private static int NonNestedIndexOf(string typeString, int startIndex, params char[] c)
+        {
+            int level = 0;
+            for (var i = startIndex; i < typeString.Length; i++)
+            {
+                if (typeString[i] == '<') level++;
+                else if (typeString[i] == '>') level--;
+                else if (c.Contains(typeString[i]) && level == 0) return i;
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// Parses a subsection of the given string into a TypeCode and size, returning the nested content
+        /// as a remainder.
+        /// Given a string of  ARRAY{STRING}, the remainer will be 'STRING' and the returned typecode will be ARRAY.
+        /// </summary>
+        private static bool TryParsePartial(string complexName, out TypeCode typeCode, out int? size, out string remainder)
+        {
+            typeCode = TypeCode.Unspecified;
+            size = null;
+            remainder = null;
+            if (string.IsNullOrEmpty(complexName))
+            {
+                return false;
+            }
+
+            int remainderStart = complexName.IndexOfAny(new[] { '<', '(' });
+            remainderStart = remainderStart != -1 ? remainderStart : complexName.Length;
+            typeCode = TypeCodeExtensions.GetTypeCode(complexName.Substring(0, remainderStart));
+            if (typeCode == TypeCode.Unspecified)
+            {
+                return false;
+            }
+            if (complexName.Length > remainderStart)
+            {
+                if (complexName[remainderStart] == '(')
+                {
+                    //get the size and remainder to send back
+                    var sizeEnd = complexName.IndexOf(')');
+                    if (sizeEnd == -1)
+                    {
+                        return false;
+                    }
+                    var sizeString = complexName.Substring(remainderStart + 1, sizeEnd - remainderStart - 1).Trim();
+                    if (!sizeString.Equals("MAX", StringComparison.OrdinalIgnoreCase) &&
+                         int.TryParse(sizeString, out int parsedSize))
+                    {
+                        size = parsedSize;
+                    }
+                    remainder = complexName.Substring(sizeEnd + 1).Trim();
+                }
+                else
+                {
+                    var innerEnd = complexName.LastIndexOf('>');
+                    if (innerEnd == -1)
+                    {
+                        return false;
+                    }
+                    //get the remainder to send back.
+                    remainder = complexName.Substring(remainderStart + 1, innerEnd - remainderStart - 1).Trim();
+                }
+            }
+            return true;
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            if (ArrayElementType != null)
+            {
+                return $"ARRAY<{ArrayElementType}>";
+            }
+            if (StructMembers != null && StructMembers.Count > 0)
+            {
+                var s = new StringBuilder();
+                foreach (var keyValuePair in StructMembers)
+                {
+                    s.Append(s.Length == 0 ? "STRUCT<" : ", ");
+                    s.Append($"{keyValuePair.Key}:{keyValuePair.Value}");
+                }
+                s.Append(">");
+                return s.ToString();
+            }
+            return Size.HasValue ? $"{TypeCode.GetOriginalName()}({Size})" : TypeCode.GetOriginalName();
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameterCollection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameterCollection.cs
@@ -226,12 +226,19 @@ namespace Google.Cloud.Spanner.Data
             FillSpannerInternalTypes(requestParamTypes);
         }
 
+        /// <summary>
+        /// This helper removes the leading '@' in case the developer accidentally used
+        /// it in his parameter name.
+        /// </summary>
+        private string GetCorrectedParameterName(string parameterName) 
+            => parameterName?.StartsWith("@") ?? false ? parameterName.Substring(1) : parameterName;
+
         private void FillSpannerInternalValues(MapField<string, Value> valueDictionary)
         {
             foreach (var parameter in _innerList)
             {
-                valueDictionary[parameter.ParameterName] =
-                    ValueConversion.ToValue(parameter.GetValidatedValue(), parameter.SpannerDbType);
+                valueDictionary[GetCorrectedParameterName(parameter.ParameterName)]
+                    = parameter.SpannerDbType.ToProtobufValue(parameter.GetValidatedValue());
             }
         }
 
@@ -239,7 +246,8 @@ namespace Google.Cloud.Spanner.Data
         {
             foreach (var parameter in _innerList)
             {
-                typeDictionary[parameter.ParameterName] = parameter.SpannerDbType.ToProtobufType();
+                typeDictionary[GetCorrectedParameterName(parameter.ParameterName)]
+                    = parameter.SpannerDbType.ToProtobufType();
             }
         }
 

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Type.Extensions.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Type.Extensions.cs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
+using System.Collections.Generic;
+using Google.Api.Gax;
 
 namespace Google.Cloud.Spanner.V1
 {
@@ -20,37 +21,41 @@ namespace Google.Cloud.Spanner.V1
     /// </summary>
     public static class TypeCodeExtensions
     {
+        private static readonly Dictionary<string, TypeCode> s_originalNameToCode
+            = new Dictionary<string, TypeCode>
+            {
+                {TypeCode.Bool.ToString().ToUpperInvariant(), TypeCode.Bool},
+                {TypeCode.Unspecified.ToString().ToUpperInvariant(), TypeCode.Unspecified},
+                {TypeCode.Int64.ToString().ToUpperInvariant(), TypeCode.Int64},
+                {TypeCode.Float64.ToString().ToUpperInvariant(), TypeCode.Float64},
+                {TypeCode.Timestamp.ToString().ToUpperInvariant(), TypeCode.Timestamp},
+                {TypeCode.Date.ToString().ToUpperInvariant(), TypeCode.Date},
+                {TypeCode.String.ToString().ToUpperInvariant(), TypeCode.String},
+                {TypeCode.Bytes.ToString().ToUpperInvariant(), TypeCode.Bytes},
+                {TypeCode.Array.ToString().ToUpperInvariant(), TypeCode.Array},
+                {TypeCode.Struct.ToString().ToUpperInvariant(), TypeCode.Struct},
+            };
+
         /// <summary>
         /// </summary>
         /// <param name="typeCode"></param>
         /// <returns></returns>
         public static string GetOriginalName(this TypeCode typeCode)
         {
-            switch (typeCode)
-            {
-                case TypeCode.Unspecified:
-                    return "UKNOWN";
-                case TypeCode.Bool:
-                    return "BOOL";
-                case TypeCode.Int64:
-                    return "INT64";
-                case TypeCode.Float64:
-                    return "FLOAT64";
-                case TypeCode.Timestamp:
-                    return "TIMESTAMP";
-                case TypeCode.Date:
-                    return "DATE";
-                case TypeCode.String:
-                    return "STRING";
-                case TypeCode.Bytes:
-                    return "BYTES";
-                case TypeCode.Array:
-                    return "ARRAY";
-                case TypeCode.Struct:
-                    return "STRUCT";
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(typeCode), typeCode, null);
-            }
+            return typeCode.ToString().ToUpperInvariant();
+        }
+
+        /// <summary>
+        /// Returns a TypeCode given its original string representation.
+        /// </summary>
+        /// <param name="originalName"></param>
+        /// <returns></returns>
+        public static TypeCode GetTypeCode(string originalName)
+        {
+            GaxPreconditions.CheckNotNull(originalName, nameof(originalName));
+            return s_originalNameToCode.TryGetValue(originalName.Trim(), out var typeCode)
+                ? typeCode
+                : TypeCode.Unspecified;
         }
     }
 }


### PR DESCRIPTION
This commit supports in-progress work for Spanner EF.
It cleans up a lot of the support around type conversions.
Now, SpannerDbType is the central place for all type and value conversions.

There is an outstanding TODO to support value conversions to IReadOnlyList.
This will allow the developer to declare a property of type IReadOnlyList<String> and have it match to a database type of ARRAY<STRING> without need of a ColumnAttribute.

