### PR TITLE
Default literal analyzer

### DIFF
--- a/tools/Google.Cloud.Tools.Analyzers.Tests/DefaultLiteralTest.cs
+++ b/tools/Google.Cloud.Tools.Analyzers.Tests/DefaultLiteralTest.cs
@@ -102,18 +102,7 @@ public class A
         bool? x = default;
     }
 }";
-            var expected = CreateDiagnostic("bool?", 6, 19);
-            VerifyCSharpDiagnostic(test, expected);
-
-            var newSource = @"
-public class A
-{
-    public void B()
-    {
-        bool? x = default(bool?);
-    }
-}";
-            VerifyCSharpFix(test, newSource);
+            VerifyCSharpDiagnostic(test);
         }
 
         [Fact]

--- a/tools/Google.Cloud.Tools.Analyzers.Tests/DefaultLiteralTest.cs
+++ b/tools/Google.Cloud.Tools.Analyzers.Tests/DefaultLiteralTest.cs
@@ -26,6 +26,39 @@ namespace Google.Cloud.Tools.Analyzers.Tests
     public class DefaultLiteralTest : CodeFixVerifier
     {
         [Fact]
+        public void DefaultBool()
+        {
+            var test = @"
+public class A
+{
+    public void B(bool x = default) { }
+}";
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [Fact]
+        public void DefaultEnum()
+        {
+            var test = @"
+public class A
+{
+    public void B(System.DateTimeKind x = default) { }
+}";
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [Fact]
+        public void DefaultInt()
+        {
+            var test = @"
+public class A
+{
+    public void B(int x = default) { }
+}";
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [Fact]
         public void DefaultNullableBool()
         {
             var test = @"
@@ -53,7 +86,7 @@ public class A
     public void B(object? x = default) { }
 }";
             VerifyCSharpDiagnostic(test);
-        }
+        }    
 
         [Fact]
         public void DefaultNullableEnum()

--- a/tools/Google.Cloud.Tools.Analyzers.Tests/DefaultLiteralTest.cs
+++ b/tools/Google.Cloud.Tools.Analyzers.Tests/DefaultLiteralTest.cs
@@ -37,6 +37,20 @@ public class A
         }
 
         [Fact]
+        public void DefaultBoolLocal()
+        {
+            var test = @"
+public class A
+{
+    public void B()
+    {
+        bool x = default;
+    }
+}";
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [Fact]
         public void DefaultEnum()
         {
             var test = @"
@@ -73,6 +87,31 @@ public class A
 public class A
 {
     public void B(bool? x = default(bool?)) { }
+}";
+            VerifyCSharpFix(test, newSource);
+        }
+
+        [Fact]
+        public void DefaultNullableBoolLocal()
+        {
+            var test = @"
+public class A
+{
+    public void B()
+    {
+        bool? x = default;
+    }
+}";
+            var expected = CreateDiagnostic("bool?", 6, 19);
+            VerifyCSharpDiagnostic(test, expected);
+
+            var newSource = @"
+public class A
+{
+    public void B()
+    {
+        bool? x = default(bool?);
+    }
 }";
             VerifyCSharpFix(test, newSource);
         }

--- a/tools/Google.Cloud.Tools.Analyzers.Tests/Helpers/DiagnosticVerifier.Helper.cs
+++ b/tools/Google.Cloud.Tools.Analyzers.Tests/Helpers/DiagnosticVerifier.Helper.cs
@@ -154,8 +154,9 @@ namespace TestHelper
                 .CurrentSolution
                 .AddProject(projectId, TestProjectName, TestProjectName, language)
                 .WithProjectParseOptions(projectId,
-                    CSharpParseOptions.Default.WithFeatures(
-                        new[] { new KeyValuePair<string, string>("IOperation", "true") }))
+                    CSharpParseOptions.Default
+                        .WithLanguageVersion(LanguageVersion.CSharp7_1)
+                        .WithFeatures(new[] { new KeyValuePair<string, string>("IOperation", "true") }))
                 .AddMetadataReference(projectId, CorlibReference)
                 .AddMetadataReference(projectId, SystemCoreReference)
                 .AddMetadataReference(projectId, CSharpSymbolsReference)

--- a/tools/Google.Cloud.Tools.Analyzers/DefaultLiteralAnalyzer.cs
+++ b/tools/Google.Cloud.Tools.Analyzers/DefaultLiteralAnalyzer.cs
@@ -56,6 +56,19 @@ namespace Google.Cloud.Tools.Analyzers
                 if (underlyingType.IsPrimitive() ||
                     underlyingType.BaseType?.SpecialType == SpecialType.System_Enum)
                 {
+                    // Check to see if https://github.com/dotnet/roslyn/issues/22578 has been fixed so we don't warn unnecessarily on parameters.
+                    // It would be nice to use context.SemanticModel.GetConstantValue instead so we can avoid warning in general, but it doesn't
+                    // seem to work: it always reports no constant value for the default literal.
+                    var parameterNode = context.Node.AncestorsAndSelf().OfType<ParameterSyntax>().FirstOrDefault();
+                    if (parameterNode != null)
+                    {
+                        var parameter = context.SemanticModel.GetDeclaredSymbol(parameterNode, context.CancellationToken);
+                        if (parameter.HasExplicitDefaultValue && parameter.ExplicitDefaultValue == null)
+                        {
+                            return;
+                        }
+                    }
+
                     context.ReportDiagnostic(
                         Diagnostic.Create(
                             Rule,

--- a/tools/Google.Cloud.Tools.Analyzers/DefaultLiteralAnalyzer.cs
+++ b/tools/Google.Cloud.Tools.Analyzers/DefaultLiteralAnalyzer.cs
@@ -1,0 +1,68 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Semantics;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Google.Cloud.Tools.Analyzers
+{
+    /// <summary>
+    /// Warns about default literal expressions triggering https://github.com/dotnet/roslyn/issues/22578.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class DefaultLiteralAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "GCP0004";
+        private const string Category = "Usage";
+
+        private static readonly LocalizableString Title = "Unintended default literal value";
+        private static readonly LocalizableString MessageFormat = "The default literal expression results in a zero value, not 'null' as likely intended. Use 'default({0})' instead.";
+        private static readonly LocalizableString Description = "Default literal expressions for nullable types use a 0, rather than the expected null, literal value.";
+        private static DiagnosticDescriptor Rule =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.RegisterSyntaxNodeAction(AnalyzeDefaultLiteral, SyntaxKind.DefaultLiteralExpression);
+        }
+
+        private static void AnalyzeDefaultLiteral(SyntaxNodeAnalysisContext context)
+        {
+            var typeInfo = context.SemanticModel.GetTypeInfo(context.Node, context.CancellationToken);            
+            if (typeInfo.ConvertedType.IsNullable(out var underlyingType))
+            {
+                if (underlyingType.IsPrimitive() ||
+                    underlyingType.BaseType?.SpecialType == SpecialType.System_Enum)
+                {
+                    context.ReportDiagnostic(
+                        Diagnostic.Create(
+                            Rule,
+                            context.Node.GetLocation(),
+                            typeInfo.ConvertedType.ToDisplayString()));
+                }
+            }
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.Analyzers/DefaultLiteralCodeFixProvider.cs
+++ b/tools/Google.Cloud.Tools.Analyzers/DefaultLiteralCodeFixProvider.cs
@@ -1,0 +1,80 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Semantics;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Tools.Analyzers
+{
+    /// <summary>
+    /// Code fix provider for the <see cref="DefaultLiteralAnalyzer"/>.
+    /// </summary>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(DefaultLiteralCodeFixProvider)), Shared]
+    public class DefaultLiteralCodeFixProvider : CodeFixProvider
+    {
+        private const string Title = "Convert to default value expression";
+
+        public sealed override ImmutableArray<string> FixableDiagnosticIds
+        {
+            get { return ImmutableArray.Create(DefaultLiteralAnalyzer.DiagnosticId); }
+        }
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var document = context.Document;
+            var semanticModel = await document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+            var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var defaultLiteralExpression =
+                root.FindToken(context.Span.Start).Parent.AncestorsAndSelf().OfType<LiteralExpressionSyntax>().FirstOrDefault();
+            if (defaultLiteralExpression == null ||
+                !defaultLiteralExpression.IsKind(SyntaxKind.DefaultLiteralExpression))
+            {
+                return;
+            }
+
+            var typeInfo = semanticModel.GetTypeInfo(defaultLiteralExpression, context.CancellationToken);
+            if (typeInfo.ConvertedType.IsNullable(out _))
+            {
+                // Note: this should use a generator's DefaultExpression method, but for some reason, VS chokes on its result:
+                //       the preview can't be displayed and choosing to apply the fix fails to do so and also wipes out the undo stack.
+                var defaultExpression = SyntaxFactory.ParseExpression($"default({typeInfo.ConvertedType.ToDisplayString()})");
+
+                var newDocument = document.WithSyntaxRoot(root.ReplaceNode(defaultLiteralExpression, defaultExpression));
+
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        title: Title,
+                        createChangedDocument: c => Task.FromResult(newDocument),
+                        equivalenceKey: Title),
+                    context.Diagnostics);
+            }        
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.Analyzers/SymbolExtensions.cs
+++ b/tools/Google.Cloud.Tools.Analyzers/SymbolExtensions.cs
@@ -35,6 +35,19 @@ namespace Google.Cloud.Tools.Analyzers
             SpecialType.System_Double
         };
 
+        internal static bool IsNullable(this ITypeSymbol type, out ITypeSymbol underlyingType)
+        {
+            if (type.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T)
+            {
+                underlyingType = null;
+                return false;
+            }
+
+            var namedType = (INamedTypeSymbol)type;
+            underlyingType = namedType.TypeArguments[0];
+            return true;
+        }
+
         internal static ITypeSymbol GetVariableType(this ISymbol symbol)
         {
             switch (symbol)


### PR DESCRIPTION
Fixes #1594

Note that the issue only seems to affect value types that have a default value expressible as a constant, like 0 or false, so the analyzer only checks for these.