### PR TITLE
Cleanup BigtableClient.MutateRowsAsync calls to use params

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/BigtableFixture.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/BigtableFixture.cs
@@ -147,14 +147,11 @@ namespace Google.Cloud.Bigtable.V2.IntegrationTests
             await DefaultTableClient.MutateRowAsync(
                 tableName,
                 rowKey,
-                new[]
-                {
-                    Mutations.SetCell(
-                        familyName,
-                        qualifierName.Value,
-                        value.Value,
-                        version)
-                });
+                Mutations.SetCell(
+                    familyName,
+                    qualifierName.Value,
+                    value.Value,
+                    version));
 
             await BigtableAssert.HasSingleValueAsync(
                 DefaultTableClient,

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/ReadRowsTest.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/ReadRowsTest.cs
@@ -162,20 +162,16 @@ namespace Google.Cloud.Bigtable.V2.IntegrationTests
             await client.MutateRowAsync(
                 tableName,
                 rowKey,
-                new[]
-                {
-                    Mutations.SetCell(
-                        BigtableFixture.ColumnFamily1,
-                        "row_index",
-                        "0",
-                        new BigtableVersion(1)),
-                    Mutations.SetCell(
-                        BigtableFixture.OtherColumnFamily,
-                        "row_exists",
-                        "true",
-                        new BigtableVersion(2))
-
-                });
+                Mutations.SetCell(
+                    BigtableFixture.ColumnFamily1,
+                    "row_index",
+                    "0",
+                    new BigtableVersion(1)),
+                Mutations.SetCell(
+                    BigtableFixture.OtherColumnFamily,
+                    "row_exists",
+                    "true",
+                    new BigtableVersion(2)));
 
             var row = client.ReadRow(tableName, rowKey, RowFilters.ValueRegex("true"));
             Assert.Equal(rowKey.Value, row.Key);
@@ -197,20 +193,16 @@ namespace Google.Cloud.Bigtable.V2.IntegrationTests
             await client.MutateRowAsync(
                 tableName,
                 rowKey,
-                new[]
-                {
-                    Mutations.SetCell(
-                        BigtableFixture.ColumnFamily1,
-                        "row_index",
-                        "0",
-                        new BigtableVersion(1)),
-                    Mutations.SetCell(
-                        BigtableFixture.OtherColumnFamily,
-                        "row_exists",
-                        "true",
-                        new BigtableVersion(2))
-
-                });
+                Mutations.SetCell(
+                    BigtableFixture.ColumnFamily1,
+                    "row_index",
+                    "0",
+                    new BigtableVersion(1)),
+                Mutations.SetCell(
+                    BigtableFixture.OtherColumnFamily,
+                    "row_exists",
+                    "true",
+                    new BigtableVersion(2)));
 
             var row = await client.ReadRowAsync(tableName, rowKey, RowFilters.ValueRegex("true"));
             Assert.Equal(rowKey.Value, row.Key);


### PR DESCRIPTION
(probably doesn't need review...will merge when green)