### PR TITLE
Empty docs for EF.

### DIFF
--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/docs/index.md
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/docs/index.md
@@ -1,0 +1,12 @@
+{{title}}
+
+`Google.Cloud.EntityFrameworkCore.Spanner` is the EF Core provider for Cloud Spanner.
+
+{{installation}}
+
+{{auth}}
+
+# Getting started
+
+
+


### PR DESCRIPTION
this fixes an error when doing a release (EF is missing a doc).
