### PR TITLE
Ensure the run integration test script does not fail on Linux.

### DIFF
--- a/runintegrationtests.sh
+++ b/runintegrationtests.sh
@@ -6,6 +6,9 @@
 set -e
 source toolversions.sh
 
+SCRIPT=$(readlink -f "$0")
+ROOT_DIR=$(dirname "$SCRIPT")
+
 RETRY_ARG=
 COVERAGE_ARG=
 
@@ -28,7 +31,7 @@ done
 
 # We only overwrite integration-test-failures.txt at the very end,
 # so that if we abort tests early, we don't assume there's nothing to retry.
-FAILURE_FILE=$(realpath integration-test-failures.txt)
+FAILURE_FILE=$ROOT_DIR/integration-test-failures.txt
 FAILURE_TEMP_FILE=${FAILURE_FILE}.tmp
 
 rm -f $FAILURE_TEMP_FILE
@@ -36,7 +39,7 @@ touch $FAILURE_TEMP_FILE
 
 cd apis
 
-if [[ "$RETRY_ARG" == "yes" ]]
+if [[ "$RETRY_ARG" == "yes" && (-f "$FAILURE_FILE")]]
 then
   declare -r testdirs=$(cat $FAILURE_FILE)
 else
@@ -61,3 +64,14 @@ do
 done
 
 mv -f $FAILURE_TEMP_FILE $FAILURE_FILE
+
+# Print status of this run including any failed tests.
+declare -r failed=$(cat $FAILURE_FILE | wc -l)
+if [ $failed == '0' ] 
+then
+  echo "All tests passed!"
+else 
+  echo "Number of Failed Tests: $failed"
+  cat $FAILURE_FILE
+  exit 1
+fi


### PR DESCRIPTION
The 'realpath' command fails on Linux when the file does not exist (but does not fail on windows).