### PR TITLE
Fixes an issue where an unused session could still be running its pre…

### DIFF
--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/Logger.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/Logger.cs
@@ -193,7 +193,7 @@ namespace Google.Cloud.Spanner.V1.Internal.Logging
         {
             if (LogLevel >= LogLevel.Error)
             {
-                WriteLine(messageFunc());
+                WriteLine($"{messageFunc()}, Exception = {exception}");
             }
         }
 


### PR DESCRIPTION
…warm when its released synchronously back into the pool.  To fix this, we now have a condition that all returned sessions from a pool have their prewarm completed before they can be used.

Also fixes a minor issue in the Logger where the exception was not logged.