### PR TITLE
[Bigtable] Use generated table names in integration tests

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/ReadRowsTest.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/ReadRowsTest.cs
@@ -478,11 +478,7 @@ namespace Google.Cloud.Bigtable.V2.IntegrationTests
         [Fact]
         public async Task ReadRows_Validate_SingleIteration()
         {
-            var tableName = new TableName(
-                _fixture.InstanceName.ProjectId,
-                _fixture.InstanceName.InstanceId,
-                "ReadRows_Validate_SingleIteration_Table");
-            await _fixture.CreateTable(tableName);
+            var tableName = await _fixture.CreateTable();
             var client = _fixture.TableClient;
 
             var rowKey = await _fixture.InsertRowAsync(tableName);


### PR DESCRIPTION
I forgot to do this when converting to use a single instance in #1637