### PR TITLE
Add a skipped test for issue 1641

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DownloadObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DownloadObjectTest.cs
@@ -18,6 +18,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -279,6 +280,18 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             _fixture.Client.DownloadObject(_fixture.ReadBucket, _fixture.LargeObject, stream,
                 new DownloadObjectOptions { Range = new RangeHeaderValue(2000, 2999) });
             var expected = _fixture.LargeContent.Skip(2000).Take(1000).ToArray();
+            var actual = stream.ToArray();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact(Skip = "Issue 1641; not fixed yet")]
+        public void DownloadGzippedFile()
+        {
+            // The file has a Content-Encoding of gzip, and it's stored compressed.
+            // We should still be able to download it, and the result should be the original plain text.
+            var stream = new MemoryStream();
+            _fixture.Client.DownloadObject(StorageFixture.CrossLanguageTestBucket, "gzipped-text.txt", stream);
+            var expected = Encoding.UTF8.GetBytes("hello world");
             var actual = stream.ToArray();
             Assert.Equal(expected, actual);
         }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/NormalizationTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/NormalizationTest.cs
@@ -20,13 +20,11 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
 {
     /// <summary>
     /// Tests that ensure the client does *not* perform any normalization.
-    /// The bucket <see cref="s_bucket"/> contains two files, which are both named "Café"
+    /// The bucket <see cref="StorageFixture.CrossLanguageTestBucket"/> contains two files named "Café"
     /// but using different normalization. The client should be able to retrieve both.
     /// </summary>
     public class NormalizationTest
     {
-        private const string s_bucket = "storage-library-test-bucket";
-
         [Theory]
         // Normalization Form C: a single character for e-acute.
         // URL should end with Caf%C3%A9
@@ -37,11 +35,11 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
         public void FetchObjectAndCheckContent(string name, string expectedContent)
         {
             var client = StorageClient.Create();
-            var obj = client.GetObject(s_bucket, name);
+            var obj = client.GetObject(StorageFixture.CrossLanguageTestBucket, name);
             Assert.Equal(name, obj.Name);
 
             var stream = new MemoryStream();
-            client.DownloadObject(s_bucket, name, stream);
+            client.DownloadObject(StorageFixture.CrossLanguageTestBucket, name, stream);
             string text = Encoding.UTF8.GetString(stream.ToArray());
             Assert.Equal(expectedContent, text);
         }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
@@ -39,6 +39,8 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
     [CollectionDefinition(nameof(StorageFixture))]
     public sealed class StorageFixture : IDisposable, ICollectionFixture<StorageFixture>
     {
+        internal const string CrossLanguageTestBucket = "storage-library-test-bucket";
+
         private const string ProjectEnvironmentVariable = "TEST_PROJECT";
         private const string RequesterPaysProjectEnvironmentVariable = "REQUESTER_PAYS_TEST_PROJECT";
         private const string RequesterPaysCredentialsEnvironmentVariable = "REQUESTER_PAYS_CREDENTIALS";


### PR DESCRIPTION
This commit can be merged safely, as the test is skipped - it makes
it easy to validate the overall thrust of #1641. It doesn't attempt
to address what happens if the client doesn't support gzip data.