### PR TITLE
Add Integration tests for Google.Cloud.Diagnostics.AspNet.Trace 

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/CloudTraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/CloudTraceTest.cs
@@ -1,0 +1,96 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Diagnostics.Common.Tests;
+using System;
+using System.Web;
+using Xunit;
+using System.IO;
+using Google.Cloud.Diagnostics.Common.IntegrationTests;
+using Google.Protobuf.WellKnownTypes;
+using System.Threading;
+
+namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
+{
+    public class CloudTraceTest : IDisposable
+    {
+        private readonly string _projectId;
+        private readonly string _testId;
+        private readonly Timestamp _startTime;
+
+        private readonly TraceEntryPolling _polling = new TraceEntryPolling();
+
+        public CloudTraceTest()
+        {
+            _projectId = Utils.GetProjectIdFromEnvironment();
+            _testId = Utils.GetTestId();
+            _startTime = Timestamp.FromDateTime(DateTime.UtcNow);
+
+            // Set up a fake HttpContext to trace with.
+            var response = new HttpResponse(File.CreateText(Path.GetTempFileName()));
+            var request = new HttpRequest("some-file", $"http://some-site.com/{_testId}", "");
+            HttpContext.Current = new HttpContext(request, response);
+        }
+
+        // Remove the HttpContext from the test.
+        public void Dispose() => HttpContext.Current = null;
+        
+        [Fact]
+        public void Trace()
+        {
+            using (var cloudTrace = CloudTrace.InitializeInternal(new HttpApplication(), _projectId))
+            {
+                cloudTrace.BeginRequest(null, null);
+                cloudTrace.EndRequest(null, null);
+            }
+
+            var trace = _polling.GetTrace($"/{_testId}", _startTime);
+            Assert.NotNull(trace);
+            Assert.Single(trace.Spans);
+        }
+
+        [Fact]
+        public void No_Trace()
+        {
+            var predicate = TraceDecisionPredicate.Create((req) => false);
+            using (var cloudTrace = CloudTrace.InitializeInternal(new HttpApplication(), 
+                projectId: _projectId, traceFallbackPredicate: predicate))
+            {
+                cloudTrace.BeginRequest(null, null);
+                cloudTrace.EndRequest(null, null);
+            }
+
+            var trace = _polling.GetTrace($"/{_testId}", _startTime, false);
+            Assert.Null(trace);
+        }
+
+        [Fact]
+        public void Trace_Multiple_Spans()
+        {
+            using (var cloudTrace = CloudTrace.InitializeInternal(new HttpApplication(), _projectId))
+            {
+                cloudTrace.BeginRequest(null, null);
+                using (CloudTrace.Tracer.StartSpan("/another-trace"))
+                {
+                    Thread.Sleep(TimeSpan.FromMilliseconds(10));
+                }
+                cloudTrace.EndRequest(null, null);
+            }
+
+            var trace = _polling.GetTrace($"/{_testId}", _startTime);
+            Assert.NotNull(trace);
+            Assert.Equal(2, trace.Spans.Count);
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
@@ -137,6 +137,13 @@ namespace Google.Cloud.Diagnostics.AspNet
             TraceOptions options = null, TraceServiceClient client = null,
             TraceDecisionPredicate traceFallbackPredicate = null)
         {
+            InitializeInternal(application, projectId, options, client, traceFallbackPredicate);
+        }
+
+        internal static CloudTrace InitializeInternal(HttpApplication application, string projectId = null,
+            TraceOptions options = null, TraceServiceClient client = null,
+            TraceDecisionPredicate traceFallbackPredicate = null)
+        {
             GaxPreconditions.CheckNotNull(application, nameof(application));
 
             projectId = Project.GetAndCheckProjectId(projectId);
@@ -146,12 +153,13 @@ namespace Google.Cloud.Diagnostics.AspNet
             application.BeginRequest += trace.BeginRequest;
             application.EndRequest += trace.EndRequest;
             application.Disposed += (object sender, EventArgs e) => { trace.Dispose(); };
+            return trace;
         }
 
         /// <inheritdoc />
         public void Dispose() => _consumer.Dispose();
 
-        private void BeginRequest(object sender, EventArgs e)
+        internal void BeginRequest(object sender, EventArgs e)
         {
             var request = HttpContext.Current.Request;
             string header = request.Headers.Get(TraceHeaderContext.TraceHeader);
@@ -182,7 +190,7 @@ namespace Google.Cloud.Diagnostics.AspNet
             tracer.AnnotateSpan(Labels.AgentLabel);
         }
 
-        private void EndRequest(object sender, EventArgs e)
+        internal void EndRequest(object sender, EventArgs e)
         {
             ISpan span = ContextInstanceManager.Get<ISpan>();
             if (span == null)

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
@@ -140,6 +140,9 @@ namespace Google.Cloud.Diagnostics.AspNet
             InitializeInternal(application, projectId, options, client, traceFallbackPredicate);
         }
 
+        /// <summary>
+        /// Only used for testing.  See <see cref="Initialize"/> for details.
+        /// </summary>
         internal static CloudTrace InitializeInternal(HttpApplication application, string projectId = null,
             TraceOptions options = null, TraceServiceClient client = null,
             TraceDecisionPredicate traceFallbackPredicate = null)

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/Labels.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/Labels.cs
@@ -46,7 +46,7 @@ namespace Google.Cloud.Diagnostics.AspNet
             return new Dictionary<string, string>
             {
                 { LabelsCommon.HttpRequestSize, request.ContentLength.ToString() },
-                { LabelsCommon.HttpHost, request.UserHostName },
+                { LabelsCommon.HttpHost, request.UserHostName ?? "" },
                 { LabelsCommon.HttpMethod, request.HttpMethod }
             };
         }


### PR DESCRIPTION
These are sudo integration tests as we still have to fake the HttpContext as an HttpApplication cannot be started programatically.