### PR TITLE
Change throughput tool target frameworks

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.ThroughputTool/Google.Cloud.Storage.V1.ThroughputTool.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.ThroughputTool/Google.Cloud.Storage.V1.ThroughputTool.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;net47</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)'!='Windows_NT'">netcoreapp1.0; netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)'!='Windows_NT'">netcoreapp1.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This was causing a CI build failure internally. If net47 or
netcoreapp2.0 need investigating separately, we can tweak them
locally - and if they end up being required, we can install net47 at
that point.