### PR TITLE
Remove hard coded test project ids.

### DIFF
--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/TestDatabaseFixture.cs
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/TestDatabaseFixture.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
     {
         private readonly Lazy<Task> _creationTask;
         public string TestInstanceName => "spannerintegration";
-        public string TestProjectName => Environment.GetEnvironmentVariable("TEST_PROJECT") ?? "cloud-sharp-jenkins";
+        public string TestProjectName => Environment.GetEnvironmentVariable("TEST_PROJECT");
         public string ConnectionString => $"{NoDbConnectionString}/databases/{DatabaseName}";
         public string NoDbConnectionString => $"Data Source=projects/{TestProjectName}/instances/{TestInstanceName}";
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TestDatabaseFixture.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TestDatabaseFixture.cs
@@ -31,7 +31,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
 
         public string TestInstanceName => "spannerintegration";
 
-        public string TestProjectName => Environment.GetEnvironmentVariable("TEST_PROJECT") ?? "cloud-sharp-jenkins";
+        public string TestProjectName => Environment.GetEnvironmentVariable("TEST_PROJECT");
 
         public string ConnectionString => "Data Source=projects/" + TestProjectName + "/instances/" + TestInstanceName
             + "/databases/" + DatabaseName;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SnippetFixture.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SnippetFixture.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Spanner.Data.Snippets
 
         public string TestInstanceName => "spannerintegration";
 
-        public string TestProjectName => Environment.GetEnvironmentVariable("TEST_PROJECT") ?? "cloud-sharp-jenkins";
+        public string TestProjectName => Environment.GetEnvironmentVariable("TEST_PROJECT");
 
         public string ConnectionString => $"Data Source=projects/{TestProjectName}/instances/{TestInstanceName}"
             + $"/databases/{TestDatabaseName}";


### PR DESCRIPTION
This could cause confusion as those w/o access to the project will get an auth error instead of a failure about the env var being set.