### PR TITLE
Refactor test projects to extract commonality

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryFixture.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryFixture.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Apis.Bigquery.v2.Data;
+using Google.Cloud.ClientTesting;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -34,16 +35,13 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
     /// operate on.
     /// </summary>
     [CollectionDefinition(nameof(BigQueryFixture))]
-    public class BigQueryFixture : IDisposable, ICollectionFixture<BigQueryFixture>
+    public class BigQueryFixture : CloudProjectFixtureBase, ICollectionFixture<BigQueryFixture>
     {
-        private const string ProjectEnvironmentVariable = "TEST_PROJECT";
-
         /// <summary>
         /// Used to generate dataset IDs which are still clearly identifiable with this test.
         /// </summary>
         private int extraDatasetCounter;
 
-        public string ProjectId { get; }
         public string DatasetId { get; }
         public string LabelsDatasetId { get; }
         public string HighScoreTableId { get; } = "highscores";
@@ -53,13 +51,6 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
 
         public BigQueryFixture()
         {
-            ProjectId = Environment.GetEnvironmentVariable(ProjectEnvironmentVariable);
-            if (string.IsNullOrEmpty(ProjectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
-            }
-
             var now = DateTime.UtcNow;
             DatasetId = now.ToString("'test'_yyyyMMddTHHmmssfff", CultureInfo.InvariantCulture);
             LabelsDatasetId = now.ToString("'testlabels'_yyyyMMddTHHmmssfff", CultureInfo.InvariantCulture);
@@ -280,13 +271,9 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Thread.Sleep(2500);
         }
 
-
-        public void Dispose()
-        {
-            // TODO: Consider deleting the dataset here. It
-            // might be nice to clean up after ourselves, but realistically
-            // we won't be creating much data, and it's useful to be able to see
-            // it after tests have finished, particularly on failure.
-        }
+        // TODO: Consider deleting the dataset here. It
+        // might be nice to clean up after ourselves, but realistically
+        // we won't be creating much data, and it's useful to be able to see
+        // it after tests have finished, particularly on failure.
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/BigQuerySnippetFixture.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/BigQuerySnippetFixture.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.ClientTesting;
 using Google.Cloud.Storage.V1;
 using System;
 using System.Collections.Generic;
@@ -26,12 +27,10 @@ namespace Google.Cloud.BigQuery.V2.Snippets
     /// All entities use the same partition, which is then wiped at the end of the run.
     /// </summary>
     [CollectionDefinition(nameof(BigQuerySnippetFixture))]
-    public sealed class BigQuerySnippetFixture : IDisposable, ICollectionFixture<BigQuerySnippetFixture>
+    public sealed class BigQuerySnippetFixture : CloudProjectFixtureBase, ICollectionFixture<BigQuerySnippetFixture>
     {
-        private const string ProjectEnvironmentVariable = "TEST_PROJECT";
         private const string DatasetPrefix = "snippets_";
 
-        public string ProjectId { get; }
         public string GameDatasetId { get; }
         public BigQueryClient Client { get; }
         // This table should not have inserts made during the test,
@@ -49,12 +48,6 @@ namespace Google.Cloud.BigQuery.V2.Snippets
 
         public BigQuerySnippetFixture()
         {
-            ProjectId = Environment.GetEnvironmentVariable(ProjectEnvironmentVariable);
-            if (string.IsNullOrEmpty(ProjectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
-            }
             Client = BigQueryClient.Create(ProjectId);
             GameDatasetId = CreateGameDataset();
             StorageBucketName = GenerateStorageBucketName();
@@ -116,12 +109,9 @@ namespace Google.Cloud.BigQuery.V2.Snippets
             return id;
         }
 
-        public void Dispose()
-        {
-            // TODO: Work out a way of actually deleting the datasets. If we try to delete them here,
-            // we get an error due to them still being in use.
-            // For the moment, run the tools/Google.Cloud.BigQuery.V2.CleanTestData program
-            // periodically.
-        }
+        // TODO: Work out a way of actually deleting the datasets. If we try to delete them here,
+        // we get an error due to them still being in use.
+        // For the moment, run the tools/Google.Cloud.BigQuery.V2.CleanTestData program
+        // periodically.
     }
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/BigtableFixture.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/BigtableFixture.cs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Api.Gax.Grpc;
-using Google.Apis.Auth.OAuth2;
 using Google.Cloud.Bigtable.Admin.V2;
+using Google.Cloud.ClientTesting;
 using Grpc.Core;
 using System;
 using System.Collections.Generic;
@@ -24,12 +23,14 @@ using Xunit;
 
 namespace Google.Cloud.Bigtable.V2.IntegrationTests
 {
+    // Note: this does not use CloudProjectFixtureBase as a base class, as an emulator can be used as an alternative.
+    // If that pattern becomes more widespread, we can bring that into CloudProjectFixtureBase.
     [CollectionDefinition(nameof(BigtableFixture))]
     public class BigtableFixture : IDisposable, ICollectionFixture<BigtableFixture>
     {
         private const string EmulatorEnvironmentVariable = "BIGTABLE_EMULATOR_HOST";
         private const string TestInstanceEnvironmentVariable = "BIGTABLE_TEST_INSTANCE";
-        private const string TestProjectEnvironmentVariable = "TEST_PROJECT";
+        private const string TestProjectEnvironmentVariable = CloudProjectFixtureBase.TestProjectEnvironmentVariable;
 
         public const string ColumnFamily1 = "cf1";
         public const string OtherColumnFamily = "test_data";

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/DatastoreFixture.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/DatastoreFixture.cs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+using Google.Cloud.ClientTesting;
 using System;
 using System.Linq;
 using Xunit;
@@ -22,26 +23,17 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
     /// All entities use the same partition, which is then wiped at the end of the run.
     /// </summary>
     [CollectionDefinition(nameof(DatastoreFixture))]
-    public sealed class DatastoreFixture : IDisposable, ICollectionFixture<DatastoreFixture>
+    public sealed class DatastoreFixture : CloudProjectFixtureBase, ICollectionFixture<DatastoreFixture>
     {
-        private const string ProjectEnvironmentVariable = "TEST_PROJECT";
-
-        public string ProjectId { get; }
         public string NamespaceId { get; }
         public PartitionId PartitionId => new PartitionId { ProjectId = ProjectId, NamespaceId = NamespaceId };
 
         public DatastoreFixture()
         {
-            ProjectId = Environment.GetEnvironmentVariable(ProjectEnvironmentVariable);
-            if (string.IsNullOrEmpty(ProjectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
-            }
             NamespaceId = "test-" + Guid.NewGuid();
         }
 
-        public void Dispose()
+        public override void Dispose()
         {
             var client = DatastoreClient.Create();
             // Delete all the entities in our partition.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreSnippetFixture.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreSnippetFixture.cs
@@ -11,10 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+using Google.Cloud.ClientTesting;
 using System;
 using System.Linq;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Google.Cloud.Datastore.V1.Snippets
 {
@@ -23,11 +23,8 @@ namespace Google.Cloud.Datastore.V1.Snippets
     /// All entities use the same partition, which is then wiped at the end of the run.
     /// </summary>
     [CollectionDefinition(nameof(DatastoreSnippetFixture))]
-    public sealed class DatastoreSnippetFixture : IDisposable, ICollectionFixture<DatastoreSnippetFixture>
+    public sealed class DatastoreSnippetFixture : CloudProjectFixtureBase, ICollectionFixture<DatastoreSnippetFixture>
     {
-        private const string ProjectEnvironmentVariable = "TEST_PROJECT";
-
-        public string ProjectId { get; }
         public string NamespaceId { get; }
         public PartitionId PartitionId => new PartitionId { ProjectId = ProjectId, NamespaceId = NamespaceId };
         public string BookKind = "book";
@@ -39,12 +36,6 @@ namespace Google.Cloud.Datastore.V1.Snippets
 
         public DatastoreSnippetFixture()
         {
-            ProjectId = Environment.GetEnvironmentVariable(ProjectEnvironmentVariable);
-            if (string.IsNullOrEmpty(ProjectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
-            }
             NamespaceId = "test-" + Guid.NewGuid();
             AddSampleBooks();
             AddSampleTasks();
@@ -82,7 +73,7 @@ namespace Google.Cloud.Datastore.V1.Snippets
             _learnDatastoreKey = response.MutationResults[0].Key;
         }
 
-        public void Dispose()
+        public override void Dispose()
         {
             var client = DatastoreClient.Create();
             // Delete all the entities in our partition.

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.Snippets/DebuggerServiceFixture.cs
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.Snippets/DebuggerServiceFixture.cs
@@ -12,35 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
+using Google.Cloud.ClientTesting;
 using Xunit;
 
 namespace Google.Cloud.Debugger.V2.Snippets
 {
     /// <summary>
     /// Fixture which is set up at the start of the test run, and torn down at the end.
-    /// The Google Cloud Project name is fetched from the TEST_PROJECT environment variable.
+    /// (Currently this fixture does nothing more than providing the project ID.)
     /// </summary>
     [CollectionDefinition(nameof(DebuggerServiceFixture))]
-    public sealed class DebuggerServiceFixture : IDisposable, ICollectionFixture<DebuggerServiceFixture>
+    public sealed class DebuggerServiceFixture : CloudProjectFixtureBase, ICollectionFixture<DebuggerServiceFixture>
     {
-        private const string ProjectEnvironmentVariable = "TEST_PROJECT";
-
-        public string ProjectId { get; }
-
-        public DebuggerServiceFixture()
-        {
-            ProjectId = Environment.GetEnvironmentVariable(ProjectEnvironmentVariable);
-            if (string.IsNullOrEmpty(ProjectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
-            }
-        }
-
-        public void Dispose()
-        {
-            // No-op
-        }
     }
 }

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.sln
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.sln
@@ -1,46 +1,64 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.6
+VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Debugger.V2", "Google.Cloud.Debugger.V2\Google.Cloud.Debugger.V2.csproj", "{939FA175-86CE-4B80-98E8-EDE676FD7821}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Debugger.V2.Snippets", "Google.Cloud.Debugger.V2.Snippets\Google.Cloud.Debugger.V2.Snippets.csproj", "{475EC66A-501B-4C3D-88BE-C188C59C64C5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|x64.Build.0 = Debug|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|x86.Build.0 = Debug|Any CPU
 		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|Any CPU.Build.0 = Release|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|x64.ActiveCfg = Release|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|x64.Build.0 = Release|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|x86.ActiveCfg = Release|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|x86.Build.0 = Release|Any CPU
 		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Debug|x64.Build.0 = Debug|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Debug|x86.Build.0 = Debug|Any CPU
 		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Release|x64.ActiveCfg = Release|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Release|x64.Build.0 = Release|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Release|x86.ActiveCfg = Release|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Release|x86.Build.0 = Release|Any CPU
 		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Debug|x64.ActiveCfg = Debug|x64
-		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Debug|x64.Build.0 = Debug|x64
-		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Debug|x86.ActiveCfg = Debug|x86
-		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Debug|x86.Build.0 = Debug|x86
+		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Debug|x64.Build.0 = Debug|Any CPU
+		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Debug|x86.Build.0 = Debug|Any CPU
 		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Release|x64.ActiveCfg = Release|x64
-		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Release|x64.Build.0 = Release|x64
-		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Release|x86.ActiveCfg = Release|x86
-		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Release|x86.Build.0 = Release|x86
+		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Release|x64.ActiveCfg = Release|Any CPU
+		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Release|x64.Build.0 = Release|Any CPU
+		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Release|x86.ActiveCfg = Release|Any CPU
+		{D1D0DE0E-05CA-4F10-8165-FCD862EFA24E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4CB8F873-C225-4592-BAF2-84ED66CFCFD4}
 	EndGlobalSection
 EndGlobal

--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/TestDatabaseFixture.cs
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/TestDatabaseFixture.cs
@@ -19,6 +19,7 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Threading.Tasks;
 using Google.Api.Gax;
+using Google.Cloud.ClientTesting;
 using Google.Cloud.Spanner.Data;
 using Xunit;
 
@@ -28,13 +29,12 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
 {
     // ReSharper disable once ClassNeverInstantiated.Global
     [CollectionDefinition(nameof(TestDatabaseFixture))]
-    public class TestDatabaseFixture : IDisposable, ICollectionFixture<TestDatabaseFixture>
+    public class TestDatabaseFixture : CloudProjectFixtureBase, ICollectionFixture<TestDatabaseFixture>
     {
         private readonly Lazy<Task> _creationTask;
         public string TestInstanceName => "spannerintegration";
-        public string TestProjectName => Environment.GetEnvironmentVariable("TEST_PROJECT") ?? "cloud-sharp-jenkins";
         public string ConnectionString => $"{NoDbConnectionString}/databases/{DatabaseName}";
-        public string NoDbConnectionString => $"Data Source=projects/{TestProjectName}/instances/{TestInstanceName}";
+        public string NoDbConnectionString => $"Data Source=projects/{ProjectId}/instances/{TestInstanceName}";
 
         // scratch can be used to run tests on a precreated db.
         // all tests are designed to be re-run on an existing db (previously written state will
@@ -48,7 +48,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
 
         public TestDatabaseFixture() => _creationTask = new Lazy<Task>(EnsureTestDatabaseImplAsync);
 
-        public void Dispose()
+        public override void Dispose()
         {
             using (var connection = new SpannerConnection(NoDbConnectionString))
             {

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ErrorReportingFixture.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ErrorReportingFixture.cs
@@ -11,35 +11,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-using System;
+using Google.Cloud.ClientTesting;
 using Xunit;
 
 namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
 {
     /// <summary>
     /// Fixture which is set up at the start of the test run, and torn down at the end.
-    /// The Google Cloud Project name is fetched from the TEST_PROJECT environment variable.
+    /// (Currently this fixture does nothing more than providing the project ID.)
     /// </summary>
     [CollectionDefinition(nameof(ErrorReportingFixture))]
-    public sealed class ErrorReportingFixture: IDisposable, ICollectionFixture<ErrorReportingFixture>
+    public sealed class ErrorReportingFixture: CloudProjectFixtureBase, ICollectionFixture<ErrorReportingFixture>
     {
-        private const string ProjectEnvironmentVariable = "TEST_PROJECT";
-
-        public string ProjectId { get; }
-
-        public ErrorReportingFixture()
-        {
-            ProjectId = Environment.GetEnvironmentVariable(ProjectEnvironmentVariable);
-            if (string.IsNullOrEmpty(ProjectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
-            }
-        }
-
-        public void Dispose()
-        {
-            // TODO: Delete events? Not ideal...
-        }
     }
 }

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.sln
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26114.2
+VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ErrorReporting.V1Beta1", "Google.Cloud.ErrorReporting.V1Beta1\Google.Cloud.ErrorReporting.V1Beta1.csproj", "{7408D53D-88E6-42BB-B79A-1B18B027633D}"
 EndProject
@@ -12,54 +11,73 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{7E477049-0
 		docs\index.md = docs\index.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{75685FC8-185C-4D09-BBF6-80D3B247324B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{75685FC8-185C-4D09-BBF6-80D3B247324B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ErrorReporting.V1Beta1.SmokeTests", "Google.Cloud.ErrorReporting.V1Beta1.SmokeTests\Google.Cloud.ErrorReporting.V1Beta1.SmokeTests.csproj", "{82216A32-A869-48D0-B4F6-18B9CF32F321}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ErrorReporting.V1Beta1.SmokeTests", "Google.Cloud.ErrorReporting.V1Beta1.SmokeTests\Google.Cloud.ErrorReporting.V1Beta1.SmokeTests.csproj", "{82216A32-A869-48D0-B4F6-18B9CF32F321}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Debug|x64.Build.0 = Debug|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Debug|x86.Build.0 = Debug|Any CPU
 		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Release|x64.ActiveCfg = Release|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Release|x64.Build.0 = Release|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Release|x86.ActiveCfg = Release|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Release|x86.Build.0 = Release|Any CPU
 		{BDA29173-1B20-4111-86BC-1B292744FFA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BDA29173-1B20-4111-86BC-1B292744FFA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BDA29173-1B20-4111-86BC-1B292744FFA7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BDA29173-1B20-4111-86BC-1B292744FFA7}.Debug|x64.Build.0 = Debug|Any CPU
+		{BDA29173-1B20-4111-86BC-1B292744FFA7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BDA29173-1B20-4111-86BC-1B292744FFA7}.Debug|x86.Build.0 = Debug|Any CPU
 		{BDA29173-1B20-4111-86BC-1B292744FFA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BDA29173-1B20-4111-86BC-1B292744FFA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BDA29173-1B20-4111-86BC-1B292744FFA7}.Release|x64.ActiveCfg = Release|Any CPU
+		{BDA29173-1B20-4111-86BC-1B292744FFA7}.Release|x64.Build.0 = Release|Any CPU
+		{BDA29173-1B20-4111-86BC-1B292744FFA7}.Release|x86.ActiveCfg = Release|Any CPU
+		{BDA29173-1B20-4111-86BC-1B292744FFA7}.Release|x86.Build.0 = Release|Any CPU
 		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Debug|x64.ActiveCfg = Debug|x64
-		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Debug|x64.Build.0 = Debug|x64
-		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Debug|x86.ActiveCfg = Debug|x86
-		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Debug|x86.Build.0 = Debug|x86
+		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Debug|x64.Build.0 = Debug|Any CPU
+		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Debug|x86.Build.0 = Debug|Any CPU
 		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Release|x64.ActiveCfg = Release|x64
-		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Release|x64.Build.0 = Release|x64
-		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Release|x86.ActiveCfg = Release|x86
-		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Release|x86.Build.0 = Release|x86
+		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Release|x64.ActiveCfg = Release|Any CPU
+		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Release|x64.Build.0 = Release|Any CPU
+		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Release|x86.ActiveCfg = Release|Any CPU
+		{75685FC8-185C-4D09-BBF6-80D3B247324B}.Release|x86.Build.0 = Release|Any CPU
 		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Debug|x64.ActiveCfg = Debug|x64
-		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Debug|x64.Build.0 = Debug|x64
-		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Debug|x86.ActiveCfg = Debug|x86
-		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Debug|x86.Build.0 = Debug|x86
+		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Debug|x64.Build.0 = Debug|Any CPU
+		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Debug|x86.Build.0 = Debug|Any CPU
 		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Release|Any CPU.Build.0 = Release|Any CPU
-		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Release|x64.ActiveCfg = Release|x64
-		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Release|x64.Build.0 = Release|x64
-		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Release|x86.ActiveCfg = Release|x86
-		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Release|x86.Build.0 = Release|x86
+		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Release|x64.ActiveCfg = Release|Any CPU
+		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Release|x64.Build.0 = Release|Any CPU
+		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Release|x86.ActiveCfg = Release|Any CPU
+		{82216A32-A869-48D0-B4F6-18B9CF32F321}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8A6369EC-78A5-4B25-ADB1-F283D4030ECD}
 	EndGlobalSection
 EndGlobal

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/FirestoreFixture.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/FirestoreFixture.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.ClientTesting;
 using Google.Cloud.Firestore.IntegrationTests.Models;
 using System;
 using System.Collections.Generic;
@@ -22,7 +23,7 @@ using Xunit;
 namespace Google.Cloud.Firestore.IntegrationTests
 {
     [CollectionDefinition(nameof(FirestoreFixture))]
-    public class FirestoreFixture : IDisposable, ICollectionFixture<FirestoreFixture>
+    public class FirestoreFixture : CloudProjectFixtureBase, ICollectionFixture<FirestoreFixture>
     {
         // This is not the test project environment variable used by other integration tests,
         // as Datastore and Firestore can't both be active in the same project.
@@ -46,19 +47,12 @@ namespace Google.Cloud.Firestore.IntegrationTests
 
         private int _uniqueCollectionCounter = 0;
 
-        public FirestoreFixture()
+        public FirestoreFixture() : base(ProjectEnvironmentVariable)
         {
-            string projectId = Environment.GetEnvironmentVariable(ProjectEnvironmentVariable);
-            if (string.IsNullOrEmpty(projectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
-            }
-
             // Currently, only the default database is supported... so we create all our collections with a randomly-generated prefix.
             // When multiple databases are supported, we'll create a new one per test run.
             CollectionPrefix = Guid.NewGuid().ToString();
-            FirestoreDb = FirestoreDb.Create(projectId);
+            FirestoreDb = FirestoreDb.Create(ProjectId);
             NonQueryCollection = FirestoreDb.Collection(CollectionPrefix + "-non-query");
             HighScoreCollection = FirestoreDb.Collection(CollectionPrefix + "-high-scores");
             Task.Run(PopulateCollections).Wait();
@@ -90,10 +84,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
             return FirestoreDb.Collection($"{CollectionPrefix}-unique-{counter}");
         }
 
-        public void Dispose()
-        {
-            // No-op for now. With multiple-database support, we'll create a database
-            // on construction and delete it here.
-        }
+        // No clean-up for now. With multiple-database support, we'll create a database
+        // on construction and delete it here.
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/FirestoreFixture.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/FirestoreFixture.cs
@@ -12,23 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.ClientTesting;
 using System;
-using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Google.Cloud.Firestore.Snippets
 {
     [CollectionDefinition(nameof(FirestoreFixture))]
-    public class FirestoreFixture : IDisposable, ICollectionFixture<FirestoreFixture>
+    public class FirestoreFixture : CloudProjectFixtureBase, ICollectionFixture<FirestoreFixture>
     {
         // This is not the test project environment variable used by other integration tests,
         // as Datastore and Firestore can't both be active in the same project.
         private const string ProjectEnvironmentVariable = "FIRESTORE_TEST_PROJECT";
         public FirestoreDb FirestoreDb { get; }
-
-        public string ProjectId => FirestoreDb.ProjectId;
 
         /// <summary>
         /// A randomly generated prefix for collections.
@@ -47,19 +44,12 @@ namespace Google.Cloud.Firestore.Snippets
 
         private int _uniqueCollectionCounter = 0;
 
-        public FirestoreFixture()
+        public FirestoreFixture() : base(ProjectEnvironmentVariable)
         {
-            string projectId = Environment.GetEnvironmentVariable(ProjectEnvironmentVariable);
-            if (string.IsNullOrEmpty(projectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
-            }
-
             // Currently, only the default database is supported... so we create all our collections with a randomly-generated prefix.
             // When multiple databases are supported, we'll create a new one per test run.
             CollectionPrefix = Guid.NewGuid().ToString();
-            FirestoreDb = FirestoreDb.Create(projectId);
+            FirestoreDb = FirestoreDb.Create(ProjectId);
             NonQueryCollection = FirestoreDb.Collection(CollectionPrefix + "-non-query");
             HighScoreCollection = FirestoreDb.Collection(CollectionPrefix + "-high-scores");
         }
@@ -74,10 +64,7 @@ namespace Google.Cloud.Firestore.Snippets
             return FirestoreDb.Collection($"{CollectionPrefix}-unique-{counter}");
         }
 
-        public void Dispose()
-        {
-            // No-op for now. With multiple-database support, we'll create a database
-            // on construction and delete it here.
-        }
+        // No clean-up for now. With multiple-database support, we'll create a database
+        // on construction and delete it here.
     }
 }

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Log4NetSnippetFixture.cs
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Log4NetSnippetFixture.cs
@@ -12,36 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Cloud.Logging.V2;
-using System;
+using Google.Cloud.ClientTesting;
 using Xunit;
 
 namespace Google.Cloud.Logging.Log4Net.Snippets
 {
     [CollectionDefinition(nameof(Log4NetSnippetFixture))]
-    public sealed class Log4NetSnippetFixture : IDisposable, ICollectionFixture<Log4NetSnippetFixture>
+    public sealed class Log4NetSnippetFixture : CloudProjectFixtureBase, ICollectionFixture<Log4NetSnippetFixture>
     {
-        private const string ProjectEnvironmentVariable = "TEST_PROJECT";
-
-        public string ProjectId { get; }
-
         public string LogId { get; } = "Log4NetTestLog";
 
-        public Log4NetSnippetFixture()
-        {
-            ProjectId = Environment.GetEnvironmentVariable(ProjectEnvironmentVariable);
-            if (string.IsNullOrEmpty(ProjectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
-            }
-        }
-
-        public void Dispose()
-        {
-            // No clean-up here, because:
-            // - We can't assert log entries in tests, so it's useful to be able to check them manually later.
-            // - If the log entries haven't arrived yet, deleting them would cause an exception anyway.
-        }
+        // No clean-up, because:
+        // - We can't assert log entries in tests, so it's useful to be able to check them manually later.
+        // - If the log entries haven't arrived yet, deleting them would cause an exception anyway.
     }
 }

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.sln
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Logging.Log4Net", "Google.Cloud.Logging.Log4Net\Google.Cloud.Logging.Log4Net.csproj", "{B27E7461-3714-44F6-BD2D-E7579A85F759}"
 EndProject
@@ -8,13 +8,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Logging.Log4Ne
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Logging.Log4Net.Tests", "Google.Cloud.Logging.Log4Net.Tests\Google.Cloud.Logging.Log4Net.Tests.csproj", "{C359B60F-6E40-43EA-BEF3-9C1222BA7B28}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Logging.V2", "..\Google.Cloud.Logging.V2\Google.Cloud.Logging.V2\Google.Cloud.Logging.V2.csproj", "{61E66C33-BE6F-4787-8F0A-5184E54A6922}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Logging.V2", "..\Google.Cloud.Logging.V2\Google.Cloud.Logging.V2\Google.Cloud.Logging.V2.csproj", "{61E66C33-BE6F-4787-8F0A-5184E54A6922}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Logging.Type", "..\Google.Cloud.Logging.Type\Google.Cloud.Logging.Type\Google.Cloud.Logging.Type.csproj", "{CF0F2040-3817-4117-B727-97FCE93ACE02}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Logging.Type", "..\Google.Cloud.Logging.Type\Google.Cloud.Logging.Type\Google.Cloud.Logging.Type.csproj", "{CF0F2040-3817-4117-B727-97FCE93ACE02}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.DevTools.Common", "..\Google.Cloud.DevTools.Common\Google.Cloud.DevTools.Common\Google.Cloud.DevTools.Common.csproj", "{3EB6DD63-407E-4C5B-B1D6-655C7FDAF3DE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.DevTools.Common", "..\Google.Cloud.DevTools.Common\Google.Cloud.DevTools.Common\Google.Cloud.DevTools.Common.csproj", "{3EB6DD63-407E-4C5B-B1D6-655C7FDAF3DE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -88,18 +88,21 @@ Global
 		{3EB6DD63-407E-4C5B-B1D6-655C7FDAF3DE}.Release|x86.Build.0 = Release|Any CPU
 		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Debug|x64.ActiveCfg = Debug|x64
-		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Debug|x64.Build.0 = Debug|x64
-		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Debug|x86.ActiveCfg = Debug|x86
-		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Debug|x86.Build.0 = Debug|x86
+		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Debug|x64.Build.0 = Debug|Any CPU
+		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Debug|x86.Build.0 = Debug|Any CPU
 		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Release|x64.ActiveCfg = Release|x64
-		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Release|x64.Build.0 = Release|x64
-		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Release|x86.ActiveCfg = Release|x86
-		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Release|x86.Build.0 = Release|x86
+		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Release|x64.ActiveCfg = Release|Any CPU
+		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Release|x64.Build.0 = Release|Any CPU
+		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Release|x86.ActiveCfg = Release|Any CPU
+		{BEB122CD-099A-44AD-8AF5-45FC6315F6C0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {05D3C6B5-B305-4284-B357-3D3971D4536D}
 	EndGlobalSection
 EndGlobal

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/MonitoringFixture.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/MonitoringFixture.cs
@@ -11,35 +11,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-using System;
+using Google.Cloud.ClientTesting;
 using Xunit;
 
 namespace Google.Cloud.Monitoring.V3
 {
     /// <summary>
     /// Fixture which is set up at the start of the test run, and torn down at the end.
-    /// The Google Cloud Project name is fetched from the TEST_PROJECT environment variable.
+    /// (Currently this fixture does nothing more than providing the project ID.)
     /// </summary>
     [CollectionDefinition(nameof(MonitoringFixture))]
-    public sealed class MonitoringFixture: IDisposable, ICollectionFixture<MonitoringFixture>
+    public sealed class MonitoringFixture: CloudProjectFixtureBase, ICollectionFixture<MonitoringFixture>
     {
-        private const string ProjectEnvironmentVariable = "TEST_PROJECT";
-
-        public string ProjectId { get; }
-
-        public MonitoringFixture()
-        {
-            ProjectId = Environment.GetEnvironmentVariable(ProjectEnvironmentVariable);
-            if (string.IsNullOrEmpty(ProjectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
-            }
-        }
-
-        public void Dispose()
-        {
-            // No-op
-        }
     }
 }

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.sln
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26114.2
+VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Monitoring.V3", "Google.Cloud.Monitoring.V3\Google.Cloud.Monitoring.V3.csproj", "{E15626D3-88A8-483A-B51E-F728BF5502C3}"
 EndProject
@@ -12,54 +11,73 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{1BB4B59A-5
 		docs\index.md = docs\index.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{C434E081-1F68-4C33-8246-4B602C6B9DF3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{C434E081-1F68-4C33-8246-4B602C6B9DF3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Monitoring.V3.SmokeTests", "Google.Cloud.Monitoring.V3.SmokeTests\Google.Cloud.Monitoring.V3.SmokeTests.csproj", "{EEE91E65-3734-42C7-AF91-F22F63E19A70}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Monitoring.V3.SmokeTests", "Google.Cloud.Monitoring.V3.SmokeTests\Google.Cloud.Monitoring.V3.SmokeTests.csproj", "{EEE91E65-3734-42C7-AF91-F22F63E19A70}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E15626D3-88A8-483A-B51E-F728BF5502C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E15626D3-88A8-483A-B51E-F728BF5502C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E15626D3-88A8-483A-B51E-F728BF5502C3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E15626D3-88A8-483A-B51E-F728BF5502C3}.Debug|x64.Build.0 = Debug|Any CPU
+		{E15626D3-88A8-483A-B51E-F728BF5502C3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E15626D3-88A8-483A-B51E-F728BF5502C3}.Debug|x86.Build.0 = Debug|Any CPU
 		{E15626D3-88A8-483A-B51E-F728BF5502C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E15626D3-88A8-483A-B51E-F728BF5502C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E15626D3-88A8-483A-B51E-F728BF5502C3}.Release|x64.ActiveCfg = Release|Any CPU
+		{E15626D3-88A8-483A-B51E-F728BF5502C3}.Release|x64.Build.0 = Release|Any CPU
+		{E15626D3-88A8-483A-B51E-F728BF5502C3}.Release|x86.ActiveCfg = Release|Any CPU
+		{E15626D3-88A8-483A-B51E-F728BF5502C3}.Release|x86.Build.0 = Release|Any CPU
 		{78BEF984-45BA-4385-A8B4-468AE94E64D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{78BEF984-45BA-4385-A8B4-468AE94E64D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78BEF984-45BA-4385-A8B4-468AE94E64D3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{78BEF984-45BA-4385-A8B4-468AE94E64D3}.Debug|x64.Build.0 = Debug|Any CPU
+		{78BEF984-45BA-4385-A8B4-468AE94E64D3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{78BEF984-45BA-4385-A8B4-468AE94E64D3}.Debug|x86.Build.0 = Debug|Any CPU
 		{78BEF984-45BA-4385-A8B4-468AE94E64D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{78BEF984-45BA-4385-A8B4-468AE94E64D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{78BEF984-45BA-4385-A8B4-468AE94E64D3}.Release|x64.ActiveCfg = Release|Any CPU
+		{78BEF984-45BA-4385-A8B4-468AE94E64D3}.Release|x64.Build.0 = Release|Any CPU
+		{78BEF984-45BA-4385-A8B4-468AE94E64D3}.Release|x86.ActiveCfg = Release|Any CPU
+		{78BEF984-45BA-4385-A8B4-468AE94E64D3}.Release|x86.Build.0 = Release|Any CPU
 		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Debug|x64.ActiveCfg = Debug|x64
-		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Debug|x64.Build.0 = Debug|x64
-		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Debug|x86.ActiveCfg = Debug|x86
-		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Debug|x86.Build.0 = Debug|x86
+		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Debug|x64.Build.0 = Debug|Any CPU
+		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Debug|x86.Build.0 = Debug|Any CPU
 		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Release|x64.ActiveCfg = Release|x64
-		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Release|x64.Build.0 = Release|x64
-		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Release|x86.ActiveCfg = Release|x86
-		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Release|x86.Build.0 = Release|x86
+		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Release|x64.ActiveCfg = Release|Any CPU
+		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Release|x64.Build.0 = Release|Any CPU
+		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Release|x86.ActiveCfg = Release|Any CPU
+		{C434E081-1F68-4C33-8246-4B602C6B9DF3}.Release|x86.Build.0 = Release|Any CPU
 		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Debug|x64.ActiveCfg = Debug|x64
-		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Debug|x64.Build.0 = Debug|x64
-		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Debug|x86.ActiveCfg = Debug|x86
-		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Debug|x86.Build.0 = Debug|x86
+		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Debug|x64.Build.0 = Debug|Any CPU
+		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Debug|x86.Build.0 = Debug|Any CPU
 		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Release|x64.ActiveCfg = Release|x64
-		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Release|x64.Build.0 = Release|x64
-		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Release|x86.ActiveCfg = Release|x86
-		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Release|x86.Build.0 = Release|x86
+		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Release|x64.ActiveCfg = Release|Any CPU
+		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Release|x64.Build.0 = Release|Any CPU
+		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Release|x86.ActiveCfg = Release|Any CPU
+		{EEE91E65-3734-42C7-AF91-F22F63E19A70}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DA64E1AF-EBFC-440A-B49A-809151234F98}
 	EndGlobalSection
 EndGlobal

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/PubsubFixture.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/PubsubFixture.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.ClientTesting;
 using System;
 using System.Linq;
 using Xunit;
@@ -19,29 +20,16 @@ using Xunit;
 namespace Google.Cloud.PubSub.V1.IntegrationTests
 {
     [CollectionDefinition(nameof(PubsubFixture))]
-    public sealed class PubsubFixture : IDisposable, ICollectionFixture<PubsubFixture>
+    public sealed class PubsubFixture : CloudProjectFixtureBase, ICollectionFixture<PubsubFixture>
     {
-        private const string ProjectEnvironmentVariable = "TEST_PROJECT";
         private const string TopicPrefix = "integration-topic-";
         private const string SubscriptionPrefix = "integration-sub-";
-
-        public string ProjectId { get; }
-
-        public PubsubFixture()
-        {
-            ProjectId = Environment.GetEnvironmentVariable(ProjectEnvironmentVariable);
-            if (string.IsNullOrEmpty(ProjectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
-            }
-        }
 
         internal string CreateTopicId() => TopicPrefix + Guid.NewGuid().ToString().ToLowerInvariant();
 
         internal string CreateSubscriptionId() => SubscriptionPrefix + Guid.NewGuid().ToString().ToLowerInvariant();
 
-        public void Dispose()
+        public override void Dispose()
         {
             var subscriber = SubscriberClient.Create();
             var subscriptions = subscriber.ListSubscriptions(new ProjectName(ProjectId))

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/PubsubSnippetFixture.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/PubsubSnippetFixture.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.ClientTesting;
 using Grpc.Core;
 using System;
 using System.Linq;
@@ -24,24 +25,10 @@ namespace Google.Cloud.PubSub.V1.Snippets
     /// Topics and subscriptions are created with specific prefixes, and deleted in tear-down.
     /// </summary>
     [CollectionDefinition(nameof(PubsubSnippetFixture))]
-    public sealed class PubsubSnippetFixture : IDisposable, ICollectionFixture<PubsubSnippetFixture>
+    public sealed class PubsubSnippetFixture : CloudProjectFixtureBase, ICollectionFixture<PubsubSnippetFixture>
     {
-        private const string ProjectEnvironmentVariable = "TEST_PROJECT";
-        private const string NotificationUrlEnvironmentVariable = "TEST_PROJECT_NOTIFICATION_URL";
         private const string TopicPrefix = "snippet-topic-";
         private const string SubscriptionPrefix = "snippet-sub-";
-
-        public string ProjectId { get; }
-
-        public PubsubSnippetFixture()
-        {
-            ProjectId = Environment.GetEnvironmentVariable(ProjectEnvironmentVariable);
-            if (string.IsNullOrEmpty(ProjectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
-            }
-        }
 
         /// <summary>
         /// Create a topic ID with a prefix which is used to check which topics to delete at the end of the test.
@@ -53,7 +40,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
         /// </summary>
         internal string CreateSubscriptionId() => SubscriptionPrefix + Guid.NewGuid().ToString().ToLowerInvariant();
 
-        public void Dispose()
+        public override void Dispose()
         {
             var subscriber = SubscriberClient.Create();
             var subscriptions = subscriber.ListSubscriptions(new ProjectName(ProjectId))

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.sln
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.15
+VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.PubSub.V1", "Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj", "{768566BC-8F77-4F7C-8A15-F8A11308B74B}"
 EndProject
@@ -14,7 +14,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.PubSub.V1.Inte
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{66EEA937-94C9-4080-A579-6734337D01DB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.PubSub.V1.SmokeTests", "Google.Cloud.PubSub.V1.SmokeTests\Google.Cloud.PubSub.V1.SmokeTests.csproj", "{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.PubSub.V1.SmokeTests", "Google.Cloud.PubSub.V1.SmokeTests\Google.Cloud.PubSub.V1.SmokeTests.csproj", "{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -100,16 +100,16 @@ Global
 		{66EEA937-94C9-4080-A579-6734337D01DB}.Release|x86.Build.0 = Release|Any CPU
 		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Debug|x64.ActiveCfg = Debug|x64
-		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Debug|x64.Build.0 = Debug|x64
-		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Debug|x86.ActiveCfg = Debug|x86
-		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Debug|x86.Build.0 = Debug|x86
+		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Debug|x64.Build.0 = Debug|Any CPU
+		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Debug|x86.Build.0 = Debug|Any CPU
 		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Release|x64.ActiveCfg = Release|x64
-		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Release|x64.Build.0 = Release|x64
-		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Release|x86.ActiveCfg = Release|x86
-		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Release|x86.Build.0 = Release|x86
+		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Release|x64.ActiveCfg = Release|Any CPU
+		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Release|x64.Build.0 = Release|Any CPU
+		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Release|x86.ActiveCfg = Release|Any CPU
+		{DE881FF4-7D5A-469A-AD1C-1C59701CDCA3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
@@ -109,7 +109,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         [Fact]
         public async Task BadDbName()
         {
-            string connectionString = $"Data Source=projects/{_testFixture.TestProjectName}/instances/"
+            string connectionString = $"Data Source=projects/{_testFixture.ProjectId}/instances/"
                 + $"{_testFixture.TestInstanceName}/databases/badjuju";
             // ReSharper disable once RedundantAssignment
             int rowsRead = -1;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TestDatabaseFixture.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TestDatabaseFixture.cs
@@ -18,6 +18,7 @@ using System;
 using System.Threading.Tasks;
 using Google.Api.Gax;
 using Xunit;
+using Google.Cloud.ClientTesting;
 
 #endregion
 
@@ -25,19 +26,16 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
 {
     // ReSharper disable once ClassNeverInstantiated.Global
     [CollectionDefinition(nameof(TestDatabaseFixture))]
-    public class TestDatabaseFixture : IDisposable, ICollectionFixture<TestDatabaseFixture>
+    public class TestDatabaseFixture : CloudProjectFixtureBase, ICollectionFixture<TestDatabaseFixture>
     {
         private readonly Lazy<Task> _creationTask;
 
         public string TestInstanceName => "spannerintegration";
 
-        public string TestProjectName => Environment.GetEnvironmentVariable("TEST_PROJECT") ?? "cloud-sharp-jenkins";
+        public string ConnectionString => $"Data Source=projects/{ProjectId}/instances/{TestInstanceName}"
+            + $"/databases/{DatabaseName}";
 
-        public string ConnectionString => "Data Source=projects/" + TestProjectName + "/instances/" + TestInstanceName
-            + "/databases/" + DatabaseName;
-
-        public string NoDbConnectionString => "Data Source=projects/" + TestProjectName + "/instances/" +
-            TestInstanceName;
+        public string NoDbConnectionString => $"Data Source=projects/{ProjectId}/instances/{TestInstanceName}";
 
         // scratch can be used to run tests on a precreated db.
         // all tests are designed to be re-run on an exiting db (previously written state will
@@ -58,7 +56,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
 
         public TestDatabaseFixture() => _creationTask = new Lazy<Task>(EnsureTestDatabaseImplAsync);
 
-        public void Dispose()
+        public override void Dispose()
         {
             using (var connection = new SpannerConnection(NoDbConnectionString))
             {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SnippetFixture.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SnippetFixture.cs
@@ -18,6 +18,7 @@ using System;
 using System.Threading.Tasks;
 using Google.Cloud.Spanner.Admin.Database.V1;
 using Xunit;
+using Google.Cloud.ClientTesting;
 // ReSharper disable MemberCanBePrivate.Global
 
 #endregion
@@ -26,18 +27,16 @@ namespace Google.Cloud.Spanner.Data.Snippets
 {
     // ReSharper disable once ClassNeverInstantiated.Global
     [CollectionDefinition(nameof(SnippetFixture))]
-    public class SnippetFixture : IDisposable, ICollectionFixture<SnippetFixture>
+    public class SnippetFixture : CloudProjectFixtureBase, ICollectionFixture<SnippetFixture>
     {
         private readonly Lazy<Task> _creationTask;
 
         public string TestInstanceName => "spannerintegration";
 
-        public string TestProjectName => Environment.GetEnvironmentVariable("TEST_PROJECT") ?? "cloud-sharp-jenkins";
-
-        public string ConnectionString => $"Data Source=projects/{TestProjectName}/instances/{TestInstanceName}"
+        public string ConnectionString => $"Data Source=projects/{ProjectId}/instances/{TestInstanceName}"
             + $"/databases/{TestDatabaseName}";
 
-        private string NoDbConnectionString => $"Data Source=projects/{TestProjectName}/instances/{TestInstanceName}";
+        private string NoDbConnectionString => $"Data Source=projects/{ProjectId}/instances/{TestInstanceName}";
 
         public string TestDatabaseName { get; } =
             "t_" + Guid.NewGuid().ToString("N").Substring(0, 28);
@@ -48,11 +47,11 @@ namespace Google.Cloud.Spanner.Data.Snippets
 
         public SnippetFixture() => _creationTask = new Lazy<Task>(EnsureTestDatabaseImplAsync);
 
-        public void Dispose()
+        public override void Dispose()
         {
             var databaseAdminClient = DatabaseAdminClient.Create();
             databaseAdminClient.DropDatabase(
-                new DatabaseName(TestProjectName, TestInstanceName, TestDatabaseName));
+                new DatabaseName(ProjectId, TestInstanceName, TestDatabaseName));
         }
 
         public Task EnsureTestDatabaseAsync() => _creationTask.Value;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
@@ -38,7 +38,7 @@ namespace Google.Cloud.Spanner.Data.Snippets
         public SpannerConnectionSnippets(SnippetFixture fixture)
         {
             _fixture = fixture;
-            _projectId = _fixture.TestProjectName;
+            _projectId = _fixture.ProjectId;
             _instanceName = _fixture.TestInstanceName;
             _databaseName = _fixture.TestDatabaseName;
         }

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/TraceServiceFixture.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/TraceServiceFixture.cs
@@ -11,35 +11,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-using System;
+using Google.Cloud.ClientTesting;
 using Xunit;
 
 namespace Google.Cloud.Trace.V1.Snippets
 {
     /// <summary>
     /// Fixture which is set up at the start of the test run, and torn down at the end.
-    /// The Google Cloud Project name is fetched from the TEST_PROJECT environment variable.
+    /// (Currently this fixture does nothing more than providing the project ID.)
     /// </summary>
     [CollectionDefinition(nameof(TraceServiceFixture))]
-    public sealed class TraceServiceFixture: IDisposable, ICollectionFixture<TraceServiceFixture>
+    public sealed class TraceServiceFixture: CloudProjectFixtureBase, ICollectionFixture<TraceServiceFixture>
     {
-        private const string ProjectEnvironmentVariable = "TEST_PROJECT";
-
-        public string ProjectId { get; }
-
-        public TraceServiceFixture()
-        {
-            ProjectId = Environment.GetEnvironmentVariable(ProjectEnvironmentVariable);
-            if (string.IsNullOrEmpty(ProjectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {ProjectEnvironmentVariable} environment variable before running tests");
-            }
-        }
-
-        public void Dispose()
-        {
-            // No-op
-        }
     }
 }

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.sln
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26114.2
+VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Trace.V1", "Google.Cloud.Trace.V1\Google.Cloud.Trace.V1.csproj", "{939FA175-86CE-4B80-98E8-EDE676FD7821}"
 EndProject
@@ -12,54 +11,73 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{567D4C59-8
 		docs\index.md = docs\index.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Trace.V1.SmokeTests", "Google.Cloud.Trace.V1.SmokeTests\Google.Cloud.Trace.V1.SmokeTests.csproj", "{8760DF50-0916-43EE-B4D2-D46A536B0DD8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Trace.V1.SmokeTests", "Google.Cloud.Trace.V1.SmokeTests\Google.Cloud.Trace.V1.SmokeTests.csproj", "{8760DF50-0916-43EE-B4D2-D46A536B0DD8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|x64.Build.0 = Debug|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|x86.Build.0 = Debug|Any CPU
 		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|Any CPU.Build.0 = Release|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|x64.ActiveCfg = Release|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|x64.Build.0 = Release|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|x86.ActiveCfg = Release|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|x86.Build.0 = Release|Any CPU
 		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Debug|x64.Build.0 = Debug|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Debug|x86.Build.0 = Debug|Any CPU
 		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Release|x64.ActiveCfg = Release|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Release|x64.Build.0 = Release|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Release|x86.ActiveCfg = Release|Any CPU
+		{475EC66A-501B-4C3D-88BE-C188C59C64C5}.Release|x86.Build.0 = Release|Any CPU
 		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Debug|x64.ActiveCfg = Debug|x64
-		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Debug|x64.Build.0 = Debug|x64
-		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Debug|x86.ActiveCfg = Debug|x86
-		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Debug|x86.Build.0 = Debug|x86
+		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Debug|x64.Build.0 = Debug|Any CPU
+		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Debug|x86.Build.0 = Debug|Any CPU
 		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Release|x64.ActiveCfg = Release|x64
-		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Release|x64.Build.0 = Release|x64
-		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Release|x86.ActiveCfg = Release|x86
-		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Release|x86.Build.0 = Release|x86
+		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Release|x64.ActiveCfg = Release|Any CPU
+		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Release|x64.Build.0 = Release|Any CPU
+		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Release|x86.ActiveCfg = Release|Any CPU
+		{348EFC7E-2ADC-420F-BDE5-1000E0603FDB}.Release|x86.Build.0 = Release|Any CPU
 		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Debug|x64.ActiveCfg = Debug|x64
-		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Debug|x64.Build.0 = Debug|x64
-		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Debug|x86.ActiveCfg = Debug|x86
-		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Debug|x86.Build.0 = Debug|x86
+		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Debug|x64.Build.0 = Debug|Any CPU
+		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Debug|x86.Build.0 = Debug|Any CPU
 		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Release|x64.ActiveCfg = Release|x64
-		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Release|x64.Build.0 = Release|x64
-		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Release|x86.ActiveCfg = Release|x86
-		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Release|x86.Build.0 = Release|x86
+		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Release|x64.ActiveCfg = Release|Any CPU
+		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Release|x64.Build.0 = Release|Any CPU
+		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Release|x86.ActiveCfg = Release|Any CPU
+		{8760DF50-0916-43EE-B4D2-D46A536B0DD8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5B17FA64-A3EF-4760-A9E1-B157198E72B3}
 	EndGlobalSection
 EndGlobal

--- a/tools/Google.Cloud.ClientTesting/CloudProjectFixtureBase.cs
+++ b/tools/Google.Cloud.ClientTesting/CloudProjectFixtureBase.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Google.Cloud.ClientTesting
+{
+    /// <summary>
+    /// Base class for fixtures in integration and snippet tests which rely on Google Cloud projects.
+    /// </summary>
+    public abstract class CloudProjectFixtureBase : IDisposable
+    {
+        public const string TestProjectEnvironmentVariable = "TEST_PROJECT";
+
+        /// <summary>
+        /// The Google Cloud Project ID to use for tests.
+        /// </summary>
+        public string ProjectId { get; }
+
+        protected CloudProjectFixtureBase(string testProjectEnvironmentVariable = TestProjectEnvironmentVariable)
+        {
+            ProjectId = Environment.GetEnvironmentVariable(testProjectEnvironmentVariable);
+            if (string.IsNullOrEmpty(ProjectId))
+            {
+                throw new InvalidOperationException(
+                    $"Please set the {testProjectEnvironmentVariable} environment variable to your test project ID before running tests");
+            }
+        }
+
+        /// <summary>
+        /// No-op disposal. Override this to provide cleanup (usually of data created for tests)
+        /// at the end of the test run. 
+        /// </summary>
+        public virtual void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
After this has been merged, the TEST_PROJECT constant should only
occur once in the repo.

We might want to consider more functionality in the future, such as
ID generation. (There are lots of calls to Guid.NewGuid() with a
variety of lower casing etc.)