### PR TITLE
Deleting Storage objects before deleting a bucket

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.CleanTestData/Program.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.CleanTestData/Program.cs
@@ -52,13 +52,7 @@ namespace Google.Storage.V2.CleanTestData
 
         private static void DeleteBucket(StorageClient client, string bucket)
         {
-            var objects = client.ListObjects(bucket, options: new ListObjectsOptions { Versions = true });
-            foreach (var obj in objects)
-            {
-                client.DeleteObject(bucket, obj.Name, new DeleteObjectOptions { Generation = obj.Generation });
-                Console.WriteLine($"Deleted {bucket} / {obj.Name} / v{obj.Generation}");
-            }
-            client.DeleteBucket(bucket);
+            client.DeleteBucket(bucket, new DeleteBucketOptions { DeleteObjects = true });
             // Avoid running into quota issues
             Thread.Sleep(2000);
             Console.WriteLine($"Deleted {bucket}");

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DeleteBucketTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DeleteBucketTest.cs
@@ -1,0 +1,230 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Storage.v1.Data;
+using System.Net;
+using Xunit;
+
+namespace Google.Cloud.Storage.V1.IntegrationTests
+{
+    using System.Threading.Tasks;
+    using static TestHelpers;
+
+    [Collection(nameof(StorageFixture))]
+    public class DeleteBucketTest
+    {
+        // Only overloads accepting Bucket are tested, but the overloads accepting string go
+        // through almost all the same code.
+
+        private readonly StorageFixture _fixture;
+
+        public DeleteBucketTest(StorageFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public void DeleteBucket_NonExistent()
+        {
+            string name = _fixture.GenerateBucketName();
+            var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.DeleteBucket(name));
+        }
+
+
+        [Fact]
+        public void DeleteBucket_Empty_NoPrecondition()
+        {
+            var bucket = CreateBucket();
+            DeleteBucket(bucket);
+            AssertBucketDeleted(bucket);
+        }
+
+        [Fact]
+        public void DeleteBucket_Empty_IncorrectPrecondition()
+        {
+            var bucket = CreateBucket();
+            var options = new DeleteBucketOptions { IfMetagenerationMatch = bucket.Metageneration + 1 };
+            var exception = Assert.Throws<GoogleApiException>(() => DeleteBucket(bucket, options));
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+            AssertBucketNotDeleted(bucket);
+        }
+
+        [Fact]
+        public void DeleteBucket_Empty_CorrectPrecondition()
+        {
+            var bucket = CreateBucket();
+            var options = new DeleteBucketOptions { IfMetagenerationMatch = bucket.Metageneration };
+            DeleteBucket(bucket, options);
+            AssertBucketDeleted(bucket);
+        }
+
+        [Fact]
+        public void DeleteBucket_WithObject_Fails()
+        {
+            var bucket = CreateBucket();
+            _fixture.Client.UploadObject(bucket.Name, "file", null, GenerateData(128));
+            var exception = Assert.Throws<GoogleApiException>(() => DeleteBucket(bucket));
+            Assert.Equal(HttpStatusCode.Conflict, exception.HttpStatusCode);
+            AssertBucketNotDeleted(bucket);
+        }
+
+        [Fact]
+        public void DeleteBucket_DeleteObjects_NoPrecondition()
+        {
+            var bucket = CreateBucket();
+            _fixture.Client.UploadObject(bucket.Name, "file", null, GenerateData(128));
+            var options = new DeleteBucketOptions { DeleteObjects = true };
+            DeleteBucket(bucket, options);
+            AssertBucketDeleted(bucket);
+        }
+
+        [Fact]
+        public void DeleteBucket_DeleteObjects_IncorrectPrecondition()
+        {
+            var bucket = CreateBucket();
+            _fixture.Client.UploadObject(bucket.Name, "file", null, GenerateData(128));
+            var options = new DeleteBucketOptions { DeleteObjects = true, IfMetagenerationMatch = bucket.Metageneration + 1 };
+            var exception = Assert.Throws<GoogleApiException>(() => DeleteBucket(bucket, options));
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+            // The file should still exist if the precondition wasn't met.
+            _fixture.Client.GetObject(bucket.Name, "file");
+            AssertBucketNotDeleted(bucket);
+        }
+
+        [Fact]
+        public void DeleteBucket_DeleteObjects_CorrectPrecondition()
+        {
+            var bucket = CreateBucket();
+            _fixture.Client.UploadObject(bucket.Name, "file", null, GenerateData(128));
+            var options = new DeleteBucketOptions { DeleteObjects = true, IfMetagenerationMatch = bucket.Metageneration };
+            DeleteBucket(bucket, options);
+            AssertBucketDeleted(bucket);
+        }
+
+        [Fact]
+        public void DeleteBucketAsync_NonExistent()
+        {
+            string name = _fixture.GenerateBucketName();
+            var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.DeleteBucket(name));
+        }
+
+
+        [Fact]
+        public async Task DeleteBucketAsync_Empty_NoPrecondition()
+        {
+            var bucket = CreateBucket();
+            await DeleteBucketAsync(bucket);
+            AssertBucketDeleted(bucket);
+        }
+
+        [Fact]
+        public async Task DeleteBucketAsync_Empty_IncorrectPrecondition()
+        {
+            var bucket = CreateBucket();
+            var options = new DeleteBucketOptions { IfMetagenerationMatch = bucket.Metageneration + 1 };
+            var exception = await Assert.ThrowsAsync<GoogleApiException>(() => DeleteBucketAsync(bucket, options));
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+            AssertBucketNotDeleted(bucket);
+        }
+
+        [Fact]
+        public async Task DeleteBucketAsync_Empty_CorrectPrecondition()
+        {
+            var bucket = CreateBucket();
+            var options = new DeleteBucketOptions { IfMetagenerationMatch = bucket.Metageneration };
+            await DeleteBucketAsync(bucket, options);
+            AssertBucketDeleted(bucket);
+        }
+
+        [Fact]
+        public async Task DeleteBucketAsync_WithObject_Fails()
+        {
+            var bucket = CreateBucket();
+            _fixture.Client.UploadObject(bucket.Name, "file", null, GenerateData(128));
+            var exception = await Assert.ThrowsAsync<GoogleApiException>(() => DeleteBucketAsync(bucket));
+            Assert.Equal(HttpStatusCode.Conflict, exception.HttpStatusCode);
+            AssertBucketNotDeleted(bucket);
+        }
+
+        [Fact]
+        public async Task DeleteBucketAsync_DeleteObjects_NoPrecondition()
+        {
+            var bucket = CreateBucket();
+            _fixture.Client.UploadObject(bucket.Name, "file", null, GenerateData(128));
+            var options = new DeleteBucketOptions { DeleteObjects = true };
+            await DeleteBucketAsync(bucket, options);
+            AssertBucketDeleted(bucket);
+        }
+
+        [Fact]
+        public async Task DeleteBucketAsync_DeleteObjects_IncorrectPrecondition()
+        {
+            var bucket = CreateBucket();
+            _fixture.Client.UploadObject(bucket.Name, "file", null, GenerateData(128));
+            var options = new DeleteBucketOptions { DeleteObjects = true, IfMetagenerationMatch = bucket.Metageneration + 1 };
+            var exception = await Assert.ThrowsAsync<GoogleApiException>(() => DeleteBucketAsync(bucket, options));
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+            // The file should still exist if the precondition wasn't met.
+            _fixture.Client.GetObject(bucket.Name, "file");
+            AssertBucketNotDeleted(bucket);
+        }
+
+        [Fact]
+        public async Task DeleteBucketAsync_DeleteObjects_CorrectPrecondition()
+        {
+            var bucket = CreateBucket();
+            _fixture.Client.UploadObject(bucket.Name, "file", null, GenerateData(128));
+            var options = new DeleteBucketOptions { DeleteObjects = true, IfMetagenerationMatch = bucket.Metageneration };
+            await DeleteBucketAsync(bucket, options);
+            AssertBucketDeleted(bucket);
+        }
+
+        private void DeleteBucket(Bucket bucket, DeleteBucketOptions options = null)
+        {
+            try
+            {
+                _fixture.Client.DeleteBucket(bucket, options);
+                _fixture.UnregisterBucket(bucket.Name);
+            }
+            finally
+            {
+                StorageFixture.SleepAfterBucketCreateDelete();
+            }
+        }
+
+        private async Task DeleteBucketAsync(Bucket bucket, DeleteBucketOptions options = null)
+        {
+            try
+            {
+                await _fixture.Client.DeleteBucketAsync(bucket, options);
+                _fixture.UnregisterBucket(bucket.Name);
+            }
+            finally
+            {
+                StorageFixture.SleepAfterBucketCreateDelete();
+            }
+        }
+
+        private void AssertBucketDeleted(Bucket bucket)
+        {
+            var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.GetBucket(bucket.Name));
+            Assert.Equal(HttpStatusCode.NotFound, exception.HttpStatusCode);
+        }
+
+        private void AssertBucketNotDeleted(Bucket bucket) => _fixture.Client.GetBucket(bucket.Name);
+
+        private Bucket CreateBucket()
+        {
+            var name = _fixture.GenerateBucketName();
+            return _fixture.CreateBucket(name, false);
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/StorageSnippetFixture.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/StorageSnippetFixture.cs
@@ -124,12 +124,7 @@ namespace Google.Cloud.Storage.V1.Snippets
             var client = StorageClient.Create();
             foreach (var bucket in _bucketsToDelete)
             {
-                var objects = client.ListObjects(bucket, null, new ListObjectsOptions { Versions = true }).ToList();
-                foreach (var obj in objects)
-                {
-                    client.DeleteObject(obj, new DeleteObjectOptions { Generation = obj.Generation });
-                }
-                client.DeleteBucket(bucket);
+                client.DeleteBucket(bucket, new DeleteBucketOptions { DeleteObjects = true });
                 SleepAfterBucketCreateDelete();
             }
             foreach (var file in _localFilesToDelete)

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DeleteBucketOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DeleteBucketOptions.cs
@@ -40,6 +40,29 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public string UserProject { get; set; }
 
+        /// <summary>
+        /// If set to true, all objects within the bucket will be deleted before attempting
+        /// to delete the bucket itself.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is a best-effort attempt, with no guarantees of atomicity:
+        /// it's entirely possible for the operation to fail having deleted some objects
+        /// but not all of them. If a precondition is specified, it is checked before deleting any
+        /// objects, and applied again when deleting the bucket, but is not checked while deleting
+        /// the objects. The behavior is unspecified if objects are modified, added or deleted while
+        /// this operation is taking place.
+        /// </para>
+        /// <para>
+        /// The objects are deleted sequentially. If you need to delete buckets with many objects, you
+        /// may wish to implement a parallel solution in application code instead of using this option.
+        /// </para>
+        /// <para>
+        /// If <see cref="UserProject"/> is set, that project will be billed for all operations.
+        /// </para>
+        /// </remarks>
+        public bool? DeleteObjects { get; set; }
+
         internal void ModifyRequest(BucketsResource.DeleteRequest request)
         {
             if (IfMetagenerationMatch != null && IfMetagenerationNotMatch != null)
@@ -58,6 +81,23 @@ namespace Google.Cloud.Storage.V1
             {
                 request.UserProject = UserProject;
             }
+        }
+
+        /// <summary>
+        /// If this set of options contains any preconditions, return a
+        /// <see cref="GetBucketOptions"/> with the same set of options. Otherwise, return null.
+        /// </summary>
+        internal GetBucketOptions CreateGetBucketOptionsForPreconditions()
+        {
+            long? match = IfMetagenerationMatch;
+            long? notMatch = IfMetagenerationNotMatch;
+            return match == null && notMatch == null ? null :
+                new GetBucketOptions
+                {
+                    IfMetagenerationMatch = match,
+                    IfMetagenerationNotMatch = notMatch,
+                    UserProject = UserProject
+                };
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0-beta00</Version>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.cs
@@ -98,13 +98,15 @@ namespace Google.Cloud.Storage.V1
         /// This method also checks for nullity, so callers don't need to do that first.
         /// This method is internal rather than private for testing purposes.
         /// </summary>
-        internal static void ValidateBucketName(string bucket)
+        /// <returns>The input, to allow inline validation</returns>
+        internal static string ValidateBucketName(string bucket)
         {
             GaxPreconditions.CheckNotNull(bucket, nameof(bucket));
             if (!ValidBucketName.IsMatch(bucket))
             {
                 throw new ArgumentException($"Invalid bucket name '{bucket}' - see https://cloud.google.com/storage/docs/bucket-naming", nameof(bucket));
             }
+            return bucket;
         }
 
         /// <summary>
@@ -112,13 +114,16 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         /// <param name="bucket">Bucket to validate</param>
         /// <param name="paramName">The parameter name in the calling method</param>
-        private void ValidateBucket(Bucket bucket, string paramName)
+        /// <returns>The validated bucket name</returns>
+        private string ValidateBucket(Bucket bucket, string paramName)
         {
             GaxPreconditions.CheckNotNull(bucket, paramName);
-            GaxPreconditions.CheckArgument(bucket.Name != null, paramName, "Bucket must have a name");
-            GaxPreconditions.CheckArgument(ValidBucketName.IsMatch(bucket.Name),
+            string name = bucket.Name;
+            GaxPreconditions.CheckArgument(name != null, paramName, "Bucket must have a name");
+            GaxPreconditions.CheckArgument(ValidBucketName.IsMatch(name),
                 paramName,
                 "Invalid bucket name '{0}' - see https://cloud.google.com/storage/docs/bucket-naming", bucket.Name);
+            return name;
         }
 
         /// <summary>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -501,7 +501,7 @@
     "id": "Google.Cloud.Storage.V1",
     "productName": "Google Cloud Storage",
     "productUrl": "https://cloud.google.com/storage/",
-    "version": "2.1.0",
+    "version": "2.2.0-beta00",
     "type": "rest",
     "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
     "dependencies": {


### PR DESCRIPTION
This is a not-for-submission draft PR to allow deleting a buckets objects while deleting the bucket itself.

It has no tests at the moment, which are clearly needed... but I wanted to get some confirmation that this feels appropriate first.

In particular, there's no parallelism here, which potentially there could be - but then it would require configuration for exactly how parallel everything should be, etc. Maybe that could be added later? Thoughts welcome.