### PR TITLE
Add snippets for Storage notifications

### DIFF
--- a/apis/Google.Cloud.Storage.V1/docs/index.md
+++ b/apis/Google.Cloud.Storage.V1/docs/index.md
@@ -64,3 +64,16 @@ one, you can do so either for all operations with a particular
 `StorageClient` or on individual ones.
 
 [!code-cs[](obj/snippets/Google.Cloud.Storage.V1.StorageClient.txt#CustomerSuppliedEncryptionKeys)]
+
+## Change notification via Google Cloud Pub/Sub
+
+You can configure a bucket to send a change notification to a
+[Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) topic
+when changes occur. The sample below shows how to create a Pub/Sub
+topic, set its permissions so that the change notifications can be
+published to it, and then create the notification configuration on a
+bucket. You'll need to add a dependency on the
+`Google.Cloud.PubSub.V1` NuGet package to create the topic and
+manage its permissions.
+
+[!code-cs[](obj/snippets/Google.Cloud.Storage.V1.StorageClient.txt#NotificationsOverview)]


### PR DESCRIPTION
There are regular snippets for all the new methods, and an example
walking the user through how to create and give permissions to the
PubSub topic.

(It's a bit hairy right now; I want to improve this by adding
convenience methods to IAM.)