### PR TITLE
Provide an escape hatch for hash validation failures

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DownloadObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DownloadObjectTest.cs
@@ -296,6 +296,19 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        public void DownloadGzippedFile_IgnoreHash()
+        {
+            // The file has a Content-Encoding of gzip, and it's stored compressed.
+            // We can't currently validate the hash, but the escape hatch allows us to download it anyway.
+            var stream = new MemoryStream();
+            _fixture.Client.DownloadObject(StorageFixture.CrossLanguageTestBucket, "gzipped-text.txt", stream,
+                new DownloadObjectOptions { HashValidationMode = HashValidationMode.Never });
+            var expected = Encoding.UTF8.GetBytes("hello world");
+            var actual = stream.ToArray();
+            Assert.Equal(expected, actual);
+        }
+
         private Object GetLatestVersionOfMultiversionObject()
         {
             var service = _fixture.Client.Service;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DownloadObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DownloadObjectOptions.cs
@@ -74,6 +74,18 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public string UserProject { get; set; }
 
+        /// <summary>
+        /// Specifies whether or not the object's hash code should be validated. If this property is null,
+        /// the hash code will always be validated.
+        /// </summary>
+        /// <remarks>
+        /// This is effectively an escape hatch for situations where hash validation fails.
+        /// See https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/1641 for background
+        /// on this option. It is recommended that you leave this option unset unless you are knowingly
+        /// downloading data for an object where hashing will fail.
+        /// </remarks>
+        public HashValidationMode? HashValidationMode { get; set; }
+
         internal void ModifyDownloader(MediaDownloader downloader)
         {
             if (ChunkSize != null)

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/HashValidationMode.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/HashValidationMode.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Storage.V1
+{
+    /// <summary>
+    /// Describes the circumstances under which the hash of an object is validated.
+    /// </summary>
+    public enum HashValidationMode
+    {
+        /// <summary>
+        /// The hash is always validated.
+        /// </summary>
+        Always = 0,
+
+        /// <summary>
+        /// The hash is never validated; data integrity errors may still be exposed
+        /// via other network layers, but there is a risk of data loss.
+        /// </summary>
+        Never = 1
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.DownloadObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.DownloadObject.cs
@@ -142,9 +142,10 @@ namespace Google.Cloud.Storage.V1
                 }
             });
 
-        private HashValidatingDownloader CreateDownloader(DownloadObjectOptions options)
+        private MediaDownloader CreateDownloader(DownloadObjectOptions options)
         {
-            var downloader = new HashValidatingDownloader(Service);
+            MediaDownloader downloader = options.HashValidationMode == HashValidationMode.Never
+                ? new MediaDownloader(Service) : new HashValidatingDownloader(Service);
             downloader.ModifyRequest += _versionHeaderAction;
             options?.ModifyDownloader(downloader);
             ApplyEncryptionKey(options?.EncryptionKey, downloader);


### PR DESCRIPTION
This is the first part of solving #1641. It's only a workaround, but
it's a start.

Note that there's no HashValidationMode.WhenAvailable yet; I'm not
convinced that we have a reliable signal for when we won't be able
to validate the hash, so I'd rather not add the enum value yet.
If/when we get that signal, we can add the enum value.

The aim of this PR is to unblock users until a fuller solution is
available, without delaying a GA release of Google.Cloud.Storage.V1 v2.1.0.