### PR TITLE
Add convenience methods for IAM

### DIFF
--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Tests/Google.Cloud.Iam.V1.Tests.csproj
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Tests/Google.Cloud.Iam.V1.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Features>IOperation</Features>
+    <IsPackable>false</IsPackable>
+    <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
+    <ProjectReference Include="..\Google.Cloud.Iam.V1\Google.Cloud.Iam.V1.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Moq" Version="4.7.145" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
+    <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Tests/PolicyTest.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Tests/PolicyTest.cs
@@ -1,0 +1,158 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Google.Cloud.Iam.V1.Tests
+{
+    public class PolicyTest
+    {
+        [Fact]
+        public void AddRoleMember_RoleExists_MemberExists()
+        {
+            var policy = new Policy
+            {
+                Bindings =
+                {
+                    new Binding { Role = "other", Members = { "x", "y", "z" } },
+                    new Binding { Role = "target", Members = { "a", "b", "c" } },
+                }
+            };
+            var expected = policy.Clone();
+            Assert.False(policy.AddRoleMember("target", "b"));
+            Assert.Equal(expected, policy); // No change
+        }
+
+        [Fact]
+        public void AddRoleMember_RoleExists_NewMember()
+        {
+            var policy = new Policy
+            {
+                Bindings =
+                {
+                    new Binding { Role = "other", Members = { "x", "y", "z" } },
+                    new Binding { Role = "target", Members = { "a", "b", "c" } },
+                }
+            };
+            var expected = new Policy
+            {
+                Bindings =
+                {
+                    new Binding { Role = "other", Members = { "x", "y", "z" } },
+                    new Binding { Role = "target", Members = { "a", "b", "c", "d" } },
+                }
+            };
+            Assert.True(policy.AddRoleMember("target", "d"));
+            Assert.Equal(expected, policy);
+        }
+
+        [Fact]
+        public void AddRoleMember_NewRole()
+        {
+            var policy = new Policy
+            {
+                Bindings =
+                {
+                    new Binding { Role = "other", Members = { "x", "y", "z" } },
+                }
+            };
+            var expected = new Policy
+            {
+                Bindings =
+                {
+                    new Binding { Role = "other", Members = { "x", "y", "z" } },
+                    new Binding { Role = "target", Members = { "d" } },
+                }
+            };
+            Assert.True(policy.AddRoleMember("target", "d"));
+            Assert.Equal(expected, policy);
+        }
+
+        [Fact]
+        public void RemoveRoleMember_RoleExists_MemberExists_OtherMembers()
+        {
+            var policy = new Policy
+            {
+                Bindings =
+                {
+                    new Binding { Role = "other", Members = { "x", "y", "z" } },
+                    new Binding { Role = "target", Members = { "a", "b", "c" } },
+                }
+            };
+            var expected = new Policy
+            {
+                Bindings =
+                {
+                    new Binding { Role = "other", Members = { "x", "y", "z" } },
+                    new Binding { Role = "target", Members = { "a", "c" } },
+                }
+            };
+            Assert.True(policy.RemoveRoleMember("target", "b"));
+            Assert.Equal(expected, policy);
+        }
+
+        [Fact]
+        public void RemoveRoleMember_RoleExists_MemberExists_LastMember()
+        {
+            var policy = new Policy
+            {
+                Bindings =
+                {
+                    new Binding { Role = "other", Members = { "x", "y", "z" } },
+                    new Binding { Role = "target", Members = { "b" } },
+                }
+            };
+            var expected = new Policy
+            {
+                Bindings =
+                {
+                    new Binding { Role = "other", Members = { "x", "y", "z" } },
+                }
+            };
+            Assert.True(policy.RemoveRoleMember("target", "b"));
+            Assert.Equal(expected, policy);
+        }
+
+        [Fact]
+        public void RemoveRoleMember_RoleExists_NoMember()
+        {
+            var policy = new Policy
+            {
+                Bindings =
+                {
+                    new Binding { Role = "other", Members = { "x", "y", "z" } },
+                    new Binding { Role = "target", Members = { "a", "b", "c" } },
+                }
+            };
+            var expected = policy.Clone();
+            Assert.False(policy.RemoveRoleMember("target", "d"));
+            Assert.Equal(expected, policy);
+        }
+
+        [Fact]
+        public void RemoveRoleMember_NoRole()
+        {
+            var policy = new Policy
+            {
+                Bindings =
+                {
+                    new Binding { Role = "other", Members = { "x", "y", "z" } },
+                }
+            };
+            var expected = policy.Clone();
+            Assert.False(policy.RemoveRoleMember("target", "d"));
+            Assert.Equal(expected, policy);
+        }
+    }
+}

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Tests/coverage.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
+  <Filters>
+    <IncludeFilters>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Iam.V1</ModuleMask>
+      </FilterEntry>
+    </IncludeFilters>
+  </Filters>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Iam.V1.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.sln
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.sln
@@ -1,20 +1,52 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26114.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Iam.V1", "Google.Cloud.Iam.V1\Google.Cloud.Iam.V1.csproj", "{8BF4C91C-5611-444B-8550-D67DEBAF72F1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Iam.V1.Tests", "Google.Cloud.Iam.V1.Tests\Google.Cloud.Iam.V1.Tests.csproj", "{00D82DC9-DF5C-4F79-A366-36C12BF3EA9C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{33F59057-9298-4578-86CE-D4B92BE41979}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8BF4C91C-5611-444B-8550-D67DEBAF72F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8BF4C91C-5611-444B-8550-D67DEBAF72F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8BF4C91C-5611-444B-8550-D67DEBAF72F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8BF4C91C-5611-444B-8550-D67DEBAF72F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00D82DC9-DF5C-4F79-A366-36C12BF3EA9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00D82DC9-DF5C-4F79-A366-36C12BF3EA9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00D82DC9-DF5C-4F79-A366-36C12BF3EA9C}.Debug|x64.ActiveCfg = Debug|x64
+		{00D82DC9-DF5C-4F79-A366-36C12BF3EA9C}.Debug|x64.Build.0 = Debug|x64
+		{00D82DC9-DF5C-4F79-A366-36C12BF3EA9C}.Debug|x86.ActiveCfg = Debug|x86
+		{00D82DC9-DF5C-4F79-A366-36C12BF3EA9C}.Debug|x86.Build.0 = Debug|x86
+		{00D82DC9-DF5C-4F79-A366-36C12BF3EA9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00D82DC9-DF5C-4F79-A366-36C12BF3EA9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00D82DC9-DF5C-4F79-A366-36C12BF3EA9C}.Release|x64.ActiveCfg = Release|x64
+		{00D82DC9-DF5C-4F79-A366-36C12BF3EA9C}.Release|x64.Build.0 = Release|x64
+		{00D82DC9-DF5C-4F79-A366-36C12BF3EA9C}.Release|x86.ActiveCfg = Release|x86
+		{00D82DC9-DF5C-4F79-A366-36C12BF3EA9C}.Release|x86.Build.0 = Release|x86
+		{33F59057-9298-4578-86CE-D4B92BE41979}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33F59057-9298-4578-86CE-D4B92BE41979}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33F59057-9298-4578-86CE-D4B92BE41979}.Debug|x64.ActiveCfg = Debug|x64
+		{33F59057-9298-4578-86CE-D4B92BE41979}.Debug|x64.Build.0 = Debug|x64
+		{33F59057-9298-4578-86CE-D4B92BE41979}.Debug|x86.ActiveCfg = Debug|x86
+		{33F59057-9298-4578-86CE-D4B92BE41979}.Debug|x86.Build.0 = Debug|x86
+		{33F59057-9298-4578-86CE-D4B92BE41979}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33F59057-9298-4578-86CE-D4B92BE41979}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33F59057-9298-4578-86CE-D4B92BE41979}.Release|x64.ActiveCfg = Release|x64
+		{33F59057-9298-4578-86CE-D4B92BE41979}.Release|x64.Build.0 = Release|x64
+		{33F59057-9298-4578-86CE-D4B92BE41979}.Release|x86.ActiveCfg = Release|x86
+		{33F59057-9298-4578-86CE-D4B92BE41979}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/PolicyPartial.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/PolicyPartial.cs
@@ -1,0 +1,81 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Google.Cloud.Iam.V1
+{
+    // Convenience methods for Policy
+    public partial class Policy
+    {
+        /// <summary>
+        /// Adds the specified member to the specified role. If the role does
+        /// not already exist, it is created.
+        /// </summary>
+        /// <param name="role">The role to add the member to. Must not be null or empty.</param>
+        /// <param name="member">The member to add to the role. Must not be null or empty.</param>
+        /// <returns><c>true</c> if the policy was changed; <c>false</c> if the member already existed in the role.</returns>
+        public bool AddRoleMember(string role, string member)
+        {
+            GaxPreconditions.CheckNotNullOrEmpty(role, nameof(role));
+            GaxPreconditions.CheckNotNullOrEmpty(member, nameof(member));
+            var binding = FindRole(role);
+            if (binding == null)
+            {
+                Bindings.Add(new Binding { Role = role, Members = { member } });
+                return true;
+            }
+            if (binding.Members.Contains(member))
+            {
+                return false;
+            }
+            binding.Members.Add(member);
+            return true;
+        }
+
+        /// <summary>
+        /// Removes the specified member to the specified role, if they belong to it. If the role becomes empty after
+        /// removing the member, it is removed from the policy.
+        /// </summary>
+        /// <param name="role">The role to remove the member from. Must not be null or empty.</param>
+        /// <param name="member">The member to remove from the role. Must not be null or empty.</param>
+        /// <returns><c>true</c> if the policy was changed; <c>false</c> if the member didn't exist in the role
+        /// or the role didn't exist.</returns>
+        public bool RemoveRoleMember(string role, string member)
+        {
+            GaxPreconditions.CheckNotNullOrEmpty(role, nameof(role));
+            GaxPreconditions.CheckNotNullOrEmpty(member, nameof(member));
+            var binding = FindRole(role);
+            if (binding == null)
+            {
+                return false;
+            }
+            if (!binding.Members.Remove(member))
+            {
+                return false;
+            }
+            if (binding.Members.Count == 0)
+            {
+                Bindings.Remove(binding);
+            }
+            return true;
+        }
+
+        private Binding FindRole(string role) => Bindings.FirstOrDefault(binding => binding.Role == role);
+    }
+}


### PR DESCRIPTION
- AddRoleMember
- RemoveRoleMember

Both indicate whether or not they've changed anything.

We might also want to add a "get/act/set-if-necessary" with retries
for concurrency method later, but that takes a little more design
work.

(At some point we can then do a new IAM release, and use it from the Storage Pub/Sub snippets.)