### PR TITLE
Change how we detect Windows

### DIFF
--- a/buildrelease.sh
+++ b/buildrelease.sh
@@ -41,7 +41,7 @@ for project in $projects
 do
   # Don't pack the whole solution - just the project. (Avoids packing dependent
   # projects such as Google.LongRunning.)
-  dotnet pack --no-build -o $PWD/nuget -c Release apis/$project/$project
+  dotnet pack --no-build --no-restore -o $PWD/nuget -c Release apis/$project/$project
 done
 
 # TODO: Make builddocs.sh cope with being run from any directory.

--- a/runintegrationtests.sh
+++ b/runintegrationtests.sh
@@ -12,7 +12,6 @@ ROOT_DIR=$(dirname "$SCRIPT")
 APIS=()
 RETRY_ARG=
 COVERAGE_ARG=
-IS_WINDOWS=false
 
 while (( "$#" )); do
   if [[ "$1" == "--retry" ]]
@@ -32,12 +31,6 @@ if [[ ${#APIS[@]} != 0 && "$RETRY_ARG" == "yes" ]]
 then
   echo "The --retry flag cannot be used when specifying projects to test."
   exit 1
-fi
-
-OS="$(uname -s)"
-if [[ $OS == *"CYGWIN"* || $OS == *"MINGW"* || $OS == *"MSYS_NT"* ]]
-then
-  IS_WINDOWS=true
 fi
 
 # We only overwrite integration-test-failures.txt at the very end,
@@ -84,7 +77,7 @@ do
   if [[ "$testdir" =~ Metadata ]]
   then
     echo "Skipping $testdir; test not supported yet."
-  elif [[ "$testdir" =~ AspNet\. && $IS_WINDOWS == false ]]
+  elif [[ "$testdir" =~ AspNet\. && "$OS" != "Windows_NT" ]]
   then
     echo "Skipping $testdir; test not supported on non windows environment."
   elif [[ "$COVERAGE_ARG" == "yes" && -f "$testdir/coverage.xml" ]]


### PR DESCRIPTION
Changing the value of the OS environment variable messes up the
dotnet CLI. Using the *existing* value is what we do elsewhere, and
seems to work. We can now go back to using --no-restore when packing.

Fixes #1701.
Fixes #1698 properly.