### PR TITLE
Tweaks to Vision implementation

### DIFF
--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/AnnotateImageException.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/AnnotateImageException.cs
@@ -32,18 +32,12 @@ namespace Google.Cloud.Vision.V1
         /// </summary>
         /// <param name="response">The response containing the error. Must not be null, and the <see cref="AnnotateImageResponse.Error"/>
         /// property must not be null.</param>
-        public AnnotateImageException(AnnotateImageResponse response) : base(CheckHasError(response).Error.Message)
+        public AnnotateImageException(AnnotateImageResponse response) : base(response?.Error?.Message)
         {
-            this.Response = response;
-        }
-
-        // Annoying, but GaxPreconditions.CheckArgument doesn't return anything, because it doesn't have the whole argument.
-        // Maybe we should have an overload for that. (It's only really a problem in constructor chaining...)
-        private static AnnotateImageResponse CheckHasError(AnnotateImageResponse response)
-        {
+            // The null-conditional operator in the constructor initializer make it okay 
             GaxPreconditions.CheckNotNull(response, nameof(response));
             GaxPreconditions.CheckArgument(response.Error != null, nameof(response), "response must contain an error");
-            return response;
+            Response = response;
         }
     }
 }

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/AnnotateImageResponsePartial.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/AnnotateImageResponsePartial.cs
@@ -23,13 +23,7 @@ namespace Google.Cloud.Vision.V1
         /// </summary>
         /// <exception cref="AnnotateImageException">The <see cref="Error"/> property is non-null.</exception>
         /// <returns><c>this</c> if the message has no error.</returns>
-        public AnnotateImageResponse ThrowOnError()
-        {
-            if (Error != null)
-            {
-                throw new AnnotateImageException(this);
-            }
-            return this;
-        }
+        public AnnotateImageResponse ThrowOnError() =>
+            Error == null ? this : throw new AnnotateImageException(this);
     }
 }


### PR DESCRIPTION
- Rename source file to match class name
- Avoid a mostly-redundant method, just using null-conditionals as
  guards
- Use a throw expression to make ThrowOnError expression-bodied