### PR TITLE
Only build changes in PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ addons:
     - dotnet-sharedframework-microsoft.netcore.app-1.0.5
 
 script:
-  - ./build.sh
+  - ./build.sh --diff

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ build_script:
   - dotnet --info
   - echo "Regenerating projects: if this fails, run generateprojects.sh and commit changes"
   - bash generateprojects.sh && git diff --exit-code
-  - bash build.sh --notests
+  - bash build.sh --notests --diff
 
 # scripts to run before tests
 before_test:

--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,9 @@ while (( "$#" )); do
   then 
     echo "Not running tests..."
     runtests=false
+  elif [[ "$1" == "--diff" ]]
+  then
+    apis+=($(git diff master --name-only | grep apis/Google | cut -d/ -f 2 | uniq))
   else 
     apis+=($1)
   fi


### PR DESCRIPTION
Adds a new --diff option to build.sh, which finds which APIs have
changed vs master. Only those APIs are built. If no APIs are
detected (as per this PR...), all APIs are built.

On merge, I *think* we'll find an empty diff, and so automatically
rebuild all APIs. Hard to tell until we merge this...

Nuance: if we change something like Google.Cloud.Spanner.V1, we
won't automatically rerun tests for Google.Cloud.Spanner.Data until
the merge. Basically we rely on developers to be sensible about
that, and for the merge to pick up changes.

Coverage: the coverage report within a PR becomes a lot less useful. I'll separately look into whether we can remove the report.

Bonus: running build.sh --diff from a developer machine on their
branch works fine too...