### PR TITLE
Report progress after the final delay in Storage perf test

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.ThroughputTool/ProgressReporter.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.ThroughputTool/ProgressReporter.cs
@@ -41,12 +41,9 @@ namespace Google.Cloud.Storage.V1.ThroughputTool
         private void ReportPeriodically()
         {
             Console.WriteLine("Timestamp  Elapsed         MB     Mbps");
-            while (true)
+            while (!_tcs.Task.IsCompleted)
             {
-                if (_tcs.Task.Wait(s_reportPeriod))
-                {
-                    return;
-                }
+                _tcs.Task.Wait(s_reportPeriod);
                 DateTime now = DateTime.UtcNow;
                 TimeSpan elapsed = _stopwatch.Elapsed;
                 double totalSeconds = elapsed.TotalSeconds;


### PR DESCRIPTION
(It's just possible that the delay finishes just before the
completion, so we report interim numbers but then break out of the
loop, but it's simple this way and very unlikely to actually cause
issues.)