### PR TITLE
Handle empty coverage reports

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,20 +28,18 @@ build_script:
   - bash generateprojects.sh && git diff --exit-code
   - bash build.sh --notests --diff
 
-# scripts to run before tests
+# Scripts to run before tests
 before_test:
   - choco install codecov
 
-# run the tests with coverage
+# Run the tests with coverage
 test_script:
   - bash runcoverage.sh
   
-# scripts to run after tests
+# Create and upload code coverage report.
+# As we only build changed APIs, and some APIs don't have unit tests,
+# we need to handle the possibility of there being no coverage to
+# report on.
 after_test:
   - bash createcoveragereport.sh
-  - codecov -f "coverage/coverage-filtered.xml"
-# Docs disabled until https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/1380
-# is better understood
-  - # cd docs
-  - # bash builddocs.sh
-  - # cd ..
+  - if exist coverage/coverage-filtered.xml codecov -f "coverage/coverage-filtered.xml"

--- a/createcoveragereport.sh
+++ b/createcoveragereport.sh
@@ -11,7 +11,14 @@ then
  mkdir coverage
 fi
 
-[ -f coverage/all.dvcr ] && rm coverage/all.dvcr
+if ! compgen -G "coverage/*.dvcr"
+then
+  echo "No coverage reports found to merge."
+  # This isn't an error
+  exit 0
+fi
+
+rm -f coverage/all.dvcr
 
 echo "Merging reports..."
 $DOTCOVER merge -Source=$(echo coverage/*.dvcr | sed 's/ /;/g') -Output=coverage/all.dvcr ""


### PR DESCRIPTION
This is needed with our "diff" strategy for running CI tests.

(This should fix the AppVeyor breakage in #1722)