### PR TITLE
Parameter validation tests; default settings update

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/SimpleSubscriberTest.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/SimpleSubscriberTest.cs
@@ -640,11 +640,15 @@ namespace Google.Cloud.PubSub.V1.Tests
             }
         }
 
+        private class FakeSubscriberClient : SubscriberClient
+        {
+        }
+
         [Fact]
         public void ValidParameters()
         {
             var subscriptionName = new SubscriptionName("project", "subscriptionId");
-            var clients = new[] { SubscriberClient.Create() };
+            var clients = new[] { new FakeSubscriberClient() };
 
             var settingsDefault = new SimpleSubscriber.Settings();
             new SimpleSubscriberImpl(subscriptionName, clients, settingsDefault, null);
@@ -678,7 +682,7 @@ namespace Google.Cloud.PubSub.V1.Tests
         public void InvalidParameters()
         {
             var subscriptionName = new SubscriptionName("project", "subscriptionId");
-            var clients = new[] { SubscriberClient.Create() };
+            var clients = new[] { new FakeSubscriberClient() };
             var settings = new SimpleSubscriber.Settings();
 
             var ex1 = Assert.Throws<ArgumentNullException>(() => new SimpleSubscriberImpl(null, clients, settings, null));

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SimpleSubscriber.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SimpleSubscriber.cs
@@ -201,9 +201,9 @@ namespace Google.Cloud.PubSub.V1
         public static TimeSpan MaximumStreamAckDeadline { get; } = TimeSpan.FromMinutes(10);
 
         /// <summary>
-        /// The default message ACKnowledgement deadline of 20 seconds.
+        /// The default message ACKnowledgement deadline of 60 seconds.
         /// </summary>
-        public static TimeSpan DefaultStreamAckDeadline { get; } = TimeSpan.FromSeconds(20);
+        public static TimeSpan DefaultStreamAckDeadline { get; } = TimeSpan.FromSeconds(60);
 
         /// <summary>
         /// The minimum message ACKnowledgement extension window of 50 milliseconds.
@@ -211,9 +211,9 @@ namespace Google.Cloud.PubSub.V1
         public static TimeSpan MinimumAckExtensionWindow { get; } = TimeSpan.FromMilliseconds(50);
 
         /// <summary>
-        /// The default message ACKnowlegdment extension window of 2 seconds.
+        /// The default message ACKnowlegdment extension window of 15 seconds.
         /// </summary>
-        public static TimeSpan DefaultAckExtensionWindow { get; } = TimeSpan.FromSeconds(2);
+        public static TimeSpan DefaultAckExtensionWindow { get; } = TimeSpan.FromSeconds(15);
 
         /// <summary>
         /// Create a <see cref="SimpleSubscriber"/> instance associated with the specified <see cref="SubscriptionName"/>.


### PR DESCRIPTION
Default settings updated to make them more suitable for limited-bandwidth deployments, this will have no affect on the speed capabilities in high-bandwidth deployments