### PR TITLE
De-flake Diagnostics Logging Tests

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -298,7 +298,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
             SetupRoutes(app);
-            var options = BufferOptions.TimedBuffer(TimeSpan.FromSeconds(10));
+            var options = BufferOptions.TimedBuffer(TimeSpan.FromSeconds(20));
             LoggerOptions loggerOptions = LoggerOptions.Create(
                 LogLevel.Warning, null, null, options);
             loggerFactory.AddGoogle(ProjectId, loggerOptions);

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -17,6 +17,7 @@ using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
 using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Cloud.Logging.Type;
+using Google.Cloud.Logging.V2;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -51,7 +52,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
                 // No entries should be found as not enough entries were created to
                 // flush the buffer.
-                Assert.Empty(_polling.GetEntries(startTime, testId, 0));
+                Assert.Empty(_polling.GetEntries(startTime, testId, 0, LogSeverity.Default));
             }
         }
 
@@ -72,7 +73,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
             // While we normally should not have entries we disposed of the server
             // which should flush the buffer.
-            var results = _polling.GetEntries(startTime, testId, 2);
+            var results = _polling.GetEntries(startTime, testId, 2, LogSeverity.Error);
             Assert.Equal(2, results.Count());
             Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Error));
             Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Critical));
@@ -95,7 +96,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 await client.GetAsync($"/Main/Critical/{testId}");
 
                 // NoBufferLoggerTestApplication does not support debug or info logs.
-                var results = _polling.GetEntries(startTime, testId, 3);
+                var results = _polling.GetEntries(startTime, testId, 3, LogSeverity.Warning);
                 Assert.Equal(3, results.Count());
                 Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Warning));
                 Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Error));
@@ -125,7 +126,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
                 // Just check that a large portion of logs entires were pushed.  Not all
                 // will be pushed as some may be in the buffer.
-                var results = _polling.GetEntries(startTime, testId, 500);
+                var results = _polling.GetEntries(startTime, testId, 500, LogSeverity.Default);
                 Assert.True(results.Count() >= 500);
                 Assert.Null(results.FirstOrDefault(l => l.Severity == LogSeverity.Debug));
                 Assert.Null(results.FirstOrDefault(l => l.Severity == LogSeverity.Info));
@@ -149,14 +150,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 await client.GetAsync($"/Main/Warning/{testId}");
                 await client.GetAsync($"/Main/Error/{testId}");
 
-                var noResults = _polling.GetEntries(startTime, testId, 0);
+                var noResults = _polling.GetEntries(startTime, testId, 0, LogSeverity.Warning);
                 Assert.Empty(noResults);
 
                 await client.GetAsync($"/Main/Error/{testId}");
                 await client.GetAsync($"/Main/Critical/{testId}");
                 Thread.Sleep(TimeSpan.FromSeconds(10));
 
-                var results = _polling.GetEntries(startTime, testId, 4);
+                var results = _polling.GetEntries(startTime, testId, 4, LogSeverity.Warning);
                 Assert.Equal(4, results.Count());
                 Assert.NotNull(results.FirstOrDefault(l => l.Severity == LogSeverity.Warning));
                 Assert.Equal(2, results.Count(l => l.Severity == LogSeverity.Error));
@@ -178,7 +179,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 await client.GetAsync($"/Main/Error/{testId}");
                 await client.GetAsync($"/Main/Critical/{testId}");
 
-                var results = _polling.GetEntries(startTime, testId, 3);
+                var results = _polling.GetEntries(startTime, testId, 3, LogSeverity.Warning);
                 Assert.Equal(3, results.Count());
                 var resourceType = NoBufferResourceLoggerTestApplication.Resource.Type;
                 var buildResources = results.Where(e => e.Resource.Type.Equals(resourceType));
@@ -197,7 +198,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             using (var client = server.CreateClient())
             {
                 await client.GetAsync($"/Main/Scope/{testId}");
-                var results = _polling.GetEntries(startTime, testId, 1);
+                var results = _polling.GetEntries(startTime, testId, 1, LogSeverity.Critical);
                 var message = MainController.GetMessage(nameof(MainController.Scope), testId);
                 Assert.Contains($"Scope => {message}", results.Single().TextPayload);
             }
@@ -297,7 +298,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
             SetupRoutes(app);
-            var options = BufferOptions.TimedBuffer(TimeSpan.FromSeconds(20));
+            var options = BufferOptions.TimedBuffer(TimeSpan.FromSeconds(10));
             LoggerOptions loggerOptions = LoggerOptions.Create(
                 LogLevel.Warning, null, null, options);
             loggerFactory.AddGoogle(ProjectId, loggerOptions);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Logging/LogEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Logging/LogEntryPolling.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Cloud.Diagnostics.Common.Tests;
+using Google.Cloud.Logging.Type;
 using Google.Cloud.Logging.V2;
 using System;
 using System.Collections.Generic;
@@ -40,7 +41,8 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         /// <param name="minEntries">The minimum number of logs entries that should be waited for.
         ///     If minEntries is zero this method will wait the full timeout before checking for the
         ///     entries.</param>
-        public IEnumerable<LogEntry> GetEntries(DateTime startTime, string testId, int minEntries)
+        /// <param name="minSeverity">The minimum severity a log can be.</param>
+        public IEnumerable<LogEntry> GetEntries(DateTime startTime, string testId, int minEntries, LogSeverity minSeverity)
         {
             return GetEntries(minEntries, () =>
             {
@@ -49,7 +51,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
                 var request = new ListLogEntriesRequest
                 {
                     ResourceNames = { $"projects/{_projectId}" },
-                    Filter = $"timestamp >= \"{time}\" AND textPayload:{testId}",
+                    Filter = $"timestamp >= \"{time}\" AND textPayload:{testId} AND severity >= {minSeverity}",
                     PageSize = 1000,
                 };
                 return _client.ListLogEntries(request);


### PR DESCRIPTION
Look only for specific severity levels to avoid picking up unwanted info logs which can mess up log counts