### PR TITLE
Allow the logging tests a little longer to find entries.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Logging/LogEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Logging/LogEntryPolling.cs
@@ -32,6 +32,8 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         /// <summary>Client to use to send RPCs.</summary>
         private readonly LoggingServiceV2Client _client = LoggingServiceV2Client.Create();
 
+        internal LogEntryPolling(TimeSpan timeout) : base(timeout) { }
+
         /// <summary>
         /// Gets log entries that contain the passed in testId in the log message.  Will poll
         /// and wait for the entries to appear.


### PR DESCRIPTION
The majority of the time the entries are available withing a few seconds but occasionally take a long time to show up.  This is causing some tests to be flakey.