### PR TITLE
Update documentation based on releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 The following libraries are available at a [GA](#versioning) quality level:
 
+* [Google BigQuery](https://cloud.google.com/bigquery/) - [API docs](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.BigQuery.V2/) (GA)
 * [Google Cloud Datastore](https://cloud.google.com/datastore/) - [API docs](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Datastore.V1/) (GA)
 * Google Cloud Diagnostics for ASP.NET - [API docs](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Diagnostics.AspNet/) (GA)
 * Google Cloud Diagnostics for ASP.NET Core - [API docs](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Diagnostics.AspNetCore/) (GA)
@@ -31,10 +32,6 @@ The following libraries are available at a [GA](#versioning) quality level:
   * [Google.Cloud.Spanner.Admin.Database.V1](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Spanner.Admin.Database.V1/): Database administration API
   * [Google.Cloud.Spanner.Admin.Instance.V1](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Spanner.Admin.Instance.V1/): Instance administration API
 
-The following libraries are available at a [late beta](#versioning) quality level:
-
-* [Google BigQuery](https://cloud.google.com/bigquery/) - [API docs](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.BigQuery.V2/) (late beta)
-
 The following libraries are available at a [beta](#versioning) quality level:
 
 * [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/) - [API docs](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.BigQuery.DataTransfer.V1/) (beta)
@@ -42,6 +39,9 @@ The following libraries are available at a [beta](#versioning) quality level:
 * [Google Cloud Debugger](https://cloud.google.com/debugger/) - [API docs](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Debugger.V2) (beta)
 * [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) - [API docs](https://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Dlp.V2Beta1/) (beta)
 * [Stackdriver Error Reporting](https://cloud.google.com/error-reporting/) - [API docs](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.ErrorReporting.V1Beta1/) (beta)
+* [Google Cloud Firestore](https://cloud.google.com/firestore/): two packages are available, both beta:
+  * [Google.Cloud.Firestore](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Firestore/): High-level client library for Google Cloud Firestore (recommended)
+  * [Google.Cloud.Firestore.V1Beta1](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Firestore.V1Beta1/): Low-level access to Firestore API
 * [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) - [API docs](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.PubSub.V1/) (beta)
 * [Stackdriver Trace v2](https://cloud.google.com/trace/) - [API docs](http://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Trace.V2/) (beta)
 
@@ -123,11 +123,6 @@ the following quality levels:
 **GA**: Libraries defined at a GA (General Availability) quality level are
 expected to be stable: breaking API changes will not be made without a new major
 release.
-
-**Late Beta**: Libraries defined at a Late Beta quality level are
-expected to be mostly stable and we're working towards their release
-candidate. We will address issues and requests with a higher
-priority.
 
 **Beta**: Libraries defined at a Beta quality level are expected to
 be stable and working, but the API surface is still under active

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -16,6 +16,7 @@ supported here.
 
 GA:
 
+- [Google.Cloud.BigQuery.V2](Google.Cloud.BigQuery.V2/index.html)
 - [Google.Cloud.Datastore.V1](Google.Cloud.Datastore.V1/index.html)
 - [Google.Cloud.Diagnostics.AspNet](Google.Cloud.Diagnostics.AspNet/index.html)
 - [Google.Cloud.Diagnostics.AspNetCore](Google.Cloud.Diagnostics.AspNetCore/index.html)
@@ -23,6 +24,11 @@ GA:
 - [Google.Cloud.Logging.V2](Google.Cloud.Logging.V2/index.html)
   - Additionally, a [separate Log4Net integration package is available](Google.Cloud.Logging.Log4Net/index.html)
 - [Google.Cloud.Monitoring.V3](Google.Cloud.Monitoring.V3/index.html)
+- Google Cloud Spanner:
+  - [Google.Cloud.Spanner.Data](Google.Cloud.Spanner.Data/index.html): ADO.NET provider for Google Cloud Spanner (recommended)
+  - [Google.Cloud.Spanner.V1](Google.Cloud.Spanner.V1/index.html): Low-level access to Spanner API
+  - [Google.Cloud.Spanner.Admin.Database.V1](Google.Cloud.Spanner.Admin.Database.V1/index.html): Database administration API
+  - [Google.Cloud.Spanner.Admin.Instance.V1](Google.Cloud.Spanner.Admin.Instance.V1/index.html): Instance administration API
 - [Google.Cloud.Speech.V1](Google.Cloud.Speech.V1/index.html)
 - [Google.Cloud.Storage.V1](Google.Cloud.Storage.V1/index.html)
 - [Google.Cloud.Trace.V1](Google.Cloud.Trace.V1/index.html)
@@ -32,10 +38,6 @@ GA:
   - Additionally, a [Google.Cloud.Vision.V1P1Beta1](Google.Cloud.Vision.V1P1Beta1/index.html)
     library is available for access to beta API functionality.
 
-Late beta:
-
-- [Google.Cloud.BigQuery.V2](Google.Cloud.BigQuery.V2/index.html)
-
 Beta:
 
 - [Google.Cloud.BigQuery.DataTransfer.V1](Google.Cloud.BigQuery.DataTransfer.V1/index.html)
@@ -43,12 +45,10 @@ Beta:
 - [Google.Cloud.Debugger.V2](Google.Cloud.Debugger.V2/index.html)
 - [Google.Cloud.Dlp.V2Beta1](Google.Cloud.Dlp.V2Beta1/index.html)
 - [Google.Cloud.ErrorReporting.V1Beta1](Google.Cloud.ErrorReporting.V1Beta1/index.html)
+- Google Cloud Firestore:
+  - [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html): High-level client library for Google Cloud Firestore (recommended)
+  - [Google.Cloud.Firestore.V1Beta](Google.Cloud.Firestore.V1Beta1/index.html): Low-level access to Firestore API
 - [Google.Cloud.PubSub.V1](Google.Cloud.PubSub.V1/index.html)
-- Google Cloud Spanner:
-  - [Google.Cloud.Spanner.Data](Google.Cloud.Spanner.Data/index.html): ADO.NET provider for Google Cloud Spanner (recommended)
-  - [Google.Cloud.Spanner.V1](Google.Cloud.Spanner.V1/index.html): Low-level access to Spanner API
-  - [Google.Cloud.Spanner.Admin.Database.V1](Google.Cloud.Spanner.Admin.Database.V1/index.html): Database administration API
-  - [Google.Cloud.Spanner.Admin.Instance.V1](Google.Cloud.Spanner.Admin.Instance.V1/index.html): Instance administration API
 - [Google.Cloud.Trace.V2](Google.Cloud.Trace.V2/index.html)
 
 Alpha:


### PR DESCRIPTION
(The docs/root/index.md page hadn't been updated for the Spanner GA,
so I've rolled that in here.)

This promotes BigQuery to GA (removing the "late beta" designation
entirely) and introduces Firestore.