### PR TITLE
Disable parallelization on the AspNet Integration tests

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/AssemblyInfo.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/AssemblyInfo.cs
@@ -1,17 +1,17 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.		
-// 		
-// Licensed under the Apache License, Version 2.0 (the "License");		
-// you may not use this file except in compliance with the License.		
-// You may obtain a copy of the License at		
-// 		
-//     http://www.apache.org/licenses/LICENSE-2.0		
-// 		
-// Unless required by applicable law or agreed to in writing, software		
-// distributed under the License is distributed on an "AS IS" BASIS,		
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.		
-// See the License for the specific language governing permissions and		
-// limitations under the License.		
-		
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using Xunit;		
 		
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/AssemblyInfo.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.		
+// 		
+// Licensed under the Apache License, Version 2.0 (the "License");		
+// you may not use this file except in compliance with the License.		
+// You may obtain a copy of the License at		
+// 		
+//     http://www.apache.org/licenses/LICENSE-2.0		
+// 		
+// Unless required by applicable law or agreed to in writing, software		
+// distributed under the License is distributed on an "AS IS" BASIS,		
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.		
+// See the License for the specific language governing permissions and		
+// limitations under the License.		
+		
+using Xunit;		
+		
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/CloudTraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/CloudTraceTest.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         private readonly string _testId;
         private readonly Timestamp _startTime;
 
-        private readonly TraceOptions _noBuffer = TraceOptions.Create(bufferOptions: BufferOptions.NoBuffer());
+        private static readonly TraceOptions _noBuffer = TraceOptions.Create(bufferOptions: BufferOptions.NoBuffer());
         private readonly TraceEntryPolling _polling = new TraceEntryPolling();
 
         public CloudTraceTest()

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/CloudTraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/CloudTraceTest.cs
@@ -54,6 +54,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
             using (var cloudTrace = CloudTrace.InitializeInternal(new HttpApplication(), _projectId, _noBuffer))
             {
                 cloudTrace.BeginRequest(null, null);
+                Thread.Sleep(TimeSpan.FromMilliseconds(1));
                 cloudTrace.EndRequest(null, null);
             }
 
@@ -70,6 +71,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
                 projectId: _projectId, options: _noBuffer, traceFallbackPredicate: predicate))
             {
                 cloudTrace.BeginRequest(null, null);
+                Thread.Sleep(TimeSpan.FromMilliseconds(1));
                 cloudTrace.EndRequest(null, null);
             }
 

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/CloudTraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/CloudTraceTest.cs
@@ -54,7 +54,6 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
             using (var cloudTrace = CloudTrace.InitializeInternal(new HttpApplication(), _projectId, _noBuffer))
             {
                 cloudTrace.BeginRequest(null, null);
-                Thread.Sleep(TimeSpan.FromMilliseconds(1));
                 cloudTrace.EndRequest(null, null);
             }
 
@@ -71,7 +70,6 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
                 projectId: _projectId, options: _noBuffer, traceFallbackPredicate: predicate))
             {
                 cloudTrace.BeginRequest(null, null);
-                Thread.Sleep(TimeSpan.FromMilliseconds(1));
                 cloudTrace.EndRequest(null, null);
             }
 

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/CloudTraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/CloudTraceTest.cs
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Diagnostics.Common;
+using Google.Cloud.Diagnostics.Common.IntegrationTests;
 using Google.Cloud.Diagnostics.Common.Tests;
+using Google.Protobuf.WellKnownTypes;
 using System;
+using System.IO;
+using System.Threading;
 using System.Web;
 using Xunit;
-using System.IO;
-using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Protobuf.WellKnownTypes;
-using System.Threading;
 
 namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
 {
@@ -29,6 +30,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         private readonly string _testId;
         private readonly Timestamp _startTime;
 
+        private readonly TraceOptions _noBuffer = TraceOptions.Create(bufferOptions: BufferOptions.NoBuffer());
         private readonly TraceEntryPolling _polling = new TraceEntryPolling();
 
         public CloudTraceTest()
@@ -49,7 +51,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         [Fact]
         public void Trace()
         {
-            using (var cloudTrace = CloudTrace.InitializeInternal(new HttpApplication(), _projectId))
+            using (var cloudTrace = CloudTrace.InitializeInternal(new HttpApplication(), _projectId, _noBuffer))
             {
                 cloudTrace.BeginRequest(null, null);
                 cloudTrace.EndRequest(null, null);
@@ -65,7 +67,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         {
             var predicate = TraceDecisionPredicate.Create((req) => false);
             using (var cloudTrace = CloudTrace.InitializeInternal(new HttpApplication(), 
-                projectId: _projectId, traceFallbackPredicate: predicate))
+                projectId: _projectId, options: _noBuffer, traceFallbackPredicate: predicate))
             {
                 cloudTrace.BeginRequest(null, null);
                 cloudTrace.EndRequest(null, null);
@@ -78,7 +80,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         [Fact]
         public void Trace_Multiple_Spans()
         {
-            using (var cloudTrace = CloudTrace.InitializeInternal(new HttpApplication(), _projectId))
+            using (var cloudTrace = CloudTrace.InitializeInternal(new HttpApplication(), _projectId, _noBuffer))
             {
                 cloudTrace.BeginRequest(null, null);
                 using (CloudTrace.Tracer.StartSpan("/another-trace"))


### PR DESCRIPTION
They are running in parallel.  The tests operate on "HttpContext.Current" which is global (we can't use an actual IIS instance), so having multiple tests touch it which is not a good idea.  Having the tests not be in parallel shouldn't be an issue as we only have 4.