### PR TITLE
Ensure each Trace Span always has at least 1 ms of time.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
@@ -62,7 +62,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
                 span.StartTime != null &&
                 parentId == span.ParentSpanId &&
                 span.EndTime != null &&
-                (span.EndTime.Nanos - span.StartTime.Nanos) >= SimpleManagedTracer._nanosecondsInAMillisecond;
+                span.EndTime.ToDateTime() > span.StartTime.ToDateTime();
         }
 
         /// <summary>
@@ -76,9 +76,8 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         /// </summary>
         private static bool IsShortLivedSpan(TraceSpan span) 
         {
-            var totalNanos = span.EndTime.Nanos - span.StartTime.Nanos;
-            var nanosInMs = SimpleManagedTracer._nanosecondsInAMillisecond;
-            return totalNanos == nanosInMs && totalNanos <= nanosInMs * 2;
+            var totalTime = span.EndTime.ToDateTime() - span.StartTime.ToDateTime();
+            return totalTime >= TimeSpan.FromMilliseconds(1) && totalTime <= TimeSpan.FromMilliseconds(2);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/SimpleManagedTracerTest.cs
@@ -62,7 +62,23 @@ namespace Google.Cloud.Diagnostics.Common.Tests
                 span.StartTime != null &&
                 parentId == span.ParentSpanId &&
                 span.EndTime != null &&
-                span.StartTime.ToDateTime() <= span.EndTime.ToDateTime();
+                (span.EndTime.Nanos - span.StartTime.Nanos) >= SimpleManagedTracer._nanosecondsInAMillisecond;
+        }
+
+        /// <summary>
+        /// Used to ensure a <see cref="TraceSpan"/>'s that starts ends immediately 
+        /// has a total run time of 1ms.  This checks for between 1ms and 2ms allow
+        /// some wiggle-room.
+        /// 
+        /// This is needed as we tack on 1ms of time to spans that do not have 
+        /// a difference of 1ms between start and end.  If we do not the Trace
+        /// API will not record the span.
+        /// </summary>
+        private static bool IsShortLivedSpan(TraceSpan span) 
+        {
+            var totalNanos = span.EndTime.Nanos - span.StartTime.Nanos;
+            var nanosInMs = SimpleManagedTracer._nanosecondsInAMillisecond;
+            return totalNanos == nanosInMs && totalNanos <= nanosInMs * 2;
         }
 
         [Fact]
@@ -73,7 +89,8 @@ namespace Google.Cloud.Diagnostics.Common.Tests
 
             mockConsumer.Setup(c => c.Receive(
                 Match.Create<IEnumerable<TraceProto>>(
-                    t => IsValidSpan(t.Single().Spans.Single(), "span-name"))));
+                    t => IsShortLivedSpan(t.Single().Spans.Single()) &&
+                        IsValidSpan(t.Single().Spans.Single(), "span-name"))));
 
             tracer.StartSpan("span-name").Dispose();
             mockConsumer.VerifyAll();
@@ -87,7 +104,8 @@ namespace Google.Cloud.Diagnostics.Common.Tests
 
             mockConsumer.Setup(c => c.Receive(
                 Match.Create<IEnumerable<TraceProto>>(
-                    t => IsValidSpan(t.Single().Spans.Single(), "span-name"))));
+                    t => IsShortLivedSpan(t.Single().Spans.Single()) &&
+                        IsValidSpan(t.Single().Spans.Single(), "span-name"))));
 
             tracer.StartSpan("span-name").Dispose();
             mockConsumer.VerifyAll();
@@ -101,7 +119,8 @@ namespace Google.Cloud.Diagnostics.Common.Tests
 
             mockConsumer.Setup(c => c.Receive(
                 Match.Create<IEnumerable<TraceProto>>(
-                    t => IsValidSpan(t.Single().Spans.Single(), "span-name", 123))));
+                    t => IsShortLivedSpan(t.Single().Spans.Single()) &&
+                        IsValidSpan(t.Single().Spans.Single(), "span-name", 123))));
 
             tracer.StartSpan("span-name").Dispose();
             mockConsumer.VerifyAll();

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
@@ -76,9 +76,6 @@ namespace Google.Cloud.Diagnostics.Common
             public ulong SpanId() => TraceSpan.SpanId;
         }
 
-        /// <summary>The number of nanoseconds in a millisecond.</summary>
-        internal static readonly int _nanosecondsInAMillisecond = 1000000; // 1,000,000
-
         /// <summary>The trace consumer to push the trace to when completed.</summary>
         private readonly IConsumer<TraceProto> _consumer;
 
@@ -210,9 +207,12 @@ namespace Google.Cloud.Diagnostics.Common
                 // the span will not be recorded.  If this is the case bump up
                 // the time by 1 ms which is the smallest amount of time for the Trace API
                 // to record a trace. 
-                if ((span.TraceSpan.EndTime.Nanos - span.TraceSpan.StartTime.Nanos) < _nanosecondsInAMillisecond)
+                var end = span.TraceSpan.EndTime.ToDateTime();
+                var start = span.TraceSpan.StartTime.ToDateTime();
+                if ((end - start) < TimeSpan.FromMilliseconds(1))
                 {
-                    span.TraceSpan.EndTime.Nanos += _nanosecondsInAMillisecond;
+                    var newTime = span.TraceSpan.EndTime.ToDateTime().Add(TimeSpan.FromMilliseconds(1));
+                    span.TraceSpan.EndTime = Timestamp.FromDateTime(newTime);
                 }
                 _trace.Spans.Add(span.TraceSpan);
 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
@@ -210,9 +210,9 @@ namespace Google.Cloud.Diagnostics.Common
                 // the span will not be recorded.  If this is the case bump up
                 // the time by 1 ms which is the smallest amount of time for the Trace API
                 // to record a trace. 
-                if ((span.TraceSpan.EndTime.Nanos - span.TraceSpan.StartTime.Nanos) < 1000000)
+                if ((span.TraceSpan.EndTime.Nanos - span.TraceSpan.StartTime.Nanos) < _nanosecondsInAMillisecond)
                 {
-                    span.TraceSpan.EndTime.Nanos += 1000000;
+                    span.TraceSpan.EndTime.Nanos += _nanosecondsInAMillisecond;
                 }
                 _trace.Spans.Add(span.TraceSpan);
 


### PR DESCRIPTION
If a span has less than 1ms of time the Trace API will not record it.