### PR TITLE
[Bigtable] Ensure lexicographical order of families in row merger

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableClientTest.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableClientTest.cs
@@ -325,7 +325,14 @@ namespace Google.Cloud.Bigtable.V2.Tests
                             RowKey = ByteString.CopyFromUtf8("abc"),
                             FamilyName = "a",
                             Qualifier = ByteString.CopyFromUtf8("column3"),
-                            Value = ByteString.CopyFromUtf8("value3"),
+                            Value = ByteString.CopyFromUtf8("value3")
+                        },
+                        new ReadRowsResponse.Types.CellChunk
+                        {
+                            RowKey = ByteString.CopyFromUtf8("abc"),
+                            FamilyName = "Z",
+                            Qualifier = ByteString.CopyFromUtf8("column4"),
+                            Value = ByteString.CopyFromUtf8("value4"),
                             CommitRow = true
                         }
                     }
@@ -335,10 +342,23 @@ namespace Google.Cloud.Bigtable.V2.Tests
             await stream.AsAsyncEnumerable().ForEachAsync(row =>
             {
                 rowCount++;
-                var familyNames = row.Families.Select(r => r.Name).ToArray();
-                Assert.Equal("A", familyNames[0]);
-                Assert.Equal("a", familyNames[1]);
-                Assert.Equal("z", familyNames[2]);
+
+                var family = row.Families[0];
+                Assert.Equal("A", family.Name);
+                Assert.Equal("column2", family.Columns[0].Qualifier.ToStringUtf8());
+                Assert.Equal("value2", family.Columns[0].Cells[0].Value.ToStringUtf8());
+                family = row.Families[1];
+                Assert.Equal("Z", family.Name);
+                Assert.Equal("column4", family.Columns[0].Qualifier.ToStringUtf8());
+                Assert.Equal("value4", family.Columns[0].Cells[0].Value.ToStringUtf8());
+                family = row.Families[2];
+                Assert.Equal("a", family.Name);
+                Assert.Equal("column3", family.Columns[0].Qualifier.ToStringUtf8());
+                Assert.Equal("value3", family.Columns[0].Cells[0].Value.ToStringUtf8());
+                family = row.Families[3];
+                Assert.Equal("z", family.Name);
+                Assert.Equal("column1", family.Columns[0].Qualifier.ToStringUtf8());
+                Assert.Equal("value1", family.Columns[0].Cells[0].Value.ToStringUtf8());
             });
             Assert.Equal(1, rowCount);
         }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/MockReadRowsStream.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/MockReadRowsStream.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Grpc.Core;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Cloud.Bigtable.V2.Tests
+{
+    public class MockReadRowsStream : BigtableClient.ReadRowsStream
+    {
+        private IAsyncEnumerator<ReadRowsResponse> _responseStream;
+
+        public MockReadRowsStream(params ReadRowsResponse[] responses) =>
+            _responseStream = responses.ToAsyncEnumerable().GetEnumerator();
+
+        public override AsyncServerStreamingCall<ReadRowsResponse> GrpcCall => null;
+        public override IAsyncEnumerator<ReadRowsResponse> ResponseStream => _responseStream;
+    }
+}

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/RowAsyncEnumerator.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/RowAsyncEnumerator.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Bigtable.V2
     internal sealed class RowAsyncEnumerator : IAsyncEnumerator<Row>
     {
         private CellInfo _currentCell;
-        private SortedList<string, Family> _currentFamilies = new SortedList<string, Family>(StringComparer.Ordinal);
+        private readonly SortedList<string, Family> _currentFamilies = new SortedList<string, Family>(StringComparer.Ordinal);
         private RowMergeState _rowMergeState = NewRow.Instance;
         private IEnumerator<Row> _singleResponseRowEnumerator;
         private readonly ReadRowsStream _stream;


### PR DESCRIPTION
They are returned based on the order of some internal id and need to be reordered on the client.