### PR TITLE
Fix hash validation for gzipped content

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="2.2.1" />
-    <PackageReference Include="Google.Apis.Storage.v1" Version="1.31.1.1035" />
+    <PackageReference Include="Google.Apis.Storage.v1" Version="1.32.0.1035" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.5.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
   </ItemGroup>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -496,7 +496,7 @@
     "type": "rest",
     "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
     "dependencies": {
-      "Google.Apis.Storage.v1": "1.31.1.1035"
+      "Google.Apis.Storage.v1": "1.32.0.1035"
     },
     "testDependencies": {
       "Google.Cloud.Iam.V1": "1.0.0",


### PR DESCRIPTION
This fixes #1641, but I've opened #1784 for a more corner-case-like
version of the same problem.

I'd recommend reviewing HashValidatingDownloader by viewing the entirety of the new file - the diff isn't very helpful.