### PR TITLE
Allow return valid document for ValueSerializer

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueSerializer.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueSerializer.cs
@@ -119,8 +119,10 @@ namespace Google.Cloud.Firestore
             GaxPreconditions.CheckNotNull(value, nameof(value));
             switch (value)
             {
+                case IDictionary<string, Value> map:
+                    return map.ToDictionary(pair => pair.Key, pair => pair.Value);
                 case IDictionary<string, object> map:
-                    return map.ToDictionary(pair => pair.Key, pair => Serialize(pair.Value));
+                    return map.ToDictionary(pair => pair.Key, pair => (pair.Value as Value) ?? Serialize(pair.Value));
                 case object anon when IsAnonymousType(anon.GetType()):
                     return ConvertAnonymousType(anon);
                 case object attributed when IsFirestoreAttributedType(attributed.GetType()):


### PR DESCRIPTION
I have my own JsonConverter to convert json value into google protobuf value

And so I want to have raw value work with FirestoreDb api

ps: I don't know why I can't continue edit the previous pull request so I need to make new one