### PR TITLE
Permit protos to be serialized and deserialized in Firestore

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/SerializationTestData.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/SerializationTestData.cs
@@ -20,6 +20,7 @@ using System.Dynamic;
 using System.Linq;
 using wkt = Google.Protobuf.WellKnownTypes;
 using static Google.Cloud.Firestore.Tests.ProtoHelpers;
+using Xunit;
 
 namespace Google.Cloud.Firestore.Tests
 {
@@ -130,6 +131,13 @@ namespace Google.Cloud.Firestore.Tests
             // Document references
             { Database.Document("a/b"),
                 new Value { ReferenceValue = "projects/proj/databases/db/documents/a/b" } },
+        };
+
+        public static TheoryData<IMessage, Func<Value, IMessage>> ProtoValues { get; } = new TheoryData<IMessage, Func<Value, IMessage>>
+        {
+            { new Value { DoubleValue = 1.2345 }, v => v },
+            { CreateProtoTimestamp(1, 2345), v => v.TimestampValue },
+            { new Type.LatLng { Latitude = 1.5, Longitude = 1.5 }, v => v.GeoPointValue }
         };
 
         // Only equatable for the sake of testing; that's not a requirement of the serialization code.

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
@@ -116,6 +116,20 @@ namespace Google.Cloud.Firestore.Tests
             Assert.Null(DeserializeDefault(value, targetType));
         }
 
+        [Fact]
+        public void DeserializeNullToValue()
+        {
+            var value = new Value { NullValue = wkt::NullValue.NullValue };
+            Assert.Same(value, DeserializeDefault(value, typeof(Value)));
+        }
+
+        [Fact]
+        public void DeserializeToValue()
+        {
+            var value = new Value { DoubleValue = 1.234 };
+            Assert.Same(value, DeserializeDefault(value, typeof(Value)));
+        }
+
         // Just a convenience method to avoid having to specify all of this on each call.
         private static object DeserializeDefault(Value value, BclType targetType) =>
             ValueDeserializer.Default.Deserialize(SerializationTestData.Database, value, targetType);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueSerializerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueSerializerTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Cloud.Firestore.V1Beta1;
+using Google.Protobuf;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
@@ -77,6 +78,17 @@ namespace Google.Cloud.Firestore.Tests
             {
                 Assert.Equal(expectedOutput, actual);
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(SerializationTestData.ProtoValues), MemberType = typeof(SerializationTestData))]
+        public void ValueIsCloned(IMessage proto, Func<Value, IMessage> selector)
+        {
+            // Protos should be accepted, but cloned (as they're mutable, and we mutate things too)
+            var value = ValueSerializer.Serialize(proto);
+            var actual = selector(value);
+            Assert.NotSame(proto, actual);
+            Assert.Equal(proto, actual);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueDeserializer.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueDeserializer.cs
@@ -68,6 +68,13 @@ namespace Google.Cloud.Firestore
         {
             GaxPreconditions.CheckNotNull(db, nameof(db));
             GaxPreconditions.CheckNotNull(value, nameof(value));
+
+            // If we're asked for a Value, just provide it directly, even for null values.
+            if (targetType == typeof(Value))
+            {
+                return value;
+            }
+
             checked
             {
                 switch (value.ValueTypeCase)

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueSerializer.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueSerializer.cs
@@ -54,23 +54,28 @@ namespace Google.Cloud.Firestore
             (float x) => new Value { DoubleValue = x },
             (double x) => new Value { DoubleValue = x },
             (bool x) => new Value { BooleanValue = x },
-            // TODO: Clone?
-            (wkt::Timestamp x) => new Value { TimestampValue = x },
             (Timestamp x) => new Value { TimestampValue = x.ToProto() },
             (DateTime x) => new Value { TimestampValue = wkt::Timestamp.FromDateTime(x) },
             (DateTimeOffset x) => new Value { TimestampValue = wkt::Timestamp.FromDateTimeOffset(x) },
             (byte[] x) => new Value { BytesValue = ByteString.CopyFrom(x) },
             (ByteString x) => new Value { BytesValue = x },
             (Blob x) => new Value { BytesValue = x.ByteString },
-            // TODO: Clone?
-            (LatLng x) => new Value { GeoPointValue = x },
             (GeoPoint x) => new Value { GeoPointValue = x.ToProto() },
-            (DocumentReference x) => new Value { ReferenceValue = x.Path }
+            (DocumentReference x) => new Value { ReferenceValue = x.Path },
+            // Proto inputs that need cloning
+            (LatLng x) => new Value { GeoPointValue = x.Clone() },
+            (wkt::Timestamp x) => new Value { TimestampValue = x.Clone() },
+            (Value x) => x.Clone()
         };
 
         /// <summary>
         /// Serializes a single input to a Value.
         /// </summary>
+        /// <remarks>
+        /// It's important that this always clones any mutable values - which is really only
+        /// relevant when the input is already a proto. That allows the caller to then mutate the result
+        /// where appropriate.
+        /// </remarks>
         /// <param name="value">The value to serialize.</param>
         /// <returns>A Firestore Value proto.</returns>
         internal static Value Serialize(object value)


### PR DESCRIPTION
We always clone the proto when serializing, as the WriteBatch class
can modify the result. We don't clone when deserializing, as *our*
code doesn't modify the result - if user code does, it may see those
modifications if deserialization occurs more than once, but that's
probably okay.

This is an alternative to #1796. cc @Thaina - please comment if you're concerned about the cloning cost. (I'm not sure there's a good alternative at the moment though.)

The deserialization change will allow you to deserialize to a type that has a `Value` property, or an `IDictionary<string, Value` etc.