### PR TITLE
Permit serialization of specific dictionaries

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
@@ -48,7 +48,7 @@ namespace Google.Cloud.Firestore.Tests
         }
 
         [Fact]
-        public void DeserializeToDictionary()
+        public void DeserializeToObjectDictionary()
         {
             var value = new Value { MapValue = new MapValue { Fields = { { "name", new Value { StringValue = "Jon" } }, { "score", new Value { IntegerValue = 10L } } } } };
             var result = ValueDeserializer.Dictionary.Deserialize(SerializationTestData.Database, value, typeof(object));
@@ -57,6 +57,20 @@ namespace Google.Cloud.Firestore.Tests
             {
                 ["name"] = "Jon",
                 ["score"] = 10L
+            };
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void DeserializeToSpecificDictionary()
+        {
+            var value = new Value { MapValue = new MapValue { Fields = { { "x", new Value { IntegerValue = 10L } }, { "y", new Value { IntegerValue = 20L } } } } };
+            var result = ValueDeserializer.Dictionary.Deserialize(SerializationTestData.Database, value, typeof(Dictionary<string, int>));
+            Assert.IsType<Dictionary<string, int>>(result);
+            var expected = new Dictionary<string, int>
+            {
+                ["x"] = 10,
+                ["y"] = 20
             };
             Assert.Equal(expected, result);
         }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueSerializerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueSerializerTest.cs
@@ -47,6 +47,9 @@ namespace Google.Cloud.Firestore.Tests
         {
             { new Dictionary<string, object> { { "name", "Jon" }, { "score", 10 }  },
                 new Dictionary<string, Value> { { "name", new Value { StringValue = "Jon" } }, { "score", new Value { IntegerValue = 10L } } } },
+            // Use SortedDictionary to prove we accept any IDictionary<string,*>, not just Dictionary<string,*>
+            { new SortedDictionary<string, int> { { "x", 10 }, { "y", 20 }  },
+                new Dictionary<string, Value> { { "x", new Value { IntegerValue = 10 } }, { "y", new Value { IntegerValue = 20L } } } },
             { new { name = "Jon", score = 10 },
                 new Dictionary<string, Value> { { "name", new Value { StringValue = "Jon" } }, { "score", new Value { IntegerValue = 10L } } } },
             { new SerializationTestData.GameResult { Name = "Jon", Score = 10 },


### PR DESCRIPTION
For example, users can now pass a `Dictionary<string, int>`
or `Dictionary<string, Value>` to the various
DocumentReference/CollectionReference/WriteBatch methods.

Will hold off merging until we have confirmation from @Thaina that this addresses their issue, but I think it's okay to review already.