### PR TITLE
Explicitly include all constructors in API reference docs

### DIFF
--- a/docs/filterConfig.yml
+++ b/docs/filterConfig.yml
@@ -1,4 +1,7 @@
 apiRules:
+- include:
+    type: Method
+    uidRegex: \.#ctor
 - exclude:
     type: Method
     hasAttribute:


### PR DESCRIPTION
Even though these are autogenerated, they're worth including.

Fixes #1860.