### PR TITLE
Add support for BigQuery customer-managed encryption keys.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CreateCopyJobOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CreateCopyJobOptionsTest.cs
@@ -25,12 +25,14 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var options = new CreateCopyJobOptions
             {
                 CreateDisposition = CreateDisposition.CreateIfNeeded,
-                WriteDisposition = WriteDisposition.WriteIfEmpty
+                WriteDisposition = WriteDisposition.WriteIfEmpty,
+                DestinationEncryptionConfiguration = new EncryptionConfiguration { KmsKeyName = "projects/1/locations/us/keyRings/1/cryptoKeys/1" },
             };
             JobConfigurationTableCopy request = new JobConfigurationTableCopy();
             options.ModifyRequest(request);
             Assert.Equal("CREATE_IF_NEEDED", request.CreateDisposition);
             Assert.Equal("WRITE_EMPTY", request.WriteDisposition);
+            Assert.Equal("projects/1/locations/us/keyRings/1/cryptoKeys/1", request.DestinationEncryptionConfiguration.KmsKeyName);
         }        
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CreateLoadJobOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CreateLoadJobOptionsTest.cs
@@ -37,7 +37,8 @@ namespace Google.Cloud.BigQuery.V2.Tests
                 SkipLeadingRows = 10,
                 SourceFormat = FileFormat.DatastoreBackup,
                 TimePartitioning = TimePartition.CreateDailyPartitioning(expiration: null),
-                WriteDisposition = WriteDisposition.WriteAppend
+                WriteDisposition = WriteDisposition.WriteAppend,
+                DestinationEncryptionConfiguration = new EncryptionConfiguration { KmsKeyName = "projects/1/locations/us/keyRings/1/cryptoKeys/1" }
             };
 
             JobConfigurationLoad load = new JobConfigurationLoad();
@@ -57,6 +58,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.Equal("WRITE_APPEND", load.WriteDisposition);
             Assert.Equal("DAY", load.TimePartitioning.Type);
             Assert.Null(load.TimePartitioning.ExpirationMs);
+            Assert.Equal("projects/1/locations/us/keyRings/1/cryptoKeys/1", load.DestinationEncryptionConfiguration.KmsKeyName);
         }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CreateLoadJobOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CreateLoadJobOptionsTest.cs
@@ -38,7 +38,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                 SourceFormat = FileFormat.DatastoreBackup,
                 TimePartitioning = TimePartition.CreateDailyPartitioning(expiration: null),
                 WriteDisposition = WriteDisposition.WriteAppend,
-                DestinationEncryptionConfiguration = new EncryptionConfiguration { KmsKeyName = "projects/1/locations/us/keyRings/1/cryptoKeys/1" }
+                DestinationEncryptionConfiguration = new EncryptionConfiguration { KmsKeyName = "projects/1/locations/us/keyRings/1/cryptoKeys/1" },
             };
 
             JobConfigurationLoad load = new JobConfigurationLoad();

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CreateTableOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CreateTableOptionsTest.cs
@@ -32,6 +32,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                 FriendlyName = "A friendly name",
                 TimePartitioning = TimePartition.CreateDailyPartitioning(TimeSpan.FromDays(10)),
                 ExternalDataConfiguration = new ExternalDataConfiguration(),
+                EncryptionConfiguration = new EncryptionConfiguration { KmsKeyName = "projects/1/locations/us/keyRings/1/cryptoKeys/1" },
             };
             Table table = new Table();
             InsertRequest request = new InsertRequest(new BigqueryService(), table, "project", "dataset");
@@ -42,6 +43,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.Equal("DAY", table.TimePartitioning.Type);
             Assert.Equal(10 * 24 * 60 * 60 * 1000L, table.TimePartitioning.ExpirationMs);
             Assert.Same(options.ExternalDataConfiguration, table.ExternalDataConfiguration);
+            Assert.Equal("projects/1/locations/us/keyRings/1/cryptoKeys/1", table.EncryptionConfiguration.KmsKeyName);
         }
 
         [Fact]

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/QueryOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/QueryOptionsTest.cs
@@ -35,7 +35,8 @@ namespace Google.Cloud.BigQuery.V2.Tests
                 UseQueryCache = false,
                 WriteDisposition = WriteDisposition.WriteIfEmpty,
                 UseLegacySql = true,
-                ParameterMode = BigQueryParameterMode.Positional
+                ParameterMode = BigQueryParameterMode.Positional,
+                DestinationEncryptionConfiguration = new EncryptionConfiguration { KmsKeyName = "projects/1/locations/us/keyRings/1/cryptoKeys/1" }
             };
 
             JobConfigurationQuery query = new JobConfigurationQuery();
@@ -52,6 +53,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.Equal("WRITE_EMPTY", query.WriteDisposition);
             Assert.Equal(true, query.UseLegacySql);
             Assert.Equal("positional", query.ParameterMode);
+            Assert.Equal("projects/1/locations/us/keyRings/1/cryptoKeys/1", query.DestinationEncryptionConfiguration.KmsKeyName);
         }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateCopyJobOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateCopyJobOptions.cs
@@ -33,6 +33,11 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         public WriteDisposition? WriteDisposition { get; set; }
 
+        /// <summary>
+        /// The encryption configuratoin to apply to the destination table, if any.
+        /// </summary>
+        public EncryptionConfiguration DestinationEncryptionConfiguration { get; set; }
+
         internal void ModifyRequest(JobConfigurationTableCopy copy)
         {
             if (CreateDisposition != null)
@@ -42,6 +47,10 @@ namespace Google.Cloud.BigQuery.V2
             if (WriteDisposition != null)
             {
                 copy.WriteDisposition = EnumMap.ToApiValue(WriteDisposition.Value);
+            }
+            if(DestinationEncryptionConfiguration != null)
+            {
+                copy.DestinationEncryptionConfiguration = DestinationEncryptionConfiguration;
             }
         }
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateCopyJobOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateCopyJobOptions.cs
@@ -34,7 +34,7 @@ namespace Google.Cloud.BigQuery.V2
         public WriteDisposition? WriteDisposition { get; set; }
 
         /// <summary>
-        /// The encryption configuratoin to apply to the destination table, if any.
+        /// The encryption configuration to apply to the destination table, if any.
         /// </summary>
         public EncryptionConfiguration DestinationEncryptionConfiguration { get; set; }
 
@@ -48,7 +48,7 @@ namespace Google.Cloud.BigQuery.V2
             {
                 copy.WriteDisposition = EnumMap.ToApiValue(WriteDisposition.Value);
             }
-            if(DestinationEncryptionConfiguration != null)
+            if (DestinationEncryptionConfiguration != null)
             {
                 copy.DestinationEncryptionConfiguration = DestinationEncryptionConfiguration;
             }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateLoadJobOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateLoadJobOptions.cs
@@ -110,6 +110,11 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         public TimePartitioning TimePartitioning { get; set; }
 
+        /// <summary>
+        /// The encryption configuratoin to apply to the destination table, if any.
+        /// </summary>
+        public EncryptionConfiguration DestinationEncryptionConfiguration { get; set; }
+
         internal void ModifyRequest(JobConfigurationLoad load)
         {
             if (SkipLeadingRows != null)
@@ -167,6 +172,10 @@ namespace Google.Cloud.BigQuery.V2
             if (TimePartitioning != null)
             {
                 load.TimePartitioning = TimePartitioning;
+            }
+            if(DestinationEncryptionConfiguration != null)
+            {
+                load.DestinationEncryptionConfiguration = DestinationEncryptionConfiguration;
             }
         }
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateLoadJobOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateLoadJobOptions.cs
@@ -111,7 +111,7 @@ namespace Google.Cloud.BigQuery.V2
         public TimePartitioning TimePartitioning { get; set; }
 
         /// <summary>
-        /// The encryption configuratoin to apply to the destination table, if any.
+        /// The encryption configuration to apply to the destination table, if any.
         /// </summary>
         public EncryptionConfiguration DestinationEncryptionConfiguration { get; set; }
 
@@ -173,7 +173,7 @@ namespace Google.Cloud.BigQuery.V2
             {
                 load.TimePartitioning = TimePartitioning;
             }
-            if(DestinationEncryptionConfiguration != null)
+            if (DestinationEncryptionConfiguration != null)
             {
                 load.DestinationEncryptionConfiguration = DestinationEncryptionConfiguration;
             }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateTableOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateTableOptions.cs
@@ -97,7 +97,7 @@ namespace Google.Cloud.BigQuery.V2
             }
             if (EncryptionConfiguration != null)
             {
-                table.EncryptionConfiguration.KmsKeyName = EncryptionConfiguration.KmsKeyName;
+                table.EncryptionConfiguration = EncryptionConfiguration;
             }
         }
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateTableOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateTableOptions.cs
@@ -59,7 +59,7 @@ namespace Google.Cloud.BigQuery.V2
         public ViewDefinition View { get; set; }
 
         /// <summary>
-        /// The encryption configuratoin to apply to the created table, if any.
+        /// The encryption configuration to apply to the created table, if any.
         /// </summary>
         public EncryptionConfiguration EncryptionConfiguration { get; set; }
 

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateTableOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateTableOptions.cs
@@ -58,6 +58,11 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         public ViewDefinition View { get; set; }
 
+        /// <summary>
+        /// The encryption configuratoin to apply to the created table, if any.
+        /// </summary>
+        public EncryptionConfiguration EncryptionConfiguration { get; set; }
+
         internal void ModifyRequest(Table table, InsertRequest request)
         {
             if (Description != null)
@@ -89,6 +94,10 @@ namespace Google.Cloud.BigQuery.V2
             if (View != null)
             {
                 table.View = View;
+            }
+            if (EncryptionConfiguration != null)
+            {
+                table.EncryptionConfiguration.KmsKeyName = EncryptionConfiguration.KmsKeyName;
             }
         }
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/QueryOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/QueryOptions.cs
@@ -108,6 +108,11 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         public BigQueryParameterMode? ParameterMode { get; set; }
 
+        /// <summary>
+        /// The encryption configuratoin to apply to the destination table, if any.
+        /// </summary>
+        public EncryptionConfiguration DestinationEncryptionConfiguration { get; set; }
+
         internal void ModifyRequest(JobConfigurationQuery query)
         {
             // Note: no validation of combinations (flatten results etc). Leave this to the server,
@@ -160,6 +165,10 @@ namespace Google.Cloud.BigQuery.V2
             {
                 // Safe for now; we only have "named" or "positional". This is unlikely to change.
                 query.ParameterMode = ParameterMode.ToString().ToLowerInvariant();
+            }
+            if (DestinationEncryptionConfiguration != null)
+            {
+                query.DestinationEncryptionConfiguration.KmsKeyName = DestinationEncryptionConfiguration.KmsKeyName;
             }
         }
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/QueryOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/QueryOptions.cs
@@ -168,7 +168,7 @@ namespace Google.Cloud.BigQuery.V2
             }
             if (DestinationEncryptionConfiguration != null)
             {
-                query.DestinationEncryptionConfiguration.KmsKeyName = DestinationEncryptionConfiguration.KmsKeyName;
+                query.DestinationEncryptionConfiguration = DestinationEncryptionConfiguration;
             }
         }
     }


### PR DESCRIPTION
As part of a query, load job, or create table request, you can specify the encryption configuration, which just consists of a single string field containing the KMS key to use.