### PR TITLE
Firestore refactoring

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/CollectionListingTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/CollectionListingTest.cs
@@ -34,7 +34,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
             // Create documents in two collections to make sure they exist.
             var collection1 = _fixture.CreateUniqueCollection();
             var collection2 = _fixture.CreateUniqueCollection();
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             batch.Create(collection1.Document(), new { Name = "doc1" });
             batch.Create(collection2.Document(), new { Name = "doc2" });
             await batch.CommitAsync();

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/CollectionListingTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/CollectionListingTest.cs
@@ -35,8 +35,8 @@ namespace Google.Cloud.Firestore.IntegrationTests
             var collection1 = _fixture.CreateUniqueCollection();
             var collection2 = _fixture.CreateUniqueCollection();
             var batch = db.CreateWriteBatch();
-            batch.Create(collection1.GenerateDocument(), new { Name = "doc1" });
-            batch.Create(collection2.GenerateDocument(), new { Name = "doc2" });
+            batch.Create(collection1.Document(), new { Name = "doc1" });
+            batch.Create(collection2.Document(), new { Name = "doc2" });
             await batch.CommitAsync();
 
             var rootCollections = await db.ListRootCollectionsAsync().ToList();
@@ -47,7 +47,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         [Fact]
         public async Task ListCollectionsAsync()
         {
-            var doc = _fixture.NonQueryCollection.GenerateDocument();
+            var doc = _fixture.NonQueryCollection.Document();
             var col1 = doc.Collection("col1");
             var col2 = doc.Collection("col2");
             // Put documents in the collections to force them to exist.

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DataModelTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DataModelTest.cs
@@ -31,7 +31,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task TimestampTruncated()
         {
             var doc = await _fixture.NonQueryCollection.AddAsync(new { Timestamp = new Timestamp(100, 123456789) });
-            var snapshot = await doc.SnapshotAsync();
+            var snapshot = await doc.GetSnapshotAsync();
 
             var storedData = snapshot.GetValue<Timestamp>("Timestamp");
             Assert.Equal(new Timestamp(100, 123456000), storedData);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DataModelTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DataModelTest.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
             var doc = await _fixture.NonQueryCollection.AddAsync(new { Timestamp = new Timestamp(100, 123456789) });
             var snapshot = await doc.SnapshotAsync();
 
-            var storedData = snapshot.GetField<Timestamp>("Timestamp");
+            var storedData = snapshot.GetValue<Timestamp>("Timestamp");
             Assert.Equal(new Timestamp(100, 123456000), storedData);
         }
     }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DocumentCreationTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DocumentCreationTest.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
             var reference = await collection.AddAsync(new { Name = "Test" });
 
             // Make sure we can fetch it again too...
-            var snapshot = await reference.SnapshotAsync();
+            var snapshot = await reference.GetSnapshotAsync();
             Assert.True(snapshot.Exists);
             var dictionary = snapshot.ToDictionary();
             Assert.Equal("Test", dictionary["Name"]);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DocumentDeletionTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DocumentDeletionTest.cs
@@ -28,7 +28,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         [Fact]
         public async Task Delete_Unconditional_DoesntExist()
         {
-            var doc = _fixture.NonQueryCollection.GenerateDocument();
+            var doc = _fixture.NonQueryCollection.Document();
             var result = await doc.DeleteAsync();
             var afterDelete = await doc.GetSnapshotAsync();
             Assert.False(afterDelete.Exists);
@@ -37,7 +37,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         [Fact]
         public async Task Delete_Unconditional_Existed()
         {
-            var doc = _fixture.NonQueryCollection.GenerateDocument();
+            var doc = _fixture.NonQueryCollection.Document();
             var createResult = await doc.CreateAsync(new { Name = "Delete me" });
             var deleteResult = await doc.DeleteAsync();
             var afterDelete = await doc.GetSnapshotAsync();
@@ -47,7 +47,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         [Fact]
         public async Task Delete_Precondition_Success()
         {
-            var doc = _fixture.NonQueryCollection.GenerateDocument();
+            var doc = _fixture.NonQueryCollection.Document();
             var createResult = await doc.CreateAsync(new { Name = "Delete me" });
             var deleteResult = await doc.DeleteAsync(Precondition.LastUpdated(createResult.UpdateTime));
             var afterDelete = await doc.GetSnapshotAsync();
@@ -57,7 +57,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         [Fact]
         public async Task Delete_Precondition_Failed()
         {
-            var doc = _fixture.NonQueryCollection.GenerateDocument();
+            var doc = _fixture.NonQueryCollection.Document();
             var createResult = await doc.CreateAsync(new { Name = "Don't delete me" });
             var otherTimestamp = Timestamp.FromDateTimeOffset(createResult.UpdateTime.ToDateTimeOffset().AddSeconds(-1));
             var exception = await Assert.ThrowsAsync<RpcException>(() => doc.DeleteAsync(Precondition.LastUpdated(otherTimestamp)));
@@ -69,7 +69,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         [Fact]
         public async Task Delete_Precondition_DoesntExist()
         {
-            var doc = _fixture.NonQueryCollection.GenerateDocument();
+            var doc = _fixture.NonQueryCollection.Document();
             var exception = await Assert.ThrowsAsync<RpcException>(() => doc.DeleteAsync(Precondition.LastUpdated(new Timestamp(1, 0))));
             Assert.Equal(StatusCode.FailedPrecondition, exception.Status.StatusCode);
             var afterDelete = await doc.GetSnapshotAsync();

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DocumentDeletionTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DocumentDeletionTest.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         {
             var doc = _fixture.NonQueryCollection.GenerateDocument();
             var result = await doc.DeleteAsync();
-            var afterDelete = await doc.SnapshotAsync();
+            var afterDelete = await doc.GetSnapshotAsync();
             Assert.False(afterDelete.Exists);
         }
 
@@ -40,7 +40,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
             var doc = _fixture.NonQueryCollection.GenerateDocument();
             var createResult = await doc.CreateAsync(new { Name = "Delete me" });
             var deleteResult = await doc.DeleteAsync();
-            var afterDelete = await doc.SnapshotAsync();
+            var afterDelete = await doc.GetSnapshotAsync();
             Assert.False(afterDelete.Exists);
         }
 
@@ -50,7 +50,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
             var doc = _fixture.NonQueryCollection.GenerateDocument();
             var createResult = await doc.CreateAsync(new { Name = "Delete me" });
             var deleteResult = await doc.DeleteAsync(Precondition.LastUpdated(createResult.UpdateTime));
-            var afterDelete = await doc.SnapshotAsync();
+            var afterDelete = await doc.GetSnapshotAsync();
             Assert.False(afterDelete.Exists);
         }
 
@@ -62,7 +62,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
             var otherTimestamp = Timestamp.FromDateTimeOffset(createResult.UpdateTime.ToDateTimeOffset().AddSeconds(-1));
             var exception = await Assert.ThrowsAsync<RpcException>(() => doc.DeleteAsync(Precondition.LastUpdated(otherTimestamp)));
             Assert.Equal(StatusCode.FailedPrecondition, exception.Status.StatusCode);
-            var afterDelete = await doc.SnapshotAsync();
+            var afterDelete = await doc.GetSnapshotAsync();
             Assert.True(afterDelete.Exists);
         }
 
@@ -72,7 +72,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
             var doc = _fixture.NonQueryCollection.GenerateDocument();
             var exception = await Assert.ThrowsAsync<RpcException>(() => doc.DeleteAsync(Precondition.LastUpdated(new Timestamp(1, 0))));
             Assert.Equal(StatusCode.FailedPrecondition, exception.Status.StatusCode);
-            var afterDelete = await doc.SnapshotAsync();
+            var afterDelete = await doc.GetSnapshotAsync();
             Assert.False(afterDelete.Exists);
         }
     }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DocumentMutationTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DocumentMutationTest.cs
@@ -118,7 +118,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task SpecSequence()
         {
             var collection = _fixture.NonQueryCollection;
-            var docRef = collection.GenerateDocument();
+            var docRef = collection.Document();
 
             // Step 1: Create
             await docRef.CreateAsync(Map(("a.b", Map("c.d", 1)), ("e", 1)));

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DocumentMutationTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DocumentMutationTest.cs
@@ -77,9 +77,9 @@ namespace Google.Cloud.Firestore.IntegrationTests
                 { new FieldPath("Timestamp"), SentinelValue.ServerTimestamp }
             });
             var snapshot = await doc.SnapshotAsync();
-            Assert.Equal("Original", snapshot.GetField<string>("Name"));
-            Assert.False(snapshot.Contains("DeleteMe"));
-            var timestamp = snapshot.GetField<Timestamp>("Timestamp");
+            Assert.Equal("Original", snapshot.GetValue<string>("Name"));
+            Assert.False(snapshot.ContainsField("DeleteMe"));
+            var timestamp = snapshot.GetValue<Timestamp>("Timestamp");
             // Assume the machine we're running tests on isn't more than 5 minutes out of sync with the server.
             // If we're getting "roughly the right time" then that must have come from the server.
             var absDifferenceMinutes = Math.Abs((timestamp.ToDateTime() - DateTime.UtcNow).TotalMinutes);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/FirestoreFixture.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/FirestoreFixture.cs
@@ -68,7 +68,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
             var batch = FirestoreDb.CreateWriteBatch();
             foreach (var doc in documents)
             {
-                batch.Create(collection.GenerateDocument(), doc);
+                batch.Create(collection.Document(), doc);
             }
             await batch.CommitAsync();
         }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/FirestoreFixture.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/FirestoreFixture.cs
@@ -65,7 +65,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
 
         private async Task PopulateCollection(CollectionReference collection, IEnumerable<object> documents)
         {
-            var batch = FirestoreDb.CreateWriteBatch();
+            var batch = FirestoreDb.StartBatch();
             foreach (var doc in documents)
             {
                 batch.Create(collection.Document(), doc);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/QueryTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/QueryTest.cs
@@ -61,7 +61,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
             var snapshot = await query.SnapshotAsync();
 
             // Check that we got the documents we expected
-            var names = snapshot.Documents.Select(doc => doc.GetField<string>("Name")).OrderBy(x => x, StringComparer.Ordinal);
+            var names = snapshot.Documents.Select(doc => doc.GetValue<string>("Name")).OrderBy(x => x, StringComparer.Ordinal);
             Assert.Equal(HighScore.Data.Select(x => x.Name), names);
 
             // Check that the ordering is actually by document reference

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/QueryTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/QueryTest.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         {
             var query = _fixture.HighScoreCollection;
             var snapshot = await query.SnapshotAsync();
-            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data, items.OrderBy(x => x.Name, StringComparer.Ordinal));
         }
 
@@ -41,7 +41,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         {
             var query = _fixture.HighScoreCollection.Where("Score", QueryOperator.GreaterThan, 100);
             var snapshot = await query.SnapshotAsync();
-            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.Where(x => x.Score > 100), items.OrderBy(x => x.Name, StringComparer.Ordinal));
         }
 
@@ -50,7 +50,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         {
             var query = _fixture.HighScoreCollection.OrderBy("Level");
             var snapshot = await query.SnapshotAsync();
-            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.OrderBy(x => x.Level), items);
         }
 
@@ -75,7 +75,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         {
             var query = _fixture.HighScoreCollection.OrderBy("Score").OrderBy("Level");
             var snapshot = await query.SnapshotAsync();
-            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.OrderBy(x => x.Score).ThenBy(x => x.Level), items);
         }
 
@@ -84,7 +84,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         {
             var query = _fixture.HighScoreCollection.OrderBy("Score").OrderByDescending("Level");
             var snapshot = await query.SnapshotAsync();
-            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.OrderBy(x => x.Score).ThenByDescending(x => x.Level), items);
         }
 
@@ -93,7 +93,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         {
             var query = _fixture.HighScoreCollection.Select("Name", "Score");
             var snapshot = await query.SnapshotAsync();
-            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(
                 // Create the equivalent results by creating new objects
                 HighScore.Data.Select(x => new HighScore { Name = x.Name, Score = x.Score }),
@@ -117,7 +117,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         {
             var query = _fixture.HighScoreCollection.OrderBy("Level").Limit(3);
             var snapshot = await query.SnapshotAsync();
-            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.OrderBy(x => x.Level).Take(3), items);
         }
 
@@ -126,7 +126,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         {
             var query = _fixture.HighScoreCollection.OrderBy("Level").Offset(2);
             var snapshot = await query.SnapshotAsync();
-            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.OrderBy(x => x.Level).Skip(2), items);
         }
 
@@ -135,7 +135,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         {
             var query = _fixture.HighScoreCollection.OrderBy("Level").StartAt(20);
             var snapshot = await query.SnapshotAsync();
-            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.Where(x => x.Level >= 20).OrderBy(x => x.Score), items);
         }
 
@@ -144,7 +144,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         {
             var query = _fixture.HighScoreCollection.OrderBy("Level").StartAfter(20);
             var snapshot = await query.SnapshotAsync();
-            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.Where(x => x.Level > 20).OrderBy(x => x.Level), items);
         }
 
@@ -153,7 +153,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         {
             var query = _fixture.HighScoreCollection.OrderBy("Level").EndAt(20);
             var snapshot = await query.SnapshotAsync();
-            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.Where(x => x.Level <= 20).OrderBy(x => x.Level), items);
         }
 
@@ -162,7 +162,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         {
             var query = _fixture.HighScoreCollection.OrderBy("Level").EndBefore(20);
             var snapshot = await query.SnapshotAsync();
-            var items = snapshot.Documents.Select(doc => doc.Deserialize<HighScore>()).ToList();
+            var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.Where(x => x.Level < 20).OrderBy(x => x.Level), items);
         }
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/QueryTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/QueryTest.cs
@@ -31,7 +31,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task EmptyQuery()
         {
             var query = _fixture.HighScoreCollection;
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
             var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data, items.OrderBy(x => x.Name, StringComparer.Ordinal));
         }
@@ -40,7 +40,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task WhereGreaterThan()
         {
             var query = _fixture.HighScoreCollection.Where("Score", QueryOperator.GreaterThan, 100);
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
             var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.Where(x => x.Score > 100), items.OrderBy(x => x.Name, StringComparer.Ordinal));
         }
@@ -49,7 +49,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task OrderBy()
         {
             var query = _fixture.HighScoreCollection.OrderBy("Level");
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
             var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.OrderBy(x => x.Level), items);
         }
@@ -58,7 +58,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task OrderByDocumentId()
         {
             var query = _fixture.HighScoreCollection.Select("Name").OrderBy(FieldPath.DocumentId);
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
 
             // Check that we got the documents we expected
             var names = snapshot.Documents.Select(doc => doc.GetValue<string>("Name")).OrderBy(x => x, StringComparer.Ordinal);
@@ -74,7 +74,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task OrderBySecondaryAscending()
         {
             var query = _fixture.HighScoreCollection.OrderBy("Score").OrderBy("Level");
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
             var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.OrderBy(x => x.Score).ThenBy(x => x.Level), items);
         }
@@ -83,7 +83,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task OrderBySecondaryDescending()
         {
             var query = _fixture.HighScoreCollection.OrderBy("Score").OrderByDescending("Level");
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
             var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.OrderBy(x => x.Score).ThenByDescending(x => x.Level), items);
         }
@@ -92,7 +92,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task Select()
         {
             var query = _fixture.HighScoreCollection.Select("Name", "Score");
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
             var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(
                 // Create the equivalent results by creating new objects
@@ -104,7 +104,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task SelectDocumentId()
         {
             var query = _fixture.HighScoreCollection.Select(FieldPath.DocumentId);
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
 
             Assert.Equal(snapshot.Documents.Count, HighScore.Data.Length);
 
@@ -116,7 +116,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task Limit()
         {
             var query = _fixture.HighScoreCollection.OrderBy("Level").Limit(3);
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
             var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.OrderBy(x => x.Level).Take(3), items);
         }
@@ -125,7 +125,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task Offset()
         {
             var query = _fixture.HighScoreCollection.OrderBy("Level").Offset(2);
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
             var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.OrderBy(x => x.Level).Skip(2), items);
         }
@@ -134,7 +134,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task StartAt()
         {
             var query = _fixture.HighScoreCollection.OrderBy("Level").StartAt(20);
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
             var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.Where(x => x.Level >= 20).OrderBy(x => x.Score), items);
         }
@@ -143,7 +143,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task StartAfter()
         {
             var query = _fixture.HighScoreCollection.OrderBy("Level").StartAfter(20);
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
             var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.Where(x => x.Level > 20).OrderBy(x => x.Level), items);
         }
@@ -152,7 +152,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task EndAt()
         {
             var query = _fixture.HighScoreCollection.OrderBy("Level").EndAt(20);
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
             var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.Where(x => x.Level <= 20).OrderBy(x => x.Level), items);
         }
@@ -161,7 +161,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task EndBefore()
         {
             var query = _fixture.HighScoreCollection.OrderBy("Level").EndBefore(20);
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
             var items = snapshot.Documents.Select(doc => doc.ConvertTo<HighScore>()).ToList();
             Assert.Equal(HighScore.Data.Where(x => x.Level < 20).OrderBy(x => x.Level), items);
         }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/RunInTransactionTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/RunInTransactionTest.cs
@@ -40,8 +40,8 @@ namespace Google.Cloud.Firestore.IntegrationTests
                 transaction.Create(doc1, new { Name = "test1" });
                 transaction.Create(doc2, new { Name = "test2" });
             });
-            var snapshot1 = await doc1.SnapshotAsync();
-            var snapshot2 = await doc2.SnapshotAsync();
+            var snapshot1 = await doc1.GetSnapshotAsync();
+            var snapshot2 = await doc2.GetSnapshotAsync();
             AssertSerialized(snapshot1, new { Name = "test1" });
             AssertSerialized(snapshot2, new { Name = "test2" });
         }
@@ -65,7 +65,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
 
             // We only had two increment transactions, but one needed to retry
             Assert.Equal(3, attempts);
-            var result = await doc.SnapshotAsync();
+            var result = await doc.GetSnapshotAsync();
             Assert.Equal(2, result.GetValue<int>("Count"));
 
             async Task IncrementCounter(Transaction transaction)
@@ -106,7 +106,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
             Assert.True(t1.IsFaulted ^ t2.IsFaulted);
 
             Assert.Equal(2, attempts);
-            var result = await doc.SnapshotAsync();
+            var result = await doc.GetSnapshotAsync();
             Assert.Equal(1, result.GetValue<int>("Count"));
 
             async Task IncrementCounter(Transaction transaction)

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/RunInTransactionTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/RunInTransactionTest.cs
@@ -70,7 +70,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
 
             async Task IncrementCounter(Transaction transaction)
             {
-                var snapshot = await transaction.GetDocumentSnapshotAsync(doc);
+                var snapshot = await transaction.GetSnapshotAsync(doc);
                 Interlocked.Increment(ref attempts);
                 // We wouldn't want to signal again when retrying. Nothing is going
                 // to *increment* CurrentCount, so this should be safe.
@@ -111,7 +111,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
 
             async Task IncrementCounter(Transaction transaction)
             {
-                var snapshot = await transaction.GetDocumentSnapshotAsync(doc);
+                var snapshot = await transaction.GetSnapshotAsync(doc);
                 Interlocked.Increment(ref attempts);
                 // We wouldn't want to signal again when retrying. Nothing is going
                 // to *increment* CurrentCount, so this should be safe.

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/RunInTransactionTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/RunInTransactionTest.cs
@@ -32,8 +32,8 @@ namespace Google.Cloud.Firestore.IntegrationTests
         public async Task SimpleTransaction()
         {
             var db = _fixture.FirestoreDb;
-            var doc1 = _fixture.NonQueryCollection.GenerateDocument();
-            var doc2 = _fixture.NonQueryCollection.GenerateDocument();
+            var doc1 = _fixture.NonQueryCollection.Document();
+            var doc2 = _fixture.NonQueryCollection.Document();
 
             await db.RunTransactionAsync(transaction =>
             {

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/RunInTransactionTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/RunInTransactionTest.cs
@@ -66,7 +66,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
             // We only had two increment transactions, but one needed to retry
             Assert.Equal(3, attempts);
             var result = await doc.SnapshotAsync();
-            Assert.Equal(2, result.GetField<int>("Count"));
+            Assert.Equal(2, result.GetValue<int>("Count"));
 
             async Task IncrementCounter(Transaction transaction)
             {
@@ -82,7 +82,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
                 {
                     throw new TimeoutException();
                 }
-                transaction.Set(doc, new { Count = snapshot.GetField<int>("Count") + 1 });
+                transaction.Set(doc, new { Count = snapshot.GetValue<int>("Count") + 1 });
             }
         }
 
@@ -107,7 +107,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
 
             Assert.Equal(2, attempts);
             var result = await doc.SnapshotAsync();
-            Assert.Equal(1, result.GetField<int>("Count"));
+            Assert.Equal(1, result.GetValue<int>("Count"));
 
             async Task IncrementCounter(Transaction transaction)
             {
@@ -123,7 +123,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
                 {
                     throw new TimeoutException();
                 }
-                transaction.Set(doc, new { Count = snapshot.GetField<int>("Count") + 1 });
+                transaction.Set(doc, new { Count = snapshot.GetValue<int>("Count") + 1 });
             }
         }
     }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/DataModelSnippets.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/DataModelSnippets.cs
@@ -69,7 +69,7 @@ namespace Google.Cloud.Firestore.Snippets
             DocumentReference document = await collection.AddAsync(city);
 
             // Fetch the data back from the server and deserialize it.
-            DocumentSnapshot snapshot = await document.SnapshotAsync();
+            DocumentSnapshot snapshot = await document.GetSnapshotAsync();
             City citySnapshot = snapshot.ConvertTo<City>();
             Console.WriteLine(citySnapshot.Name); // Los Angeles
             // End sample
@@ -95,7 +95,7 @@ namespace Google.Cloud.Firestore.Snippets
             DocumentReference document = await collection.AddAsync(city);
 
             // Fetch the data back from the server and deserialize it.
-            DocumentSnapshot snapshot = await document.SnapshotAsync();
+            DocumentSnapshot snapshot = await document.GetSnapshotAsync();
             Dictionary<string, object> cityData = snapshot.ToDictionary();
             Console.WriteLine(cityData["Name"]); // Los Angeles
             // End sample
@@ -124,7 +124,7 @@ namespace Google.Cloud.Firestore.Snippets
             await document.SetAsync(new { Population = 3900005L }, SetOptions.MergeAll);
 
             // Fetch the latest document and print the population
-            DocumentSnapshot snapshot = await document.SnapshotAsync();
+            DocumentSnapshot snapshot = await document.GetSnapshotAsync();
             Console.WriteLine(snapshot.GetValue<long>("Population")); // 3900005
             // End sample
         }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/DataModelSnippets.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/DataModelSnippets.cs
@@ -125,7 +125,7 @@ namespace Google.Cloud.Firestore.Snippets
 
             // Fetch the latest document and print the population
             DocumentSnapshot snapshot = await document.SnapshotAsync();
-            Console.WriteLine(snapshot.GetField<long>("Population")); // 3900005
+            Console.WriteLine(snapshot.GetValue<long>("Population")); // 3900005
             // End sample
         }
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/DataModelSnippets.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/DataModelSnippets.cs
@@ -70,7 +70,7 @@ namespace Google.Cloud.Firestore.Snippets
 
             // Fetch the data back from the server and deserialize it.
             DocumentSnapshot snapshot = await document.SnapshotAsync();
-            City citySnapshot = snapshot.Deserialize<City>();
+            City citySnapshot = snapshot.ConvertTo<City>();
             Console.WriteLine(citySnapshot.Name); // Los Angeles
             // End sample
         }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/IndexSnippets.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/IndexSnippets.cs
@@ -58,7 +58,7 @@ namespace Google.Cloud.Firestore.Snippets
 
             // Query the collection for all documents where doc.Born < 1900.
             Query query = collection.Where("Born", QueryOperator.LessThan, 1900);
-            QuerySnapshot querySnapshot = await query.SnapshotAsync();
+            QuerySnapshot querySnapshot = await query.GetSnapshotAsync();
             foreach (DocumentSnapshot queryResult in querySnapshot.Documents)
             {
                 string firstName = queryResult.GetValue<string>("Name.First");

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/IndexSnippets.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/IndexSnippets.cs
@@ -44,9 +44,9 @@ namespace Google.Cloud.Firestore.Snippets
             DocumentSnapshot snapshot = await document.SnapshotAsync();
 
             // We can access individual fields by dot-separated path
-            Console.WriteLine(snapshot.GetField<string>("Name.First"));
-            Console.WriteLine(snapshot.GetField<string>("Name.Last"));
-            Console.WriteLine(snapshot.GetField<int>("Born"));
+            Console.WriteLine(snapshot.GetValue<string>("Name.First"));
+            Console.WriteLine(snapshot.GetValue<string>("Name.Last"));
+            Console.WriteLine(snapshot.GetValue<int>("Born"));
 
             // Or deserialize the whole document into a dictionary
             Dictionary<string, object> data = snapshot.ToDictionary();
@@ -61,9 +61,9 @@ namespace Google.Cloud.Firestore.Snippets
             QuerySnapshot querySnapshot = await query.SnapshotAsync();
             foreach (DocumentSnapshot queryResult in querySnapshot.Documents)
             {
-                string firstName = queryResult.GetField<string>("Name.First");
-                string lastName = queryResult.GetField<string>("Name.Last");
-                int born = queryResult.GetField<int>("Born");
+                string firstName = queryResult.GetValue<string>("Name.First");
+                string lastName = queryResult.GetValue<string>("Name.Last");
+                int born = queryResult.GetValue<int>("Born");
                 Console.WriteLine($"{firstName} {lastName}; born {born}");
             }
             // End sample

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/IndexSnippets.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/IndexSnippets.cs
@@ -41,7 +41,7 @@ namespace Google.Cloud.Firestore.Snippets
 
             // A DocumentReference doesn't contain the data - it's just a path.
             // Let's fetch the current document.
-            DocumentSnapshot snapshot = await document.SnapshotAsync();
+            DocumentSnapshot snapshot = await document.GetSnapshotAsync();
 
             // We can access individual fields by dot-separated path
             Console.WriteLine(snapshot.GetValue<string>("Name.First"));

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/UserGuideSnippets.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/UserGuideSnippets.cs
@@ -286,7 +286,7 @@ namespace Google.Cloud.Firestore.Snippets
 
             await db.RunTransactionAsync(async transaction =>
             {
-                DocumentSnapshot currentSnapshot = await transaction.GetDocumentSnapshotAsync(currentCounter);
+                DocumentSnapshot currentSnapshot = await transaction.GetSnapshotAsync(currentCounter);
                 long counter = currentSnapshot.GetValue<long>("Counter");
                 transaction.Set(dailyCounter, new { Counter = counter });
             });
@@ -310,7 +310,7 @@ namespace Google.Cloud.Firestore.Snippets
             
             long newValue = await db.RunTransactionAsync(async transaction =>
             {
-                DocumentSnapshot currentSnapshot = await transaction.GetDocumentSnapshotAsync(currentCounter);
+                DocumentSnapshot currentSnapshot = await transaction.GetSnapshotAsync(currentCounter);
                 long counter = currentSnapshot.GetValue<long>("Counter") + 1;
                 transaction.Set(currentCounter, new { Counter = counter });
                 return counter;

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/UserGuideSnippets.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/UserGuideSnippets.cs
@@ -287,7 +287,7 @@ namespace Google.Cloud.Firestore.Snippets
             await db.RunTransactionAsync(async transaction =>
             {
                 DocumentSnapshot currentSnapshot = await transaction.GetDocumentSnapshotAsync(currentCounter);
-                long counter = currentSnapshot.GetField<long>("Counter");
+                long counter = currentSnapshot.GetValue<long>("Counter");
                 transaction.Set(dailyCounter, new { Counter = counter });
             });
             // End sample
@@ -311,7 +311,7 @@ namespace Google.Cloud.Firestore.Snippets
             long newValue = await db.RunTransactionAsync(async transaction =>
             {
                 DocumentSnapshot currentSnapshot = await transaction.GetDocumentSnapshotAsync(currentCounter);
-                long counter = currentSnapshot.GetField<long>("Counter") + 1;
+                long counter = currentSnapshot.GetValue<long>("Counter") + 1;
                 transaction.Set(currentCounter, new { Counter = counter });
                 return counter;
             });
@@ -345,8 +345,8 @@ namespace Google.Cloud.Firestore.Snippets
             Console.WriteLine(snapshot.Exists);
 
             // Individual fields can be checked and fetched
-            Console.WriteLine(snapshot.Contains("Planet")); // False
-            Console.WriteLine(snapshot.GetField<string>("Name")); // Los Angeles
+            Console.WriteLine(snapshot.ContainsField("Planet")); // False
+            Console.WriteLine(snapshot.GetValue<string>("Name")); // Los Angeles
 
             // Or you can deserialize to a dictionary or a model
             City fetchedCity = snapshot.ConvertTo<City>();

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/UserGuideSnippets.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/UserGuideSnippets.cs
@@ -339,7 +339,7 @@ namespace Google.Cloud.Firestore.Snippets
             DocumentReference document = await collection.AddAsync(city);
 
             // Sample: DocumentSnapshot
-            DocumentSnapshot snapshot = await document.SnapshotAsync();
+            DocumentSnapshot snapshot = await document.GetSnapshotAsync();
             // Even if there's no document in the server, we still get a snapshot
             // back - but it knows the document doesn't exist.
             Console.WriteLine(snapshot.Exists);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/UserGuideSnippets.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/UserGuideSnippets.cs
@@ -349,7 +349,7 @@ namespace Google.Cloud.Firestore.Snippets
             Console.WriteLine(snapshot.GetField<string>("Name")); // Los Angeles
 
             // Or you can deserialize to a dictionary or a model
-            City fetchedCity = snapshot.Deserialize<City>();
+            City fetchedCity = snapshot.ConvertTo<City>();
             Console.WriteLine(fetchedCity.Name); // Los Angeles
             // End sample
         }
@@ -367,7 +367,7 @@ namespace Google.Cloud.Firestore.Snippets
             foreach (DocumentSnapshot document in allCities.Documents)
             {
                 // Do anything you'd normally do with a DocumentSnapshot
-                City city = document.Deserialize<City>();
+                City city = document.ConvertTo<City>();
                 Console.WriteLine(city.Name);
             }
 
@@ -380,7 +380,7 @@ namespace Google.Cloud.Firestore.Snippets
             foreach (DocumentSnapshot document in bigCities.Documents)
             {
                 // Do anything you'd normally do with a DocumentSnapshot
-                City city = document.Deserialize<City>();
+                City city = document.ConvertTo<City>();
                 Console.WriteLine($"{city.Name}: {city.Population}");
             }
             // End sample

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/UserGuideSnippets.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/UserGuideSnippets.cs
@@ -363,7 +363,7 @@ namespace Google.Cloud.Firestore.Snippets
             CollectionReference collection = db.Collection("cities");
 
             // A CollectionReference is a Query, so we can just fetch everything
-            QuerySnapshot allCities = await collection.SnapshotAsync();
+            QuerySnapshot allCities = await collection.GetSnapshotAsync();
             foreach (DocumentSnapshot document in allCities.Documents)
             {
                 // Do anything you'd normally do with a DocumentSnapshot
@@ -376,7 +376,7 @@ namespace Google.Cloud.Firestore.Snippets
                 .Where("Population", QueryOperator.GreaterThan, 3000000)
                 .OrderByDescending("Population");
 
-            QuerySnapshot bigCities = await bigCitiesQuery.SnapshotAsync();
+            QuerySnapshot bigCities = await bigCitiesQuery.GetSnapshotAsync();
             foreach (DocumentSnapshot document in bigCities.Documents)
             {
                 // Do anything you'd normally do with a DocumentSnapshot

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/CollectionReferenceTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/CollectionReferenceTest.cs
@@ -108,16 +108,16 @@ namespace Google.Cloud.Firestore.Tests
         }
 
         [Fact]
-        public void GenerateDocument()
+        public void Document_GeneratedId()
         {
             var db = FirestoreDb.Create("proj", "db", new FakeFirestoreClient());
             var collection = db.Collection("root");
-            var doc = collection.GenerateDocument();
+            var doc = collection.Document();
             Assert.Equal(collection, doc.Parent);
             // Can't guarantee what it is...
             Assert.Equal(20, doc.Id.Length);
             // But we shouldn't get the same one twice
-            Assert.NotEqual(doc.Id, collection.GenerateDocument().Id);
+            Assert.NotEqual(doc.Id, collection.Document().Id);
         }
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/DocumentSnapshotTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/DocumentSnapshotTest.cs
@@ -37,7 +37,7 @@ namespace Google.Cloud.Firestore.Tests
             Assert.Equal(readTime, document.ReadTime);
             Assert.False(document.Exists);
             Assert.Null(document.ToDictionary());
-            Assert.Null(document.Deserialize<SampleData>());
+            Assert.Null(document.ConvertTo<SampleData>());
             Assert.Throws<InvalidOperationException>(() => document.GetField<string>("name"));
             Assert.Throws<InvalidOperationException>(() => document.GetField<string>(new FieldPath("name")));
             Assert.False(document.TryGetField("name", out string name1));
@@ -68,10 +68,10 @@ namespace Google.Cloud.Firestore.Tests
         }
 
         [Fact]
-        public void Deserialize()
+        public void ConvertTo()
         {
             var doc = GetSampleSnapshot();
-            var sample = doc.Deserialize<SampleData>();
+            var sample = doc.ConvertTo<SampleData>();
             Assert.Equal("Test", sample.Name);
             Assert.Equal(20, sample.Nested.Score);
         }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/DocumentSnapshotTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/DocumentSnapshotTest.cs
@@ -38,10 +38,10 @@ namespace Google.Cloud.Firestore.Tests
             Assert.False(document.Exists);
             Assert.Null(document.ToDictionary());
             Assert.Null(document.ConvertTo<SampleData>());
-            Assert.Throws<InvalidOperationException>(() => document.GetField<string>("name"));
-            Assert.Throws<InvalidOperationException>(() => document.GetField<string>(new FieldPath("name")));
-            Assert.False(document.TryGetField("name", out string name1));
-            Assert.False(document.TryGetField(new FieldPath("name"), out string name2));
+            Assert.Throws<InvalidOperationException>(() => document.GetValue<string>("name"));
+            Assert.Throws<InvalidOperationException>(() => document.GetValue<string>(new FieldPath("name")));
+            Assert.False(document.TryGetValue("name", out string name1));
+            Assert.False(document.TryGetValue(new FieldPath("name"), out string name2));
         }
 
         [Fact]
@@ -88,39 +88,39 @@ namespace Google.Cloud.Firestore.Tests
         // string overloads just call FieldPath overloads, so we just test with strings
 
         [Fact]
-        public void GetField()
+        public void GetValue()
         {
             var doc = GetSampleSnapshot();
-            Assert.Equal("Test", doc.GetField<string>("Name"));
-            Assert.Equal(20, doc.GetField<int>("Nested.Score"));
-            Assert.Null(doc.GetField<string>("NullField"));
+            Assert.Equal("Test", doc.GetValue<string>("Name"));
+            Assert.Equal(20, doc.GetValue<int>("Nested.Score"));
+            Assert.Null(doc.GetValue<string>("NullField"));
         }
 
         [Fact]
-        public void TryGetField()
+        public void TryGetValue()
         {
             var doc = GetSampleSnapshot();
-            Assert.True(doc.TryGetField("Name", out string name));
-            Assert.True(doc.TryGetField("Nested.Score", out int score));
-            Assert.True(doc.TryGetField("NullField", out string shouldBeNull));
+            Assert.True(doc.TryGetValue("Name", out string name));
+            Assert.True(doc.TryGetValue("Nested.Score", out int score));
+            Assert.True(doc.TryGetValue("NullField", out string shouldBeNull));
             Assert.Equal("Test", name);
             Assert.Equal(20, score);
             Assert.Null(shouldBeNull);
-            Assert.False(doc.TryGetField("Foo", out string foo));
-            Assert.False(doc.TryGetField("Nested.Foo", out string nestedFoo));
+            Assert.False(doc.TryGetValue("Foo", out string foo));
+            Assert.False(doc.TryGetValue("Nested.Foo", out string nestedFoo));
         }
 
         [Fact]
-        public void Contains()
+        public void ContainsField()
         {
             var doc = GetSampleSnapshot();
-            Assert.True(doc.Contains("Name"));
-            Assert.True(doc.Contains("Nested"));
-            Assert.True(doc.Contains("Nested.Score"));
-            Assert.True(doc.Contains("NullField"));
-            Assert.False(doc.Contains("Missing"));
-            Assert.False(doc.Contains("Nested.Missing"));
-            Assert.False(doc.Contains("Nested.Score.Missing"));
+            Assert.True(doc.ContainsField("Name"));
+            Assert.True(doc.ContainsField("Nested"));
+            Assert.True(doc.ContainsField("Nested.Score"));
+            Assert.True(doc.ContainsField("NullField"));
+            Assert.False(doc.ContainsField("Missing"));
+            Assert.False(doc.ContainsField("Nested.Missing"));
+            Assert.False(doc.ContainsField("Nested.Score.Missing"));
         }
 
         private static DocumentSnapshot GetSampleSnapshot()

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FirestoreDbTest.RunTransactionAsync.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FirestoreDbTest.RunTransactionAsync.cs
@@ -47,7 +47,7 @@ namespace Google.Cloud.Firestore.Tests
             var db = FirestoreDb.Create("proj", "db", client);
             await db.RunTransactionAsync(async transaction =>
             {
-                await transaction.GetDocumentSnapshotAsync(db.Document("col/x"));
+                await transaction.GetSnapshotAsync(db.Document("col/x"));
                 transaction.Create(db.Document("col/doc1"), new { Name = "Test" });
                 transaction.Delete(db.Document("col/doc2"));
             });
@@ -141,7 +141,7 @@ namespace Google.Cloud.Firestore.Tests
             var exception = await Assert.ThrowsAsync<IOException>(() => db.RunTransactionAsync<int>(
                 async transaction =>
                 {
-                    await transaction.GetDocumentSnapshotAsync(db.Document("col/x"));
+                    await transaction.GetSnapshotAsync(db.Document("col/x"));
                     throw new IOException("Bang!");
                 }));
             Assert.Equal("Bang!", exception.Message);
@@ -207,7 +207,7 @@ namespace Google.Cloud.Firestore.Tests
             {
                 var db = transaction.Database;
                 callbackCount++;
-                await transaction.GetDocumentSnapshotAsync(db.Document("col/x"));
+                await transaction.GetSnapshotAsync(db.Document("col/x"));
                 transaction.Create(db.Document("col/doc1"), new { Name = "Test" });
                 transaction.Delete(db.Document("col/doc2"));
                 return callbackCount;

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FirestoreDbTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FirestoreDbTest.cs
@@ -183,7 +183,7 @@ namespace Google.Cloud.Firestore.Tests
             Assert.Equal(new Timestamp(0, 2), snapshot2.UpdateTime);
             Assert.Equal(new Timestamp(1, 3), snapshot2.ReadTime);
             Assert.Equal(docRef2, snapshot2.Reference);
-            Assert.Equal("Test", snapshot2.GetField<string>("Name"));
+            Assert.Equal("Test", snapshot2.GetValue<string>("Name"));
 
             // The third result element is just a reference to the same snapshot.
             Assert.Same(results[1], results[2]);
@@ -260,7 +260,7 @@ namespace Google.Cloud.Firestore.Tests
             Assert.Equal(new Timestamp(0, 2), snapshot2.UpdateTime);
             Assert.Equal(new Timestamp(1, 3), snapshot2.ReadTime);
             Assert.Equal(docRef2, snapshot2.Reference);
-            Assert.Equal("Test", snapshot2.GetField<string>("Name"));
+            Assert.Equal("Test", snapshot2.GetValue<string>("Name"));
             mock.VerifyAll();
         }
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FirestoreDbTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FirestoreDbTest.cs
@@ -135,7 +135,7 @@ namespace Google.Cloud.Firestore.Tests
 
         // Use the overload accepting a transaction for this test
         [Fact]
-        public async Task SnapshotAllAsync()
+        public async Task GetAllSnapshotsAsync()
         {
             string docName1 = "projects/proj/databases/db/documents/col1/doc1";
             string docName2 = "projects/proj/databases/db/documents/col2/doc2";
@@ -167,7 +167,7 @@ namespace Google.Cloud.Firestore.Tests
             var db = FirestoreDb.Create("proj", "db", mock.Object);
             var docRef1 = db.Document("col1/doc1");
             var docRef2 = db.Document("col2/doc2");
-            var results = await db.SnapshotAllAsync(new[] { docRef1, docRef2, docRef2 }, transaction, default);
+            var results = await db.GetAllSnapshotsAsync(new[] { docRef1, docRef2, docRef2 }, transaction, default);
 
             Assert.Equal(3, results.Count);
             // Note that this is the first result from the request, not the first from the response -
@@ -192,7 +192,7 @@ namespace Google.Cloud.Firestore.Tests
 
         // Use the overload that doesn't accept a transaction for this test, just for coverage
         [Fact]
-        public async Task SnapshotAllAsync_ServerError()
+        public async Task GetAllSnapshotsAsync_ServerError()
         {
             string docName1 = "projects/proj/databases/db/documents/col1/doc1";
             string docName2 = "projects/proj/databases/db/documents/col2/doc2";
@@ -212,7 +212,7 @@ namespace Google.Cloud.Firestore.Tests
             var docRef1 = db.Document("col1/doc1");
             var docRef2 = db.Document("col2/doc2");
 
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await db.SnapshotAllAsync(new[] { docRef1, docRef2 }));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await db.GetAllSnapshotsAsync(new[] { docRef1, docRef2 }));
             mock.VerifyAll();
         }
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Proto/ProtoTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Proto/ProtoTest.cs
@@ -264,7 +264,7 @@ namespace Google.Cloud.Firestore.Tests.Proto
         {
             var mock = new MockCommitClient(expectedRequest);
             FirestoreDb db = FirestoreDb.Create(ProjectId, DatabaseId, mock);
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             if (expectedError)
             {
                 var exception = Assert.ThrowsAny<Exception>(() => action(batch));

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/QueryTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/QueryTest.cs
@@ -462,14 +462,14 @@ namespace Google.Cloud.Firestore.Tests
             Assert.Equal(new Timestamp(1, 2), doc1.ReadTime);
             Assert.Equal(new Timestamp(0, 1), doc1.CreateTime);
             Assert.Equal(new Timestamp(0, 2), doc1.UpdateTime);
-            Assert.Equal("x", doc1.GetField<string>("Name"));
+            Assert.Equal("x", doc1.GetValue<string>("Name"));
 
             var doc2 = snapshot.Documents[1];
             Assert.Equal(db.Document("col/doc2"), doc2.Reference);
             Assert.Equal(new Timestamp(1, 3), doc2.ReadTime);
             Assert.Equal(new Timestamp(0, 3), doc2.CreateTime);
             Assert.Equal(new Timestamp(0, 4), doc2.UpdateTime);
-            Assert.Equal("x", doc1.GetField<string>("Name"));
+            Assert.Equal("x", doc1.GetValue<string>("Name"));
             mock.VerifyAll();
         }
 
@@ -548,14 +548,14 @@ namespace Google.Cloud.Firestore.Tests
             Assert.Equal(new Timestamp(1, 2), doc1.ReadTime);
             Assert.Equal(new Timestamp(0, 1), doc1.CreateTime);
             Assert.Equal(new Timestamp(0, 2), doc1.UpdateTime);
-            Assert.Equal("x", doc1.GetField<string>("Name"));
+            Assert.Equal("x", doc1.GetValue<string>("Name"));
 
             var doc2 = documents[1];
             Assert.Equal(db.Document("col/doc2"), doc2.Reference);
             Assert.Equal(new Timestamp(1, 3), doc2.ReadTime);
             Assert.Equal(new Timestamp(0, 3), doc2.CreateTime);
             Assert.Equal(new Timestamp(0, 4), doc2.UpdateTime);
-            Assert.Equal("x", doc1.GetField<string>("Name"));
+            Assert.Equal("x", doc1.GetValue<string>("Name"));
             mock.VerifyAll();
         }
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/QueryTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/QueryTest.cs
@@ -382,7 +382,7 @@ namespace Google.Cloud.Firestore.Tests
         }
 
         [Fact]
-        public async Task SnapshotAsync_NoDocuments()
+        public async Task GetSnapshotAsync_NoDocuments()
         {
             var mock = new Mock<FirestoreClient> { CallBase = true };
             var request = new RunQueryRequest
@@ -401,7 +401,7 @@ namespace Google.Cloud.Firestore.Tests
             mock.Setup(c => c.RunQuery(request, It.IsAny<CallSettings>())).Returns(new FakeQueryStream(responses));
             var db = FirestoreDb.Create("proj", "db", mock.Object);
             var query = db.Collection("col").Select("Name");
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
             Assert.Empty(snapshot.Documents);
             Assert.Same(query, snapshot.Query);
             Assert.Equal(new Timestamp(1, 2), snapshot.ReadTime);
@@ -410,7 +410,7 @@ namespace Google.Cloud.Firestore.Tests
         }
 
         [Fact]
-        public async Task SnapshotAsync_WithDocuments()
+        public async Task GetSnapshotAsync_WithDocuments()
         {
             var mock = new Mock<FirestoreClient> { CallBase = true };
             var request = new RunQueryRequest
@@ -452,7 +452,7 @@ namespace Google.Cloud.Firestore.Tests
             mock.Setup(c => c.RunQuery(request, It.IsAny<CallSettings>())).Returns(new FakeQueryStream(responses));
             var db = FirestoreDb.Create("proj", "db", mock.Object);
             var query = db.Collection("col").Select("Name").Offset(3);
-            var snapshot = await query.SnapshotAsync();
+            var snapshot = await query.GetSnapshotAsync();
             Assert.Equal(2, snapshot.Documents.Count);
             Assert.Same(query, snapshot.Query);
             Assert.Equal(new Timestamp(1, 2), snapshot.ReadTime); // From first document
@@ -474,7 +474,7 @@ namespace Google.Cloud.Firestore.Tests
         }
 
         [Fact]
-        public async Task SnapshotAsync_NoResponses()
+        public async Task GetSnapshotAsync_NoResponses()
         {
             var mock = new Mock<FirestoreClient> { CallBase = true };
             var request = new RunQueryRequest
@@ -491,7 +491,7 @@ namespace Google.Cloud.Firestore.Tests
             var db = FirestoreDb.Create("proj", "db", mock.Object);
             var query = db.Collection("col").Select("Name");
             // This shouldn't happen, of course - but let's check that we do what we expect.
-            await Assert.ThrowsAsync<InvalidOperationException>(() => query.SnapshotAsync());
+            await Assert.ThrowsAsync<InvalidOperationException>(() => query.GetSnapshotAsync());
             mock.VerifyAll();
         }
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/TransactionTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/TransactionTest.cs
@@ -44,9 +44,9 @@ namespace Google.Cloud.Firestore.Tests
             Assert.Equal("transaction 1", transaction.TransactionId.ToStringUtf8());
 
             var doc = db.Document("col/doc");
-            var snapshot = await transaction.GetDocumentSnapshotAsync(doc);
+            var snapshot = await transaction.GetSnapshotAsync(doc);
             Assert.Equal("transaction 1", snapshot.GetValue<string>("transaction"));
-            var query = await transaction.GetQuerySnapshotAsync(db.Collection("col"));
+            var query = await transaction.GetSnapshotAsync(db.Collection("col"));
             Assert.Empty(query.Documents);
 
             transaction.Create(doc, new { Name = "Test" });
@@ -56,34 +56,34 @@ namespace Google.Cloud.Firestore.Tests
         }
 
         [Fact]
-        public async Task GetDocumentSnapshotAsync_FailsAfterWrite()
+        public async Task GetSnapshotAsync_FailsAfterWrite()
         {
             var db = CreateFirestoreDbExpectingNoCommits();
             var transaction = await Transaction.BeginAsync(db, null, default);
             var doc = db.Document("col/doc");
             transaction.Delete(doc);
-            await Assert.ThrowsAsync<InvalidOperationException>(() => transaction.GetDocumentSnapshotAsync(doc));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => transaction.GetSnapshotAsync(doc));
         }
 
         [Fact]
-        public async Task GetAllDocumentSnapshotsAsync_FailsAfterWrite()
+        public async Task GetAllSnapshotsAsync_FailsAfterWrite()
         {
             var db = CreateFirestoreDbExpectingNoCommits();
             var transaction = await Transaction.BeginAsync(db, null, default);
             var doc1 = db.Document("col/doc1");
             var doc2 = db.Document("col/doc2");
             transaction.Delete(doc1);
-            await Assert.ThrowsAsync<InvalidOperationException>(() => transaction.GetAllDocumentSnapshotsAsync(new[] { doc1, doc2 }));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => transaction.GetAllSnapshotsAsync(new[] { doc1, doc2 }));
         }
 
         [Fact]
-        public async Task GetQuerySnaphotAsync_FailsAfterWrite()
+        public async Task GetSnaphotAsync_FailsAfterWrite()
         {
             var db = CreateFirestoreDbExpectingNoCommits();
             var transaction = await Transaction.BeginAsync(db, null, default);
             var doc = db.Document("col/doc");
             transaction.Delete(doc);
-            await Assert.ThrowsAsync<InvalidOperationException>(() => transaction.GetQuerySnapshotAsync(doc.Parent));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => transaction.GetSnapshotAsync(doc.Parent));
         }
 
         [Fact]

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/TransactionTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/TransactionTest.cs
@@ -45,7 +45,7 @@ namespace Google.Cloud.Firestore.Tests
 
             var doc = db.Document("col/doc");
             var snapshot = await transaction.GetDocumentSnapshotAsync(doc);
-            Assert.Equal("transaction 1", snapshot.GetField<string>("transaction"));
+            Assert.Equal("transaction 1", snapshot.GetValue<string>("transaction"));
             var query = await transaction.GetQuerySnapshotAsync(db.Collection("col"));
             Assert.Empty(query.Documents);
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WriteBatchTest.SentinelValues.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WriteBatchTest.SentinelValues.cs
@@ -62,7 +62,7 @@ namespace Google.Cloud.Firestore.Tests
         public void SentinelValuesInArrays(object documentData)
         {
             var db = FirestoreDb.Create("proj", "db", new FakeFirestoreClient());
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             var doc = db.Document("col/doc");
             Assert.Throws<ArgumentException>(() => batch.Set(doc, documentData, SetOptions.MergeAll));
         }
@@ -72,7 +72,7 @@ namespace Google.Cloud.Firestore.Tests
         public void NoSentinelValuesInArrays(object documentData)
         {
             var db = FirestoreDb.Create("proj", "db", new FakeFirestoreClient());
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             var doc = db.Document("col/doc");
             // Don't check the result, just that it doesn't throw.
             batch.Set(doc, documentData, SetOptions.MergeAll);
@@ -82,7 +82,7 @@ namespace Google.Cloud.Firestore.Tests
         public void SentinelValues_Simple()
         {
             var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             var doc = db.Document("col/doc");
             var data = new { Name = "Test", DeleteMe = SentinelValue.Delete, Timestamp = SentinelValue.ServerTimestamp };
             batch.Set(doc, data, SetOptions.MergeAll);
@@ -111,7 +111,7 @@ namespace Google.Cloud.Firestore.Tests
         public void SentinelValues_NestedSentinels()
         {
             var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             var doc = db.Document("col/doc");
             var data = new
             {
@@ -147,7 +147,7 @@ namespace Google.Cloud.Firestore.Tests
         public void SentinelValues_OnlyTransform()
         {
             var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             var doc = db.Document("col/doc");
             var data = new { Timestamp = SentinelValue.ServerTimestamp };
             batch.Set(doc, data, SetOptions.MergeAll);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WriteBatchTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WriteBatchTest.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Firestore.Tests
         public void Create()
         {
             var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             var doc = db.Document("col/doc");
             batch.Create(doc, new { Name = "Test", Score = 20 });
 
@@ -54,7 +54,7 @@ namespace Google.Cloud.Firestore.Tests
         public void Delete_NoPrecondition()
         {
             var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             var doc = db.Document("col/doc");
             batch.Delete(doc);
 
@@ -66,7 +66,7 @@ namespace Google.Cloud.Firestore.Tests
         public void Delete_WithPrecondition()
         {
             var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             var doc = db.Document("col/doc");
             batch.Delete(doc, Precondition.LastUpdated(new Timestamp(1 ,2)));
 
@@ -82,7 +82,7 @@ namespace Google.Cloud.Firestore.Tests
         public void Update()
         {
             var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             var doc = db.Document("col/doc");
             var updates = new Dictionary<FieldPath, object>
             {
@@ -113,7 +113,7 @@ namespace Google.Cloud.Firestore.Tests
         public void Update_WithPrecondition()
         {
             var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             var doc = db.Document("col/doc");
             var updates = new Dictionary<FieldPath, object>
             {
@@ -142,7 +142,7 @@ namespace Google.Cloud.Firestore.Tests
         {
             var options = explicitOptions ? SetOptions.Overwrite : null;
             var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             var doc = db.Document("col/doc");
             var data = new { Name = "Test", Nested = new { Value1 = 10, Value2 = 20 }, Score = 30 };
             batch.Set(doc, data, options);
@@ -168,7 +168,7 @@ namespace Google.Cloud.Firestore.Tests
         public void Set_MergeAll()
         {
             var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             var doc = db.Document("col/doc");
             var data = new { Name = "Test", Nested = new { Value1 = 10, Value2 = 20 }, Score = 30 };
             batch.Set(doc, data, SetOptions.MergeAll);
@@ -194,7 +194,7 @@ namespace Google.Cloud.Firestore.Tests
         public void Set_MergeFields()
         {
             var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             var doc = db.Document("col/doc");
             var data = new { Name = "Test", Nested = new { Value1 = 10, Value2 = 20 }, Score = 30 };
             batch.Set(doc, data, SetOptions.MergeFields("Name", "Nested.Value2"));
@@ -250,7 +250,7 @@ namespace Google.Cloud.Firestore.Tests
             mock.Setup(c => c.CommitAsync(request, It.IsAny<CallSettings>())).ReturnsAsync(response);
             var db = FirestoreDb.Create("proj", "db", mock.Object);
             var reference = db.Document("col/doc");
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             batch.Elements.AddRange(new[]
             {
                 new WriteBatch.BatchElement(write1, true),
@@ -269,7 +269,7 @@ namespace Google.Cloud.Firestore.Tests
         public void IsEmpty()
         {
             var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
-            var batch = db.CreateWriteBatch();
+            var batch = db.StartBatch();
             Assert.True(batch.IsEmpty);
             batch.Create(db.Document("col/doc"), new { Name = "Test" });
             Assert.False(batch.IsEmpty);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/CollectionReference.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/CollectionReference.cs
@@ -59,7 +59,7 @@ namespace Google.Cloud.Firestore
         /// This performs no server-side operations; it only generates the appropriate <c>DocumentReference</c>.
         /// </summary>
         /// <returns>A <see cref="DocumentReference"/> to a child document of this collection with a random ID.</returns>
-        public DocumentReference GenerateDocument() => new DocumentReference(Database, this, PathUtilities.GenerateId());
+        public DocumentReference Document() => new DocumentReference(Database, this, PathUtilities.GenerateId());
 
         /// <summary>
         /// Creates a <see cref="DocumentReference"/> for a child document of this reference.
@@ -92,7 +92,7 @@ namespace Google.Cloud.Firestore
         /// <returns>The reference for the newly-created document.</returns>
         public async Task<DocumentReference> AddAsync(object documentData, CancellationToken cancellationToken = default)
         {
-            var docRef = GenerateDocument();
+            var docRef = Document();
             var result = await docRef.CreateAsync(documentData, cancellationToken).ConfigureAwait(false);
             return docRef;
         }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentReference.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentReference.cs
@@ -150,25 +150,18 @@ namespace Google.Cloud.Firestore
             return results[0];
         }
 
-        // TODO: Check naming. Other languages just have "get", but that feels a bit odd in .NET.
-        // Options:
-        // - Get
-        // - GetSnapshot
-        // - Snapshot
-        // (All with an Async suffix, presumably.)
+        /// <summary>
+        /// Asynchronously fetches a snapshot of the document.
+        /// </summary>
+        /// <returns>A snapshot of the document. The snapshot may represent a missing document.</returns>
+        public Task<DocumentSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default) =>
+            GetSnapshotAsync(null, cancellationToken);
 
         /// <summary>
         /// Asynchronously fetches a snapshot of the document.
         /// </summary>
         /// <returns>A snapshot of the document. The snapshot may represent a missing document.</returns>
-        public Task<DocumentSnapshot> SnapshotAsync(CancellationToken cancellationToken = default) =>
-            SnapshotAsync(null, cancellationToken);
-
-        /// <summary>
-        /// Asynchronously fetches a snapshot of the document.
-        /// </summary>
-        /// <returns>A snapshot of the document. The snapshot may represent a missing document.</returns>
-        internal async Task<DocumentSnapshot> SnapshotAsync(ByteString transactionId, CancellationToken cancellationToken)
+        internal async Task<DocumentSnapshot> GetSnapshotAsync(ByteString transactionId, CancellationToken cancellationToken)
         {
             var multiple = await Database.GetDocumentSnapshotsAsync(new[] { this }, transactionId, cancellationToken).ConfigureAwait(false);
             return multiple.Single();

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentReference.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentReference.cs
@@ -97,7 +97,7 @@ namespace Google.Cloud.Firestore
         /// <returns>The write result of the server operation.</returns>
         public async Task<WriteResult> CreateAsync(object documentData, CancellationToken cancellationToken = default)
         {
-            var batch = Database.CreateWriteBatch();
+            var batch = Database.StartBatch();
             var results = await batch.Create(this, documentData).CommitAsync(cancellationToken).ConfigureAwait(false);
             return results.Single();
         }
@@ -114,7 +114,7 @@ namespace Google.Cloud.Firestore
         /// <returns>The write result of the server operation.</returns>
         public async Task<WriteResult> DeleteAsync(Precondition precondition = null, CancellationToken cancellationToken = default)
         {
-            var batch = Database.CreateWriteBatch();
+            var batch = Database.StartBatch();
             batch.Delete(this, precondition);
             var results = await batch.CommitAsync(cancellationToken).ConfigureAwait(false);
             return results[0];
@@ -129,7 +129,7 @@ namespace Google.Cloud.Firestore
         /// <returns>The write result of the server operation.</returns>
         public async Task<WriteResult> UpdateAsync(IDictionary<FieldPath, object> updates, Precondition precondition = null, CancellationToken cancellationToken = default)
         {
-            var batch = Database.CreateWriteBatch();
+            var batch = Database.StartBatch();
             batch.Update(this, updates, precondition);
             var results = await batch.CommitAsync(cancellationToken).ConfigureAwait(false);
             return results[0];
@@ -144,7 +144,7 @@ namespace Google.Cloud.Firestore
         /// <returns>The write result of the server operation.</returns>
         public async Task<WriteResult> SetAsync(object documentData, SetOptions options = null, CancellationToken cancellationToken = default)
         {
-            var batch = Database.CreateWriteBatch();
+            var batch = Database.StartBatch();
             batch.Set(this, documentData, options);
             var results = await batch.CommitAsync(cancellationToken).ConfigureAwait(false);
             return results[0];

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentSnapshot.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentSnapshot.cs
@@ -107,7 +107,7 @@ namespace Google.Cloud.Firestore
         /// <param name="path">The dot-separated field path to fetch. Must not be null or empty</param>
         /// <exception cref="InvalidOperationException">The field does not exist in the document data.</exception>
         /// <returns>The deserialized value.</returns>
-        public T GetField<T>(string path) => GetField<T>(FieldPath.FromDotSeparatedString(path));
+        public T GetValue<T>(string path) => GetValue<T>(FieldPath.FromDotSeparatedString(path));
 
         /// <summary>
         /// Attempts to fetch the given field path from the document, returning whether or not it was found, and deserializing
@@ -122,7 +122,7 @@ namespace Google.Cloud.Firestore
         /// <param name="value">When this method returns, contains the deserialized value if the field was found, or the default value
         /// of <typeparamref name="T"/> otherwise.</param>
         /// <returns>true if the field was found; false otherwise.</returns>
-        public bool TryGetField<T>(string path, out T value) => TryGetField(FieldPath.FromDotSeparatedString(path), out value);
+        public bool TryGetValue<T>(string path, out T value) => TryGetValue(FieldPath.FromDotSeparatedString(path), out value);
 
         /// <summary>
         /// Fetches a field value from the document, throwing an exception if the field does not exist.
@@ -130,7 +130,7 @@ namespace Google.Cloud.Firestore
         /// <param name="path">The field path to fetch. Must not be null.</param>
         /// <exception cref="InvalidOperationException">The field does not exist in the document data.</exception>
         /// <returns>The deserialized value.</returns>
-        public T GetField<T>(FieldPath path)
+        public T GetValue<T>(FieldPath path)
         {
             var raw = ExtractValue(path);
             GaxPreconditions.CheckState(raw != null, $"Field {path} not found in document");
@@ -150,7 +150,7 @@ namespace Google.Cloud.Firestore
         /// <param name="value">When this method returns, contains the deserialized value if the field was found, or the default value
         /// of <typeparamref name="T"/> otherwise.</param>
         /// <returns>true if the field was found; false otherwise.</returns>
-        public bool TryGetField<T>(FieldPath path, out T value)
+        public bool TryGetValue<T>(FieldPath path, out T value)
         {
             var raw = ExtractValue(path);
             if (raw == null)
@@ -168,7 +168,7 @@ namespace Google.Cloud.Firestore
         /// </summary>
         /// <param name="path">The dot-separated field path to check. Must not be null or empty.</param>
         /// <returns>true if the specified path represents a field in the document; false otherwise</returns>
-        public bool Contains(string path) => Contains(FieldPath.FromDotSeparatedString(path));
+        public bool ContainsField(string path) => ContainsField(FieldPath.FromDotSeparatedString(path));
 
         /// <summary>
         /// Determines whether or not the given field path is present in the document. If this snapshot represents
@@ -176,7 +176,7 @@ namespace Google.Cloud.Firestore
         /// </summary>
         /// <param name="path">The field path to check. Must not be null.</param>
         /// <returns>true if the specified path represents a field in the document; false otherwise</returns>
-        public bool Contains(FieldPath path) => ExtractValue(path) != null;
+        public bool ContainsField(FieldPath path) => ExtractValue(path) != null;
 
         /// <summary>
         /// Extracts the internal value for a field path, still in its serialized form, without any copying.
@@ -184,6 +184,7 @@ namespace Google.Cloud.Firestore
         /// </summary>
         internal Value ExtractValue(FieldPath path)
         {
+            GaxPreconditions.CheckNotNull(path, nameof(path));
             if (!Exists)
             {
                 return null;

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentSnapshot.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentSnapshot.cs
@@ -85,14 +85,14 @@ namespace Google.Cloud.Firestore
         /// </summary>
         /// <exception cref="InvalidOperationException">This snapshot represents a missing document, i.e. <see cref="Exists"/> is false.</exception>
         /// <returns>A <see cref="Dictionary{String, Object}"/> containing the document data, or null if this object represents a missing document.</returns>
-        public Dictionary<string, object> ToDictionary() => Deserialize<Dictionary<string, object>>();
+        public Dictionary<string, object> ToDictionary() => ConvertTo<Dictionary<string, object>>();
 
         /// <summary>
         /// Deserializes the document data as the specified type.
         /// </summary>
         /// <typeparam name="T">The type to deserialize the document data as.</typeparam>
         /// <returns>The deserialized data, or null if this object represents a missing document.</returns>
-        public T Deserialize<T>() where T : class
+        public T ConvertTo<T>() where T : class
         {
             if (!Exists)
             {

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreDb.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreDb.cs
@@ -143,7 +143,7 @@ namespace Google.Cloud.Firestore
         /// Creates a write batch, which can be used to commit multiple mutations atomically.
         /// </summary>
         /// <returns>A write batch for this database.</returns>
-        public WriteBatch CreateWriteBatch() => new WriteBatch(this);
+        public WriteBatch StartBatch() => new WriteBatch(this);
 
         internal DocumentReference GetDocumentReferenceFromResourceName(string referenceValue)
         {

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreDb.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreDb.cs
@@ -166,10 +166,10 @@ namespace Google.Cloud.Firestore
         /// <param name="documents">The document references to fetch. Must not be null, or contain null references.</param>
         /// <param name="cancellationToken">A cancellation token for the operation.</param>
         /// <returns>The document snapshots, in the same order as <paramref name="documents"/>.</returns>
-        public Task<IList<DocumentSnapshot>> SnapshotAllAsync(IEnumerable<DocumentReference> documents, CancellationToken cancellationToken = default) =>
-            SnapshotAllAsync(documents, null, cancellationToken);
+        public Task<IList<DocumentSnapshot>> GetAllSnapshotsAsync(IEnumerable<DocumentReference> documents, CancellationToken cancellationToken = default) =>
+            GetAllSnapshotsAsync(documents, null, cancellationToken);
 
-        internal async Task<IList<DocumentSnapshot>> SnapshotAllAsync(IEnumerable<DocumentReference> documents, ByteString transactionId, CancellationToken cancellationToken)
+        internal async Task<IList<DocumentSnapshot>> GetAllSnapshotsAsync(IEnumerable<DocumentReference> documents, ByteString transactionId, CancellationToken cancellationToken)
         {
             // Check for null here, but let the underlying method check for null elements.
             // We're just trying to make sure we don't evaluate it differently later.

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Query.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Query.cs
@@ -383,9 +383,9 @@ namespace Google.Cloud.Firestore
         /// </summary>
         /// <param name="cancellationToken">A cancellation token for the operation.</param>
         /// <returns>A snapshot of documents matching the query.</returns>
-        public Task<QuerySnapshot> SnapshotAsync(CancellationToken cancellationToken = default) => SnapshotAsync(null, cancellationToken);
+        public Task<QuerySnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default) => GetSnapshotAsync(null, cancellationToken);
 
-        internal async Task<QuerySnapshot> SnapshotAsync(ByteString transactionId, CancellationToken cancellationToken)
+        internal async Task<QuerySnapshot> GetSnapshotAsync(ByteString transactionId, CancellationToken cancellationToken)
         {
             var responses = StreamResponsesAsync(transactionId, cancellationToken);
             Timestamp? readTime = null;

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Transaction.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Transaction.cs
@@ -113,7 +113,7 @@ namespace Google.Cloud.Firestore
             GaxPreconditions.CheckNotNull(query, nameof(query));
             CancellationToken effectiveToken = GetEffectiveCancellationToken(cancellationToken);
             GaxPreconditions.CheckState(_writes.IsEmpty, "Firestore transactions require all reads to be executed before all writes.");
-            return query.SnapshotAsync(TransactionId, cancellationToken);
+            return query.GetSnapshotAsync(TransactionId, cancellationToken);
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Transaction.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Transaction.cs
@@ -98,7 +98,7 @@ namespace Google.Cloud.Firestore
         {
             GaxPreconditions.CheckState(_writes.IsEmpty, "Firestore transactions require all reads to be executed before all writes.");
             CancellationToken effectiveToken = GetEffectiveCancellationToken(cancellationToken);
-            return Database.SnapshotAllAsync(documentReferences, TransactionId, effectiveToken);
+            return Database.GetAllSnapshotsAsync(documentReferences, TransactionId, effectiveToken);
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Transaction.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Transaction.cs
@@ -80,7 +80,7 @@ namespace Google.Cloud.Firestore
             GaxPreconditions.CheckNotNull(documentReference, nameof(documentReference));
             GaxPreconditions.CheckState(_writes.IsEmpty, "Firestore transactions require all reads to be executed before all writes.");
             CancellationToken effectiveToken = GetEffectiveCancellationToken(cancellationToken);
-            return documentReference.SnapshotAsync(TransactionId, effectiveToken);
+            return documentReference.GetSnapshotAsync(TransactionId, effectiveToken);
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Transaction.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Transaction.cs
@@ -64,10 +64,6 @@ namespace Google.Cloud.Firestore
             return new Transaction(db, response.Transaction, cancellationToken);
         }
 
-        // TODO: Consider names of GetDocumentSnapshotAsync/GetQuerySnapshotAsync.
-        // Perhaps just SnapshotDocumentAsync and SnapshotQueryAsync?
-        // Just using SnapshotAsync overloads feels like a bad idea as they do quite different things.
-
         /// <summary>
         /// Fetch a snapshot of the document specified by <paramref name="documentReference"/>, with respect to this transaction.
         /// This method cannot be called after any write operations have been created.
@@ -75,7 +71,7 @@ namespace Google.Cloud.Firestore
         /// <param name="documentReference">The document reference to fetch. Must not be null.</param>
         /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
         /// <returns>A snapshot of the given document with respect to this transaction.</returns>
-        public Task<DocumentSnapshot> GetDocumentSnapshotAsync(DocumentReference documentReference, CancellationToken cancellationToken = default)
+        public Task<DocumentSnapshot> GetSnapshotAsync(DocumentReference documentReference, CancellationToken cancellationToken = default)
         {
             GaxPreconditions.CheckNotNull(documentReference, nameof(documentReference));
             GaxPreconditions.CheckState(_writes.IsEmpty, "Firestore transactions require all reads to be executed before all writes.");
@@ -94,7 +90,7 @@ namespace Google.Cloud.Firestore
         /// <param name="documentReferences">The document references to fetch. Must not be null, or contain null references.</param>
         /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
         /// <returns>The document snapshots, in the same order as <paramref name="documentReferences"/>.</returns>
-        public Task<IList<DocumentSnapshot>> GetAllDocumentSnapshotsAsync(IEnumerable<DocumentReference> documentReferences, CancellationToken cancellationToken = default)
+        public Task<IList<DocumentSnapshot>> GetAllSnapshotsAsync(IEnumerable<DocumentReference> documentReferences, CancellationToken cancellationToken = default)
         {
             GaxPreconditions.CheckState(_writes.IsEmpty, "Firestore transactions require all reads to be executed before all writes.");
             CancellationToken effectiveToken = GetEffectiveCancellationToken(cancellationToken);
@@ -108,7 +104,7 @@ namespace Google.Cloud.Firestore
         /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
         /// <returns>A snapshot of results of the given query with respect to this transaction.</returns>
-        public Task<QuerySnapshot> GetQuerySnapshotAsync(Query query, CancellationToken cancellationToken = default)
+        public Task<QuerySnapshot> GetSnapshotAsync(Query query, CancellationToken cancellationToken = default)
         {
             GaxPreconditions.CheckNotNull(query, nameof(query));
             CancellationToken effectiveToken = GetEffectiveCancellationToken(cancellationToken);


### PR DESCRIPTION
This PR consists of many commits, each of which is a single rename or a small set of renames.
These renames were agreed with the Firestore team, aiming for a balance between consistency across SDKs and C# idiomatic names.