### PR TITLE
Add trace ids to log entries if they exist.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -247,10 +247,17 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         {
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddMvc();
+            services.AddGoogleTrace(options => 
+            {
+                options.ProjectId = ProjectId;
+                // Don't actually trace anything.
+                options.Options = TraceOptions.Create(qpsSampleRate: 0.00000001);
+            });
         }
 
         public void SetupRoutes(IApplicationBuilder app)
         {
+            app.UseGoogleTrace();
             app.UseMvc(routes =>
             {
                 routes.MapRoute(
@@ -262,7 +269,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
     /// <summary>
     /// An application that has a <see cref="GoogleLogger"/> with no buffer that will accept all logs
-    /// of level warning or above.  Adds trace information to log entries if available.
+    /// of level warning or above.
     /// </summary>
     public class NoBufferWarningLoggerTestApplication : LoggerTestApplication
     {
@@ -272,11 +279,9 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             SetupRoutes(app);
             LoggerOptions loggerOptions = LoggerOptions.Create(
                 LogLevel.Warning, null, null, BufferOptions.NoBuffer());
-            loggerFactory.AddGoogle(ProjectId, loggerOptions, accessor: accessor);
+            loggerFactory.AddGoogle(ProjectId, loggerOptions);
         }
     }
-
-
 
     /// <summary>
     /// An application that has a <see cref="GoogleLogger"/> with no buffer that will accept all logs

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -20,9 +20,11 @@ using Google.Cloud.Logging.Type;
 using Google.Cloud.Logging.V2;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
@@ -207,6 +209,26 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 Assert.Contains($"Scope => {message}", results.Single().TextPayload);
             }
         }
+
+        [Fact]
+        public async Task Logging_Trace()
+        {
+            string traceId = "105445aa7843bc8bf206b12000100f00";
+            string testId = Utils.GetTestId();
+            DateTime startTime = DateTime.UtcNow;
+
+            var builder = new WebHostBuilder().UseStartup<NoBufferWarningLoggerTestApplication>();
+            using (var server = new TestServer(builder))
+            using (var client = server.CreateClient())
+            {
+                client.DefaultRequestHeaders.Add(TraceHeaderContext.TraceHeader,
+                    TraceHeaderContext.Create(traceId, 81237123, null).ToString());
+                await client.GetAsync($"/Main/Critical/{testId}");
+                var results = _polling.GetEntries(startTime, testId, 1, LogSeverity.Critical);
+                Assert.Contains(Utils.GetProjectIdFromEnvironment(), results.Single().Trace);
+                Assert.Contains(traceId, results.Single().Trace);
+            }
+        }
     }
 
     /// <summary>
@@ -223,6 +245,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
         public void ConfigureServices(IServiceCollection services)
         {
+            services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddMvc();
         }
 
@@ -239,18 +262,21 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
     /// <summary>
     /// An application that has a <see cref="GoogleLogger"/> with no buffer that will accept all logs
-    /// of level warning or above.
+    /// of level warning or above.  Adds trace information to log entries if available.
     /// </summary>
     public class NoBufferWarningLoggerTestApplication : LoggerTestApplication
     {
-        public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory,
+            IHttpContextAccessor accessor)
         {
             SetupRoutes(app);
             LoggerOptions loggerOptions = LoggerOptions.Create(
                 LogLevel.Warning, null, null, BufferOptions.NoBuffer());
-            loggerFactory.AddGoogle(ProjectId, loggerOptions);
+            loggerFactory.AddGoogle(ProjectId, loggerOptions, accessor: accessor);
         }
     }
+
+
 
     /// <summary>
     /// An application that has a <see cref="GoogleLogger"/> with no buffer that will accept all logs

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -273,8 +273,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
     /// </summary>
     public class NoBufferWarningLoggerTestApplication : LoggerTestApplication
     {
-        public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory,
-            IHttpContextAccessor accessor)
+        public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
             SetupRoutes(app);
             LoggerOptions loggerOptions = LoggerOptions.Create(

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/AspNetCoreSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/AspNetCoreSnippets.cs
@@ -72,7 +72,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
         // End sample
 
         // Sample: RegisterGoogleLogger
-        public void Configure(ILoggerFactory loggerFactory, IHttpContextAccessor accessor)
+        public void Configure(ILoggerFactory loggerFactory)
         {
             string projectId = "[Google Cloud Platform project ID]";
             loggerFactory.AddGoogle(projectId);
@@ -106,7 +106,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             // Sample: RegisterGoogleTracer
             public void ConfigureServices(IServiceCollection services)
             {
-                // Use the below line is needed for trace ids to be added to logs.
+                // The line below is needed for trace ids to be added to logs.
                 services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
                 string projectId = "[Google Cloud Platform project ID]";
                 services.AddGoogleTrace(options =>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/AspNetCoreSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/AspNetCoreSnippets.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
         public void Configure(ILoggerFactory loggerFactory, IHttpContextAccessor accessor)
         {
             string projectId = "[Google Cloud Platform project ID]";
-            loggerFactory.AddGoogle(projectId, accessor: accessor);
+            loggerFactory.AddGoogle(projectId);
         }
         // End sample
 
@@ -106,6 +106,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             // Sample: RegisterGoogleTracer
             public void ConfigureServices(IServiceCollection services)
             {
+                // Use the below line is needed for trace ids to be added to logs.
+                services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
                 string projectId = "[Google Cloud Platform project ID]";
                 services.AddGoogleTrace(options =>
                 {

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/AspNetCoreSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/AspNetCoreSnippets.cs
@@ -23,6 +23,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 
 namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
 {
@@ -71,10 +72,10 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
         // End sample
 
         // Sample: RegisterGoogleLogger
-        public void Configure(ILoggerFactory loggerFactory)
+        public void Configure(ILoggerFactory loggerFactory, IHttpContextAccessor accessor)
         {
             string projectId = "[Google Cloud Platform project ID]";
-            loggerFactory.AddGoogle(projectId);
+            loggerFactory.AddGoogle(projectId, accessor: accessor);
         }
         // End sample
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/GoogleLoggerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/GoogleLoggerTest.cs
@@ -128,9 +128,9 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
         public void Log()
         {
             var labels = new Dictionary<string, string> { { "some-key", "some-value" } };
-            Predicate<IEnumerable<LogEntry>> matcher = (l) =>
+            Predicate<IEnumerable<LogEntry>> matcher = logEntries =>
             {
-                LogEntry entry = l.Single();
+                LogEntry entry = logEntries.Single();
                 KeyValuePair<string, string> label = entry.Labels.Single();
                 return entry.LogName == new LogName(_projectId, _logName).ToString() &&
                     entry.Severity == LogLevel.Error.ToLogSeverity() &&
@@ -155,9 +155,9 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             string traceId = "105445aa7843bc8bf206b12000100f00";
             string fullTraceName = TraceTarget.ForProject(_projectId).GetFullTraceName(traceId);
 
-            Predicate<IEnumerable<LogEntry>> matcher = (l) =>
+            Predicate<IEnumerable<LogEntry>> matcher = logEntries =>
             {
-                LogEntry entry = l.Single();
+                LogEntry entry = logEntries.Single();
                 return entry.LogName == new LogName(_projectId, _logName).ToString() &&
                     entry.Trace == fullTraceName;
             };

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/GoogleLoggerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/GoogleLoggerTest.cs
@@ -18,6 +18,7 @@ using Google.Api.Gax.Testing;
 using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Logging.V2;
 using Google.Protobuf.WellKnownTypes;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System;
@@ -45,10 +46,10 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
 
         private GoogleLogger GetLogger(
             IConsumer<LogEntry> consumer, LogLevel logLevel = LogLevel.Information,
-            Dictionary<string, string> labels = null)
+            Dictionary<string, string> labels = null, IHttpContextAccessor accessor = null)
         {
             LoggerOptions options = LoggerOptions.Create(logLevel, labels, MonitoredResourceBuilder.GlobalResource);
-            return new GoogleLogger(consumer, s_logTarget, options, _logName, s_clock);
+            return new GoogleLogger(consumer, s_logTarget, options, _logName, s_clock, accessor);
         }
 
         [Fact]
@@ -133,6 +134,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
                 KeyValuePair<string, string> label = entry.Labels.Single();
                 return entry.LogName == new LogName(_projectId, _logName).ToString() &&
                     entry.Severity == LogLevel.Error.ToLogSeverity() &&
+                    string.IsNullOrWhiteSpace(entry.Trace) &&
                     entry.Timestamp.Equals(Timestamp.FromDateTime(s_dateTime)) &&
                     entry.TextPayload == Formatter(_logMessage, s_exception) &&
                     entry.Resource.Equals(MonitoredResourceBuilder.GlobalResource) &&
@@ -143,6 +145,37 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             var mockConsumer = new Mock<IConsumer<LogEntry>>();
             mockConsumer.Setup(c => c.Receive(Match.Create(matcher)));
             var logger = GetLogger(mockConsumer.Object, LogLevel.Information, labels);
+            logger.Log(LogLevel.Error, 0, _logMessage, s_exception, Formatter);
+            mockConsumer.VerifyAll();
+        }
+
+        [Fact]
+        public void Log_Trace()
+        {
+            string traceId = "105445aa7843bc8bf206b12000100f00";
+            string fullTraceName = TraceTarget.ForProject(_projectId).GetFullTraceName(traceId);
+
+            Predicate<IEnumerable<LogEntry>> matcher = (l) =>
+            {
+                LogEntry entry = l.Single();
+                return entry.LogName == new LogName(_projectId, _logName).ToString() &&
+                    entry.Trace == fullTraceName;
+            };
+
+            var tracerContext = TraceHeaderContext.Create(traceId, 81237123, null);
+            HeaderDictionary dict = new HeaderDictionary();
+            dict[TraceHeaderContext.TraceHeader] = tracerContext.ToString();
+
+            var mockAccessor = new Mock<IHttpContextAccessor>();
+            var mockContext = new Mock<HttpContext>();
+            var mockRequest = new Mock<HttpRequest>();
+            mockAccessor.Setup(a => a.HttpContext).Returns(mockContext.Object);
+            mockContext.Setup(c => c.Request).Returns(mockRequest.Object);
+            mockRequest.Setup(r => r.Headers).Returns(dict);
+
+            var mockConsumer = new Mock<IConsumer<LogEntry>>();
+            mockConsumer.Setup(c => c.Receive(Match.Create(matcher)));
+            var logger = GetLogger(mockConsumer.Object, LogLevel.Information, accessor: mockAccessor.Object);
             logger.Log(LogLevel.Error, 0, _logMessage, s_exception, Formatter);
             mockConsumer.VerifyAll();
         }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/HttpContextAccessorWrapper.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/HttpContextAccessorWrapper.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Google.Cloud.Diagnostics.AspNetCore
+{
+    /// <summary>
+    /// A wrapper to hold a <see cref="IHttpContextAccessor"/>.
+    /// This is used to allow easier access to the current trace id of
+    /// an HTTP request at any time.
+    /// </summary>
+    internal static class HttpContextAccessorWrapper
+    {
+        /// <summary>
+        /// The <see cref="IHttpContextAccessor"/> or null if none exists.
+        /// </summary>
+        internal static IHttpContextAccessor Accessor;
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerFactoryExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerFactoryExtensions.cs
@@ -15,6 +15,7 @@
 using Google.Api.Gax;
 using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Logging.V2;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Google.Cloud.Diagnostics.AspNetCore
@@ -50,13 +51,15 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         ///     detected from the platform.</param>
         /// <param name="options">Optional, options for the logger.</param>
         /// <param name="client">Optional, logging client.</param>
+        /// <param name="accessor"></param>
         public static ILoggerFactory AddGoogle(this ILoggerFactory factory, string projectId = null,
-            LoggerOptions options = null, LoggingServiceV2Client client = null)
+            LoggerOptions options = null, LoggingServiceV2Client client = null,
+            IHttpContextAccessor accessor = null)
         {
             GaxPreconditions.CheckNotNull(factory, nameof(factory));
             options = options ?? LoggerOptions.Create();
             projectId = Project.GetAndCheckProjectId(projectId, options.MonitoredResource);
-            return factory.AddGoogle(LogTarget.ForProject(projectId), options, client);
+            return factory.AddGoogle(LogTarget.ForProject(projectId), options, client, accessor);
         }
 
         /// <summary>
@@ -66,12 +69,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <param name="logTarget">Where to log to. Cannot be null.</param>
         /// <param name="options">Optional, options for the logger.</param>
         /// <param name="client">Optional, logging client.</param>
+        /// <param name="accessor"></param>
         public static ILoggerFactory AddGoogle(this ILoggerFactory factory, LogTarget logTarget,
-            LoggerOptions options = null, LoggingServiceV2Client client = null)
+            LoggerOptions options = null, LoggingServiceV2Client client = null,
+            IHttpContextAccessor accessor = null)
         {
             GaxPreconditions.CheckNotNull(factory, nameof(factory));
             GaxPreconditions.CheckNotNull(logTarget, nameof(logTarget));
-            factory.AddProvider(GoogleLoggerProvider.Create(logTarget, options, client));
+            factory.AddProvider(GoogleLoggerProvider.Create(logTarget, options, client, accessor));
             return factory;
         }
     }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerFactoryExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerFactoryExtensions.cs
@@ -51,7 +51,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         ///     detected from the platform.</param>
         /// <param name="options">Optional, options for the logger.</param>
         /// <param name="client">Optional, logging client.</param>
-        /// <param name="accessor"></param>
+        /// <param name="accessor">Optional, HTTP context accessor. Allows adding trace ids to log entries.</param>
         public static ILoggerFactory AddGoogle(this ILoggerFactory factory, string projectId = null,
             LoggerOptions options = null, LoggingServiceV2Client client = null,
             IHttpContextAccessor accessor = null)
@@ -69,7 +69,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <param name="logTarget">Where to log to. Cannot be null.</param>
         /// <param name="options">Optional, options for the logger.</param>
         /// <param name="client">Optional, logging client.</param>
-        /// <param name="accessor"></param>
+        /// <param name="accessor">Optional, HTTP context accessor. Allows adding trace ids to log entries.</param>
         public static ILoggerFactory AddGoogle(this ILoggerFactory factory, LogTarget logTarget,
             LoggerOptions options = null, LoggingServiceV2Client client = null,
             IHttpContextAccessor accessor = null)

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerFactoryExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerFactoryExtensions.cs
@@ -15,7 +15,6 @@
 using Google.Api.Gax;
 using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Logging.V2;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Google.Cloud.Diagnostics.AspNetCore
@@ -51,15 +50,13 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         ///     detected from the platform.</param>
         /// <param name="options">Optional, options for the logger.</param>
         /// <param name="client">Optional, logging client.</param>
-        /// <param name="accessor">Optional, HTTP context accessor. Allows adding trace ids to log entries.</param>
         public static ILoggerFactory AddGoogle(this ILoggerFactory factory, string projectId = null,
-            LoggerOptions options = null, LoggingServiceV2Client client = null,
-            IHttpContextAccessor accessor = null)
+            LoggerOptions options = null, LoggingServiceV2Client client = null)
         {
             GaxPreconditions.CheckNotNull(factory, nameof(factory));
             options = options ?? LoggerOptions.Create();
             projectId = Project.GetAndCheckProjectId(projectId, options.MonitoredResource);
-            return factory.AddGoogle(LogTarget.ForProject(projectId), options, client, accessor);
+            return factory.AddGoogle(LogTarget.ForProject(projectId), options, client);
         }
 
         /// <summary>
@@ -69,14 +66,12 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <param name="logTarget">Where to log to. Cannot be null.</param>
         /// <param name="options">Optional, options for the logger.</param>
         /// <param name="client">Optional, logging client.</param>
-        /// <param name="accessor">Optional, HTTP context accessor. Allows adding trace ids to log entries.</param>
         public static ILoggerFactory AddGoogle(this ILoggerFactory factory, LogTarget logTarget,
-            LoggerOptions options = null, LoggingServiceV2Client client = null,
-            IHttpContextAccessor accessor = null)
+            LoggerOptions options = null, LoggingServiceV2Client client = null)
         {
             GaxPreconditions.CheckNotNull(factory, nameof(factory));
             GaxPreconditions.CheckNotNull(logTarget, nameof(logTarget));
-            factory.AddProvider(GoogleLoggerProvider.Create(logTarget, options, client, accessor));
+            factory.AddProvider(GoogleLoggerProvider.Create(logTarget, options, client));
             return factory;
         }
     }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerProvider.cs
@@ -39,8 +39,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <param name="consumer">The consumer to push logs to. Cannot be null.</param>
         /// <param name="logTarget">Where to log to. Cannot be null.</param>
         /// <param name="loggerOptions">The logger options. Cannot be null.</param>
-        internal GoogleLoggerProvider(IConsumer<LogEntry> consumer, LogTarget logTarget,
-            LoggerOptions loggerOptions)
+        internal GoogleLoggerProvider(IConsumer<LogEntry> consumer, LogTarget logTarget, LoggerOptions loggerOptions)
         {
             _consumer = GaxPreconditions.CheckNotNull(consumer, nameof(consumer));
             _logTarget = GaxPreconditions.CheckNotNull(logTarget, nameof(logTarget));

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerProvider.cs
@@ -43,7 +43,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <param name="consumer">The consumer to push logs to. Cannot be null.</param>
         /// <param name="logTarget">Where to log to. Cannot be null.</param>
         /// <param name="loggerOptions">The logger options. Cannot be null.</param>
-        /// <param name="accessor"></param>
+        /// <param name="accessor">Optional, HTTP context accessor. Allows adding trace ids to log entries.</param>
         internal GoogleLoggerProvider(IConsumer<LogEntry> consumer, LogTarget logTarget,
             LoggerOptions loggerOptions, IHttpContextAccessor accessor)
         {
@@ -61,7 +61,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         ///     detected from the platform.</param>
         /// <param name="options">Optional, options for the logger.</param>
         /// <param name="client">Optional, logging client.</param>
-        /// <param name="accessor"></param>
+        /// <param name="accessor">Optional, HTTP context accessor. Allows adding trace ids to log entries.</param>
         public static GoogleLoggerProvider Create(string projectId = null,
             LoggerOptions options = null, LoggingServiceV2Client client = null, 
             IHttpContextAccessor accessor = null)
@@ -77,7 +77,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <param name="logTarget">Where to log to. Cannot be null.</param>
         /// <param name="options">Optional, options for the logger.</param>
         /// <param name="client">Optional, logging client.</param>
-        /// <param name="accessor"></param>
+        /// <param name="accessor">Optional, HTTP context accessor. Allows adding trace ids to log entries.</param>
         public static GoogleLoggerProvider Create(LogTarget logTarget,
             LoggerOptions options = null, LoggingServiceV2Client client = null,
             IHttpContextAccessor accessor = null)

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
@@ -83,6 +83,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         {
             GaxPreconditions.CheckNotNull(app, nameof(app));
             app.UseMiddleware<CloudTraceMiddleware>();
+            HttpContextAccessorWrapper.Accessor = app.ApplicationServices.GetService<IHttpContextAccessor>();
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/TraceTargetTests.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/TraceTargetTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Google.Cloud.Diagnostics.Common.Tests
+{
+    public class TraceTargetTests
+    {
+        private const string _pid = "some-pid";
+
+        [Fact]
+        public void Project()
+        {
+            TraceTarget target = TraceTarget.ForProject(_pid);
+            Assert.Equal(_pid, target.ProjectId);
+        }
+
+        [Fact]
+        public void GetFullLogName_Project()
+        {
+            string traceId = "trace-id";
+            TraceTarget target = TraceTarget.ForProject(_pid);
+            string traceName = target.GetFullTraceName(traceId);
+            Assert.Contains(traceId, traceName);
+            Assert.Contains(_pid, traceName);
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceTarget.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceTarget.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+
+namespace Google.Cloud.Diagnostics.Common
+{
+    /// <summary>
+    /// Represents the location traces will be sent to.  The Trace API only supports projects.
+    /// </summary>
+    public sealed class TraceTarget
+    {
+        /// <summary>The Google Cloud Platform project Id.</summary>
+        public string ProjectId { get; }
+
+        private TraceTarget(string projectId)
+        {
+            ProjectId = GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId));
+        }
+
+        /// <summary>
+        /// Creates a <see cref="TraceTarget"/> instance for sending trace entries to a GCP project.
+        /// </summary>
+        public static TraceTarget ForProject(string projectId) => new TraceTarget(projectId);
+
+        /// <summary>
+        /// Gets the full trace name.
+        /// See: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
+        /// </summary>
+        /// <param name="traceId">The id of the trace.</param>
+        public string GetFullTraceName(string traceId)
+        {
+            GaxPreconditions.CheckNotNullOrEmpty(traceId, nameof(traceId));
+            return $"projects/{ProjectId}/traces/{traceId}";
+        }
+    }
+}


### PR DESCRIPTION
We do this by allowing the IHttpContextAccessor to be passed into the logger.

The only disadvantage is an IHttpContextAccessor is not available during the initial initialization of netcoreapp 2.0 apps so the user would have to also initialize the logger in their configure method.  The alternative would require a large change to the API of this library and how we handle DI of most of our bits.

Fixes #1104