### PR TITLE
[Bigtable] Custom ReadRowsStream

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/RoslynHelpers.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/RoslynHelpers.cs
@@ -16,7 +16,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
-
+using System.Linq;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Google.Cloud.Bigtable.V2.GenerateClient
@@ -58,6 +58,12 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
 
         internal static MemberAccessExpressionSyntax Member(this ExpressionSyntax expression, SyntaxToken name) =>
             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expression, IdentifierName(name));
+
+        internal static ObjectCreationExpressionSyntax New(this TypeSyntax type, params ExpressionSyntax[] argumentExpressions) =>
+            type.New(argumentExpressions.Select(expression => SyntaxFactory.Argument(expression)));
+
+        internal static ObjectCreationExpressionSyntax New(this TypeSyntax type, IEnumerable<ArgumentSyntax> arguments) =>
+            ObjectCreationExpression(type, ArgumentList(SeparatedList(arguments)), initializer: null);
 
         internal static LiteralExpressionSyntax Null() =>
             LiteralExpression(SyntaxKind.NullLiteralExpression);

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/ReadRowsTest.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/ReadRowsTest.cs
@@ -58,7 +58,7 @@ namespace Google.Cloud.Bigtable.V2.IntegrationTests
                     tableName,
                     new RowSet { RowKeys = { rowKey.Value } },
                     RowFilters.CellsPerColumnLimit(1));
-                using (var enumerator = (RowAsyncEnumerator)response.AsAsyncEnumerable().GetEnumerator())
+                using (var enumerator = (RowAsyncEnumerator)response.GetEnumerator())
                 {
                     while (await enumerator.MoveNext(default))
                     {
@@ -234,7 +234,7 @@ namespace Google.Cloud.Bigtable.V2.IntegrationTests
             rowKeys.Sort();
 
             int currentRowIndex = 0;
-            await response.AsAsyncEnumerable().ForEachAsync(row =>
+            await response.ForEachAsync(row =>
             {
                 var currentRowKey = rowKeys[currentRowIndex++];
                 Assert.Equal(currentRowKey.Value, row.Key);
@@ -279,7 +279,7 @@ namespace Google.Cloud.Bigtable.V2.IntegrationTests
             rowKeys.Sort();
 
             int rowCount = 0;
-            await response.AsAsyncEnumerable().ForEachAsync(row =>
+            await response.ForEachAsync(row =>
             {
                 rowCount++;
                 int index = originalIndexes[row.Key];
@@ -325,7 +325,7 @@ namespace Google.Cloud.Bigtable.V2.IntegrationTests
             rowKeys.Sort();
 
             int rowCount = 0;
-            await response.AsAsyncEnumerable().ForEachAsync(row =>
+            await response.ForEachAsync(row =>
             {
                 rowCount++;
                 int index = originalIndexes[row.Key];
@@ -362,7 +362,7 @@ namespace Google.Cloud.Bigtable.V2.IntegrationTests
                 RowSet.FromRowRanges(RowRange.ClosedOpen(startRange, endRange)));
 
             int currentRowIndex = 0;
-            await response.AsAsyncEnumerable().ForEachAsync(row =>
+            await response.ForEachAsync(row =>
             {
                 BigtableAssert.HasSingleValue(
                     row,
@@ -397,7 +397,7 @@ namespace Google.Cloud.Bigtable.V2.IntegrationTests
                 RowFilters.ValueRegex(".*[a-z]$"));
 
             int currentRowIndex = 'a';
-            await response.AsAsyncEnumerable().ForEachAsync(row =>
+            await response.ForEachAsync(row =>
             {
                 BigtableAssert.HasSingleValue(
                     row,
@@ -431,7 +431,7 @@ namespace Google.Cloud.Bigtable.V2.IntegrationTests
                 rowsLimit: 37);
 
             int currentRowIndex = 0;
-            await response.AsAsyncEnumerable().ForEachAsync(row =>
+            await response.ForEachAsync(row =>
             {
                 BigtableAssert.HasSingleValue(
                     row,
@@ -454,13 +454,12 @@ namespace Google.Cloud.Bigtable.V2.IntegrationTests
             System.Diagnostics.Debug.WriteLine((string)rowKey);
 
             var response = client.ReadRows(tableName);
-            await response.AsAsyncEnumerable().ForEachAsync(row =>
+            await response.ForEachAsync(row =>
             {
                 Assert.Equal(rowKey.Value, row.Key);
             });
-
-            var enumerable = response.AsAsyncEnumerable();
-            Assert.Throws<InvalidOperationException>(() => enumerable.GetEnumerator());
+            
+            Assert.Throws<InvalidOperationException>(() => response.GetEnumerator());
         }
 
         [Fact]
@@ -496,7 +495,7 @@ namespace Google.Cloud.Bigtable.V2.IntegrationTests
                 RowFilters.RowKeyExact("row\0\\1"));
 
             int rowCount = 0;
-            await rowsStream.AsAsyncEnumerable().ForEachAsync(row =>
+            await rowsStream.ForEachAsync(row =>
             {
                 rowCount++;
                 Assert.Equal("row\0\\1", row.Key.ToStringUtf8());

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/BigtableClientSnippets.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/BigtableClientSnippets.cs
@@ -301,7 +301,7 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             long rowsLimit = 10;
 
             // Make the request
-            BigtableServiceApiClient.ReadRowsStream streamingResponse = client.ReadRows(
+            ReadRowsStream streamingResponse = client.ReadRows(
                 tableName,
                 rows,
                 filter,
@@ -309,7 +309,7 @@ namespace Google.Cloud.Bigtable.V2.Snippets
                 CallSettings.FromCancellationToken(cancellationToken));
 
             // Read streaming responses from server until complete
-            await streamingResponse.AsAsyncEnumerable().ForEachAsync(row =>
+            await streamingResponse.ForEachAsync(row =>
             {
                 Console.WriteLine($"Row key: {row.Key.ToStringUtf8()}");
                 foreach (Family family in row.Families)

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableClientTest.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableClientTest.cs
@@ -42,7 +42,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
                 throw new RequestMadeException();
             public override Task<ReadModifyWriteRowResponse> ReadModifyWriteRowAsync(ReadModifyWriteRowRequest request, CallSettings callSettings = null) =>
                 throw new RequestMadeException();
-            public override BigtableServiceApiClient.ReadRowsStream ReadRows(ReadRowsRequest request, CallSettings callSettings = null) =>
+            public override ReadRowsStream ReadRows(ReadRowsRequest request, CallSettings callSettings = null) =>
                 throw new RequestMadeException();
             public override BigtableServiceApiClient.SampleRowKeysStream SampleRowKeys(SampleRowKeysRequest request, CallSettings callSettings = null) =>
                 throw new RequestMadeException();
@@ -366,7 +366,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
                 });
 
             int rowCount = 0;
-            await stream.AsAsyncEnumerable().ForEachAsync(row =>
+            await stream.ForEachAsync(row =>
             {
                 rowCount++;
 

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/MockReadRowsStream.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/MockReadRowsStream.cs
@@ -18,14 +18,20 @@ using System.Linq;
 
 namespace Google.Cloud.Bigtable.V2.Tests
 {
-    public class MockReadRowsStream : BigtableServiceApiClient.ReadRowsStream
+    public class MockReadRowsStream : ReadRowsStream
     {
-        private IAsyncEnumerator<ReadRowsResponse> _responseStream;
+        public MockReadRowsStream(params ReadRowsResponse[] responses)
+            : base(new UnderlyingReadRowsStream(responses)) { }
 
-        public MockReadRowsStream(params ReadRowsResponse[] responses) =>
-            _responseStream = responses.ToAsyncEnumerable().GetEnumerator();
+        private class UnderlyingReadRowsStream : BigtableServiceApiClient.ReadRowsStream
+        {
+            private IAsyncEnumerator<ReadRowsResponse> _responseStream;
 
-        public override AsyncServerStreamingCall<ReadRowsResponse> GrpcCall => null;
-        public override IAsyncEnumerator<ReadRowsResponse> ResponseStream => _responseStream;
+            public UnderlyingReadRowsStream(params ReadRowsResponse[] responses) =>
+                _responseStream = responses.ToAsyncEnumerable().GetEnumerator();
+
+            public override AsyncServerStreamingCall<ReadRowsResponse> GrpcCall => null;
+            public override IAsyncEnumerator<ReadRowsResponse> ResponseStream => _responseStream;
+        }
     }
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/ReadRowsAcceptanceTest.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/ReadRowsAcceptanceTest.cs
@@ -60,11 +60,11 @@ namespace Google.Cloud.Bigtable.V2.Tests
                 // Do not use ToList() here. We want to get all results before the first failure.
                 responses = new List<Row>();
                 await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => stream.AsAsyncEnumerable().ForEachAsync(row => responses.Add(row)));
+                    () => stream.ForEachAsync(row => responses.Add(row)));
             }
             else
             {
-                responses = await stream.AsAsyncEnumerable().ToList();
+                responses = await stream.ToList();
             }
 
             var results = from row in responses

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.cs
@@ -51,7 +51,7 @@ namespace Google.Cloud.Bigtable.V2
         /// <returns>
         /// The server stream.
         /// </returns>
-        public virtual BigtableServiceApiClient.ReadRowsStream ReadRows(
+        public virtual ReadRowsStream ReadRows(
             ReadRowsRequest request,
             CallSettings callSettings = null)
         {
@@ -240,7 +240,7 @@ namespace Google.Cloud.Bigtable.V2
     public sealed partial class BigtableClientImpl : BigtableClient
     {
         /// <inheritdoc/>
-        public override BigtableServiceApiClient.ReadRowsStream ReadRows(
+        public override ReadRowsStream ReadRows(
             ReadRowsRequest request,
             CallSettings callSettings = null)
         {
@@ -249,7 +249,7 @@ namespace Google.Cloud.Bigtable.V2
                 request.AppProfileId = _appProfileId;
             }
 
-            return GetClient().ReadRows(request, callSettings);
+            return new ReadRowsStream(GetClient().ReadRows(request, callSettings));
         }
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientPartial.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientPartial.cs
@@ -866,7 +866,7 @@ namespace Google.Cloud.Bigtable.V2
                 filter,
                 callSettings: callSettings);
 
-            return await response.AsAsyncEnumerable().SingleOrDefault().ConfigureAwait(false);
+            return await response.SingleOrDefault().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -898,7 +898,7 @@ namespace Google.Cloud.Bigtable.V2
         /// <returns>
         /// The server stream.
         /// </returns>
-        public virtual BigtableServiceApiClient.ReadRowsStream ReadRows(
+        public virtual ReadRowsStream ReadRows(
             TableName tableName,
             RowSet rows = null,
             RowFilter filter = null,

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClientPartial.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClientPartial.cs
@@ -25,40 +25,6 @@ namespace Google.Cloud.Bigtable.V2
 {
     public partial class BigtableServiceApiClient
     {
-        public partial class ReadRowsStream
-        {
-            private RowAsyncEnumerable _rowEnumerable;
-
-            /// <summary>
-            /// Returns an asynchronous sequence of rows from this set of results.
-            /// </summary>
-            /// <returns>An asynchronous sequence of rows from this set of results.</returns>
-            public IAsyncEnumerable<Row> AsAsyncEnumerable() =>
-                _rowEnumerable ?? (_rowEnumerable = new RowAsyncEnumerable(this));
-
-            private class RowAsyncEnumerable : IAsyncEnumerable<Row>
-            {
-                private int _enumeratorCount;
-                private ReadRowsStream _stream;
-
-                public RowAsyncEnumerable(ReadRowsStream stream)
-                {
-                    _stream = stream;
-                }
-
-                public IAsyncEnumerator<Row> GetEnumerator()
-                {
-                    if (Interlocked.CompareExchange(ref _enumeratorCount, 1, 0) == 1)
-                    {
-                        throw new InvalidOperationException(
-                            $"The result from {nameof(ReadRowsStream)}.{nameof(ReadRowsStream.AsAsyncEnumerable)} can only be iterated once");
-                    }
-
-                    return new RowAsyncEnumerator(_stream);
-                }
-            }
-        }
-
         public partial class SampleRowKeysStream
         {
             /// <summary>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/ReadRowsStream.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/ReadRowsStream.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace Google.Cloud.Bigtable.V2
+{
+    /// <summary>
+    /// The stream of <see cref="Row"/> instances returned from the server.
+    /// </summary>
+    public class ReadRowsStream : IAsyncEnumerable<Row>
+    {
+        private int _enumeratorCount;
+        private BigtableServiceApiClient.ReadRowsStream _underlyingStream;
+
+        internal ReadRowsStream(BigtableServiceApiClient.ReadRowsStream underlyingStream) =>
+            _underlyingStream = underlyingStream;
+
+        /// <summary>
+        /// The underlying gRPC duplex streaming call.
+        /// </summary>
+        public AsyncServerStreamingCall<ReadRowsResponse> GrpcCall => _underlyingStream.GrpcCall;
+
+        /// <inheritdoc/>
+        public IAsyncEnumerator<Row> GetEnumerator()
+        {
+            if (Interlocked.CompareExchange(ref _enumeratorCount, 1, 0) == 1)
+            {
+                throw new InvalidOperationException($"The {nameof(ReadRowsStream)} can only be iterated once");
+            }
+
+            return new RowAsyncEnumerator(_underlyingStream);
+        }
+    }
+}

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/RowAsyncEnumerator.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/RowAsyncEnumerator.cs
@@ -21,7 +21,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using static Google.Cloud.Bigtable.V2.BigtableServiceApiClient;
 using static Google.Cloud.Bigtable.V2.ReadRowsResponse.Types;
 
 namespace Google.Cloud.Bigtable.V2
@@ -36,9 +35,9 @@ namespace Google.Cloud.Bigtable.V2
         private readonly SortedList<string, Family> _currentFamilies = new SortedList<string, Family>(StringComparer.Ordinal);
         private RowMergeState _rowMergeState = NewRow.Instance;
         private IEnumerator<Row> _singleResponseRowEnumerator;
-        private readonly ReadRowsStream _stream;
+        private readonly BigtableServiceApiClient.ReadRowsStream _stream;
 
-        public RowAsyncEnumerator(ReadRowsStream stream)
+        public RowAsyncEnumerator(BigtableServiceApiClient.ReadRowsStream stream)
         {
             _stream = stream;
         }


### PR DESCRIPTION
[Part 2 of refactoring from #1917] This allows us to "hide" the underlying ReadRowsStream that returns cell chunks so we can instead expose one that returns the reassembled rows. In the (near) future we can also add support for smart retries to this custom stream.

Recommend to review commits separately.