### PR TITLE
Return DBNull from Spanner when a null value is encountered

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TestDatabaseFixture.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TestDatabaseFixture.cs
@@ -244,12 +244,17 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                         });
                     cmd.Transaction = tx;
 
-                    for (var i = 0; i < TestTableRowCount; ++i)
+                    for (var i = 0; i < TestTableRowCount - 1; ++i)
                     {
                         cmd.Parameters["Key"].Value = "k" + i;
                         cmd.Parameters["StringValue"].Value = "v" + i;
                         await cmd.ExecuteNonQueryAsync();
                     }
+
+                    // And one extra row, with a null value.
+                    cmd.Parameters["Key"].Value = "kNull";
+                    cmd.Parameters["StringValue"].Value = DBNull.Value;
+                    await cmd.ExecuteNonQueryAsync();
 
                     await tx.CommitAsync();
                 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
@@ -410,19 +410,19 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                     }));
             using (var reader = await GetLastRowAsync())
             {
-                Assert.Null(reader.GetValue(reader.GetOrdinal("BoolValue")));
-                Assert.Null(reader.GetValue(reader.GetOrdinal("Int64Value")));
-                Assert.Null(reader.GetValue(reader.GetOrdinal("Float64Value")));
-                Assert.Null(reader.GetValue(reader.GetOrdinal("StringValue")));
-                Assert.Null(reader.GetValue(reader.GetOrdinal("TimestampValue")));
-                Assert.Null(reader.GetValue(reader.GetOrdinal("DateValue")));
-                Assert.Null(reader.GetValue(reader.GetOrdinal("BoolArrayValue")));
-                Assert.Null(reader.GetValue(reader.GetOrdinal("Int64ArrayValue")));
-                Assert.Null(reader.GetValue(reader.GetOrdinal("Float64ArrayValue")));
-                Assert.Null(reader.GetValue(reader.GetOrdinal("StringArrayValue")));
-                Assert.Null(reader.GetValue(reader.GetOrdinal("BytesArrayValue")));
-                Assert.Null(reader.GetValue(reader.GetOrdinal("TimestampArrayValue")));
-                Assert.Null(reader.GetValue(reader.GetOrdinal("DateArrayValue")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("BoolValue")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("Int64Value")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("Float64Value")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("StringValue")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("TimestampValue")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("DateValue")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("BoolArrayValue")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("Int64ArrayValue")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("Float64ArrayValue")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("StringArrayValue")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("BytesArrayValue")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("TimestampArrayValue")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("DateArrayValue")));
             }
         }
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnectionStringBuilder.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnectionStringBuilder.cs
@@ -36,6 +36,7 @@ namespace Google.Cloud.Spanner.Data
     {
         private const string CredentialFileKeyword = "CredentialFile";
         private const string DataSourceKeyword = "Data Source";
+        private const string UseClrDefaultForNullKeyword = "UseClrDefaultForNull";
         private InstanceName _instanceName;
         private DatabaseName _databaseName;
 
@@ -86,6 +87,36 @@ namespace Google.Cloud.Spanner.Data
         {
             get => GetValueOrDefault(CredentialFileKeyword);
             set => this[CredentialFileKeyword] = value;
+        }
+
+        /// <summary>
+        /// Option to change between the default handling of null database values (return <see cref="DBNull.Value">DBNull.Value</see>) or
+        /// the non-standard handling (return the default value for whatever type is requested).
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If this is <c>false</c> (the default), requesting a value from a <see cref="SpannerDataReader"/> that is null
+        /// in the database will return <see cref="DBNull.Value">DBNull.Value</see>, which may cause an <see cref="InvalidCastException"/> if
+        /// the requested type is not compatible with that value.
+        /// </para>
+        /// <para>
+        /// If this is <c>true</c>, requesting a value from a <see cref="SpannerDataReader"/> that is null in the
+        /// database will return the default value of the requested type (e.g. 0 or a null reference). This is the
+        /// behavior from release 1.0 of this package.
+        /// </para>
+        /// <para>
+        /// This property only sets the behavior for top-level values. For arrays and structs, null references and default values
+        /// are still used if the array or struct field value is null; this provides a better general experience, allowing
+        /// conversions to specific array types for example.
+        /// </para>
+        /// <para>
+        /// This property corresponds with the value of the "UseClrDefaultForNull" part of the connection string.
+        /// </para>
+        /// </remarks>
+        public bool UseClrDefaultForNull
+        {
+            get => GetValueOrDefault(UseClrDefaultForNullKeyword).Equals("True", StringComparison.OrdinalIgnoreCase);
+            set => this[UseClrDefaultForNullKeyword] = value.ToString(); // Always "True" or "False", regardless of culture.
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConversionOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConversionOptions.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2018 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Spanner.Data
+{
+    /// <summary>
+    /// Options for nuances in conversions between protobuf and CLR types.
+    /// </summary>
+    internal class SpannerConversionOptions
+    {
+        // Predefined instances; these will change as the class grows, but hopefully
+        // for most cases we can avoid creating new instances.
+        private static readonly SpannerConversionOptions s_useDBNullForNull = new SpannerConversionOptions(true);
+        private static readonly SpannerConversionOptions s_useClrDefaultForNull = new SpannerConversionOptions(false);
+
+        internal static SpannerConversionOptions Default { get; } = s_useDBNullForNull;
+
+        /// <summary>
+        /// True to return DBNull.Value for null values; false to return a null reference.
+        /// </summary>
+        internal bool UseDBNull { get; }
+
+        private SpannerConversionOptions(bool useDBNull)
+        {
+            UseDBNull = useDBNull;
+        }
+
+        /// <summary>
+        /// Determines the right conversion options to use based on the connection string of the given connection.
+        /// </summary>
+        internal static SpannerConversionOptions ForConnection(SpannerConnection spannerConnection) =>
+            ForConnectionStringBuilder(spannerConnection?.SpannerConnectionStringBuilder);
+
+        /// <summary>
+        /// Determines the right conversion options to use based on the connection string of the given connection string builder.
+        /// </summary>
+        internal static SpannerConversionOptions ForConnectionStringBuilder(SpannerConnectionStringBuilder builder) =>
+            builder == null ? Default : builder.UseClrDefaultForNull ? s_useClrDefaultForNull : s_useDBNullForNull;
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameterCollection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameterCollection.cs
@@ -220,9 +220,10 @@ namespace Google.Cloud.Spanner.Data
 
         internal void FillSpannerInternalValues(
             MapField<string, Value> valueDictionary,
-            MapField<string, V1.Type> requestParamTypes)
+            MapField<string, V1.Type> requestParamTypes,
+            SpannerConversionOptions options)
         {
-            FillSpannerInternalValues(valueDictionary);
+            FillSpannerInternalValues(valueDictionary, options);
             FillSpannerInternalTypes(requestParamTypes);
         }
 
@@ -233,12 +234,12 @@ namespace Google.Cloud.Spanner.Data
         private string GetCorrectedParameterName(string parameterName) 
             => parameterName?.StartsWith("@") ?? false ? parameterName.Substring(1) : parameterName;
 
-        private void FillSpannerInternalValues(MapField<string, Value> valueDictionary)
+        private void FillSpannerInternalValues(MapField<string, Value> valueDictionary, SpannerConversionOptions options)
         {
             foreach (var parameter in _innerList)
             {
                 valueDictionary[GetCorrectedParameterName(parameter.ParameterName)]
-                    = parameter.SpannerDbType.ToProtobufValue(parameter.GetValidatedValue());
+                    = parameter.SpannerDbType.ToProtobufValue(parameter.GetValidatedValue(), options);
             }
         }
 


### PR DESCRIPTION
A connection string property of "UseClrDefaultForNull" can be set to
true to enable the old behavior; the new behavior is the default.

We will merge this change, but the precise rollout is not determined
yet; this may be treated as a breaking change prompting a move to
2.0, or it may be treated as a bug and included in 1.1.

Fixes #1854.