### PR TITLE
[Design] Provide a hook to add custom labels to log entries

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/ILogEntryLabelProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/ILogEntryLabelProvider.cs
@@ -1,3 +1,17 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System.Collections.Generic;
 
 namespace Google.Cloud.Diagnostics.AspNetCore

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/ILogEntryLabelProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/ILogEntryLabelProvider.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace Google.Cloud.Diagnostics.AspNetCore
+{
+    /// <summary>
+    /// Provides a hook to augment labels when a log entry is being logged.
+    /// </summary>
+    public interface ILogEntryLabelProvider
+    {
+        /// <summary>
+        /// Invokes the provider to augment log entry labels.
+        /// </summary>
+        /// <param name="labels">A dictionary of log entry labels.</param>
+        void Invoke(Dictionary<string, string> labels);
+    }
+}


### PR DESCRIPTION
Initial design for #1937.

The idea is to provide a hook (`ILogEntryLabelProvider`) to augment labels of log entries being logged. These providers are resolved using the container available in `IHttpContextAccessor`.

What are your thoughts @iantalarico @jskeet?