### PR TITLE
Two new docs for Spanner

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/docs/connection_string.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/connection_string.md
@@ -1,0 +1,67 @@
+# Connection string options
+
+Spanner connection strings support the following options:
+
+# Data Source
+
+The project, instance and optionally database to use. The format is
+`projects/{project}/instances/{instance}/databases/{database}`, with
+the `databases/{database}` part being optional.
+
+Examples:
+
+- Data Source=projects/my_project/instances/my_instance
+- Data Source=projects/my_project/instances/my_instance/databases/my_database
+
+# CredentialFile
+
+A path to a JSON service account credential file to use. If this is
+not specified, the application default credentials will be used.
+(These are provided automatically when running on Google Cloud
+Platform, or a JSON service account credential file can be specified
+with the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.)
+
+Example:
+
+- CredentialFile=/path/to/credentials.json
+
+# EnableGetSchemaTable
+
+When set to true (and when targeting .NET 4.5 or .NET Standard 2.0;
+the method doesn't exist in .NET Standard 1.x),
+[SpannerDataReader.GetSchemaTable()](obj/api/Google.Cloud.Spanner.Data.SpannerDataReader.yml#Google_Cloud_Spanner_Data_SpannerDataReader_GetSchemaTable)
+will return available schema information for the query in the form
+of a `DataTable`. See the method documentation for details of the columns
+returned.
+
+Example:
+
+- EnableGetSchemaTable=true
+
+# UseClrDefaultForNull
+
+By default, null values returned by Spanner are handled in the
+following manner:
+
+"Top-level" fields are always converted to `DBNull.Value`. This
+means that calling `reader.GetString(0)` for example will throw an
+`InvalidCastException` if the value is null. This is compatible
+with other ADO.NET providers.
+
+Array and structure elements use the null value for the target type
+where possible (reference types and nullable value types), or throw
+an `InvalidCastException` if the target type is a non-nullable value
+type. For example, if an array field has values `[1, NULL, 2]` in Spanner,
+then requesting that field with `reader.GetFieldValue<int[]>("field")` will
+throw an exception, whereas `reader.GetFieldValue<int?[]>("field")`
+will return a nullable integer array where the second element is a
+null value.
+
+When `UseClrDefaultForNull` is set to true, null values returned by
+Spanner will be converted into the default CLR value for the
+requested type. This was the behavior for Google.Cloud.Spanner.Data
+v1.0.
+
+Example:
+
+- UseClrDefaultForNull=true

--- a/apis/Google.Cloud.Spanner.Data/docs/history.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/history.md
@@ -1,0 +1,25 @@
+# Version history
+
+# 2.0.0 (in progress)
+
+New features:
+
+- Batch query support
+- Connection string option to enable `SpannerDataReader.GetSchemaTable()`
+  to return schema information
+  
+Breaking changes:
+
+- Null values are returned as `DBNull.Value` by default rather
+  than the CLR default value for the type. Array and struct elements
+  use a null value where feasible, but throw `InvalidCastException`
+  when requested to be converted to a non-nullable value type. The
+  1.0 behavior can be requested using the `UseClrDefaultForNull`
+  [connection string option](connection_string.md).
+- `Hashtable` is no longer used as a default type for
+  struct values. It can still be specified explicitly.
+  The new default is `Dictionary<string, object>`.
+
+# 1.0.0, 2017-12-05
+
+Initial release.


### PR DESCRIPTION
- Brief version history
- List of connection string options

Post-launch, I'd like to update links for new features to samples/docs etc.
The markdown files are automatically processed and new links are included at the top of the page (see the [Firestore](https://googlecloudplatform.github.io/google-cloud-dotnet/docs/Google.Cloud.Firestore/index.html) docs for an example of this). It's not as eye-catching as it might be, but it's a start and we can adjust templates later.