### PR TITLE
Remove LRO dependency from DLP v2

### DIFF
--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
@@ -26,7 +26,6 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.3.0" />
-    <PackageReference Include="Google.LongRunning" Version="1.0.0" />
     <PackageReference Include="Grpc.Core" Version="1.10.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -238,9 +238,6 @@
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Data Loss Prevention API, provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.",
     "tags": [ "DLP", "data loss prevention", "privacy", "pii" ],
-    "dependencies": {
-      "Google.LongRunning": "1.0.0"
-    }
   },
 
   {


### PR DESCRIPTION
The v2 API doesn't use LROs, so we don't need the NuGet dependency.