### PR TITLE
Remove myget feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,6 +4,5 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="MyGet google-dotnet-public" value="https://www.myget.org/F/google-dotnet-public/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
We haven't needed this for ages. While we could remove NuGet.config
entirely, it's probably worth keeping just like global.json, to make
the build less dependent on external factors.