### PR TITLE
Bigtable generator changes for CancellationToken overloads.

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Google.Cloud.Bigtable.V2.GenerateClient.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Google.Cloud.Bigtable.V2.GenerateClient.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.3.0" />
     <PackageReference Include="Microsoft.Build" Version="15.6.82" />
     <PackageReference Include="Microsoft.Build.Engine" Version="15.6.82" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.6.82" />

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Program.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Program.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax.Grpc;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -34,9 +35,7 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
     {
         private const string AppProfileIdFieldName = "_appProfileId";
         private const string AppProfileIdPropertyName = "AppProfileId";
-        private const string CallSettingsTypeName = "CallSettings";
         private const string CancellationTokenParameterName = "cancellationToken";
-        private const string CancellationTokenTypeName = nameof(CancellationToken);
         private const string GetUnderlyingClientMethodName = "GetUnderlyingClient";
 
         /// <summary>
@@ -276,7 +275,7 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
                 node = node.WithBodySafe(
                     node.Invoke(
                         IdentifierName(requestParameterSyntax.Identifier),
-                        IdentifierName(CallSettingsTypeName).Member("FromCancellationToken").Invoke(IdentifierName(CancellationTokenParameterName))));
+                        IdentifierName(nameof(CallSettings)).Member(nameof(CallSettings.FromCancellationToken)).Invoke(IdentifierName(CancellationTokenParameterName))));
 
                 return node;
             }
@@ -289,7 +288,7 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
                 {
                     // Replace the CallSettings parameter with a CancellationToken parameter which doesn't have a default value.
                     node = node
-                        .WithType(ParseTypeName(CancellationTokenTypeName)).WithLeadingTrivia(node.Type.GetLeadingTrivia())
+                        .WithType(ParseTypeName(nameof(CancellationToken))).WithLeadingTrivia(node.Type.GetLeadingTrivia())
                         .WithIdentifier(Identifier(CancellationTokenParameterName))
                         .WithDefault(null);
                 }
@@ -308,7 +307,7 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
                     // Replace the parameter doc comments for the cancellation token.
                     node = node.WithContent(List(new XmlNodeSyntax[] {
                         XmlText("A "),
-                        SeeTag(TypeCref(ParseTypeName(CancellationTokenTypeName))),
+                        SeeTag(TypeCref(ParseTypeName(nameof(CancellationToken)))),
                         XmlText(XmlTextLiteral(" to use for this RPC.")) }));
                 }
 

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Program.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Program.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using static Google.Cloud.Bigtable.V2.GenerateClient.RoslynHelpers;
@@ -35,7 +36,7 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
         private const string AppProfileIdPropertyName = "AppProfileId";
         private const string CallSettingsTypeName = "CallSettings";
         private const string CancellationTokenParameterName = "cancellationToken";
-        private const string CancellationTokenTypeName = "CancellationToken";
+        private const string CancellationTokenTypeName = nameof(CancellationToken);
         private const string GetUnderlyingClientMethodName = "GetUnderlyingClient";
 
         /// <summary>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/RoslynHelpers.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/RoslynHelpers.cs
@@ -54,6 +54,9 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
         internal static InvocationExpressionSyntax Invoke(this ExpressionSyntax expression) =>
             InvocationExpression(expression);
 
+        internal static InvocationExpressionSyntax Invoke(this MethodDeclarationSyntax method, params ExpressionSyntax[] argumentExpressions) =>
+            method.Invoke(argumentExpressions.Select(argumentExpression => SyntaxFactory.Argument(argumentExpression)));
+
         internal static InvocationExpressionSyntax Invoke(this MethodDeclarationSyntax method, IEnumerable<ArgumentSyntax> arguments) =>
             IdentifierName(method.Identifier).Invoke(arguments);
 
@@ -104,7 +107,7 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
         internal static MethodDeclarationSyntax WithBodySafe(this MethodDeclarationSyntax method, ExpressionSyntax expressionBody) =>
             method.WithBody(null).WithExpressionBody(ArrowExpressionClause(expressionBody)).WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
 
-        internal static MethodDeclarationSyntax WithBodySafe(this MethodDeclarationSyntax method, BlockSyntax block) =>
-            method.WithExpressionBody(null).WithSemicolonToken(Token(SyntaxKind.None)).WithBody(block);
+        internal static MethodDeclarationSyntax WithBodySafe(this MethodDeclarationSyntax method, BlockSyntax body) =>
+            method.WithExpressionBody(null).WithSemicolonToken(Token(SyntaxKind.None)).WithBody(body);
     }
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.cs
@@ -178,6 +178,21 @@ namespace Google.Cloud.Bigtable.V2
         }
 
         /// <summary>
+        /// Mutates multiple rows in a batch. Each individual row is mutated
+        /// atomically as in MutateRow, but the entire batch is not executed
+        /// atomically.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// If the <see cref="MutateRowsRequest.AppProfileId"/> has not been specified, it will be initialized from the value stored in the client.
+        /// </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to use for this RPC.</param>
+        /// <returns>The RPC response.</returns>
+        public virtual Task<MutateRowsResponse> MutateRowsAsync(
+            MutateRowsRequest request,
+            CancellationToken cancellationToken) => MutateRowsAsync(request, CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
         /// Mutates a row atomically based on the output of a predicate Reader filter.
         /// </summary>
         /// <param name="request">
@@ -353,19 +368,6 @@ namespace Google.Cloud.Bigtable.V2
         }
 
         /// <inheritdoc/>
-        public override Task<MutateRowResponse> MutateRowAsync(
-            MutateRowRequest request,
-            CancellationToken cancellationToken)
-        {
-            if (request.AppProfileId == null)
-            {
-                request.AppProfileId = _appProfileId;
-            }
-
-            return GetUnderlyingClient().MutateRowAsync(request, cancellationToken);
-        }
-
-        /// <inheritdoc/>
         public override MutateRowResponse MutateRow(
             MutateRowRequest request,
             CallSettings callSettings = null)
@@ -410,19 +412,6 @@ namespace Google.Cloud.Bigtable.V2
         }
 
         /// <inheritdoc/>
-        public override Task<CheckAndMutateRowResponse> CheckAndMutateRowAsync(
-            CheckAndMutateRowRequest request,
-            CancellationToken cancellationToken)
-        {
-            if (request.AppProfileId == null)
-            {
-                request.AppProfileId = _appProfileId;
-            }
-
-            return GetUnderlyingClient().CheckAndMutateRowAsync(request, cancellationToken);
-        }
-
-        /// <inheritdoc/>
         public override CheckAndMutateRowResponse CheckAndMutateRow(
             CheckAndMutateRowRequest request,
             CallSettings callSettings = null)
@@ -446,19 +435,6 @@ namespace Google.Cloud.Bigtable.V2
             }
 
             return GetUnderlyingClient().ReadModifyWriteRowAsync(request, callSettings);
-        }
-
-        /// <inheritdoc/>
-        public override Task<ReadModifyWriteRowResponse> ReadModifyWriteRowAsync(
-            ReadModifyWriteRowRequest request,
-            CancellationToken cancellationToken)
-        {
-            if (request.AppProfileId == null)
-            {
-                request.AppProfileId = _appProfileId;
-            }
-
-            return GetUnderlyingClient().ReadModifyWriteRowAsync(request, cancellationToken);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This removes unnecessary overrides of the CancellationToken overloads from the BigtableClientImpl class and it also adds a CancellationToken overload to the split sync/async methods to replace the streaming MutateRows.