### PR TITLE
Add structured logs and a single default log for all AspNetCore logs.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -231,6 +231,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 Assert.Equal(3, formatParams.Count);
                 Assert.Equal(nameof(MainController.FormatParameters), formatParams["message"].StringValue);
                 Assert.Equal(testId, formatParams["id"].StringValue);
+                Assert.Equal("{message} - {id}", formatParams["{OriginalFormat}"].StringValue);
             }
         }
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -301,8 +301,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
             SetupRoutes(app);
-            LoggerOptions loggerOptions = LoggerOptions.Create(null,
-                LogLevel.Warning, null, null, BufferOptions.NoBuffer());
+            LoggerOptions loggerOptions = LoggerOptions.Create(
+                LogLevel.Warning, null, null, null, BufferOptions.NoBuffer());
             loggerFactory.AddGoogle(ProjectId, loggerOptions);
         }
     }
@@ -326,8 +326,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
             SetupRoutes(app);
-            LoggerOptions loggerOptions = LoggerOptions.Create(null,
-                LogLevel.Warning, null, Resource, BufferOptions.NoBuffer());
+            LoggerOptions loggerOptions = LoggerOptions.Create(
+                LogLevel.Warning, null, null, Resource, BufferOptions.NoBuffer());
             loggerFactory.AddGoogle(ProjectId, loggerOptions);
         }
     }
@@ -341,8 +341,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
             SetupRoutes(app);
-            LoggerOptions loggerOptions = LoggerOptions.Create(null,
-                LogLevel.Error, null, null, BufferOptions.SizedBuffer());
+            LoggerOptions loggerOptions = LoggerOptions.Create(
+                LogLevel.Error, null, null, null, BufferOptions.SizedBuffer());
             loggerFactory.AddGoogle(ProjectId, loggerOptions);
         }
     }
@@ -358,8 +358,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         {
             SetupRoutes(app);
             var options = BufferOptions.TimedBuffer(TimeSpan.FromSeconds(20));
-            LoggerOptions loggerOptions = LoggerOptions.Create(null,
-                LogLevel.Warning, null, null, options);
+            LoggerOptions loggerOptions = LoggerOptions.Create(
+                LogLevel.Warning, null, null, null, options);
             loggerFactory.AddGoogle(ProjectId, loggerOptions);
         }
     }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -207,7 +207,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 var results = _polling.GetEntries(startTime, testId, 1, LogSeverity.Critical);
                 var message = MainController.GetMessage(nameof(MainController.Scope), testId);
                 Assert.Equal(message, results.Single().JsonPayload.Fields["message"].StringValue);
-                Assert.Equal("Scope => ", results.Single().JsonPayload.Fields["scope"].StringValue);
+                Assert.Contains("Scope => ", results.Single().JsonPayload.Fields["scope"].StringValue);
             }
         }
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/GoogleLoggerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/GoogleLoggerTest.cs
@@ -50,7 +50,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             Dictionary<string, string> labels = null, IHttpContextAccessor accessor = null,
             string logName = null)
         {
-            LoggerOptions options = LoggerOptions.Create(logName, logLevel, labels, MonitoredResourceBuilder.GlobalResource);
+            LoggerOptions options = LoggerOptions.Create(logLevel, logName, labels, MonitoredResourceBuilder.GlobalResource);
             return new GoogleLogger(consumer, s_logTarget, options, _logName, s_clock, accessor);
         }
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
@@ -133,6 +133,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
                 var paramStruct = new Struct();
                 foreach (var pair in formatParams)
                 {
+                    // Consider adding formatting support for values that are IFormattable.
                     paramStruct.Fields.Add(pair.Key, Value.ForString(pair.Value?.ToString() ?? ""));
                 }
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LoggerOptions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LoggerOptions.cs
@@ -48,8 +48,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         public Dictionary<string, string> Labels { get; }
 
         private LoggerOptions(
+            LogLevel logLevel,
             string logName,
-            LogLevel logLevel, 
             Dictionary<string, string> labels,
             MonitoredResource monitoredResource, 
             BufferOptions bufferOptions,
@@ -75,8 +75,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <param name="bufferOptions">Optional, the buffer options.  Defaults to a <see cref="BufferType.Timed"/></param>
         /// <param name="retryOptions">Optional, the retry options.  Defaults to a <see cref="RetryType.None"/></param>
         public static LoggerOptions Create(
-            string logName = null,
             LogLevel logLevel = LogLevel.Information,
+            string logName = null,
             Dictionary<string, string> labels = null,
             MonitoredResource monitoredResource = null,
             BufferOptions bufferOptions = null,
@@ -87,7 +87,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             monitoredResource = monitoredResource ?? MonitoredResourceBuilder.FromPlatform();
             bufferOptions = bufferOptions ?? BufferOptions.TimedBuffer();
             retryOptions = retryOptions ?? RetryOptions.NoRetry();
-            return new LoggerOptions(logName, logLevel, labels, monitoredResource, bufferOptions, retryOptions);
+            return new LoggerOptions(logLevel, logName, labels, monitoredResource, bufferOptions, retryOptions);
         }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LoggerOptions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LoggerOptions.cs
@@ -26,8 +26,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore
     /// </summary>
     public sealed class LoggerOptions
     {
+        /// <summary>The base log name for all logs.</summary>
+        private const string _baseLogName = "aspnetcore";
+
         /// <summary>The minimum log level.</summary>
         public LogLevel LogLevel { get; }
+
+        /// <summary>The name for the all logs.</summary>
+        public string LogName { get; }
 
         /// <summary>The monitored resource. See: https://cloud.google.com/logging/docs/api/v2/resource-list </summary>
         public MonitoredResource MonitoredResource { get; }
@@ -42,9 +48,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         public Dictionary<string, string> Labels { get; }
 
         private LoggerOptions(
-            LogLevel logLevel, Dictionary<string, string> labels,
-            MonitoredResource monitoredResource, BufferOptions bufferOptions, RetryOptions retryOptions)
+            string logName,
+            LogLevel logLevel, 
+            Dictionary<string, string> labels,
+            MonitoredResource monitoredResource, 
+            BufferOptions bufferOptions,
+            RetryOptions retryOptions)
         {
+            LogName = logName;
             LogLevel = GaxPreconditions.CheckEnumValue(logLevel, nameof(logLevel));
             Labels = labels;
             MonitoredResource = monitoredResource;
@@ -56,21 +67,27 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// Create a new instance of <see cref="LoggerOptions"/>.
         /// </summary>
         /// <param name="logLevel">Optional, the minimum log level.  Defaults to <see cref="LogLevel.Information"/></param>
+        /// <param name="logName">Optional, the name of the log.  Defaults to 'aspnetcore'.</param>
         /// <param name="labels">Optional, custom labels to be added to log entries.</param>
         /// <param name="monitoredResource">Optional, the monitored resource.  The monitored resource will
         ///     be automatically detected if it is not set and will default to the global resource if the detection fails.
         ///     See: https://cloud.google.com/logging/docs/api/v2/resource-list </param>
         /// <param name="bufferOptions">Optional, the buffer options.  Defaults to a <see cref="BufferType.Timed"/></param>
         /// <param name="retryOptions">Optional, the retry options.  Defaults to a <see cref="RetryType.None"/></param>
-        public static LoggerOptions Create(LogLevel logLevel = LogLevel.Information,
+        public static LoggerOptions Create(
+            string logName = null,
+            LogLevel logLevel = LogLevel.Information,
             Dictionary<string, string> labels = null,
-            MonitoredResource monitoredResource = null, BufferOptions bufferOptions = null, RetryOptions retryOptions = null)
+            MonitoredResource monitoredResource = null,
+            BufferOptions bufferOptions = null,
+            RetryOptions retryOptions = null)
         {
+            logName = logName ?? _baseLogName;
             labels = labels ?? new Dictionary<string, string>();
             monitoredResource = monitoredResource ?? MonitoredResourceBuilder.FromPlatform();
             bufferOptions = bufferOptions ?? BufferOptions.TimedBuffer();
             retryOptions = retryOptions ?? RetryOptions.NoRetry();
-            return new LoggerOptions(logLevel, labels, monitoredResource, bufferOptions, retryOptions);
+            return new LoggerOptions(logName, logLevel, labels, monitoredResource, bufferOptions, retryOptions);
         }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Logging/LogEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Logging/LogEntryPolling.cs
@@ -53,7 +53,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
                 var request = new ListLogEntriesRequest
                 {
                     ResourceNames = { $"projects/{_projectId}" },
-                    Filter = $"timestamp >= \"{time}\" AND textPayload:{testId} AND severity >= {minSeverity}",
+                    Filter = $"timestamp >= \"{time}\" AND jsonPayload.message:\"{testId}\" AND severity >= {minSeverity} AND logName=\"projects/{_projectId}/logs/aspnetcore\"",
                     PageSize = 1000,
                 };
                 return _client.ListLogEntries(request);


### PR DESCRIPTION
This change does two things adds structured logs and sends all logs from this provider to a single Stackdriver log.

The structured log give the user more information at a more granular level which is easier to query.

Sending the logs to a single log makes browsing the logs in the Stackdriver Logs UI.  Due to how loggers are created users could get well over 10 logs one for each class using a logger which results in a large number of logs like "Microsoft.AspNetCore.*.*". This puts all logs into a single log 'aspnetcore'.  Users can further filter by the class name if they wish via the param 'log_name'. 

Fixes #1932 and fixes #2019.

