### PR TITLE
Update Bigtable versions for alpha release

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha04</Version>
+    <Version>1.0.0-alpha05</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -69,7 +69,7 @@
     "id": "Google.Cloud.Bigtable.V2",
     "productName": "Google Bigtable",
     "productUrl": "https://cloud.google.com/bigtable/",
-    "version": "1.0.0-alpha04",
+    "version": "1.0.0-alpha05",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Bigtable API.",
     "tags": [ "Bigtable" ],

--- a/tools/Google.Cloud.Docs.Snippets/Google.Cloud.Docs.Snippets.csproj
+++ b/tools/Google.Cloud.Docs.Snippets/Google.Cloud.Docs.Snippets.csproj
@@ -25,4 +25,8 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This just contains the fix here https://github.com/GoogleCloudPlatform/google-cloud-dotnet/pull/2040, but since this is probably the most common way people will set cell values, it probably deserves a new publish.

I see now I also picked up a project file change to Google.Cloud.Docs.Snippets.csproj, but it seems harmless and just used for the VS Test Explorer.