### PR TITLE
DO NOT SUBMIT: Add a header to denote API calls are coming from the Stackdriver diagnostics integration libraries

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/CloudTrace.cs
@@ -113,7 +113,8 @@ namespace Google.Cloud.Diagnostics.AspNet
             GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
 
             // Create the default values if not set.
-            client = client ?? TraceServiceClient.Create();
+            client = client ?? TraceServiceClient.Create(
+                settings: TraceServiceSettings.GetDefault().AddStackdriverHeader());
             options = options ?? TraceOptions.Create(); 
             _traceFallbackPredicate = traceFallbackPredicate ?? TraceDecisionPredicate.Default;
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerProvider.cs
@@ -81,7 +81,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         {
             // Check params and set defaults if unset.
             GaxPreconditions.CheckNotNull(logTarget, nameof(logTarget));
-            client = client ?? LoggingServiceV2Client.Create();
+            client = client ?? LoggingServiceV2Client.Create(
+                settings: LoggingServiceV2Settings.GetDefault().AppendStackdriverAssemblyVersion());
             options = options ?? LoggerOptions.Create();
 
             // Get the proper consumer from the options and add a logger provider.

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
@@ -107,7 +107,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             var serviceOptions = new TraceServiceOptions();
             setupAction(serviceOptions);
 
-            var client = serviceOptions.Client ?? TraceServiceClient.Create();
+            var client = serviceOptions.Client ?? TraceServiceClient.Create(
+                settings: TraceServiceSettings.GetDefault().AppendStackdriverAssemblyVersion());
             var options = serviceOptions.Options ?? TraceOptions.Create();
             var traceFallbackPredicate = serviceOptions.TraceFallbackPredicate ?? TraceDecisionPredicate.Default;
             var projectId = Project.GetAndCheckProjectId(serviceOptions.ProjectId);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/ServiceSettingsBaseExtensionsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/ServiceSettingsBaseExtensionsTest.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Logging.V2;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Google.Cloud.Diagnostics.Common.Tests
+{
+    public class ServiceSettingsBaseExtensionsTest
+    {
+        private static readonly Regex StackdriverHeaderRegex = new Regex(@".sdi/[1-9].");
+
+        [Fact]
+        public void AddStackdriverHeader()
+        {
+            var settings = LoggingServiceV2Settings.GetDefault();
+            Assert.DoesNotMatch(StackdriverHeaderRegex, settings.VersionHeaderBuilder.ToString());
+
+            settings.AppendStackdriverAssemblyVersion();
+            Assert.Matches(StackdriverHeaderRegex, settings.VersionHeaderBuilder.ToString());
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/EventTarget.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/EventTarget.cs
@@ -100,7 +100,8 @@ namespace Google.Cloud.Diagnostics.Common
             return new EventTarget
             {
                 Kind = EventTargetKind.Logging,
-                LoggingClient = loggingClient ?? LoggingServiceV2Client.Create(),
+                LoggingClient = loggingClient ?? LoggingServiceV2Client.Create(
+                    settings: LoggingServiceV2Settings.GetDefault().AppendStackdriverAssemblyVersion()),
                 LogTarget = GaxPreconditions.CheckNotNull(logTarget, nameof(logTarget)),
                 LogName = GaxPreconditions.CheckNotNullOrEmpty(logName, nameof(logName)),
                 MonitoredResource = monitoredResource ?? MonitoredResourceBuilder.FromPlatform(),

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.4.0-beta01" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="2.0.0" />
     <PackageReference Include="Google.Cloud.Trace.V1" Version="1.0.0" />
     <PackageReference Include="Grpc.Core" Version="1.10.0" PrivateAssets="None" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ServiceSettingsBaseExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ServiceSettingsBaseExtensions.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+
+namespace Google.Cloud.Diagnostics.Common
+{
+    /// <summary>
+    /// Extension methods for <see cref="ServiceSettingsBase"/>.
+    /// </summary>
+    public static class ServiceSettingsBaseExtensions
+    {
+        /// <summary>
+        /// The name of the stackdriver diagnostics version key.  Do not change this!
+        /// </summary>
+        private const string StackdriverDiagnosticsHeaderKey = "sdi";
+
+        /// <summary>
+        /// Add to the name and version of this library to the version header string 
+        /// of the 'x-goog-api-client' header.
+        /// </summary>
+        /// <typeparam name="T">A <see cref="ServiceSettingsBase"/>.</typeparam>
+        /// <param name="settings">The settings where the name and version of this 
+        ///     library will be added.</param>
+        /// <returns>The modified <paramref name="settings"/> object.</returns>
+        public static T AppendStackdriverAssemblyVersion<T>(this T settings) where T : ServiceSettingsBase
+        {
+            GaxPreconditions.CheckNotNull(settings, nameof(settings));
+            settings.VersionHeaderBuilder.AppendAssemblyVersion(
+                StackdriverDiagnosticsHeaderKey, typeof(ServiceSettingsBaseExtensions));
+            return settings;
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ServiceSettingsBaseExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ServiceSettingsBaseExtensions.cs
@@ -23,12 +23,13 @@ namespace Google.Cloud.Diagnostics.Common
     public static class ServiceSettingsBaseExtensions
     {
         /// <summary>
-        /// The name of the stackdriver diagnostics version key.  Do not change this!
+        /// The name of the stackdriver diagnostics version key.  Do not change this as
+        /// down stream services may depend on this key.
         /// </summary>
         private const string StackdriverDiagnosticsHeaderKey = "sdi";
 
         /// <summary>
-        /// Add to the name and version of this library to the version header string 
+        /// Add the name and version of this library to the header string 
         /// of the 'x-goog-api-client' header.
         /// </summary>
         /// <typeparam name="T">A <see cref="ServiceSettingsBase"/>.</typeparam>


### PR DESCRIPTION
This is blocked on the GA release of Google.Api.Gax.Grpc 2.4.0 (which should happen next week).

@jskeet I don't think adding more testing than what I have is needed nor am I sure what else would be useful.  Thoughts?