### PR TITLE
Fix failing integration tests.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/AssemblyInfo.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/AssemblyInfo.cs
@@ -14,4 +14,6 @@
 
 using Xunit;
 
+// This is needed to ensure trace tests that rely on the RateLimiter
+// do not affect each other.
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/AssemblyInfo.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
@@ -91,8 +91,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             using (var server = new TestServer(webHostBuilder))
             using (var client = server.CreateClient())
             {
-                await TestLogging(testId, startTime, client);
                 await TestTrace(testId, startTime, client);
+                await TestLogging(testId, startTime, client);
                 await TestErrorReporting(testId, startTime, client);
             }
         }
@@ -107,8 +107,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
         private static async Task TestTrace(string testId, DateTime startTime, HttpClient client)
         {
-            RateLimiter.Reset();
-
             var response = await client.GetAsync($"/Trace/Trace/{testId}");
 
             var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
@@ -33,6 +33,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 {
     public class DiagnosticsWebHostTests
     {
+        public DiagnosticsWebHostTests()
+        {
+            // The rate limiter instance is static and only set once.  If we do not reset it at the
+            // beginning of each tests the qps will not change.  This is dependent on the tests not
+            // running in parallel.
+            RateLimiter.Reset();
+        }
+
         [Fact]
         public void UseGoogleDiagnostics_ConfiguresServices()
         {


### PR DESCRIPTION
We do two things here:
- Add a rate limiter reset to the diag web host tests.
- Run tests in serial.  We need to do this as the tests depend on the rater limiter being reset