### PR TITLE
Regenerate all APIs

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DataTransferServiceClient.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DataTransferServiceClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -78,7 +78,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -106,8 +106,8 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -126,8 +126,8 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(20000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(20000),
             delayMultiplier: 1.0
         );
 
@@ -157,7 +157,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -187,7 +187,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -216,7 +216,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -245,7 +245,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -275,7 +275,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -305,7 +305,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -335,7 +335,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -364,7 +364,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -394,7 +394,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -424,7 +424,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -454,7 +454,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -484,7 +484,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -514,7 +514,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -614,7 +614,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// </summary>
         public virtual DataTransferService.DataTransferServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -700,7 +700,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             GetDataSourceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -739,7 +739,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             GetDataSourceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -829,7 +829,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             ListDataSourcesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -849,7 +849,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             ListDataSourcesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -952,7 +952,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             CreateTransferConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -989,7 +989,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             CreateTransferConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1010,7 +1010,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// </returns>
         public virtual stt::Task<TransferConfig> UpdateTransferConfigAsync(
             TransferConfig transferConfig,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             gaxgrpc::CallSettings callSettings = null) => UpdateTransferConfigAsync(
                 new UpdateTransferConfigRequest
                 {
@@ -1037,7 +1037,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// </returns>
         public virtual stt::Task<TransferConfig> UpdateTransferConfigAsync(
             TransferConfig transferConfig,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             st::CancellationToken cancellationToken) => UpdateTransferConfigAsync(
                 transferConfig,
                 updateMask,
@@ -1061,7 +1061,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// </returns>
         public virtual TransferConfig UpdateTransferConfig(
             TransferConfig transferConfig,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             gaxgrpc::CallSettings callSettings = null) => UpdateTransferConfig(
                 new UpdateTransferConfigRequest
                 {
@@ -1087,7 +1087,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             UpdateTransferConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1126,7 +1126,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             UpdateTransferConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1209,7 +1209,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             DeleteTransferConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1245,7 +1245,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             DeleteTransferConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1327,7 +1327,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             GetTransferConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1364,7 +1364,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             GetTransferConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1451,7 +1451,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             ListTransferConfigsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1470,7 +1470,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             ListTransferConfigsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1499,8 +1499,8 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// </returns>
         public virtual stt::Task<ScheduleTransferRunsResponse> ScheduleTransferRunsAsync(
             TransferConfigNameOneof parent,
-            protowkt::Timestamp startTime,
-            protowkt::Timestamp endTime,
+            pbwkt::Timestamp startTime,
+            pbwkt::Timestamp endTime,
             gaxgrpc::CallSettings callSettings = null) => ScheduleTransferRunsAsync(
                 new ScheduleTransferRunsRequest
                 {
@@ -1536,8 +1536,8 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// </returns>
         public virtual stt::Task<ScheduleTransferRunsResponse> ScheduleTransferRunsAsync(
             TransferConfigNameOneof parent,
-            protowkt::Timestamp startTime,
-            protowkt::Timestamp endTime,
+            pbwkt::Timestamp startTime,
+            pbwkt::Timestamp endTime,
             st::CancellationToken cancellationToken) => ScheduleTransferRunsAsync(
                 parent,
                 startTime,
@@ -1570,8 +1570,8 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// </returns>
         public virtual ScheduleTransferRunsResponse ScheduleTransferRuns(
             TransferConfigNameOneof parent,
-            protowkt::Timestamp startTime,
-            protowkt::Timestamp endTime,
+            pbwkt::Timestamp startTime,
+            pbwkt::Timestamp endTime,
             gaxgrpc::CallSettings callSettings = null) => ScheduleTransferRuns(
                 new ScheduleTransferRunsRequest
                 {
@@ -1600,7 +1600,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             ScheduleTransferRunsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1643,7 +1643,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             ScheduleTransferRunsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1725,7 +1725,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             GetTransferRunRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1762,7 +1762,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             GetTransferRunRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1841,7 +1841,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             DeleteTransferRunRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1875,7 +1875,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             DeleteTransferRunRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1964,7 +1964,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             ListTransferRunsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1983,7 +1983,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             ListTransferRunsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2070,7 +2070,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             ListTransferLogsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2089,7 +2089,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             ListTransferLogsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2191,7 +2191,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             CheckValidCredsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2238,7 +2238,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             CheckValidCredsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -2252,12 +2252,12 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         private readonly gaxgrpc::ApiCall<ListDataSourcesRequest, ListDataSourcesResponse> _callListDataSources;
         private readonly gaxgrpc::ApiCall<CreateTransferConfigRequest, TransferConfig> _callCreateTransferConfig;
         private readonly gaxgrpc::ApiCall<UpdateTransferConfigRequest, TransferConfig> _callUpdateTransferConfig;
-        private readonly gaxgrpc::ApiCall<DeleteTransferConfigRequest, protowkt::Empty> _callDeleteTransferConfig;
+        private readonly gaxgrpc::ApiCall<DeleteTransferConfigRequest, pbwkt::Empty> _callDeleteTransferConfig;
         private readonly gaxgrpc::ApiCall<GetTransferConfigRequest, TransferConfig> _callGetTransferConfig;
         private readonly gaxgrpc::ApiCall<ListTransferConfigsRequest, ListTransferConfigsResponse> _callListTransferConfigs;
         private readonly gaxgrpc::ApiCall<ScheduleTransferRunsRequest, ScheduleTransferRunsResponse> _callScheduleTransferRuns;
         private readonly gaxgrpc::ApiCall<GetTransferRunRequest, TransferRun> _callGetTransferRun;
-        private readonly gaxgrpc::ApiCall<DeleteTransferRunRequest, protowkt::Empty> _callDeleteTransferRun;
+        private readonly gaxgrpc::ApiCall<DeleteTransferRunRequest, pbwkt::Empty> _callDeleteTransferRun;
         private readonly gaxgrpc::ApiCall<ListTransferRunsRequest, ListTransferRunsResponse> _callListTransferRuns;
         private readonly gaxgrpc::ApiCall<ListTransferLogsRequest, ListTransferLogsResponse> _callListTransferLogs;
         private readonly gaxgrpc::ApiCall<CheckValidCredsRequest, CheckValidCredsResponse> _callCheckValidCreds;
@@ -2280,7 +2280,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
                 GrpcClient.CreateTransferConfigAsync, GrpcClient.CreateTransferConfig, effectiveSettings.CreateTransferConfigSettings);
             _callUpdateTransferConfig = clientHelper.BuildApiCall<UpdateTransferConfigRequest, TransferConfig>(
                 GrpcClient.UpdateTransferConfigAsync, GrpcClient.UpdateTransferConfig, effectiveSettings.UpdateTransferConfigSettings);
-            _callDeleteTransferConfig = clientHelper.BuildApiCall<DeleteTransferConfigRequest, protowkt::Empty>(
+            _callDeleteTransferConfig = clientHelper.BuildApiCall<DeleteTransferConfigRequest, pbwkt::Empty>(
                 GrpcClient.DeleteTransferConfigAsync, GrpcClient.DeleteTransferConfig, effectiveSettings.DeleteTransferConfigSettings);
             _callGetTransferConfig = clientHelper.BuildApiCall<GetTransferConfigRequest, TransferConfig>(
                 GrpcClient.GetTransferConfigAsync, GrpcClient.GetTransferConfig, effectiveSettings.GetTransferConfigSettings);
@@ -2290,7 +2290,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
                 GrpcClient.ScheduleTransferRunsAsync, GrpcClient.ScheduleTransferRuns, effectiveSettings.ScheduleTransferRunsSettings);
             _callGetTransferRun = clientHelper.BuildApiCall<GetTransferRunRequest, TransferRun>(
                 GrpcClient.GetTransferRunAsync, GrpcClient.GetTransferRun, effectiveSettings.GetTransferRunSettings);
-            _callDeleteTransferRun = clientHelper.BuildApiCall<DeleteTransferRunRequest, protowkt::Empty>(
+            _callDeleteTransferRun = clientHelper.BuildApiCall<DeleteTransferRunRequest, pbwkt::Empty>(
                 GrpcClient.DeleteTransferRunAsync, GrpcClient.DeleteTransferRun, effectiveSettings.DeleteTransferRunSettings);
             _callListTransferRuns = clientHelper.BuildApiCall<ListTransferRunsRequest, ListTransferRunsResponse>(
                 GrpcClient.ListTransferRunsAsync, GrpcClient.ListTransferRuns, effectiveSettings.ListTransferRunsSettings);
@@ -2332,8 +2332,8 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -2341,12 +2341,12 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         partial void Modify_ListDataSourcesApiCall(ref gaxgrpc::ApiCall<ListDataSourcesRequest, ListDataSourcesResponse> call);
         partial void Modify_CreateTransferConfigApiCall(ref gaxgrpc::ApiCall<CreateTransferConfigRequest, TransferConfig> call);
         partial void Modify_UpdateTransferConfigApiCall(ref gaxgrpc::ApiCall<UpdateTransferConfigRequest, TransferConfig> call);
-        partial void Modify_DeleteTransferConfigApiCall(ref gaxgrpc::ApiCall<DeleteTransferConfigRequest, protowkt::Empty> call);
+        partial void Modify_DeleteTransferConfigApiCall(ref gaxgrpc::ApiCall<DeleteTransferConfigRequest, pbwkt::Empty> call);
         partial void Modify_GetTransferConfigApiCall(ref gaxgrpc::ApiCall<GetTransferConfigRequest, TransferConfig> call);
         partial void Modify_ListTransferConfigsApiCall(ref gaxgrpc::ApiCall<ListTransferConfigsRequest, ListTransferConfigsResponse> call);
         partial void Modify_ScheduleTransferRunsApiCall(ref gaxgrpc::ApiCall<ScheduleTransferRunsRequest, ScheduleTransferRunsResponse> call);
         partial void Modify_GetTransferRunApiCall(ref gaxgrpc::ApiCall<GetTransferRunRequest, TransferRun> call);
-        partial void Modify_DeleteTransferRunApiCall(ref gaxgrpc::ApiCall<DeleteTransferRunRequest, protowkt::Empty> call);
+        partial void Modify_DeleteTransferRunApiCall(ref gaxgrpc::ApiCall<DeleteTransferRunRequest, pbwkt::Empty> call);
         partial void Modify_ListTransferRunsApiCall(ref gaxgrpc::ApiCall<ListTransferRunsRequest, ListTransferRunsResponse> call);
         partial void Modify_ListTransferLogsApiCall(ref gaxgrpc::ApiCall<ListTransferLogsRequest, ListTransferLogsResponse> call);
         partial void Modify_CheckValidCredsApiCall(ref gaxgrpc::ApiCall<CheckValidCredsRequest, CheckValidCredsResponse> call);

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/ResourceNames.cs
@@ -15,15 +15,15 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.BigQuery.DataTransfer.V1
 {
     /// <summary>
     /// Resource name for the 'project' resource.
     /// </summary>
-    public sealed partial class ProjectName : gax::IResourceName, s::IEquatable<ProjectName>
+    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
 
@@ -45,7 +45,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <see cref="ProjectName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
@@ -108,7 +108,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     /// <summary>
     /// Resource name for the 'location' resource.
     /// </summary>
-    public sealed partial class LocationName : gax::IResourceName, s::IEquatable<LocationName>
+    public sealed partial class LocationName : gax::IResourceName, sys::IEquatable<LocationName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}");
 
@@ -130,7 +130,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <see cref="LocationName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="locationName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="locationName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
@@ -200,7 +200,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     /// <summary>
     /// Resource name for the 'project_data_source' resource.
     /// </summary>
-    public sealed partial class ProjectDataSourceName : gax::IResourceName, s::IEquatable<ProjectDataSourceName>
+    public sealed partial class ProjectDataSourceName : gax::IResourceName, sys::IEquatable<ProjectDataSourceName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/dataSources/{data_source}");
 
@@ -222,7 +222,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <see cref="ProjectDataSourceName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectDataSourceName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectDataSourceName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectDataSourceName">The project_data_source resource name in string form. Must not be <c>null</c>.</param>
@@ -292,7 +292,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     /// <summary>
     /// Resource name for the 'location_data_source' resource.
     /// </summary>
-    public sealed partial class LocationDataSourceName : gax::IResourceName, s::IEquatable<LocationDataSourceName>
+    public sealed partial class LocationDataSourceName : gax::IResourceName, sys::IEquatable<LocationDataSourceName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}/dataSources/{data_source}");
 
@@ -314,7 +314,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <see cref="LocationDataSourceName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="locationDataSourceName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="locationDataSourceName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="locationDataSourceName">The location_data_source resource name in string form. Must not be <c>null</c>.</param>
@@ -391,7 +391,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     /// <summary>
     /// Resource name for the 'project_transfer_config' resource.
     /// </summary>
-    public sealed partial class ProjectTransferConfigName : gax::IResourceName, s::IEquatable<ProjectTransferConfigName>
+    public sealed partial class ProjectTransferConfigName : gax::IResourceName, sys::IEquatable<ProjectTransferConfigName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/transferConfigs/{transfer_config}");
 
@@ -413,7 +413,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <see cref="ProjectTransferConfigName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectTransferConfigName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectTransferConfigName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectTransferConfigName">The project_transfer_config resource name in string form. Must not be <c>null</c>.</param>
@@ -483,7 +483,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     /// <summary>
     /// Resource name for the 'location_transfer_config' resource.
     /// </summary>
-    public sealed partial class LocationTransferConfigName : gax::IResourceName, s::IEquatable<LocationTransferConfigName>
+    public sealed partial class LocationTransferConfigName : gax::IResourceName, sys::IEquatable<LocationTransferConfigName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}/transferConfigs/{transfer_config}");
 
@@ -505,7 +505,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <see cref="LocationTransferConfigName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="locationTransferConfigName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="locationTransferConfigName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="locationTransferConfigName">The location_transfer_config resource name in string form. Must not be <c>null</c>.</param>
@@ -582,7 +582,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     /// <summary>
     /// Resource name for the 'project_run' resource.
     /// </summary>
-    public sealed partial class ProjectRunName : gax::IResourceName, s::IEquatable<ProjectRunName>
+    public sealed partial class ProjectRunName : gax::IResourceName, sys::IEquatable<ProjectRunName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/transferConfigs/{transfer_config}/runs/{run}");
 
@@ -604,7 +604,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <see cref="ProjectRunName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectRunName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectRunName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectRunName">The project_run resource name in string form. Must not be <c>null</c>.</param>
@@ -681,7 +681,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     /// <summary>
     /// Resource name for the 'location_run' resource.
     /// </summary>
-    public sealed partial class LocationRunName : gax::IResourceName, s::IEquatable<LocationRunName>
+    public sealed partial class LocationRunName : gax::IResourceName, sys::IEquatable<LocationRunName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}/transferConfigs/{transfer_config}/runs/{run}");
 
@@ -703,7 +703,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <see cref="LocationRunName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="locationRunName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="locationRunName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="locationRunName">The location_run resource name in string form. Must not be <c>null</c>.</param>
@@ -794,7 +794,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     /// <item><description>LocationName: A resource of type 'location'.</description></item>
     /// </list>
     /// </remarks>
-    public sealed partial class ParentNameOneof : gax::IResourceName, s::IEquatable<ParentNameOneof>
+    public sealed partial class ParentNameOneof : gax::IResourceName, sys::IEquatable<ParentNameOneof>
     {
         /// <summary>
         /// The possible contents of <see cref="ParentNameOneof"/>.
@@ -831,7 +831,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
         /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="s::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
         /// <returns>The parsed <see cref="ParentNameOneof"/> if successful.</returns>
         public static ParentNameOneof Parse(string name, bool allowUnknown)
         {
@@ -840,7 +840,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             {
                 return result;
             }
-            throw new s::ArgumentException("Invalid name", nameof(name));
+            throw new sys::ArgumentException("Invalid name", nameof(name));
         }
 
         /// <summary>
@@ -925,7 +925,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
             if (!IsValid(type, name))
             {
-                throw new s::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
             }
         }
 
@@ -943,7 +943,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         {
             if (Type != type)
             {
-                throw new s::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
             }
             return (T)Name;
         }
@@ -952,7 +952,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="ProjectName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="ProjectName"/>.
         /// </remarks>
         public ProjectName ProjectName => CheckAndReturn<ProjectName>(OneofType.ProjectName);
@@ -961,7 +961,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="LocationName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="LocationName"/>.
         /// </remarks>
         public LocationName LocationName => CheckAndReturn<LocationName>(OneofType.LocationName);
@@ -998,7 +998,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     /// <item><description>LocationDataSourceName: A resource of type 'location_data_source'.</description></item>
     /// </list>
     /// </remarks>
-    public sealed partial class DataSourceNameOneof : gax::IResourceName, s::IEquatable<DataSourceNameOneof>
+    public sealed partial class DataSourceNameOneof : gax::IResourceName, sys::IEquatable<DataSourceNameOneof>
     {
         /// <summary>
         /// The possible contents of <see cref="DataSourceNameOneof"/>.
@@ -1035,7 +1035,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
         /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="s::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
         /// <returns>The parsed <see cref="DataSourceNameOneof"/> if successful.</returns>
         public static DataSourceNameOneof Parse(string name, bool allowUnknown)
         {
@@ -1044,7 +1044,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             {
                 return result;
             }
-            throw new s::ArgumentException("Invalid name", nameof(name));
+            throw new sys::ArgumentException("Invalid name", nameof(name));
         }
 
         /// <summary>
@@ -1129,7 +1129,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
             if (!IsValid(type, name))
             {
-                throw new s::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
             }
         }
 
@@ -1147,7 +1147,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         {
             if (Type != type)
             {
-                throw new s::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
             }
             return (T)Name;
         }
@@ -1156,7 +1156,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="ProjectDataSourceName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="ProjectDataSourceName"/>.
         /// </remarks>
         public ProjectDataSourceName ProjectDataSourceName => CheckAndReturn<ProjectDataSourceName>(OneofType.ProjectDataSourceName);
@@ -1165,7 +1165,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="LocationDataSourceName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="LocationDataSourceName"/>.
         /// </remarks>
         public LocationDataSourceName LocationDataSourceName => CheckAndReturn<LocationDataSourceName>(OneofType.LocationDataSourceName);
@@ -1202,7 +1202,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     /// <item><description>LocationTransferConfigName: A resource of type 'location_transfer_config'.</description></item>
     /// </list>
     /// </remarks>
-    public sealed partial class TransferConfigNameOneof : gax::IResourceName, s::IEquatable<TransferConfigNameOneof>
+    public sealed partial class TransferConfigNameOneof : gax::IResourceName, sys::IEquatable<TransferConfigNameOneof>
     {
         /// <summary>
         /// The possible contents of <see cref="TransferConfigNameOneof"/>.
@@ -1239,7 +1239,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
         /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="s::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
         /// <returns>The parsed <see cref="TransferConfigNameOneof"/> if successful.</returns>
         public static TransferConfigNameOneof Parse(string name, bool allowUnknown)
         {
@@ -1248,7 +1248,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             {
                 return result;
             }
-            throw new s::ArgumentException("Invalid name", nameof(name));
+            throw new sys::ArgumentException("Invalid name", nameof(name));
         }
 
         /// <summary>
@@ -1333,7 +1333,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
             if (!IsValid(type, name))
             {
-                throw new s::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
             }
         }
 
@@ -1351,7 +1351,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         {
             if (Type != type)
             {
-                throw new s::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
             }
             return (T)Name;
         }
@@ -1360,7 +1360,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="ProjectTransferConfigName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="ProjectTransferConfigName"/>.
         /// </remarks>
         public ProjectTransferConfigName ProjectTransferConfigName => CheckAndReturn<ProjectTransferConfigName>(OneofType.ProjectTransferConfigName);
@@ -1369,7 +1369,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="LocationTransferConfigName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="LocationTransferConfigName"/>.
         /// </remarks>
         public LocationTransferConfigName LocationTransferConfigName => CheckAndReturn<LocationTransferConfigName>(OneofType.LocationTransferConfigName);
@@ -1406,7 +1406,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     /// <item><description>LocationRunName: A resource of type 'location_run'.</description></item>
     /// </list>
     /// </remarks>
-    public sealed partial class RunNameOneof : gax::IResourceName, s::IEquatable<RunNameOneof>
+    public sealed partial class RunNameOneof : gax::IResourceName, sys::IEquatable<RunNameOneof>
     {
         /// <summary>
         /// The possible contents of <see cref="RunNameOneof"/>.
@@ -1443,7 +1443,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
         /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="s::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
         /// <returns>The parsed <see cref="RunNameOneof"/> if successful.</returns>
         public static RunNameOneof Parse(string name, bool allowUnknown)
         {
@@ -1452,7 +1452,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             {
                 return result;
             }
-            throw new s::ArgumentException("Invalid name", nameof(name));
+            throw new sys::ArgumentException("Invalid name", nameof(name));
         }
 
         /// <summary>
@@ -1537,7 +1537,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
             if (!IsValid(type, name))
             {
-                throw new s::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
             }
         }
 
@@ -1555,7 +1555,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         {
             if (Type != type)
             {
-                throw new s::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
             }
             return (T)Name;
         }
@@ -1564,7 +1564,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="ProjectRunName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="ProjectRunName"/>.
         /// </remarks>
         public ProjectRunName ProjectRunName => CheckAndReturn<ProjectRunName>(OneofType.ProjectRunName);
@@ -1573,7 +1573,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="LocationRunName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="LocationRunName"/>.
         /// </remarks>
         public LocationRunName LocationRunName => CheckAndReturn<LocationRunName>(OneofType.LocationRunName);
@@ -1604,9 +1604,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class CheckValidCredsRequest
     {
         /// <summary>
-        /// <see cref="DataSourceNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.DataSourceNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public DataSourceNameOneof DataSourceNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.DataSourceNameOneof DataSourceNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.BigQuery.DataTransfer.V1.DataSourceNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1617,9 +1617,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class CreateTransferConfigRequest
     {
         /// <summary>
-        /// <see cref="ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ParentNameOneof ParentAsParentNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.ParentNameOneof ParentAsParentNameOneof
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.BigQuery.DataTransfer.V1.ParentNameOneof.Parse(Parent, true); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1630,9 +1630,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class DataSource
     {
         /// <summary>
-        /// <see cref="DataSourceNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.DataSourceNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public DataSourceNameOneof DataSourceNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.DataSourceNameOneof DataSourceNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.BigQuery.DataTransfer.V1.DataSourceNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1643,9 +1643,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class DeleteTransferConfigRequest
     {
         /// <summary>
-        /// <see cref="TransferConfigNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public TransferConfigNameOneof TransferConfigNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof TransferConfigNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1656,9 +1656,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class DeleteTransferRunRequest
     {
         /// <summary>
-        /// <see cref="RunNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.RunNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public RunNameOneof RunNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.RunNameOneof RunNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.BigQuery.DataTransfer.V1.RunNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1669,9 +1669,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class GetDataSourceRequest
     {
         /// <summary>
-        /// <see cref="DataSourceNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.DataSourceNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public DataSourceNameOneof DataSourceNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.DataSourceNameOneof DataSourceNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.BigQuery.DataTransfer.V1.DataSourceNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1682,9 +1682,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class GetTransferConfigRequest
     {
         /// <summary>
-        /// <see cref="TransferConfigNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public TransferConfigNameOneof TransferConfigNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof TransferConfigNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1695,9 +1695,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class GetTransferRunRequest
     {
         /// <summary>
-        /// <see cref="RunNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.RunNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public RunNameOneof RunNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.RunNameOneof RunNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.BigQuery.DataTransfer.V1.RunNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1708,9 +1708,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class ListDataSourcesRequest
     {
         /// <summary>
-        /// <see cref="ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ParentNameOneof ParentAsParentNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.ParentNameOneof ParentAsParentNameOneof
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.BigQuery.DataTransfer.V1.ParentNameOneof.Parse(Parent, true); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1721,9 +1721,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class ListTransferConfigsRequest
     {
         /// <summary>
-        /// <see cref="ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ParentNameOneof ParentAsParentNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.ParentNameOneof ParentAsParentNameOneof
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.BigQuery.DataTransfer.V1.ParentNameOneof.Parse(Parent, true); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1734,9 +1734,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class ListTransferLogsRequest
     {
         /// <summary>
-        /// <see cref="RunNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.RunNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public RunNameOneof ParentAsRunNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.RunNameOneof ParentAsRunNameOneof
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.BigQuery.DataTransfer.V1.RunNameOneof.Parse(Parent, true); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1747,9 +1747,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class ListTransferRunsRequest
     {
         /// <summary>
-        /// <see cref="TransferConfigNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public TransferConfigNameOneof ParentAsTransferConfigNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof ParentAsTransferConfigNameOneof
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof.Parse(Parent, true); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1760,9 +1760,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class ScheduleTransferRunsRequest
     {
         /// <summary>
-        /// <see cref="TransferConfigNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public TransferConfigNameOneof ParentAsTransferConfigNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof ParentAsTransferConfigNameOneof
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof.Parse(Parent, true); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1773,9 +1773,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class TransferConfig
     {
         /// <summary>
-        /// <see cref="TransferConfigNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public TransferConfigNameOneof TransferConfigNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof TransferConfigNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.BigQuery.DataTransfer.V1.TransferConfigNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1786,9 +1786,9 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     public partial class TransferRun
     {
         /// <summary>
-        /// <see cref="RunNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.BigQuery.DataTransfer.V1.RunNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public RunNameOneof RunNameOneof
+        public Google.Cloud.BigQuery.DataTransfer.V1.RunNameOneof RunNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.BigQuery.DataTransfer.V1.RunNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableInstanceAdminClient.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableInstanceAdminClient.cs
@@ -18,10 +18,10 @@ using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using iam = Google.Cloud.Iam.V1;
 using lro = Google.LongRunning;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -90,7 +90,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -121,8 +121,8 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(5),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(5),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 2.0
         );
 
@@ -141,8 +141,8 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(60000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(60000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.0
         );
 
@@ -171,7 +171,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -190,10 +190,10 @@ namespace Google.Cloud.Bigtable.Admin.V2
         public lro::OperationsSettings CreateInstanceOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000L)),
-                s::TimeSpan.FromMilliseconds(500L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000L)),
+                sys::TimeSpan.FromMilliseconds(500L),
                 1.5,
-                s::TimeSpan.FromMilliseconds(5000L))
+                sys::TimeSpan.FromMilliseconds(5000L))
         };
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -252,7 +252,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -282,7 +282,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -301,10 +301,10 @@ namespace Google.Cloud.Bigtable.Admin.V2
         public lro::OperationsSettings PartialUpdateInstanceOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000L)),
-                s::TimeSpan.FromMilliseconds(500L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000L)),
+                sys::TimeSpan.FromMilliseconds(500L),
                 1.5,
-                s::TimeSpan.FromMilliseconds(5000L))
+                sys::TimeSpan.FromMilliseconds(5000L))
         };
 
         /// <summary>
@@ -333,7 +333,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -362,7 +362,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -381,10 +381,10 @@ namespace Google.Cloud.Bigtable.Admin.V2
         public lro::OperationsSettings CreateClusterOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000L)),
-                s::TimeSpan.FromMilliseconds(500L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000L)),
+                sys::TimeSpan.FromMilliseconds(500L),
                 1.5,
-                s::TimeSpan.FromMilliseconds(5000L))
+                sys::TimeSpan.FromMilliseconds(5000L))
         };
 
         /// <summary>
@@ -413,7 +413,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -443,7 +443,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -473,7 +473,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -492,10 +492,10 @@ namespace Google.Cloud.Bigtable.Admin.V2
         public lro::OperationsSettings UpdateClusterOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000L)),
-                s::TimeSpan.FromMilliseconds(500L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000L)),
+                sys::TimeSpan.FromMilliseconds(500L),
                 1.5,
-                s::TimeSpan.FromMilliseconds(5000L))
+                sys::TimeSpan.FromMilliseconds(5000L))
         };
 
         /// <summary>
@@ -524,7 +524,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -553,7 +553,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -583,7 +583,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -613,7 +613,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -643,7 +643,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -662,10 +662,10 @@ namespace Google.Cloud.Bigtable.Admin.V2
         public lro::OperationsSettings UpdateAppProfileOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000L)),
-                s::TimeSpan.FromMilliseconds(5L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000L)),
+                sys::TimeSpan.FromMilliseconds(5L),
                 1.5,
-                s::TimeSpan.FromMilliseconds(5000L))
+                sys::TimeSpan.FromMilliseconds(5000L))
         };
 
         /// <summary>
@@ -693,7 +693,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -723,7 +723,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -752,7 +752,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -782,7 +782,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -898,7 +898,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </summary>
         public virtual BigtableInstanceAdmin.BigtableInstanceAdminClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -1046,7 +1046,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             CreateInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1078,7 +1078,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             CreateInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1086,7 +1086,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </summary>
         public virtual lro::OperationsClient CreateInstanceOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -1181,7 +1181,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             GetInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1218,7 +1218,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             GetInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1300,7 +1300,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             ListInstancesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1337,7 +1337,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             ListInstancesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1358,7 +1358,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </returns>
         public virtual stt::Task<lro::Operation<Instance, UpdateInstanceMetadata>> PartialUpdateInstanceAsync(
             Instance instance,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             gaxgrpc::CallSettings callSettings = null) => PartialUpdateInstanceAsync(
                 new PartialUpdateInstanceRequest
                 {
@@ -1385,7 +1385,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </returns>
         public virtual stt::Task<lro::Operation<Instance, UpdateInstanceMetadata>> PartialUpdateInstanceAsync(
             Instance instance,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             st::CancellationToken cancellationToken) => PartialUpdateInstanceAsync(
                 instance,
                 updateMask,
@@ -1409,7 +1409,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </returns>
         public virtual lro::Operation<Instance, UpdateInstanceMetadata> PartialUpdateInstance(
             Instance instance,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             gaxgrpc::CallSettings callSettings = null) => PartialUpdateInstance(
                 new PartialUpdateInstanceRequest
                 {
@@ -1434,7 +1434,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             PartialUpdateInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1466,7 +1466,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             PartialUpdateInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1474,7 +1474,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </summary>
         public virtual lro::OperationsClient PartialUpdateInstanceOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -1566,7 +1566,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             DeleteInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1600,7 +1600,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             DeleteInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1724,7 +1724,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             CreateClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1756,7 +1756,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             CreateClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1764,7 +1764,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </summary>
         public virtual lro::OperationsClient CreateClusterOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -1859,7 +1859,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             GetClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1896,7 +1896,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             GetClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1984,7 +1984,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             ListClustersRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2021,7 +2021,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             ListClustersRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2040,7 +2040,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             Cluster request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2072,7 +2072,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             Cluster request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2080,7 +2080,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </summary>
         public virtual lro::OperationsClient UpdateClusterOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -2172,7 +2172,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             DeleteClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2206,7 +2206,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             DeleteClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2350,7 +2350,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             CreateAppProfileRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2397,7 +2397,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             CreateAppProfileRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2499,7 +2499,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             GetAppProfileRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2546,7 +2546,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             GetAppProfileRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2650,7 +2650,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             ListAppProfilesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2674,7 +2674,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             ListAppProfilesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2700,7 +2700,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </returns>
         public virtual stt::Task<lro::Operation<AppProfile, UpdateAppProfileMetadata>> UpdateAppProfileAsync(
             AppProfile appProfile,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             gaxgrpc::CallSettings callSettings = null) => UpdateAppProfileAsync(
                 new UpdateAppProfileRequest
                 {
@@ -2732,7 +2732,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </returns>
         public virtual stt::Task<lro::Operation<AppProfile, UpdateAppProfileMetadata>> UpdateAppProfileAsync(
             AppProfile appProfile,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             st::CancellationToken cancellationToken) => UpdateAppProfileAsync(
                 appProfile,
                 updateMask,
@@ -2761,7 +2761,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </returns>
         public virtual lro::Operation<AppProfile, UpdateAppProfileMetadata> UpdateAppProfile(
             AppProfile appProfile,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             gaxgrpc::CallSettings callSettings = null) => UpdateAppProfile(
                 new UpdateAppProfileRequest
                 {
@@ -2791,7 +2791,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             UpdateAppProfileRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2828,7 +2828,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             UpdateAppProfileRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2836,7 +2836,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </summary>
         public virtual lro::OperationsClient UpdateAppProfileOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -2948,7 +2948,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             DeleteAppProfileRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2992,7 +2992,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             DeleteAppProfileRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3105,7 +3105,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             iam::GetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3156,7 +3156,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             iam::GetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3293,7 +3293,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             iam::SetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3344,7 +3344,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             iam::SetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3477,7 +3477,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             iam::TestIamPermissionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3526,7 +3526,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             iam::TestIamPermissionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -3540,17 +3540,17 @@ namespace Google.Cloud.Bigtable.Admin.V2
         private readonly gaxgrpc::ApiCall<GetInstanceRequest, Instance> _callGetInstance;
         private readonly gaxgrpc::ApiCall<ListInstancesRequest, ListInstancesResponse> _callListInstances;
         private readonly gaxgrpc::ApiCall<PartialUpdateInstanceRequest, lro::Operation> _callPartialUpdateInstance;
-        private readonly gaxgrpc::ApiCall<DeleteInstanceRequest, protowkt::Empty> _callDeleteInstance;
+        private readonly gaxgrpc::ApiCall<DeleteInstanceRequest, pbwkt::Empty> _callDeleteInstance;
         private readonly gaxgrpc::ApiCall<CreateClusterRequest, lro::Operation> _callCreateCluster;
         private readonly gaxgrpc::ApiCall<GetClusterRequest, Cluster> _callGetCluster;
         private readonly gaxgrpc::ApiCall<ListClustersRequest, ListClustersResponse> _callListClusters;
         private readonly gaxgrpc::ApiCall<Cluster, lro::Operation> _callUpdateCluster;
-        private readonly gaxgrpc::ApiCall<DeleteClusterRequest, protowkt::Empty> _callDeleteCluster;
+        private readonly gaxgrpc::ApiCall<DeleteClusterRequest, pbwkt::Empty> _callDeleteCluster;
         private readonly gaxgrpc::ApiCall<CreateAppProfileRequest, AppProfile> _callCreateAppProfile;
         private readonly gaxgrpc::ApiCall<GetAppProfileRequest, AppProfile> _callGetAppProfile;
         private readonly gaxgrpc::ApiCall<ListAppProfilesRequest, ListAppProfilesResponse> _callListAppProfiles;
         private readonly gaxgrpc::ApiCall<UpdateAppProfileRequest, lro::Operation> _callUpdateAppProfile;
-        private readonly gaxgrpc::ApiCall<DeleteAppProfileRequest, protowkt::Empty> _callDeleteAppProfile;
+        private readonly gaxgrpc::ApiCall<DeleteAppProfileRequest, pbwkt::Empty> _callDeleteAppProfile;
         private readonly gaxgrpc::ApiCall<iam::GetIamPolicyRequest, iam::Policy> _callGetIamPolicy;
         private readonly gaxgrpc::ApiCall<iam::SetIamPolicyRequest, iam::Policy> _callSetIamPolicy;
         private readonly gaxgrpc::ApiCall<iam::TestIamPermissionsRequest, iam::TestIamPermissionsResponse> _callTestIamPermissions;
@@ -3587,7 +3587,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             _callPartialUpdateInstance = clientHelper.BuildApiCall<PartialUpdateInstanceRequest, lro::Operation>(
                 GrpcClient.PartialUpdateInstanceAsync, GrpcClient.PartialUpdateInstance, effectiveSettings.PartialUpdateInstanceSettings)
                 .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"instance.name={request.Instance.Name}"));
-            _callDeleteInstance = clientHelper.BuildApiCall<DeleteInstanceRequest, protowkt::Empty>(
+            _callDeleteInstance = clientHelper.BuildApiCall<DeleteInstanceRequest, pbwkt::Empty>(
                 GrpcClient.DeleteInstanceAsync, GrpcClient.DeleteInstance, effectiveSettings.DeleteInstanceSettings)
                 .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"name={request.Name}"));
             _callCreateCluster = clientHelper.BuildApiCall<CreateClusterRequest, lro::Operation>(
@@ -3602,7 +3602,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             _callUpdateCluster = clientHelper.BuildApiCall<Cluster, lro::Operation>(
                 GrpcClient.UpdateClusterAsync, GrpcClient.UpdateCluster, effectiveSettings.UpdateClusterSettings)
                 .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"name={request.Name}"));
-            _callDeleteCluster = clientHelper.BuildApiCall<DeleteClusterRequest, protowkt::Empty>(
+            _callDeleteCluster = clientHelper.BuildApiCall<DeleteClusterRequest, pbwkt::Empty>(
                 GrpcClient.DeleteClusterAsync, GrpcClient.DeleteCluster, effectiveSettings.DeleteClusterSettings)
                 .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"name={request.Name}"));
             _callCreateAppProfile = clientHelper.BuildApiCall<CreateAppProfileRequest, AppProfile>(
@@ -3617,7 +3617,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             _callUpdateAppProfile = clientHelper.BuildApiCall<UpdateAppProfileRequest, lro::Operation>(
                 GrpcClient.UpdateAppProfileAsync, GrpcClient.UpdateAppProfile, effectiveSettings.UpdateAppProfileSettings)
                 .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"app_profile.name={request.AppProfile.Name}"));
-            _callDeleteAppProfile = clientHelper.BuildApiCall<DeleteAppProfileRequest, protowkt::Empty>(
+            _callDeleteAppProfile = clientHelper.BuildApiCall<DeleteAppProfileRequest, pbwkt::Empty>(
                 GrpcClient.DeleteAppProfileAsync, GrpcClient.DeleteAppProfile, effectiveSettings.DeleteAppProfileSettings)
                 .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"name={request.Name}"));
             _callGetIamPolicy = clientHelper.BuildApiCall<iam::GetIamPolicyRequest, iam::Policy>(
@@ -3673,8 +3673,8 @@ namespace Google.Cloud.Bigtable.Admin.V2
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -3682,17 +3682,17 @@ namespace Google.Cloud.Bigtable.Admin.V2
         partial void Modify_GetInstanceApiCall(ref gaxgrpc::ApiCall<GetInstanceRequest, Instance> call);
         partial void Modify_ListInstancesApiCall(ref gaxgrpc::ApiCall<ListInstancesRequest, ListInstancesResponse> call);
         partial void Modify_PartialUpdateInstanceApiCall(ref gaxgrpc::ApiCall<PartialUpdateInstanceRequest, lro::Operation> call);
-        partial void Modify_DeleteInstanceApiCall(ref gaxgrpc::ApiCall<DeleteInstanceRequest, protowkt::Empty> call);
+        partial void Modify_DeleteInstanceApiCall(ref gaxgrpc::ApiCall<DeleteInstanceRequest, pbwkt::Empty> call);
         partial void Modify_CreateClusterApiCall(ref gaxgrpc::ApiCall<CreateClusterRequest, lro::Operation> call);
         partial void Modify_GetClusterApiCall(ref gaxgrpc::ApiCall<GetClusterRequest, Cluster> call);
         partial void Modify_ListClustersApiCall(ref gaxgrpc::ApiCall<ListClustersRequest, ListClustersResponse> call);
         partial void Modify_UpdateClusterApiCall(ref gaxgrpc::ApiCall<Cluster, lro::Operation> call);
-        partial void Modify_DeleteClusterApiCall(ref gaxgrpc::ApiCall<DeleteClusterRequest, protowkt::Empty> call);
+        partial void Modify_DeleteClusterApiCall(ref gaxgrpc::ApiCall<DeleteClusterRequest, pbwkt::Empty> call);
         partial void Modify_CreateAppProfileApiCall(ref gaxgrpc::ApiCall<CreateAppProfileRequest, AppProfile> call);
         partial void Modify_GetAppProfileApiCall(ref gaxgrpc::ApiCall<GetAppProfileRequest, AppProfile> call);
         partial void Modify_ListAppProfilesApiCall(ref gaxgrpc::ApiCall<ListAppProfilesRequest, ListAppProfilesResponse> call);
         partial void Modify_UpdateAppProfileApiCall(ref gaxgrpc::ApiCall<UpdateAppProfileRequest, lro::Operation> call);
-        partial void Modify_DeleteAppProfileApiCall(ref gaxgrpc::ApiCall<DeleteAppProfileRequest, protowkt::Empty> call);
+        partial void Modify_DeleteAppProfileApiCall(ref gaxgrpc::ApiCall<DeleteAppProfileRequest, pbwkt::Empty> call);
         partial void Modify_GetIamPolicyApiCall(ref gaxgrpc::ApiCall<iam::GetIamPolicyRequest, iam::Policy> call);
         partial void Modify_SetIamPolicyApiCall(ref gaxgrpc::ApiCall<iam::SetIamPolicyRequest, iam::Policy> call);
         partial void Modify_TestIamPermissionsApiCall(ref gaxgrpc::ApiCall<iam::TestIamPermissionsRequest, iam::TestIamPermissionsResponse> call);

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableTableAdminClient.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableTableAdminClient.cs
@@ -17,10 +17,10 @@
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using lro = Google.LongRunning;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -81,7 +81,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -109,8 +109,8 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -129,8 +129,8 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(20000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(20000),
             delayMultiplier: 1.0
         );
 
@@ -159,7 +159,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -188,7 +188,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -207,10 +207,10 @@ namespace Google.Cloud.Bigtable.Admin.V2
         public lro::OperationsSettings CreateTableFromSnapshotOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000L)),
-                s::TimeSpan.FromMilliseconds(500L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000L)),
+                sys::TimeSpan.FromMilliseconds(500L),
                 1.5,
-                s::TimeSpan.FromMilliseconds(5000L))
+                sys::TimeSpan.FromMilliseconds(5000L))
         };
 
         /// <summary>
@@ -239,7 +239,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -269,7 +269,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -299,7 +299,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -328,7 +328,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -357,7 +357,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -387,7 +387,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -417,7 +417,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -446,7 +446,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -465,10 +465,10 @@ namespace Google.Cloud.Bigtable.Admin.V2
         public lro::OperationsSettings SnapshotTableOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000L)),
-                s::TimeSpan.FromMilliseconds(500L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000L)),
+                sys::TimeSpan.FromMilliseconds(500L),
                 1.5,
-                s::TimeSpan.FromMilliseconds(5000L))
+                sys::TimeSpan.FromMilliseconds(5000L))
         };
 
         /// <summary>
@@ -497,7 +497,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -527,7 +527,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -556,7 +556,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -672,7 +672,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </summary>
         public virtual BigtableTableAdmin.BigtableTableAdminClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -795,7 +795,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             CreateTableRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -836,7 +836,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             CreateTableRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -984,7 +984,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             CreateTableFromSnapshotRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1022,7 +1022,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             CreateTableFromSnapshotRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1030,7 +1030,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </summary>
         public virtual lro::OperationsClient CreateTableFromSnapshotOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -1130,7 +1130,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             ListTablesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1149,7 +1149,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             ListTablesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1234,7 +1234,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             GetTableRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1271,7 +1271,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             GetTableRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1353,7 +1353,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             DeleteTableRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1387,7 +1387,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             DeleteTableRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1508,7 +1508,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             ModifyColumnFamiliesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1551,7 +1551,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             ModifyColumnFamiliesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1572,7 +1572,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             DropRowRangeRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1610,7 +1610,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             DropRowRangeRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1727,7 +1727,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             GenerateConsistencyTokenRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1780,7 +1780,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             GenerateConsistencyTokenRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1908,7 +1908,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             CheckConsistencyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1959,7 +1959,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             CheckConsistencyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2128,7 +2128,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             SnapshotTableRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2166,7 +2166,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             SnapshotTableRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2174,7 +2174,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </summary>
         public virtual lro::OperationsClient SnapshotTableOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -2292,7 +2292,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             GetSnapshotRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2339,7 +2339,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             GetSnapshotRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2447,7 +2447,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             ListSnapshotsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2471,7 +2471,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             ListSnapshotsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2573,7 +2573,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             DeleteSnapshotRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2617,7 +2617,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             DeleteSnapshotRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -2631,15 +2631,15 @@ namespace Google.Cloud.Bigtable.Admin.V2
         private readonly gaxgrpc::ApiCall<CreateTableFromSnapshotRequest, lro::Operation> _callCreateTableFromSnapshot;
         private readonly gaxgrpc::ApiCall<ListTablesRequest, ListTablesResponse> _callListTables;
         private readonly gaxgrpc::ApiCall<GetTableRequest, Table> _callGetTable;
-        private readonly gaxgrpc::ApiCall<DeleteTableRequest, protowkt::Empty> _callDeleteTable;
+        private readonly gaxgrpc::ApiCall<DeleteTableRequest, pbwkt::Empty> _callDeleteTable;
         private readonly gaxgrpc::ApiCall<ModifyColumnFamiliesRequest, Table> _callModifyColumnFamilies;
-        private readonly gaxgrpc::ApiCall<DropRowRangeRequest, protowkt::Empty> _callDropRowRange;
+        private readonly gaxgrpc::ApiCall<DropRowRangeRequest, pbwkt::Empty> _callDropRowRange;
         private readonly gaxgrpc::ApiCall<GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse> _callGenerateConsistencyToken;
         private readonly gaxgrpc::ApiCall<CheckConsistencyRequest, CheckConsistencyResponse> _callCheckConsistency;
         private readonly gaxgrpc::ApiCall<SnapshotTableRequest, lro::Operation> _callSnapshotTable;
         private readonly gaxgrpc::ApiCall<GetSnapshotRequest, Snapshot> _callGetSnapshot;
         private readonly gaxgrpc::ApiCall<ListSnapshotsRequest, ListSnapshotsResponse> _callListSnapshots;
-        private readonly gaxgrpc::ApiCall<DeleteSnapshotRequest, protowkt::Empty> _callDeleteSnapshot;
+        private readonly gaxgrpc::ApiCall<DeleteSnapshotRequest, pbwkt::Empty> _callDeleteSnapshot;
 
         /// <summary>
         /// Constructs a client wrapper for the BigtableTableAdmin service, with the specified gRPC client and settings.
@@ -2667,13 +2667,13 @@ namespace Google.Cloud.Bigtable.Admin.V2
             _callGetTable = clientHelper.BuildApiCall<GetTableRequest, Table>(
                 GrpcClient.GetTableAsync, GrpcClient.GetTable, effectiveSettings.GetTableSettings)
                 .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"name={request.Name}"));
-            _callDeleteTable = clientHelper.BuildApiCall<DeleteTableRequest, protowkt::Empty>(
+            _callDeleteTable = clientHelper.BuildApiCall<DeleteTableRequest, pbwkt::Empty>(
                 GrpcClient.DeleteTableAsync, GrpcClient.DeleteTable, effectiveSettings.DeleteTableSettings)
                 .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"name={request.Name}"));
             _callModifyColumnFamilies = clientHelper.BuildApiCall<ModifyColumnFamiliesRequest, Table>(
                 GrpcClient.ModifyColumnFamiliesAsync, GrpcClient.ModifyColumnFamilies, effectiveSettings.ModifyColumnFamiliesSettings)
                 .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"name={request.Name}"));
-            _callDropRowRange = clientHelper.BuildApiCall<DropRowRangeRequest, protowkt::Empty>(
+            _callDropRowRange = clientHelper.BuildApiCall<DropRowRangeRequest, pbwkt::Empty>(
                 GrpcClient.DropRowRangeAsync, GrpcClient.DropRowRange, effectiveSettings.DropRowRangeSettings)
                 .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"name={request.Name}"));
             _callGenerateConsistencyToken = clientHelper.BuildApiCall<GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>(
@@ -2691,7 +2691,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             _callListSnapshots = clientHelper.BuildApiCall<ListSnapshotsRequest, ListSnapshotsResponse>(
                 GrpcClient.ListSnapshotsAsync, GrpcClient.ListSnapshots, effectiveSettings.ListSnapshotsSettings)
                 .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"parent={request.Parent}"));
-            _callDeleteSnapshot = clientHelper.BuildApiCall<DeleteSnapshotRequest, protowkt::Empty>(
+            _callDeleteSnapshot = clientHelper.BuildApiCall<DeleteSnapshotRequest, pbwkt::Empty>(
                 GrpcClient.DeleteSnapshotAsync, GrpcClient.DeleteSnapshot, effectiveSettings.DeleteSnapshotSettings)
                 .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"name={request.Name}"));
             Modify_ApiCall(ref _callCreateTable);
@@ -2728,8 +2728,8 @@ namespace Google.Cloud.Bigtable.Admin.V2
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -2737,15 +2737,15 @@ namespace Google.Cloud.Bigtable.Admin.V2
         partial void Modify_CreateTableFromSnapshotApiCall(ref gaxgrpc::ApiCall<CreateTableFromSnapshotRequest, lro::Operation> call);
         partial void Modify_ListTablesApiCall(ref gaxgrpc::ApiCall<ListTablesRequest, ListTablesResponse> call);
         partial void Modify_GetTableApiCall(ref gaxgrpc::ApiCall<GetTableRequest, Table> call);
-        partial void Modify_DeleteTableApiCall(ref gaxgrpc::ApiCall<DeleteTableRequest, protowkt::Empty> call);
+        partial void Modify_DeleteTableApiCall(ref gaxgrpc::ApiCall<DeleteTableRequest, pbwkt::Empty> call);
         partial void Modify_ModifyColumnFamiliesApiCall(ref gaxgrpc::ApiCall<ModifyColumnFamiliesRequest, Table> call);
-        partial void Modify_DropRowRangeApiCall(ref gaxgrpc::ApiCall<DropRowRangeRequest, protowkt::Empty> call);
+        partial void Modify_DropRowRangeApiCall(ref gaxgrpc::ApiCall<DropRowRangeRequest, pbwkt::Empty> call);
         partial void Modify_GenerateConsistencyTokenApiCall(ref gaxgrpc::ApiCall<GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse> call);
         partial void Modify_CheckConsistencyApiCall(ref gaxgrpc::ApiCall<CheckConsistencyRequest, CheckConsistencyResponse> call);
         partial void Modify_SnapshotTableApiCall(ref gaxgrpc::ApiCall<SnapshotTableRequest, lro::Operation> call);
         partial void Modify_GetSnapshotApiCall(ref gaxgrpc::ApiCall<GetSnapshotRequest, Snapshot> call);
         partial void Modify_ListSnapshotsApiCall(ref gaxgrpc::ApiCall<ListSnapshotsRequest, ListSnapshotsResponse> call);
-        partial void Modify_DeleteSnapshotApiCall(ref gaxgrpc::ApiCall<DeleteSnapshotRequest, protowkt::Empty> call);
+        partial void Modify_DeleteSnapshotApiCall(ref gaxgrpc::ApiCall<DeleteSnapshotRequest, pbwkt::Empty> call);
         partial void OnConstruction(BigtableTableAdmin.BigtableTableAdminClient grpcClient, BigtableTableAdminSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
         /// <summary>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/ResourceNames.cs
@@ -15,15 +15,15 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Bigtable.Admin.V2
 {
     /// <summary>
     /// Resource name for the 'project' resource.
     /// </summary>
-    public sealed partial class ProjectName : gax::IResourceName, s::IEquatable<ProjectName>
+    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
 
@@ -45,7 +45,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <see cref="ProjectName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
@@ -108,7 +108,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
     /// <summary>
     /// Resource name for the 'instance' resource.
     /// </summary>
-    public sealed partial class InstanceName : gax::IResourceName, s::IEquatable<InstanceName>
+    public sealed partial class InstanceName : gax::IResourceName, sys::IEquatable<InstanceName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}");
 
@@ -130,7 +130,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <see cref="InstanceName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="instanceName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="instanceName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="instanceName">The instance resource name in string form. Must not be <c>null</c>.</param>
@@ -200,7 +200,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
     /// <summary>
     /// Resource name for the 'app_profile' resource.
     /// </summary>
-    public sealed partial class AppProfileName : gax::IResourceName, s::IEquatable<AppProfileName>
+    public sealed partial class AppProfileName : gax::IResourceName, sys::IEquatable<AppProfileName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}/appProfiles/{app_profile}");
 
@@ -222,7 +222,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <see cref="AppProfileName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="appProfileName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="appProfileName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="appProfileName">The app_profile resource name in string form. Must not be <c>null</c>.</param>
@@ -299,7 +299,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
     /// <summary>
     /// Resource name for the 'cluster' resource.
     /// </summary>
-    public sealed partial class ClusterName : gax::IResourceName, s::IEquatable<ClusterName>
+    public sealed partial class ClusterName : gax::IResourceName, sys::IEquatable<ClusterName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}/clusters/{cluster}");
 
@@ -321,7 +321,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <see cref="ClusterName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="clusterName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="clusterName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="clusterName">The cluster resource name in string form. Must not be <c>null</c>.</param>
@@ -398,7 +398,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
     /// <summary>
     /// Resource name for the 'location' resource.
     /// </summary>
-    public sealed partial class LocationName : gax::IResourceName, s::IEquatable<LocationName>
+    public sealed partial class LocationName : gax::IResourceName, sys::IEquatable<LocationName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}");
 
@@ -420,7 +420,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <see cref="LocationName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="locationName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="locationName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
@@ -490,7 +490,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
     /// <summary>
     /// Resource name for the 'snapshot' resource.
     /// </summary>
-    public sealed partial class SnapshotName : gax::IResourceName, s::IEquatable<SnapshotName>
+    public sealed partial class SnapshotName : gax::IResourceName, sys::IEquatable<SnapshotName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/{snapshot}");
 
@@ -512,7 +512,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <see cref="SnapshotName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="snapshotName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="snapshotName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="snapshotName">The snapshot resource name in string form. Must not be <c>null</c>.</param>
@@ -596,7 +596,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
     /// <summary>
     /// Resource name for the 'table' resource.
     /// </summary>
-    public sealed partial class TableName : gax::IResourceName, s::IEquatable<TableName>
+    public sealed partial class TableName : gax::IResourceName, sys::IEquatable<TableName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}/tables/{table}");
 
@@ -618,7 +618,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <see cref="TableName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="tableName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="tableName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="tableName">The table resource name in string form. Must not be <c>null</c>.</param>
@@ -696,9 +696,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class CheckConsistencyRequest
     {
         /// <summary>
-        /// <see cref="TableName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.TableName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public TableName TableName
+        public Google.Cloud.Bigtable.Admin.V2.TableName TableName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.TableName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -709,18 +709,18 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class Cluster
     {
         /// <summary>
-        /// <see cref="ClusterName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.ClusterName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ClusterName ClusterName
+        public Google.Cloud.Bigtable.Admin.V2.ClusterName ClusterName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.ClusterName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="LocationName"/>-typed view over the <see cref="Location"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.LocationName"/>-typed view over the <see cref="Location"/> resource name property.
         /// </summary>
-        public LocationName LocationAsLocationName
+        public Google.Cloud.Bigtable.Admin.V2.LocationName LocationAsLocationName
         {
             get { return string.IsNullOrEmpty(Location) ? null : Google.Cloud.Bigtable.Admin.V2.LocationName.Parse(Location); }
             set { Location = value != null ? value.ToString() : ""; }
@@ -731,9 +731,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class CreateAppProfileRequest
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public InstanceName ParentAsInstanceName
+        public Google.Cloud.Bigtable.Admin.V2.InstanceName ParentAsInstanceName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Bigtable.Admin.V2.InstanceName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -744,9 +744,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class CreateClusterRequest
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public InstanceName ParentAsInstanceName
+        public Google.Cloud.Bigtable.Admin.V2.InstanceName ParentAsInstanceName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Bigtable.Admin.V2.InstanceName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -757,9 +757,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class CreateInstanceRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ProjectName ParentAsProjectName
+        public Google.Cloud.Bigtable.Admin.V2.ProjectName ParentAsProjectName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Bigtable.Admin.V2.ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -770,18 +770,18 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class CreateTableFromSnapshotRequest
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public InstanceName ParentAsInstanceName
+        public Google.Cloud.Bigtable.Admin.V2.InstanceName ParentAsInstanceName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Bigtable.Admin.V2.InstanceName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="SnapshotName"/>-typed view over the <see cref="SourceSnapshot"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.SnapshotName"/>-typed view over the <see cref="SourceSnapshot"/> resource name property.
         /// </summary>
-        public SnapshotName SourceSnapshotAsSnapshotName
+        public Google.Cloud.Bigtable.Admin.V2.SnapshotName SourceSnapshotAsSnapshotName
         {
             get { return string.IsNullOrEmpty(SourceSnapshot) ? null : Google.Cloud.Bigtable.Admin.V2.SnapshotName.Parse(SourceSnapshot); }
             set { SourceSnapshot = value != null ? value.ToString() : ""; }
@@ -792,9 +792,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class CreateTableRequest
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public InstanceName ParentAsInstanceName
+        public Google.Cloud.Bigtable.Admin.V2.InstanceName ParentAsInstanceName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Bigtable.Admin.V2.InstanceName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -805,9 +805,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class DeleteAppProfileRequest
     {
         /// <summary>
-        /// <see cref="AppProfileName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.AppProfileName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public AppProfileName AppProfileName
+        public Google.Cloud.Bigtable.Admin.V2.AppProfileName AppProfileName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.AppProfileName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -818,9 +818,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class DeleteClusterRequest
     {
         /// <summary>
-        /// <see cref="ClusterName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.ClusterName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ClusterName ClusterName
+        public Google.Cloud.Bigtable.Admin.V2.ClusterName ClusterName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.ClusterName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -831,9 +831,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class DeleteInstanceRequest
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.InstanceName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public InstanceName InstanceName
+        public Google.Cloud.Bigtable.Admin.V2.InstanceName InstanceName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.InstanceName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -844,9 +844,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class DeleteSnapshotRequest
     {
         /// <summary>
-        /// <see cref="SnapshotName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.SnapshotName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public SnapshotName SnapshotName
+        public Google.Cloud.Bigtable.Admin.V2.SnapshotName SnapshotName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.SnapshotName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -857,9 +857,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class DeleteTableRequest
     {
         /// <summary>
-        /// <see cref="TableName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.TableName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public TableName TableName
+        public Google.Cloud.Bigtable.Admin.V2.TableName TableName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.TableName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -870,9 +870,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class DropRowRangeRequest
     {
         /// <summary>
-        /// <see cref="TableName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.TableName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public TableName TableName
+        public Google.Cloud.Bigtable.Admin.V2.TableName TableName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.TableName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -883,9 +883,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class GenerateConsistencyTokenRequest
     {
         /// <summary>
-        /// <see cref="TableName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.TableName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public TableName TableName
+        public Google.Cloud.Bigtable.Admin.V2.TableName TableName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.TableName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -896,9 +896,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class GetAppProfileRequest
     {
         /// <summary>
-        /// <see cref="AppProfileName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.AppProfileName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public AppProfileName AppProfileName
+        public Google.Cloud.Bigtable.Admin.V2.AppProfileName AppProfileName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.AppProfileName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -909,9 +909,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class GetClusterRequest
     {
         /// <summary>
-        /// <see cref="ClusterName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.ClusterName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ClusterName ClusterName
+        public Google.Cloud.Bigtable.Admin.V2.ClusterName ClusterName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.ClusterName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -922,9 +922,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class GetInstanceRequest
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.InstanceName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public InstanceName InstanceName
+        public Google.Cloud.Bigtable.Admin.V2.InstanceName InstanceName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.InstanceName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -935,9 +935,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class GetSnapshotRequest
     {
         /// <summary>
-        /// <see cref="SnapshotName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.SnapshotName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public SnapshotName SnapshotName
+        public Google.Cloud.Bigtable.Admin.V2.SnapshotName SnapshotName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.SnapshotName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -948,9 +948,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class GetTableRequest
     {
         /// <summary>
-        /// <see cref="TableName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.TableName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public TableName TableName
+        public Google.Cloud.Bigtable.Admin.V2.TableName TableName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.TableName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -961,9 +961,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class Instance
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.InstanceName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public InstanceName InstanceName
+        public Google.Cloud.Bigtable.Admin.V2.InstanceName InstanceName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.InstanceName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -974,9 +974,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class ListAppProfilesRequest
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public InstanceName ParentAsInstanceName
+        public Google.Cloud.Bigtable.Admin.V2.InstanceName ParentAsInstanceName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Bigtable.Admin.V2.InstanceName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -987,9 +987,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class ListClustersRequest
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public InstanceName ParentAsInstanceName
+        public Google.Cloud.Bigtable.Admin.V2.InstanceName ParentAsInstanceName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Bigtable.Admin.V2.InstanceName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1000,9 +1000,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class ListInstancesRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ProjectName ParentAsProjectName
+        public Google.Cloud.Bigtable.Admin.V2.ProjectName ParentAsProjectName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Bigtable.Admin.V2.ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1013,9 +1013,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class ListSnapshotsRequest
     {
         /// <summary>
-        /// <see cref="ClusterName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.ClusterName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ClusterName ParentAsClusterName
+        public Google.Cloud.Bigtable.Admin.V2.ClusterName ParentAsClusterName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Bigtable.Admin.V2.ClusterName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1026,9 +1026,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class ListTablesRequest
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public InstanceName ParentAsInstanceName
+        public Google.Cloud.Bigtable.Admin.V2.InstanceName ParentAsInstanceName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Bigtable.Admin.V2.InstanceName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1039,9 +1039,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class ModifyColumnFamiliesRequest
     {
         /// <summary>
-        /// <see cref="TableName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.TableName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public TableName TableName
+        public Google.Cloud.Bigtable.Admin.V2.TableName TableName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.TableName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1052,9 +1052,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class Snapshot
     {
         /// <summary>
-        /// <see cref="SnapshotName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.SnapshotName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public SnapshotName SnapshotName
+        public Google.Cloud.Bigtable.Admin.V2.SnapshotName SnapshotName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.SnapshotName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1065,27 +1065,27 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class SnapshotTableRequest
     {
         /// <summary>
-        /// <see cref="TableName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.TableName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public TableName TableName
+        public Google.Cloud.Bigtable.Admin.V2.TableName TableName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.TableName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="ClusterName"/>-typed view over the <see cref="Cluster"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.ClusterName"/>-typed view over the <see cref="Cluster"/> resource name property.
         /// </summary>
-        public ClusterName ClusterAsClusterName
+        public Google.Cloud.Bigtable.Admin.V2.ClusterName ClusterAsClusterName
         {
             get { return string.IsNullOrEmpty(Cluster) ? null : Google.Cloud.Bigtable.Admin.V2.ClusterName.Parse(Cluster); }
             set { Cluster = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="SnapshotName"/>-typed view over the <see cref="SnapshotId"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.SnapshotName"/>-typed view over the <see cref="SnapshotId"/> resource name property.
         /// </summary>
-        public SnapshotName SnapshotIdAsSnapshotName
+        public Google.Cloud.Bigtable.Admin.V2.SnapshotName SnapshotIdAsSnapshotName
         {
             get { return string.IsNullOrEmpty(SnapshotId) ? null : Google.Cloud.Bigtable.Admin.V2.SnapshotName.Parse(SnapshotId); }
             set { SnapshotId = value != null ? value.ToString() : ""; }
@@ -1096,9 +1096,9 @@ namespace Google.Cloud.Bigtable.Admin.V2
     public partial class Table
     {
         /// <summary>
-        /// <see cref="TableName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.Admin.V2.TableName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public TableName TableName
+        public Google.Cloud.Bigtable.Admin.V2.TableName TableName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Bigtable.Admin.V2.TableName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/BigtableServiceApiClientSnippets.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/BigtableServiceApiClientSnippets.g.cs
@@ -92,7 +92,7 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             BigtableServiceApiClient bigtableServiceApiClient = await BigtableServiceApiClient.CreateAsync();
             // Initialize request argument(s)
             TableName tableName = new TableName("[PROJECT]", "[INSTANCE]", "[TABLE]");
-            ByteString rowKey = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString rowKey = ByteString.Empty;
             IEnumerable<Mutation> mutations = new List<Mutation>();
             // Make the request
             MutateRowResponse response = await bigtableServiceApiClient.MutateRowAsync(tableName, rowKey, mutations);
@@ -107,7 +107,7 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             BigtableServiceApiClient bigtableServiceApiClient = BigtableServiceApiClient.Create();
             // Initialize request argument(s)
             TableName tableName = new TableName("[PROJECT]", "[INSTANCE]", "[TABLE]");
-            ByteString rowKey = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString rowKey = ByteString.Empty;
             IEnumerable<Mutation> mutations = new List<Mutation>();
             // Make the request
             MutateRowResponse response = bigtableServiceApiClient.MutateRow(tableName, rowKey, mutations);
@@ -125,7 +125,7 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             MutateRowRequest request = new MutateRowRequest
             {
                 TableNameAsTableName = new TableName("[PROJECT]", "[INSTANCE]", "[TABLE]"),
-                RowKey = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                RowKey = ByteString.Empty,
                 Mutations = { },
             };
             // Make the request
@@ -143,7 +143,7 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             MutateRowRequest request = new MutateRowRequest
             {
                 TableNameAsTableName = new TableName("[PROJECT]", "[INSTANCE]", "[TABLE]"),
-                RowKey = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                RowKey = ByteString.Empty,
                 Mutations = { },
             };
             // Make the request
@@ -186,7 +186,7 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             BigtableServiceApiClient bigtableServiceApiClient = await BigtableServiceApiClient.CreateAsync();
             // Initialize request argument(s)
             TableName tableName = new TableName("[PROJECT]", "[INSTANCE]", "[TABLE]");
-            ByteString rowKey = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString rowKey = ByteString.Empty;
             RowFilter predicateFilter = new RowFilter();
             IEnumerable<Mutation> trueMutations = new List<Mutation>();
             IEnumerable<Mutation> falseMutations = new List<Mutation>();
@@ -203,7 +203,7 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             BigtableServiceApiClient bigtableServiceApiClient = BigtableServiceApiClient.Create();
             // Initialize request argument(s)
             TableName tableName = new TableName("[PROJECT]", "[INSTANCE]", "[TABLE]");
-            ByteString rowKey = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString rowKey = ByteString.Empty;
             RowFilter predicateFilter = new RowFilter();
             IEnumerable<Mutation> trueMutations = new List<Mutation>();
             IEnumerable<Mutation> falseMutations = new List<Mutation>();
@@ -223,7 +223,7 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             CheckAndMutateRowRequest request = new CheckAndMutateRowRequest
             {
                 TableNameAsTableName = new TableName("[PROJECT]", "[INSTANCE]", "[TABLE]"),
-                RowKey = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                RowKey = ByteString.Empty,
             };
             // Make the request
             CheckAndMutateRowResponse response = await bigtableServiceApiClient.CheckAndMutateRowAsync(request);
@@ -240,7 +240,7 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             CheckAndMutateRowRequest request = new CheckAndMutateRowRequest
             {
                 TableNameAsTableName = new TableName("[PROJECT]", "[INSTANCE]", "[TABLE]"),
-                RowKey = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                RowKey = ByteString.Empty,
             };
             // Make the request
             CheckAndMutateRowResponse response = bigtableServiceApiClient.CheckAndMutateRow(request);
@@ -256,7 +256,7 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             BigtableServiceApiClient bigtableServiceApiClient = await BigtableServiceApiClient.CreateAsync();
             // Initialize request argument(s)
             TableName tableName = new TableName("[PROJECT]", "[INSTANCE]", "[TABLE]");
-            ByteString rowKey = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString rowKey = ByteString.Empty;
             IEnumerable<ReadModifyWriteRule> rules = new List<ReadModifyWriteRule>();
             // Make the request
             ReadModifyWriteRowResponse response = await bigtableServiceApiClient.ReadModifyWriteRowAsync(tableName, rowKey, rules);
@@ -271,7 +271,7 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             BigtableServiceApiClient bigtableServiceApiClient = BigtableServiceApiClient.Create();
             // Initialize request argument(s)
             TableName tableName = new TableName("[PROJECT]", "[INSTANCE]", "[TABLE]");
-            ByteString rowKey = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString rowKey = ByteString.Empty;
             IEnumerable<ReadModifyWriteRule> rules = new List<ReadModifyWriteRule>();
             // Make the request
             ReadModifyWriteRowResponse response = bigtableServiceApiClient.ReadModifyWriteRow(tableName, rowKey, rules);
@@ -289,7 +289,7 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             ReadModifyWriteRowRequest request = new ReadModifyWriteRowRequest
             {
                 TableNameAsTableName = new TableName("[PROJECT]", "[INSTANCE]", "[TABLE]"),
-                RowKey = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                RowKey = ByteString.Empty,
                 Rules = { },
             };
             // Make the request
@@ -307,7 +307,7 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             ReadModifyWriteRowRequest request = new ReadModifyWriteRowRequest
             {
                 TableNameAsTableName = new TableName("[PROJECT]", "[INSTANCE]", "[TABLE]"),
-                RowKey = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                RowKey = ByteString.Empty,
                 Rules = { },
             };
             // Make the request

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.cs
@@ -16,14 +16,14 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
-using System.Linq;
+using linq = System.Linq;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
 using Google.Api.Gax;
@@ -50,7 +50,7 @@ namespace Google.Cloud.Bigtable.V2
             ReadRowsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace Google.Cloud.Bigtable.V2
             SampleRowKeysRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Google.Cloud.Bigtable.V2
             MutateRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace Google.Cloud.Bigtable.V2
             MutateRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace Google.Cloud.Bigtable.V2
             MutateRowsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace Google.Cloud.Bigtable.V2
             MutateRowsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -210,7 +210,7 @@ namespace Google.Cloud.Bigtable.V2
             CheckAndMutateRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -249,7 +249,7 @@ namespace Google.Cloud.Bigtable.V2
             CheckAndMutateRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -273,7 +273,7 @@ namespace Google.Cloud.Bigtable.V2
             ReadModifyWriteRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -320,7 +320,7 @@ namespace Google.Cloud.Bigtable.V2
             ReadModifyWriteRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
     }
 

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.cs
@@ -16,14 +16,14 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
-using System.Linq;
+using linq = System.Linq;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
 
@@ -72,7 +72,7 @@ namespace Google.Cloud.Bigtable.V2
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Google.Cloud.Bigtable.V2
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -100,8 +100,8 @@ namespace Google.Cloud.Bigtable.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -120,8 +120,8 @@ namespace Google.Cloud.Bigtable.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(20000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(20000),
             delayMultiplier: 1.0
         );
 
@@ -132,7 +132,7 @@ namespace Google.Cloud.Bigtable.V2
         /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings ReadRowsSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
-            gaxgrpc::CallTiming.FromTimeout(s::TimeSpan.FromMilliseconds(600000)));
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)));
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for calls to <c>BigtableServiceApiClient.SampleRowKeys</c>.
@@ -141,7 +141,7 @@ namespace Google.Cloud.Bigtable.V2
         /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings SampleRowKeysSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
-            gaxgrpc::CallTiming.FromTimeout(s::TimeSpan.FromMilliseconds(600000)));
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)));
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
@@ -169,7 +169,7 @@ namespace Google.Cloud.Bigtable.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -180,7 +180,7 @@ namespace Google.Cloud.Bigtable.V2
         /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings MutateRowsSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
-            gaxgrpc::CallTiming.FromTimeout(s::TimeSpan.FromMilliseconds(600000)));
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)));
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
@@ -207,7 +207,7 @@ namespace Google.Cloud.Bigtable.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -236,7 +236,7 @@ namespace Google.Cloud.Bigtable.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -346,7 +346,7 @@ namespace Google.Cloud.Bigtable.V2
         /// </summary>
         public virtual Bigtable.BigtableClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -369,7 +369,7 @@ namespace Google.Cloud.Bigtable.V2
             ReadRowsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -398,7 +398,7 @@ namespace Google.Cloud.Bigtable.V2
             SampleRowKeysRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -433,7 +433,7 @@ namespace Google.Cloud.Bigtable.V2
         /// </returns>
         public virtual stt::Task<MutateRowResponse> MutateRowAsync(
             TableName tableName,
-            proto::ByteString rowKey,
+            pb::ByteString rowKey,
             scg::IEnumerable<Mutation> mutations,
             gaxgrpc::CallSettings callSettings = null) => MutateRowAsync(
                 new MutateRowRequest
@@ -469,7 +469,7 @@ namespace Google.Cloud.Bigtable.V2
         /// </returns>
         public virtual stt::Task<MutateRowResponse> MutateRowAsync(
             TableName tableName,
-            proto::ByteString rowKey,
+            pb::ByteString rowKey,
             scg::IEnumerable<Mutation> mutations,
             st::CancellationToken cancellationToken) => MutateRowAsync(
                 tableName,
@@ -502,7 +502,7 @@ namespace Google.Cloud.Bigtable.V2
         /// </returns>
         public virtual MutateRowResponse MutateRow(
             TableName tableName,
-            proto::ByteString rowKey,
+            pb::ByteString rowKey,
             scg::IEnumerable<Mutation> mutations,
             gaxgrpc::CallSettings callSettings = null) => MutateRow(
                 new MutateRowRequest
@@ -530,7 +530,7 @@ namespace Google.Cloud.Bigtable.V2
             MutateRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -569,7 +569,7 @@ namespace Google.Cloud.Bigtable.V2
             MutateRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -590,7 +590,7 @@ namespace Google.Cloud.Bigtable.V2
             MutateRowsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -640,7 +640,7 @@ namespace Google.Cloud.Bigtable.V2
         /// </returns>
         public virtual stt::Task<CheckAndMutateRowResponse> CheckAndMutateRowAsync(
             TableName tableName,
-            proto::ByteString rowKey,
+            pb::ByteString rowKey,
             RowFilter predicateFilter,
             scg::IEnumerable<Mutation> trueMutations,
             scg::IEnumerable<Mutation> falseMutations,
@@ -650,8 +650,8 @@ namespace Google.Cloud.Bigtable.V2
                     TableNameAsTableName = gax::GaxPreconditions.CheckNotNull(tableName, nameof(tableName)),
                     RowKey = gax::GaxPreconditions.CheckNotNull(rowKey, nameof(rowKey)),
                     PredicateFilter = predicateFilter, // Optional
-                    TrueMutations = { trueMutations ?? Enumerable.Empty<Mutation>() }, // Optional
-                    FalseMutations = { falseMutations ?? Enumerable.Empty<Mutation>() }, // Optional
+                    TrueMutations = { trueMutations ?? linq::Enumerable.Empty<Mutation>() }, // Optional
+                    FalseMutations = { falseMutations ?? linq::Enumerable.Empty<Mutation>() }, // Optional
                 },
                 callSettings);
 
@@ -695,7 +695,7 @@ namespace Google.Cloud.Bigtable.V2
         /// </returns>
         public virtual stt::Task<CheckAndMutateRowResponse> CheckAndMutateRowAsync(
             TableName tableName,
-            proto::ByteString rowKey,
+            pb::ByteString rowKey,
             RowFilter predicateFilter,
             scg::IEnumerable<Mutation> trueMutations,
             scg::IEnumerable<Mutation> falseMutations,
@@ -747,7 +747,7 @@ namespace Google.Cloud.Bigtable.V2
         /// </returns>
         public virtual CheckAndMutateRowResponse CheckAndMutateRow(
             TableName tableName,
-            proto::ByteString rowKey,
+            pb::ByteString rowKey,
             RowFilter predicateFilter,
             scg::IEnumerable<Mutation> trueMutations,
             scg::IEnumerable<Mutation> falseMutations,
@@ -757,8 +757,8 @@ namespace Google.Cloud.Bigtable.V2
                     TableNameAsTableName = gax::GaxPreconditions.CheckNotNull(tableName, nameof(tableName)),
                     RowKey = gax::GaxPreconditions.CheckNotNull(rowKey, nameof(rowKey)),
                     PredicateFilter = predicateFilter, // Optional
-                    TrueMutations = { trueMutations ?? Enumerable.Empty<Mutation>() }, // Optional
-                    FalseMutations = { falseMutations ?? Enumerable.Empty<Mutation>() }, // Optional
+                    TrueMutations = { trueMutations ?? linq::Enumerable.Empty<Mutation>() }, // Optional
+                    FalseMutations = { falseMutations ?? linq::Enumerable.Empty<Mutation>() }, // Optional
                 },
                 callSettings);
 
@@ -778,7 +778,7 @@ namespace Google.Cloud.Bigtable.V2
             CheckAndMutateRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -815,7 +815,7 @@ namespace Google.Cloud.Bigtable.V2
             CheckAndMutateRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -847,7 +847,7 @@ namespace Google.Cloud.Bigtable.V2
         /// </returns>
         public virtual stt::Task<ReadModifyWriteRowResponse> ReadModifyWriteRowAsync(
             TableName tableName,
-            proto::ByteString rowKey,
+            pb::ByteString rowKey,
             scg::IEnumerable<ReadModifyWriteRule> rules,
             gaxgrpc::CallSettings callSettings = null) => ReadModifyWriteRowAsync(
                 new ReadModifyWriteRowRequest
@@ -887,7 +887,7 @@ namespace Google.Cloud.Bigtable.V2
         /// </returns>
         public virtual stt::Task<ReadModifyWriteRowResponse> ReadModifyWriteRowAsync(
             TableName tableName,
-            proto::ByteString rowKey,
+            pb::ByteString rowKey,
             scg::IEnumerable<ReadModifyWriteRule> rules,
             st::CancellationToken cancellationToken) => ReadModifyWriteRowAsync(
                 tableName,
@@ -924,7 +924,7 @@ namespace Google.Cloud.Bigtable.V2
         /// </returns>
         public virtual ReadModifyWriteRowResponse ReadModifyWriteRow(
             TableName tableName,
-            proto::ByteString rowKey,
+            pb::ByteString rowKey,
             scg::IEnumerable<ReadModifyWriteRule> rules,
             gaxgrpc::CallSettings callSettings = null) => ReadModifyWriteRow(
                 new ReadModifyWriteRowRequest
@@ -955,7 +955,7 @@ namespace Google.Cloud.Bigtable.V2
             ReadModifyWriteRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1000,7 +1000,7 @@ namespace Google.Cloud.Bigtable.V2
             ReadModifyWriteRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1065,11 +1065,11 @@ namespace Google.Cloud.Bigtable.V2
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiServerStreamingCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/ResourceNames.cs
@@ -15,15 +15,15 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Bigtable.V2
 {
     /// <summary>
     /// Resource name for the 'table' resource.
     /// </summary>
-    public sealed partial class TableName : gax::IResourceName, s::IEquatable<TableName>
+    public sealed partial class TableName : gax::IResourceName, sys::IEquatable<TableName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}/tables/{table}");
 
@@ -45,7 +45,7 @@ namespace Google.Cloud.Bigtable.V2
         /// <see cref="TableName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="tableName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="tableName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="tableName">The table resource name in string form. Must not be <c>null</c>.</param>
@@ -123,9 +123,9 @@ namespace Google.Cloud.Bigtable.V2
     public partial class CheckAndMutateRowRequest
     {
         /// <summary>
-        /// <see cref="TableName"/>-typed view over the <see cref="TableName"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.V2.TableName"/>-typed view over the <see cref="TableName"/> resource name property.
         /// </summary>
-        public TableName TableNameAsTableName
+        public Google.Cloud.Bigtable.V2.TableName TableNameAsTableName
         {
             get { return string.IsNullOrEmpty(TableName) ? null : Google.Cloud.Bigtable.V2.TableName.Parse(TableName); }
             set { TableName = value != null ? value.ToString() : ""; }
@@ -136,9 +136,9 @@ namespace Google.Cloud.Bigtable.V2
     public partial class MutateRowRequest
     {
         /// <summary>
-        /// <see cref="TableName"/>-typed view over the <see cref="TableName"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.V2.TableName"/>-typed view over the <see cref="TableName"/> resource name property.
         /// </summary>
-        public TableName TableNameAsTableName
+        public Google.Cloud.Bigtable.V2.TableName TableNameAsTableName
         {
             get { return string.IsNullOrEmpty(TableName) ? null : Google.Cloud.Bigtable.V2.TableName.Parse(TableName); }
             set { TableName = value != null ? value.ToString() : ""; }
@@ -149,9 +149,9 @@ namespace Google.Cloud.Bigtable.V2
     public partial class MutateRowsRequest
     {
         /// <summary>
-        /// <see cref="TableName"/>-typed view over the <see cref="TableName"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.V2.TableName"/>-typed view over the <see cref="TableName"/> resource name property.
         /// </summary>
-        public TableName TableNameAsTableName
+        public Google.Cloud.Bigtable.V2.TableName TableNameAsTableName
         {
             get { return string.IsNullOrEmpty(TableName) ? null : Google.Cloud.Bigtable.V2.TableName.Parse(TableName); }
             set { TableName = value != null ? value.ToString() : ""; }
@@ -162,9 +162,9 @@ namespace Google.Cloud.Bigtable.V2
     public partial class ReadModifyWriteRowRequest
     {
         /// <summary>
-        /// <see cref="TableName"/>-typed view over the <see cref="TableName"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.V2.TableName"/>-typed view over the <see cref="TableName"/> resource name property.
         /// </summary>
-        public TableName TableNameAsTableName
+        public Google.Cloud.Bigtable.V2.TableName TableNameAsTableName
         {
             get { return string.IsNullOrEmpty(TableName) ? null : Google.Cloud.Bigtable.V2.TableName.Parse(TableName); }
             set { TableName = value != null ? value.ToString() : ""; }
@@ -175,9 +175,9 @@ namespace Google.Cloud.Bigtable.V2
     public partial class ReadRowsRequest
     {
         /// <summary>
-        /// <see cref="TableName"/>-typed view over the <see cref="TableName"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.V2.TableName"/>-typed view over the <see cref="TableName"/> resource name property.
         /// </summary>
-        public TableName TableNameAsTableName
+        public Google.Cloud.Bigtable.V2.TableName TableNameAsTableName
         {
             get { return string.IsNullOrEmpty(TableName) ? null : Google.Cloud.Bigtable.V2.TableName.Parse(TableName); }
             set { TableName = value != null ? value.ToString() : ""; }
@@ -188,9 +188,9 @@ namespace Google.Cloud.Bigtable.V2
     public partial class SampleRowKeysRequest
     {
         /// <summary>
-        /// <see cref="TableName"/>-typed view over the <see cref="TableName"/> resource name property.
+        /// <see cref="Google.Cloud.Bigtable.V2.TableName"/>-typed view over the <see cref="TableName"/> resource name property.
         /// </summary>
-        public TableName TableNameAsTableName
+        public Google.Cloud.Bigtable.V2.TableName TableNameAsTableName
         {
             get { return string.IsNullOrEmpty(TableName) ? null : Google.Cloud.Bigtable.V2.TableName.Parse(TableName); }
             set { TableName = value != null ? value.ToString() : ""; }

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterManagerClient.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterManagerClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -95,7 +95,7 @@ namespace Google.Cloud.Container.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace Google.Cloud.Container.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -123,8 +123,8 @@ namespace Google.Cloud.Container.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -143,8 +143,8 @@ namespace Google.Cloud.Container.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(20000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(20000),
             delayMultiplier: 1.0
         );
 
@@ -174,7 +174,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -204,7 +204,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -233,7 +233,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -262,7 +262,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -291,7 +291,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -320,7 +320,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -349,7 +349,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -378,7 +378,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -407,7 +407,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -436,7 +436,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -465,7 +465,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -494,7 +494,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -524,7 +524,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -554,7 +554,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -584,7 +584,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -613,7 +613,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -643,7 +643,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -673,7 +673,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -703,7 +703,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -732,7 +732,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -762,7 +762,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -791,7 +791,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -820,7 +820,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -849,7 +849,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -878,7 +878,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -907,7 +907,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -936,7 +936,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -965,7 +965,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -994,7 +994,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -1023,7 +1023,7 @@ namespace Google.Cloud.Container.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -1123,7 +1123,7 @@ namespace Google.Cloud.Container.V1
         /// </summary>
         public virtual ClusterManager.ClusterManagerClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -1230,7 +1230,7 @@ namespace Google.Cloud.Container.V1
             ListClustersRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1269,7 +1269,7 @@ namespace Google.Cloud.Container.V1
             ListClustersRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1387,7 +1387,7 @@ namespace Google.Cloud.Container.V1
             GetClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1424,7 +1424,7 @@ namespace Google.Cloud.Container.V1
             GetClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1593,7 +1593,7 @@ namespace Google.Cloud.Container.V1
             CreateClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1654,7 +1654,7 @@ namespace Google.Cloud.Container.V1
             CreateClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1787,7 +1787,7 @@ namespace Google.Cloud.Container.V1
             UpdateClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1824,7 +1824,7 @@ namespace Google.Cloud.Container.V1
             UpdateClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1843,7 +1843,7 @@ namespace Google.Cloud.Container.V1
             UpdateNodePoolRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1880,7 +1880,7 @@ namespace Google.Cloud.Container.V1
             UpdateNodePoolRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1899,7 +1899,7 @@ namespace Google.Cloud.Container.V1
             SetNodePoolAutoscalingRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1936,7 +1936,7 @@ namespace Google.Cloud.Container.V1
             SetNodePoolAutoscalingRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2081,7 +2081,7 @@ namespace Google.Cloud.Container.V1
             SetLoggingServiceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2118,7 +2118,7 @@ namespace Google.Cloud.Container.V1
             SetLoggingServiceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2263,7 +2263,7 @@ namespace Google.Cloud.Container.V1
             SetMonitoringServiceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2300,7 +2300,7 @@ namespace Google.Cloud.Container.V1
             SetMonitoringServiceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2436,7 +2436,7 @@ namespace Google.Cloud.Container.V1
             SetAddonsConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2473,7 +2473,7 @@ namespace Google.Cloud.Container.V1
             SetAddonsConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2624,7 +2624,7 @@ namespace Google.Cloud.Container.V1
             SetLocationsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2661,7 +2661,7 @@ namespace Google.Cloud.Container.V1
             SetLocationsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2800,7 +2800,7 @@ namespace Google.Cloud.Container.V1
             UpdateMasterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2837,7 +2837,7 @@ namespace Google.Cloud.Container.V1
             UpdateMasterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2858,7 +2858,7 @@ namespace Google.Cloud.Container.V1
             SetMasterAuthRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2899,7 +2899,7 @@ namespace Google.Cloud.Container.V1
             SetMasterAuthRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3049,7 +3049,7 @@ namespace Google.Cloud.Container.V1
             DeleteClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3102,7 +3102,7 @@ namespace Google.Cloud.Container.V1
             DeleteClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3202,7 +3202,7 @@ namespace Google.Cloud.Container.V1
             ListOperationsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3239,7 +3239,7 @@ namespace Google.Cloud.Container.V1
             ListOperationsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3357,7 +3357,7 @@ namespace Google.Cloud.Container.V1
             GetOperationRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3394,7 +3394,7 @@ namespace Google.Cloud.Container.V1
             GetOperationRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3506,7 +3506,7 @@ namespace Google.Cloud.Container.V1
             CancelOperationRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3540,7 +3540,7 @@ namespace Google.Cloud.Container.V1
             CancelOperationRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3640,7 +3640,7 @@ namespace Google.Cloud.Container.V1
             GetServerConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3677,7 +3677,7 @@ namespace Google.Cloud.Container.V1
             GetServerConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3795,7 +3795,7 @@ namespace Google.Cloud.Container.V1
             ListNodePoolsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3832,7 +3832,7 @@ namespace Google.Cloud.Container.V1
             ListNodePoolsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3965,7 +3965,7 @@ namespace Google.Cloud.Container.V1
             GetNodePoolRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4002,7 +4002,7 @@ namespace Google.Cloud.Container.V1
             GetNodePoolRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4135,7 +4135,7 @@ namespace Google.Cloud.Container.V1
             CreateNodePoolRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4172,7 +4172,7 @@ namespace Google.Cloud.Container.V1
             CreateNodePoolRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4305,7 +4305,7 @@ namespace Google.Cloud.Container.V1
             DeleteNodePoolRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4342,7 +4342,7 @@ namespace Google.Cloud.Container.V1
             DeleteNodePoolRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4479,7 +4479,7 @@ namespace Google.Cloud.Container.V1
             RollbackNodePoolUpgradeRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4518,7 +4518,7 @@ namespace Google.Cloud.Container.V1
             RollbackNodePoolUpgradeRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4537,7 +4537,7 @@ namespace Google.Cloud.Container.V1
             SetNodePoolManagementRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4574,7 +4574,7 @@ namespace Google.Cloud.Container.V1
             SetNodePoolManagementRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4593,7 +4593,7 @@ namespace Google.Cloud.Container.V1
             SetLabelsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4630,7 +4630,7 @@ namespace Google.Cloud.Container.V1
             SetLabelsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4763,7 +4763,7 @@ namespace Google.Cloud.Container.V1
             SetLegacyAbacRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4800,7 +4800,7 @@ namespace Google.Cloud.Container.V1
             SetLegacyAbacRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4918,7 +4918,7 @@ namespace Google.Cloud.Container.V1
             StartIPRotationRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -4955,7 +4955,7 @@ namespace Google.Cloud.Container.V1
             StartIPRotationRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -5073,7 +5073,7 @@ namespace Google.Cloud.Container.V1
             CompleteIPRotationRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -5110,7 +5110,7 @@ namespace Google.Cloud.Container.V1
             CompleteIPRotationRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -5129,7 +5129,7 @@ namespace Google.Cloud.Container.V1
             SetNodePoolSizeRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -5166,7 +5166,7 @@ namespace Google.Cloud.Container.V1
             SetNodePoolSizeRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -5299,7 +5299,7 @@ namespace Google.Cloud.Container.V1
             SetNetworkPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -5336,7 +5336,7 @@ namespace Google.Cloud.Container.V1
             SetNetworkPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -5472,7 +5472,7 @@ namespace Google.Cloud.Container.V1
             SetMaintenancePolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -5509,7 +5509,7 @@ namespace Google.Cloud.Container.V1
             SetMaintenancePolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -5534,7 +5534,7 @@ namespace Google.Cloud.Container.V1
         private readonly gaxgrpc::ApiCall<DeleteClusterRequest, Operation> _callDeleteCluster;
         private readonly gaxgrpc::ApiCall<ListOperationsRequest, ListOperationsResponse> _callListOperations;
         private readonly gaxgrpc::ApiCall<GetOperationRequest, Operation> _callGetOperation;
-        private readonly gaxgrpc::ApiCall<CancelOperationRequest, protowkt::Empty> _callCancelOperation;
+        private readonly gaxgrpc::ApiCall<CancelOperationRequest, pbwkt::Empty> _callCancelOperation;
         private readonly gaxgrpc::ApiCall<GetServerConfigRequest, ServerConfig> _callGetServerConfig;
         private readonly gaxgrpc::ApiCall<ListNodePoolsRequest, ListNodePoolsResponse> _callListNodePools;
         private readonly gaxgrpc::ApiCall<GetNodePoolRequest, NodePool> _callGetNodePool;
@@ -5590,7 +5590,7 @@ namespace Google.Cloud.Container.V1
                 GrpcClient.ListOperationsAsync, GrpcClient.ListOperations, effectiveSettings.ListOperationsSettings);
             _callGetOperation = clientHelper.BuildApiCall<GetOperationRequest, Operation>(
                 GrpcClient.GetOperationAsync, GrpcClient.GetOperation, effectiveSettings.GetOperationSettings);
-            _callCancelOperation = clientHelper.BuildApiCall<CancelOperationRequest, protowkt::Empty>(
+            _callCancelOperation = clientHelper.BuildApiCall<CancelOperationRequest, pbwkt::Empty>(
                 GrpcClient.CancelOperationAsync, GrpcClient.CancelOperation, effectiveSettings.CancelOperationSettings);
             _callGetServerConfig = clientHelper.BuildApiCall<GetServerConfigRequest, ServerConfig>(
                 GrpcClient.GetServerConfigAsync, GrpcClient.GetServerConfig, effectiveSettings.GetServerConfigSettings);
@@ -5688,8 +5688,8 @@ namespace Google.Cloud.Container.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -5708,7 +5708,7 @@ namespace Google.Cloud.Container.V1
         partial void Modify_DeleteClusterApiCall(ref gaxgrpc::ApiCall<DeleteClusterRequest, Operation> call);
         partial void Modify_ListOperationsApiCall(ref gaxgrpc::ApiCall<ListOperationsRequest, ListOperationsResponse> call);
         partial void Modify_GetOperationApiCall(ref gaxgrpc::ApiCall<GetOperationRequest, Operation> call);
-        partial void Modify_CancelOperationApiCall(ref gaxgrpc::ApiCall<CancelOperationRequest, protowkt::Empty> call);
+        partial void Modify_CancelOperationApiCall(ref gaxgrpc::ApiCall<CancelOperationRequest, pbwkt::Empty> call);
         partial void Modify_GetServerConfigApiCall(ref gaxgrpc::ApiCall<GetServerConfigRequest, ServerConfig> call);
         partial void Modify_ListNodePoolsApiCall(ref gaxgrpc::ApiCall<ListNodePoolsRequest, ListNodePoolsResponse> call);
         partial void Modify_GetNodePoolApiCall(ref gaxgrpc::ApiCall<GetNodePoolRequest, NodePool> call);

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ResourceNames.cs
@@ -15,8 +15,8 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Container.V1
 {

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ClusterControllerClient.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ClusterControllerClient.cs
@@ -17,10 +17,10 @@
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using lro = Google.LongRunning;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -76,7 +76,7 @@ namespace Google.Cloud.Dataproc.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace Google.Cloud.Dataproc.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -104,8 +104,8 @@ namespace Google.Cloud.Dataproc.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -124,8 +124,8 @@ namespace Google.Cloud.Dataproc.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(10000),
-            maxDelay: s::TimeSpan.FromMilliseconds(10000),
+            delay: sys::TimeSpan.FromMilliseconds(10000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(10000),
             delayMultiplier: 1.0
         );
 
@@ -154,7 +154,7 @@ namespace Google.Cloud.Dataproc.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -173,10 +173,10 @@ namespace Google.Cloud.Dataproc.V1
         public lro::OperationsSettings CreateClusterOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000L)),
-                s::TimeSpan.FromMilliseconds(1000L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000L)),
+                sys::TimeSpan.FromMilliseconds(1000L),
                 2.0,
-                s::TimeSpan.FromMilliseconds(10000L))
+                sys::TimeSpan.FromMilliseconds(10000L))
         };
 
         /// <summary>
@@ -204,7 +204,7 @@ namespace Google.Cloud.Dataproc.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -223,10 +223,10 @@ namespace Google.Cloud.Dataproc.V1
         public lro::OperationsSettings UpdateClusterOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000L)),
-                s::TimeSpan.FromMilliseconds(1000L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000L)),
+                sys::TimeSpan.FromMilliseconds(1000L),
                 2.0,
-                s::TimeSpan.FromMilliseconds(10000L))
+                sys::TimeSpan.FromMilliseconds(10000L))
         };
 
         /// <summary>
@@ -255,7 +255,7 @@ namespace Google.Cloud.Dataproc.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -274,10 +274,10 @@ namespace Google.Cloud.Dataproc.V1
         public lro::OperationsSettings DeleteClusterOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000L)),
-                s::TimeSpan.FromMilliseconds(1000L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000L)),
+                sys::TimeSpan.FromMilliseconds(1000L),
                 2.0,
-                s::TimeSpan.FromMilliseconds(10000L))
+                sys::TimeSpan.FromMilliseconds(10000L))
         };
 
         /// <summary>
@@ -306,7 +306,7 @@ namespace Google.Cloud.Dataproc.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -336,7 +336,7 @@ namespace Google.Cloud.Dataproc.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -365,7 +365,7 @@ namespace Google.Cloud.Dataproc.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(300000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -384,10 +384,10 @@ namespace Google.Cloud.Dataproc.V1
         public lro::OperationsSettings DiagnoseClusterOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(30000L)),
-                s::TimeSpan.FromMilliseconds(1000L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000L)),
+                sys::TimeSpan.FromMilliseconds(1000L),
                 2.0,
-                s::TimeSpan.FromMilliseconds(10000L))
+                sys::TimeSpan.FromMilliseconds(10000L))
         };
 
         /// <summary>
@@ -486,7 +486,7 @@ namespace Google.Cloud.Dataproc.V1
         /// </summary>
         public virtual ClusterController.ClusterControllerClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -598,7 +598,7 @@ namespace Google.Cloud.Dataproc.V1
             CreateClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -630,7 +630,7 @@ namespace Google.Cloud.Dataproc.V1
             CreateClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -638,7 +638,7 @@ namespace Google.Cloud.Dataproc.V1
         /// </summary>
         public virtual lro::OperationsClient CreateClusterOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -670,7 +670,7 @@ namespace Google.Cloud.Dataproc.V1
             UpdateClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -702,7 +702,7 @@ namespace Google.Cloud.Dataproc.V1
             UpdateClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -710,7 +710,7 @@ namespace Google.Cloud.Dataproc.V1
         /// </summary>
         public virtual lro::OperationsClient UpdateClusterOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -745,7 +745,7 @@ namespace Google.Cloud.Dataproc.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual stt::Task<lro::Operation<protowkt::Empty, ClusterOperationMetadata>> DeleteClusterAsync(
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, ClusterOperationMetadata>> DeleteClusterAsync(
             string projectId,
             string region,
             string clusterName,
@@ -777,7 +777,7 @@ namespace Google.Cloud.Dataproc.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual stt::Task<lro::Operation<protowkt::Empty, ClusterOperationMetadata>> DeleteClusterAsync(
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, ClusterOperationMetadata>> DeleteClusterAsync(
             string projectId,
             string region,
             string clusterName,
@@ -806,7 +806,7 @@ namespace Google.Cloud.Dataproc.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual lro::Operation<protowkt::Empty, ClusterOperationMetadata> DeleteCluster(
+        public virtual lro::Operation<pbwkt::Empty, ClusterOperationMetadata> DeleteCluster(
             string projectId,
             string region,
             string clusterName,
@@ -831,11 +831,11 @@ namespace Google.Cloud.Dataproc.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual stt::Task<lro::Operation<protowkt::Empty, ClusterOperationMetadata>> DeleteClusterAsync(
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, ClusterOperationMetadata>> DeleteClusterAsync(
             DeleteClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -844,9 +844,9 @@ namespace Google.Cloud.Dataproc.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A task representing the result of polling the operation.</returns>
-        public virtual stt::Task<lro::Operation<protowkt::Empty, ClusterOperationMetadata>> PollOnceDeleteClusterAsync(
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, ClusterOperationMetadata>> PollOnceDeleteClusterAsync(
             string operationName,
-            gaxgrpc::CallSettings callSettings = null) => lro::Operation<protowkt::Empty, ClusterOperationMetadata>.PollOnceFromNameAsync(
+            gaxgrpc::CallSettings callSettings = null) => lro::Operation<pbwkt::Empty, ClusterOperationMetadata>.PollOnceFromNameAsync(
                 gax::GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 DeleteClusterOperationsClient,
                 callSettings);
@@ -863,11 +863,11 @@ namespace Google.Cloud.Dataproc.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual lro::Operation<protowkt::Empty, ClusterOperationMetadata> DeleteCluster(
+        public virtual lro::Operation<pbwkt::Empty, ClusterOperationMetadata> DeleteCluster(
             DeleteClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -875,7 +875,7 @@ namespace Google.Cloud.Dataproc.V1
         /// </summary>
         public virtual lro::OperationsClient DeleteClusterOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -884,9 +884,9 @@ namespace Google.Cloud.Dataproc.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The result of polling the operation.</returns>
-        public virtual lro::Operation<protowkt::Empty, ClusterOperationMetadata> PollOnceDeleteCluster(
+        public virtual lro::Operation<pbwkt::Empty, ClusterOperationMetadata> PollOnceDeleteCluster(
             string operationName,
-            gaxgrpc::CallSettings callSettings = null) => lro::Operation<protowkt::Empty, ClusterOperationMetadata>.PollOnceFromName(
+            gaxgrpc::CallSettings callSettings = null) => lro::Operation<pbwkt::Empty, ClusterOperationMetadata>.PollOnceFromName(
                 gax::GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 DeleteClusterOperationsClient,
                 callSettings);
@@ -1000,7 +1000,7 @@ namespace Google.Cloud.Dataproc.V1
             GetClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1037,7 +1037,7 @@ namespace Google.Cloud.Dataproc.V1
             GetClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1134,7 +1134,7 @@ namespace Google.Cloud.Dataproc.V1
             ListClustersRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1153,7 +1153,7 @@ namespace Google.Cloud.Dataproc.V1
             ListClustersRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1177,7 +1177,7 @@ namespace Google.Cloud.Dataproc.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual stt::Task<lro::Operation<protowkt::Empty, DiagnoseClusterResults>> DiagnoseClusterAsync(
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, DiagnoseClusterResults>> DiagnoseClusterAsync(
             string projectId,
             string region,
             string clusterName,
@@ -1211,7 +1211,7 @@ namespace Google.Cloud.Dataproc.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual stt::Task<lro::Operation<protowkt::Empty, DiagnoseClusterResults>> DiagnoseClusterAsync(
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, DiagnoseClusterResults>> DiagnoseClusterAsync(
             string projectId,
             string region,
             string clusterName,
@@ -1242,7 +1242,7 @@ namespace Google.Cloud.Dataproc.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual lro::Operation<protowkt::Empty, DiagnoseClusterResults> DiagnoseCluster(
+        public virtual lro::Operation<pbwkt::Empty, DiagnoseClusterResults> DiagnoseCluster(
             string projectId,
             string region,
             string clusterName,
@@ -1269,11 +1269,11 @@ namespace Google.Cloud.Dataproc.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual stt::Task<lro::Operation<protowkt::Empty, DiagnoseClusterResults>> DiagnoseClusterAsync(
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, DiagnoseClusterResults>> DiagnoseClusterAsync(
             DiagnoseClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1282,9 +1282,9 @@ namespace Google.Cloud.Dataproc.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A task representing the result of polling the operation.</returns>
-        public virtual stt::Task<lro::Operation<protowkt::Empty, DiagnoseClusterResults>> PollOnceDiagnoseClusterAsync(
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, DiagnoseClusterResults>> PollOnceDiagnoseClusterAsync(
             string operationName,
-            gaxgrpc::CallSettings callSettings = null) => lro::Operation<protowkt::Empty, DiagnoseClusterResults>.PollOnceFromNameAsync(
+            gaxgrpc::CallSettings callSettings = null) => lro::Operation<pbwkt::Empty, DiagnoseClusterResults>.PollOnceFromNameAsync(
                 gax::GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 DiagnoseClusterOperationsClient,
                 callSettings);
@@ -1303,11 +1303,11 @@ namespace Google.Cloud.Dataproc.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual lro::Operation<protowkt::Empty, DiagnoseClusterResults> DiagnoseCluster(
+        public virtual lro::Operation<pbwkt::Empty, DiagnoseClusterResults> DiagnoseCluster(
             DiagnoseClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1315,7 +1315,7 @@ namespace Google.Cloud.Dataproc.V1
         /// </summary>
         public virtual lro::OperationsClient DiagnoseClusterOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -1324,9 +1324,9 @@ namespace Google.Cloud.Dataproc.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The result of polling the operation.</returns>
-        public virtual lro::Operation<protowkt::Empty, DiagnoseClusterResults> PollOnceDiagnoseCluster(
+        public virtual lro::Operation<pbwkt::Empty, DiagnoseClusterResults> PollOnceDiagnoseCluster(
             string operationName,
-            gaxgrpc::CallSettings callSettings = null) => lro::Operation<protowkt::Empty, DiagnoseClusterResults>.PollOnceFromName(
+            gaxgrpc::CallSettings callSettings = null) => lro::Operation<pbwkt::Empty, DiagnoseClusterResults>.PollOnceFromName(
                 gax::GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 DiagnoseClusterOperationsClient,
                 callSettings);
@@ -1395,8 +1395,8 @@ namespace Google.Cloud.Dataproc.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -1529,12 +1529,12 @@ namespace Google.Cloud.Dataproc.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public override async stt::Task<lro::Operation<protowkt::Empty, ClusterOperationMetadata>> DeleteClusterAsync(
+        public override async stt::Task<lro::Operation<pbwkt::Empty, ClusterOperationMetadata>> DeleteClusterAsync(
             DeleteClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
             Modify_DeleteClusterRequest(ref request, ref callSettings);
-            return new lro::Operation<protowkt::Empty, ClusterOperationMetadata>(
+            return new lro::Operation<pbwkt::Empty, ClusterOperationMetadata>(
                 await _callDeleteCluster.Async(request, callSettings).ConfigureAwait(false), DeleteClusterOperationsClient);
         }
 
@@ -1550,12 +1550,12 @@ namespace Google.Cloud.Dataproc.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public override lro::Operation<protowkt::Empty, ClusterOperationMetadata> DeleteCluster(
+        public override lro::Operation<pbwkt::Empty, ClusterOperationMetadata> DeleteCluster(
             DeleteClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
             Modify_DeleteClusterRequest(ref request, ref callSettings);
-            return new lro::Operation<protowkt::Empty, ClusterOperationMetadata>(
+            return new lro::Operation<pbwkt::Empty, ClusterOperationMetadata>(
                 _callDeleteCluster.Sync(request, callSettings), DeleteClusterOperationsClient);
         }
 
@@ -1658,12 +1658,12 @@ namespace Google.Cloud.Dataproc.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public override async stt::Task<lro::Operation<protowkt::Empty, DiagnoseClusterResults>> DiagnoseClusterAsync(
+        public override async stt::Task<lro::Operation<pbwkt::Empty, DiagnoseClusterResults>> DiagnoseClusterAsync(
             DiagnoseClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
             Modify_DiagnoseClusterRequest(ref request, ref callSettings);
-            return new lro::Operation<protowkt::Empty, DiagnoseClusterResults>(
+            return new lro::Operation<pbwkt::Empty, DiagnoseClusterResults>(
                 await _callDiagnoseCluster.Async(request, callSettings).ConfigureAwait(false), DiagnoseClusterOperationsClient);
         }
 
@@ -1681,12 +1681,12 @@ namespace Google.Cloud.Dataproc.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public override lro::Operation<protowkt::Empty, DiagnoseClusterResults> DiagnoseCluster(
+        public override lro::Operation<pbwkt::Empty, DiagnoseClusterResults> DiagnoseCluster(
             DiagnoseClusterRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
             Modify_DiagnoseClusterRequest(ref request, ref callSettings);
-            return new lro::Operation<protowkt::Empty, DiagnoseClusterResults>(
+            return new lro::Operation<pbwkt::Empty, DiagnoseClusterResults>(
                 _callDiagnoseCluster.Sync(request, callSettings), DiagnoseClusterOperationsClient);
         }
 

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/JobControllerClient.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/JobControllerClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -71,7 +71,7 @@ namespace Google.Cloud.Dataproc.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace Google.Cloud.Dataproc.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -99,8 +99,8 @@ namespace Google.Cloud.Dataproc.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -119,8 +119,8 @@ namespace Google.Cloud.Dataproc.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(30000),
-            maxDelay: s::TimeSpan.FromMilliseconds(30000),
+            delay: sys::TimeSpan.FromMilliseconds(30000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(30000),
             delayMultiplier: 1.0
         );
 
@@ -149,7 +149,7 @@ namespace Google.Cloud.Dataproc.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -179,7 +179,7 @@ namespace Google.Cloud.Dataproc.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -209,7 +209,7 @@ namespace Google.Cloud.Dataproc.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -238,7 +238,7 @@ namespace Google.Cloud.Dataproc.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -267,7 +267,7 @@ namespace Google.Cloud.Dataproc.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -297,7 +297,7 @@ namespace Google.Cloud.Dataproc.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -397,7 +397,7 @@ namespace Google.Cloud.Dataproc.V1
         /// </summary>
         public virtual JobController.JobControllerClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -509,7 +509,7 @@ namespace Google.Cloud.Dataproc.V1
             SubmitJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -546,7 +546,7 @@ namespace Google.Cloud.Dataproc.V1
             SubmitJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -658,7 +658,7 @@ namespace Google.Cloud.Dataproc.V1
             GetJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -695,7 +695,7 @@ namespace Google.Cloud.Dataproc.V1
             GetJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -792,7 +792,7 @@ namespace Google.Cloud.Dataproc.V1
             ListJobsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -811,7 +811,7 @@ namespace Google.Cloud.Dataproc.V1
             ListJobsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -830,7 +830,7 @@ namespace Google.Cloud.Dataproc.V1
             UpdateJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -867,7 +867,7 @@ namespace Google.Cloud.Dataproc.V1
             UpdateJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -991,7 +991,7 @@ namespace Google.Cloud.Dataproc.V1
             CancelJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1034,7 +1034,7 @@ namespace Google.Cloud.Dataproc.V1
             CancelJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1147,7 +1147,7 @@ namespace Google.Cloud.Dataproc.V1
             DeleteJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1183,7 +1183,7 @@ namespace Google.Cloud.Dataproc.V1
             DeleteJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1198,7 +1198,7 @@ namespace Google.Cloud.Dataproc.V1
         private readonly gaxgrpc::ApiCall<ListJobsRequest, ListJobsResponse> _callListJobs;
         private readonly gaxgrpc::ApiCall<UpdateJobRequest, Job> _callUpdateJob;
         private readonly gaxgrpc::ApiCall<CancelJobRequest, Job> _callCancelJob;
-        private readonly gaxgrpc::ApiCall<DeleteJobRequest, protowkt::Empty> _callDeleteJob;
+        private readonly gaxgrpc::ApiCall<DeleteJobRequest, pbwkt::Empty> _callDeleteJob;
 
         /// <summary>
         /// Constructs a client wrapper for the JobController service, with the specified gRPC client and settings.
@@ -1220,7 +1220,7 @@ namespace Google.Cloud.Dataproc.V1
                 GrpcClient.UpdateJobAsync, GrpcClient.UpdateJob, effectiveSettings.UpdateJobSettings);
             _callCancelJob = clientHelper.BuildApiCall<CancelJobRequest, Job>(
                 GrpcClient.CancelJobAsync, GrpcClient.CancelJob, effectiveSettings.CancelJobSettings);
-            _callDeleteJob = clientHelper.BuildApiCall<DeleteJobRequest, protowkt::Empty>(
+            _callDeleteJob = clientHelper.BuildApiCall<DeleteJobRequest, pbwkt::Empty>(
                 GrpcClient.DeleteJobAsync, GrpcClient.DeleteJob, effectiveSettings.DeleteJobSettings);
             Modify_ApiCall(ref _callSubmitJob);
             Modify_SubmitJobApiCall(ref _callSubmitJob);
@@ -1242,8 +1242,8 @@ namespace Google.Cloud.Dataproc.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -1252,7 +1252,7 @@ namespace Google.Cloud.Dataproc.V1
         partial void Modify_ListJobsApiCall(ref gaxgrpc::ApiCall<ListJobsRequest, ListJobsResponse> call);
         partial void Modify_UpdateJobApiCall(ref gaxgrpc::ApiCall<UpdateJobRequest, Job> call);
         partial void Modify_CancelJobApiCall(ref gaxgrpc::ApiCall<CancelJobRequest, Job> call);
-        partial void Modify_DeleteJobApiCall(ref gaxgrpc::ApiCall<DeleteJobRequest, protowkt::Empty> call);
+        partial void Modify_DeleteJobApiCall(ref gaxgrpc::ApiCall<DeleteJobRequest, pbwkt::Empty> call);
         partial void OnConstruction(JobController.JobControllerClient grpcClient, JobControllerSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
         /// <summary>

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ResourceNames.cs
@@ -15,8 +15,8 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Dataproc.V1
 {

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreClientSnippets.g.cs
@@ -204,7 +204,7 @@ namespace Google.Cloud.Datastore.V1.Snippets
             // Initialize request argument(s)
             string projectId = "";
             CommitRequest.Types.Mode mode = CommitRequest.Types.Mode.Unspecified;
-            ByteString transaction = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString transaction = ByteString.Empty;
             IEnumerable<Mutation> mutations = new List<Mutation>();
             // Make the request
             CommitResponse response = await datastoreClient.CommitAsync(projectId, mode, transaction, mutations);
@@ -220,7 +220,7 @@ namespace Google.Cloud.Datastore.V1.Snippets
             // Initialize request argument(s)
             string projectId = "";
             CommitRequest.Types.Mode mode = CommitRequest.Types.Mode.Unspecified;
-            ByteString transaction = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString transaction = ByteString.Empty;
             IEnumerable<Mutation> mutations = new List<Mutation>();
             // Make the request
             CommitResponse response = datastoreClient.Commit(projectId, mode, transaction, mutations);
@@ -304,7 +304,7 @@ namespace Google.Cloud.Datastore.V1.Snippets
             DatastoreClient datastoreClient = await DatastoreClient.CreateAsync();
             // Initialize request argument(s)
             string projectId = "";
-            ByteString transaction = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString transaction = ByteString.Empty;
             // Make the request
             RollbackResponse response = await datastoreClient.RollbackAsync(projectId, transaction);
             // End snippet
@@ -318,7 +318,7 @@ namespace Google.Cloud.Datastore.V1.Snippets
             DatastoreClient datastoreClient = DatastoreClient.Create();
             // Initialize request argument(s)
             string projectId = "";
-            ByteString transaction = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString transaction = ByteString.Empty;
             // Make the request
             RollbackResponse response = datastoreClient.Rollback(projectId, transaction);
             // End snippet
@@ -335,7 +335,7 @@ namespace Google.Cloud.Datastore.V1.Snippets
             RollbackRequest request = new RollbackRequest
             {
                 ProjectId = "",
-                Transaction = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                Transaction = ByteString.Empty,
             };
             // Make the request
             RollbackResponse response = await datastoreClient.RollbackAsync(request);
@@ -352,7 +352,7 @@ namespace Google.Cloud.Datastore.V1.Snippets
             RollbackRequest request = new RollbackRequest
             {
                 ProjectId = "",
-                Transaction = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                Transaction = ByteString.Empty,
             };
             // Make the request
             RollbackResponse response = datastoreClient.Rollback(request);

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClient.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -72,7 +72,7 @@ namespace Google.Cloud.Datastore.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Google.Cloud.Datastore.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -100,8 +100,8 @@ namespace Google.Cloud.Datastore.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -120,8 +120,8 @@ namespace Google.Cloud.Datastore.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(60000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(60000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.0
         );
 
@@ -151,7 +151,7 @@ namespace Google.Cloud.Datastore.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -181,7 +181,7 @@ namespace Google.Cloud.Datastore.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -210,7 +210,7 @@ namespace Google.Cloud.Datastore.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -239,7 +239,7 @@ namespace Google.Cloud.Datastore.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -268,7 +268,7 @@ namespace Google.Cloud.Datastore.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -297,7 +297,7 @@ namespace Google.Cloud.Datastore.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -327,7 +327,7 @@ namespace Google.Cloud.Datastore.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -429,7 +429,7 @@ namespace Google.Cloud.Datastore.V1
         /// </summary>
         public virtual Datastore.DatastoreClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -538,7 +538,7 @@ namespace Google.Cloud.Datastore.V1
             LookupRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -575,7 +575,7 @@ namespace Google.Cloud.Datastore.V1
             LookupRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -594,7 +594,7 @@ namespace Google.Cloud.Datastore.V1
             RunQueryRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -631,7 +631,7 @@ namespace Google.Cloud.Datastore.V1
             RunQueryRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -710,7 +710,7 @@ namespace Google.Cloud.Datastore.V1
             BeginTransactionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -747,7 +747,7 @@ namespace Google.Cloud.Datastore.V1
             BeginTransactionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -789,14 +789,14 @@ namespace Google.Cloud.Datastore.V1
         public virtual stt::Task<CommitResponse> CommitAsync(
             string projectId,
             CommitRequest.Types.Mode mode,
-            proto::ByteString transaction,
+            pb::ByteString transaction,
             scg::IEnumerable<Mutation> mutations,
             gaxgrpc::CallSettings callSettings = null) => CommitAsync(
                 new CommitRequest
                 {
                     ProjectId = gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)),
                     Mode = mode,
-                    Transaction = transaction ?? Google.Protobuf.ByteString.Empty, // Optional
+                    Transaction = transaction ?? pb::ByteString.Empty, // Optional
                     Mutations = { gax::GaxPreconditions.CheckNotNull(mutations, nameof(mutations)) },
                 },
                 callSettings);
@@ -840,7 +840,7 @@ namespace Google.Cloud.Datastore.V1
         public virtual stt::Task<CommitResponse> CommitAsync(
             string projectId,
             CommitRequest.Types.Mode mode,
-            proto::ByteString transaction,
+            pb::ByteString transaction,
             scg::IEnumerable<Mutation> mutations,
             st::CancellationToken cancellationToken) => CommitAsync(
                 projectId,
@@ -888,14 +888,14 @@ namespace Google.Cloud.Datastore.V1
         public virtual CommitResponse Commit(
             string projectId,
             CommitRequest.Types.Mode mode,
-            proto::ByteString transaction,
+            pb::ByteString transaction,
             scg::IEnumerable<Mutation> mutations,
             gaxgrpc::CallSettings callSettings = null) => Commit(
                 new CommitRequest
                 {
                     ProjectId = gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)),
                     Mode = mode,
-                    Transaction = transaction ?? Google.Protobuf.ByteString.Empty, // Optional
+                    Transaction = transaction ?? pb::ByteString.Empty, // Optional
                     Mutations = { gax::GaxPreconditions.CheckNotNull(mutations, nameof(mutations)) },
                 },
                 callSettings);
@@ -1046,7 +1046,7 @@ namespace Google.Cloud.Datastore.V1
             CommitRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1085,7 +1085,7 @@ namespace Google.Cloud.Datastore.V1
             CommitRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1106,7 +1106,7 @@ namespace Google.Cloud.Datastore.V1
         /// </returns>
         public virtual stt::Task<RollbackResponse> RollbackAsync(
             string projectId,
-            proto::ByteString transaction,
+            pb::ByteString transaction,
             gaxgrpc::CallSettings callSettings = null) => RollbackAsync(
                 new RollbackRequest
                 {
@@ -1133,7 +1133,7 @@ namespace Google.Cloud.Datastore.V1
         /// </returns>
         public virtual stt::Task<RollbackResponse> RollbackAsync(
             string projectId,
-            proto::ByteString transaction,
+            pb::ByteString transaction,
             st::CancellationToken cancellationToken) => RollbackAsync(
                 projectId,
                 transaction,
@@ -1157,7 +1157,7 @@ namespace Google.Cloud.Datastore.V1
         /// </returns>
         public virtual RollbackResponse Rollback(
             string projectId,
-            proto::ByteString transaction,
+            pb::ByteString transaction,
             gaxgrpc::CallSettings callSettings = null) => Rollback(
                 new RollbackRequest
                 {
@@ -1182,7 +1182,7 @@ namespace Google.Cloud.Datastore.V1
             RollbackRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1219,7 +1219,7 @@ namespace Google.Cloud.Datastore.V1
             RollbackRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1320,7 +1320,7 @@ namespace Google.Cloud.Datastore.V1
             AllocateIdsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1359,7 +1359,7 @@ namespace Google.Cloud.Datastore.V1
             AllocateIdsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1460,7 +1460,7 @@ namespace Google.Cloud.Datastore.V1
             ReserveIdsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1499,7 +1499,7 @@ namespace Google.Cloud.Datastore.V1
             ReserveIdsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1563,8 +1563,8 @@ namespace Google.Cloud.Datastore.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/ResourceNames.cs
@@ -15,8 +15,8 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Datastore.V1
 {

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Controller2Client.cs
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Controller2Client.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -68,7 +68,7 @@ namespace Google.Cloud.Debugger.V2
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Google.Cloud.Debugger.V2
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -96,8 +96,8 @@ namespace Google.Cloud.Debugger.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -116,8 +116,8 @@ namespace Google.Cloud.Debugger.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(60000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(60000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.0
         );
 
@@ -146,7 +146,7 @@ namespace Google.Cloud.Debugger.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -176,7 +176,7 @@ namespace Google.Cloud.Debugger.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -206,7 +206,7 @@ namespace Google.Cloud.Debugger.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -308,7 +308,7 @@ namespace Google.Cloud.Debugger.V2
         /// </summary>
         public virtual Controller2.Controller2Client GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -429,7 +429,7 @@ namespace Google.Cloud.Debugger.V2
             RegisterDebuggeeRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -484,7 +484,7 @@ namespace Google.Cloud.Debugger.V2
             RegisterDebuggeeRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -611,7 +611,7 @@ namespace Google.Cloud.Debugger.V2
             ListActiveBreakpointsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -672,7 +672,7 @@ namespace Google.Cloud.Debugger.V2
             ListActiveBreakpointsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -800,7 +800,7 @@ namespace Google.Cloud.Debugger.V2
             UpdateActiveBreakpointRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -851,7 +851,7 @@ namespace Google.Cloud.Debugger.V2
             UpdateActiveBreakpointRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -895,8 +895,8 @@ namespace Google.Cloud.Debugger.V2
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Debugger2Client.cs
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Debugger2Client.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -70,7 +70,7 @@ namespace Google.Cloud.Debugger.V2
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace Google.Cloud.Debugger.V2
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -98,8 +98,8 @@ namespace Google.Cloud.Debugger.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -118,8 +118,8 @@ namespace Google.Cloud.Debugger.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(60000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(60000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.0
         );
 
@@ -148,7 +148,7 @@ namespace Google.Cloud.Debugger.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -178,7 +178,7 @@ namespace Google.Cloud.Debugger.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -208,7 +208,7 @@ namespace Google.Cloud.Debugger.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -238,7 +238,7 @@ namespace Google.Cloud.Debugger.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -268,7 +268,7 @@ namespace Google.Cloud.Debugger.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -370,7 +370,7 @@ namespace Google.Cloud.Debugger.V2
         /// </summary>
         public virtual Debugger2.Debugger2Client GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -485,7 +485,7 @@ namespace Google.Cloud.Debugger.V2
             SetBreakpointRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -522,7 +522,7 @@ namespace Google.Cloud.Debugger.V2
             SetBreakpointRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -634,7 +634,7 @@ namespace Google.Cloud.Debugger.V2
             GetBreakpointRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -671,7 +671,7 @@ namespace Google.Cloud.Debugger.V2
             GetBreakpointRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -780,7 +780,7 @@ namespace Google.Cloud.Debugger.V2
             DeleteBreakpointRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -814,7 +814,7 @@ namespace Google.Cloud.Debugger.V2
             DeleteBreakpointRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -911,7 +911,7 @@ namespace Google.Cloud.Debugger.V2
             ListBreakpointsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -948,7 +948,7 @@ namespace Google.Cloud.Debugger.V2
             ListBreakpointsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1045,7 +1045,7 @@ namespace Google.Cloud.Debugger.V2
             ListDebuggeesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1082,7 +1082,7 @@ namespace Google.Cloud.Debugger.V2
             ListDebuggeesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1094,7 +1094,7 @@ namespace Google.Cloud.Debugger.V2
     {
         private readonly gaxgrpc::ApiCall<SetBreakpointRequest, SetBreakpointResponse> _callSetBreakpoint;
         private readonly gaxgrpc::ApiCall<GetBreakpointRequest, GetBreakpointResponse> _callGetBreakpoint;
-        private readonly gaxgrpc::ApiCall<DeleteBreakpointRequest, protowkt::Empty> _callDeleteBreakpoint;
+        private readonly gaxgrpc::ApiCall<DeleteBreakpointRequest, pbwkt::Empty> _callDeleteBreakpoint;
         private readonly gaxgrpc::ApiCall<ListBreakpointsRequest, ListBreakpointsResponse> _callListBreakpoints;
         private readonly gaxgrpc::ApiCall<ListDebuggeesRequest, ListDebuggeesResponse> _callListDebuggees;
 
@@ -1112,7 +1112,7 @@ namespace Google.Cloud.Debugger.V2
                 GrpcClient.SetBreakpointAsync, GrpcClient.SetBreakpoint, effectiveSettings.SetBreakpointSettings);
             _callGetBreakpoint = clientHelper.BuildApiCall<GetBreakpointRequest, GetBreakpointResponse>(
                 GrpcClient.GetBreakpointAsync, GrpcClient.GetBreakpoint, effectiveSettings.GetBreakpointSettings);
-            _callDeleteBreakpoint = clientHelper.BuildApiCall<DeleteBreakpointRequest, protowkt::Empty>(
+            _callDeleteBreakpoint = clientHelper.BuildApiCall<DeleteBreakpointRequest, pbwkt::Empty>(
                 GrpcClient.DeleteBreakpointAsync, GrpcClient.DeleteBreakpoint, effectiveSettings.DeleteBreakpointSettings);
             _callListBreakpoints = clientHelper.BuildApiCall<ListBreakpointsRequest, ListBreakpointsResponse>(
                 GrpcClient.ListBreakpointsAsync, GrpcClient.ListBreakpoints, effectiveSettings.ListBreakpointsSettings);
@@ -1136,14 +1136,14 @@ namespace Google.Cloud.Debugger.V2
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
         partial void Modify_SetBreakpointApiCall(ref gaxgrpc::ApiCall<SetBreakpointRequest, SetBreakpointResponse> call);
         partial void Modify_GetBreakpointApiCall(ref gaxgrpc::ApiCall<GetBreakpointRequest, GetBreakpointResponse> call);
-        partial void Modify_DeleteBreakpointApiCall(ref gaxgrpc::ApiCall<DeleteBreakpointRequest, protowkt::Empty> call);
+        partial void Modify_DeleteBreakpointApiCall(ref gaxgrpc::ApiCall<DeleteBreakpointRequest, pbwkt::Empty> call);
         partial void Modify_ListBreakpointsApiCall(ref gaxgrpc::ApiCall<ListBreakpointsRequest, ListBreakpointsResponse> call);
         partial void Modify_ListDebuggeesApiCall(ref gaxgrpc::ApiCall<ListDebuggeesRequest, ListDebuggeesResponse> call);
         partial void OnConstruction(Debugger2.Debugger2Client grpcClient, Debugger2Settings effectiveSettings, gaxgrpc::ClientHelper clientHelper);

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/ResourceNames.cs
@@ -15,8 +15,8 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Debugger.V2
 {

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpServiceClient.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpServiceClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -90,7 +90,7 @@ namespace Google.Cloud.Dlp.V2
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Google.Cloud.Dlp.V2
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -118,8 +118,8 @@ namespace Google.Cloud.Dlp.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -138,8 +138,8 @@ namespace Google.Cloud.Dlp.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(20000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(20000),
             delayMultiplier: 1.0
         );
 
@@ -169,7 +169,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -199,7 +199,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -229,7 +229,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -259,7 +259,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -289,7 +289,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -318,7 +318,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -347,7 +347,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -377,7 +377,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -407,7 +407,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -437,7 +437,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -466,7 +466,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -495,7 +495,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -525,7 +525,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -555,7 +555,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -585,7 +585,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -614,7 +614,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -644,7 +644,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -674,7 +674,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -704,7 +704,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -733,7 +733,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -763,7 +763,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -793,7 +793,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -823,7 +823,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -852,7 +852,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -881,7 +881,7 @@ namespace Google.Cloud.Dlp.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -981,7 +981,7 @@ namespace Google.Cloud.Dlp.V2
         /// </summary>
         public virtual DlpService.DlpServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -1003,7 +1003,7 @@ namespace Google.Cloud.Dlp.V2
             InspectContentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1046,7 +1046,7 @@ namespace Google.Cloud.Dlp.V2
             InspectContentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1067,7 +1067,7 @@ namespace Google.Cloud.Dlp.V2
             RedactImageRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1108,7 +1108,7 @@ namespace Google.Cloud.Dlp.V2
             RedactImageRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1129,7 +1129,7 @@ namespace Google.Cloud.Dlp.V2
             DeidentifyContentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1170,7 +1170,7 @@ namespace Google.Cloud.Dlp.V2
             DeidentifyContentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1189,7 +1189,7 @@ namespace Google.Cloud.Dlp.V2
             ReidentifyContentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1226,7 +1226,7 @@ namespace Google.Cloud.Dlp.V2
             ReidentifyContentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1247,7 +1247,7 @@ namespace Google.Cloud.Dlp.V2
             ListInfoTypesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1288,7 +1288,7 @@ namespace Google.Cloud.Dlp.V2
             ListInfoTypesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1308,7 +1308,7 @@ namespace Google.Cloud.Dlp.V2
             CreateInspectTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1347,7 +1347,7 @@ namespace Google.Cloud.Dlp.V2
             CreateInspectTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1366,7 +1366,7 @@ namespace Google.Cloud.Dlp.V2
             UpdateInspectTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1403,7 +1403,7 @@ namespace Google.Cloud.Dlp.V2
             UpdateInspectTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1422,7 +1422,7 @@ namespace Google.Cloud.Dlp.V2
             GetInspectTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1459,7 +1459,7 @@ namespace Google.Cloud.Dlp.V2
             GetInspectTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1478,7 +1478,7 @@ namespace Google.Cloud.Dlp.V2
             ListInspectTemplatesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1497,7 +1497,7 @@ namespace Google.Cloud.Dlp.V2
             ListInspectTemplatesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1516,7 +1516,7 @@ namespace Google.Cloud.Dlp.V2
             DeleteInspectTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1550,7 +1550,7 @@ namespace Google.Cloud.Dlp.V2
             DeleteInspectTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1570,7 +1570,7 @@ namespace Google.Cloud.Dlp.V2
             CreateDeidentifyTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1609,7 +1609,7 @@ namespace Google.Cloud.Dlp.V2
             CreateDeidentifyTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1628,7 +1628,7 @@ namespace Google.Cloud.Dlp.V2
             UpdateDeidentifyTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1665,7 +1665,7 @@ namespace Google.Cloud.Dlp.V2
             UpdateDeidentifyTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1684,7 +1684,7 @@ namespace Google.Cloud.Dlp.V2
             GetDeidentifyTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1721,7 +1721,7 @@ namespace Google.Cloud.Dlp.V2
             GetDeidentifyTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1740,7 +1740,7 @@ namespace Google.Cloud.Dlp.V2
             ListDeidentifyTemplatesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1759,7 +1759,7 @@ namespace Google.Cloud.Dlp.V2
             ListDeidentifyTemplatesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1778,7 +1778,7 @@ namespace Google.Cloud.Dlp.V2
             DeleteDeidentifyTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1812,7 +1812,7 @@ namespace Google.Cloud.Dlp.V2
             DeleteDeidentifyTemplateRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1832,7 +1832,7 @@ namespace Google.Cloud.Dlp.V2
             CreateDlpJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1871,7 +1871,7 @@ namespace Google.Cloud.Dlp.V2
             CreateDlpJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1890,7 +1890,7 @@ namespace Google.Cloud.Dlp.V2
             ListDlpJobsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1909,7 +1909,7 @@ namespace Google.Cloud.Dlp.V2
             ListDlpJobsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1928,7 +1928,7 @@ namespace Google.Cloud.Dlp.V2
             GetDlpJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1965,7 +1965,7 @@ namespace Google.Cloud.Dlp.V2
             GetDlpJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1986,7 +1986,7 @@ namespace Google.Cloud.Dlp.V2
             DeleteDlpJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2024,7 +2024,7 @@ namespace Google.Cloud.Dlp.V2
             DeleteDlpJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2045,7 +2045,7 @@ namespace Google.Cloud.Dlp.V2
             CancelDlpJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2083,7 +2083,7 @@ namespace Google.Cloud.Dlp.V2
             CancelDlpJobRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2102,7 +2102,7 @@ namespace Google.Cloud.Dlp.V2
             ListJobTriggersRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2121,7 +2121,7 @@ namespace Google.Cloud.Dlp.V2
             ListJobTriggersRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2140,7 +2140,7 @@ namespace Google.Cloud.Dlp.V2
             GetJobTriggerRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2177,7 +2177,7 @@ namespace Google.Cloud.Dlp.V2
             GetJobTriggerRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2196,7 +2196,7 @@ namespace Google.Cloud.Dlp.V2
             DeleteJobTriggerRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2230,7 +2230,7 @@ namespace Google.Cloud.Dlp.V2
             DeleteJobTriggerRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2249,7 +2249,7 @@ namespace Google.Cloud.Dlp.V2
             UpdateJobTriggerRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2286,7 +2286,7 @@ namespace Google.Cloud.Dlp.V2
             UpdateJobTriggerRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2306,7 +2306,7 @@ namespace Google.Cloud.Dlp.V2
             CreateJobTriggerRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2345,7 +2345,7 @@ namespace Google.Cloud.Dlp.V2
             CreateJobTriggerRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -2364,20 +2364,20 @@ namespace Google.Cloud.Dlp.V2
         private readonly gaxgrpc::ApiCall<UpdateInspectTemplateRequest, InspectTemplate> _callUpdateInspectTemplate;
         private readonly gaxgrpc::ApiCall<GetInspectTemplateRequest, InspectTemplate> _callGetInspectTemplate;
         private readonly gaxgrpc::ApiCall<ListInspectTemplatesRequest, ListInspectTemplatesResponse> _callListInspectTemplates;
-        private readonly gaxgrpc::ApiCall<DeleteInspectTemplateRequest, protowkt::Empty> _callDeleteInspectTemplate;
+        private readonly gaxgrpc::ApiCall<DeleteInspectTemplateRequest, pbwkt::Empty> _callDeleteInspectTemplate;
         private readonly gaxgrpc::ApiCall<CreateDeidentifyTemplateRequest, DeidentifyTemplate> _callCreateDeidentifyTemplate;
         private readonly gaxgrpc::ApiCall<UpdateDeidentifyTemplateRequest, DeidentifyTemplate> _callUpdateDeidentifyTemplate;
         private readonly gaxgrpc::ApiCall<GetDeidentifyTemplateRequest, DeidentifyTemplate> _callGetDeidentifyTemplate;
         private readonly gaxgrpc::ApiCall<ListDeidentifyTemplatesRequest, ListDeidentifyTemplatesResponse> _callListDeidentifyTemplates;
-        private readonly gaxgrpc::ApiCall<DeleteDeidentifyTemplateRequest, protowkt::Empty> _callDeleteDeidentifyTemplate;
+        private readonly gaxgrpc::ApiCall<DeleteDeidentifyTemplateRequest, pbwkt::Empty> _callDeleteDeidentifyTemplate;
         private readonly gaxgrpc::ApiCall<CreateDlpJobRequest, DlpJob> _callCreateDlpJob;
         private readonly gaxgrpc::ApiCall<ListDlpJobsRequest, ListDlpJobsResponse> _callListDlpJobs;
         private readonly gaxgrpc::ApiCall<GetDlpJobRequest, DlpJob> _callGetDlpJob;
-        private readonly gaxgrpc::ApiCall<DeleteDlpJobRequest, protowkt::Empty> _callDeleteDlpJob;
-        private readonly gaxgrpc::ApiCall<CancelDlpJobRequest, protowkt::Empty> _callCancelDlpJob;
+        private readonly gaxgrpc::ApiCall<DeleteDlpJobRequest, pbwkt::Empty> _callDeleteDlpJob;
+        private readonly gaxgrpc::ApiCall<CancelDlpJobRequest, pbwkt::Empty> _callCancelDlpJob;
         private readonly gaxgrpc::ApiCall<ListJobTriggersRequest, ListJobTriggersResponse> _callListJobTriggers;
         private readonly gaxgrpc::ApiCall<GetJobTriggerRequest, JobTrigger> _callGetJobTrigger;
-        private readonly gaxgrpc::ApiCall<DeleteJobTriggerRequest, protowkt::Empty> _callDeleteJobTrigger;
+        private readonly gaxgrpc::ApiCall<DeleteJobTriggerRequest, pbwkt::Empty> _callDeleteJobTrigger;
         private readonly gaxgrpc::ApiCall<UpdateJobTriggerRequest, JobTrigger> _callUpdateJobTrigger;
         private readonly gaxgrpc::ApiCall<CreateJobTriggerRequest, JobTrigger> _callCreateJobTrigger;
 
@@ -2409,7 +2409,7 @@ namespace Google.Cloud.Dlp.V2
                 GrpcClient.GetInspectTemplateAsync, GrpcClient.GetInspectTemplate, effectiveSettings.GetInspectTemplateSettings);
             _callListInspectTemplates = clientHelper.BuildApiCall<ListInspectTemplatesRequest, ListInspectTemplatesResponse>(
                 GrpcClient.ListInspectTemplatesAsync, GrpcClient.ListInspectTemplates, effectiveSettings.ListInspectTemplatesSettings);
-            _callDeleteInspectTemplate = clientHelper.BuildApiCall<DeleteInspectTemplateRequest, protowkt::Empty>(
+            _callDeleteInspectTemplate = clientHelper.BuildApiCall<DeleteInspectTemplateRequest, pbwkt::Empty>(
                 GrpcClient.DeleteInspectTemplateAsync, GrpcClient.DeleteInspectTemplate, effectiveSettings.DeleteInspectTemplateSettings);
             _callCreateDeidentifyTemplate = clientHelper.BuildApiCall<CreateDeidentifyTemplateRequest, DeidentifyTemplate>(
                 GrpcClient.CreateDeidentifyTemplateAsync, GrpcClient.CreateDeidentifyTemplate, effectiveSettings.CreateDeidentifyTemplateSettings);
@@ -2419,7 +2419,7 @@ namespace Google.Cloud.Dlp.V2
                 GrpcClient.GetDeidentifyTemplateAsync, GrpcClient.GetDeidentifyTemplate, effectiveSettings.GetDeidentifyTemplateSettings);
             _callListDeidentifyTemplates = clientHelper.BuildApiCall<ListDeidentifyTemplatesRequest, ListDeidentifyTemplatesResponse>(
                 GrpcClient.ListDeidentifyTemplatesAsync, GrpcClient.ListDeidentifyTemplates, effectiveSettings.ListDeidentifyTemplatesSettings);
-            _callDeleteDeidentifyTemplate = clientHelper.BuildApiCall<DeleteDeidentifyTemplateRequest, protowkt::Empty>(
+            _callDeleteDeidentifyTemplate = clientHelper.BuildApiCall<DeleteDeidentifyTemplateRequest, pbwkt::Empty>(
                 GrpcClient.DeleteDeidentifyTemplateAsync, GrpcClient.DeleteDeidentifyTemplate, effectiveSettings.DeleteDeidentifyTemplateSettings);
             _callCreateDlpJob = clientHelper.BuildApiCall<CreateDlpJobRequest, DlpJob>(
                 GrpcClient.CreateDlpJobAsync, GrpcClient.CreateDlpJob, effectiveSettings.CreateDlpJobSettings);
@@ -2427,15 +2427,15 @@ namespace Google.Cloud.Dlp.V2
                 GrpcClient.ListDlpJobsAsync, GrpcClient.ListDlpJobs, effectiveSettings.ListDlpJobsSettings);
             _callGetDlpJob = clientHelper.BuildApiCall<GetDlpJobRequest, DlpJob>(
                 GrpcClient.GetDlpJobAsync, GrpcClient.GetDlpJob, effectiveSettings.GetDlpJobSettings);
-            _callDeleteDlpJob = clientHelper.BuildApiCall<DeleteDlpJobRequest, protowkt::Empty>(
+            _callDeleteDlpJob = clientHelper.BuildApiCall<DeleteDlpJobRequest, pbwkt::Empty>(
                 GrpcClient.DeleteDlpJobAsync, GrpcClient.DeleteDlpJob, effectiveSettings.DeleteDlpJobSettings);
-            _callCancelDlpJob = clientHelper.BuildApiCall<CancelDlpJobRequest, protowkt::Empty>(
+            _callCancelDlpJob = clientHelper.BuildApiCall<CancelDlpJobRequest, pbwkt::Empty>(
                 GrpcClient.CancelDlpJobAsync, GrpcClient.CancelDlpJob, effectiveSettings.CancelDlpJobSettings);
             _callListJobTriggers = clientHelper.BuildApiCall<ListJobTriggersRequest, ListJobTriggersResponse>(
                 GrpcClient.ListJobTriggersAsync, GrpcClient.ListJobTriggers, effectiveSettings.ListJobTriggersSettings);
             _callGetJobTrigger = clientHelper.BuildApiCall<GetJobTriggerRequest, JobTrigger>(
                 GrpcClient.GetJobTriggerAsync, GrpcClient.GetJobTrigger, effectiveSettings.GetJobTriggerSettings);
-            _callDeleteJobTrigger = clientHelper.BuildApiCall<DeleteJobTriggerRequest, protowkt::Empty>(
+            _callDeleteJobTrigger = clientHelper.BuildApiCall<DeleteJobTriggerRequest, pbwkt::Empty>(
                 GrpcClient.DeleteJobTriggerAsync, GrpcClient.DeleteJobTrigger, effectiveSettings.DeleteJobTriggerSettings);
             _callUpdateJobTrigger = clientHelper.BuildApiCall<UpdateJobTriggerRequest, JobTrigger>(
                 GrpcClient.UpdateJobTriggerAsync, GrpcClient.UpdateJobTrigger, effectiveSettings.UpdateJobTriggerSettings);
@@ -2499,8 +2499,8 @@ namespace Google.Cloud.Dlp.V2
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -2513,20 +2513,20 @@ namespace Google.Cloud.Dlp.V2
         partial void Modify_UpdateInspectTemplateApiCall(ref gaxgrpc::ApiCall<UpdateInspectTemplateRequest, InspectTemplate> call);
         partial void Modify_GetInspectTemplateApiCall(ref gaxgrpc::ApiCall<GetInspectTemplateRequest, InspectTemplate> call);
         partial void Modify_ListInspectTemplatesApiCall(ref gaxgrpc::ApiCall<ListInspectTemplatesRequest, ListInspectTemplatesResponse> call);
-        partial void Modify_DeleteInspectTemplateApiCall(ref gaxgrpc::ApiCall<DeleteInspectTemplateRequest, protowkt::Empty> call);
+        partial void Modify_DeleteInspectTemplateApiCall(ref gaxgrpc::ApiCall<DeleteInspectTemplateRequest, pbwkt::Empty> call);
         partial void Modify_CreateDeidentifyTemplateApiCall(ref gaxgrpc::ApiCall<CreateDeidentifyTemplateRequest, DeidentifyTemplate> call);
         partial void Modify_UpdateDeidentifyTemplateApiCall(ref gaxgrpc::ApiCall<UpdateDeidentifyTemplateRequest, DeidentifyTemplate> call);
         partial void Modify_GetDeidentifyTemplateApiCall(ref gaxgrpc::ApiCall<GetDeidentifyTemplateRequest, DeidentifyTemplate> call);
         partial void Modify_ListDeidentifyTemplatesApiCall(ref gaxgrpc::ApiCall<ListDeidentifyTemplatesRequest, ListDeidentifyTemplatesResponse> call);
-        partial void Modify_DeleteDeidentifyTemplateApiCall(ref gaxgrpc::ApiCall<DeleteDeidentifyTemplateRequest, protowkt::Empty> call);
+        partial void Modify_DeleteDeidentifyTemplateApiCall(ref gaxgrpc::ApiCall<DeleteDeidentifyTemplateRequest, pbwkt::Empty> call);
         partial void Modify_CreateDlpJobApiCall(ref gaxgrpc::ApiCall<CreateDlpJobRequest, DlpJob> call);
         partial void Modify_ListDlpJobsApiCall(ref gaxgrpc::ApiCall<ListDlpJobsRequest, ListDlpJobsResponse> call);
         partial void Modify_GetDlpJobApiCall(ref gaxgrpc::ApiCall<GetDlpJobRequest, DlpJob> call);
-        partial void Modify_DeleteDlpJobApiCall(ref gaxgrpc::ApiCall<DeleteDlpJobRequest, protowkt::Empty> call);
-        partial void Modify_CancelDlpJobApiCall(ref gaxgrpc::ApiCall<CancelDlpJobRequest, protowkt::Empty> call);
+        partial void Modify_DeleteDlpJobApiCall(ref gaxgrpc::ApiCall<DeleteDlpJobRequest, pbwkt::Empty> call);
+        partial void Modify_CancelDlpJobApiCall(ref gaxgrpc::ApiCall<CancelDlpJobRequest, pbwkt::Empty> call);
         partial void Modify_ListJobTriggersApiCall(ref gaxgrpc::ApiCall<ListJobTriggersRequest, ListJobTriggersResponse> call);
         partial void Modify_GetJobTriggerApiCall(ref gaxgrpc::ApiCall<GetJobTriggerRequest, JobTrigger> call);
-        partial void Modify_DeleteJobTriggerApiCall(ref gaxgrpc::ApiCall<DeleteJobTriggerRequest, protowkt::Empty> call);
+        partial void Modify_DeleteJobTriggerApiCall(ref gaxgrpc::ApiCall<DeleteJobTriggerRequest, pbwkt::Empty> call);
         partial void Modify_UpdateJobTriggerApiCall(ref gaxgrpc::ApiCall<UpdateJobTriggerRequest, JobTrigger> call);
         partial void Modify_CreateJobTriggerApiCall(ref gaxgrpc::ApiCall<CreateJobTriggerRequest, JobTrigger> call);
         partial void OnConstruction(DlpService.DlpServiceClient grpcClient, DlpServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/ResourceNames.cs
@@ -15,15 +15,15 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Dlp.V2
 {
     /// <summary>
     /// Resource name for the 'organization' resource.
     /// </summary>
-    public sealed partial class OrganizationName : gax::IResourceName, s::IEquatable<OrganizationName>
+    public sealed partial class OrganizationName : gax::IResourceName, sys::IEquatable<OrganizationName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}");
 
@@ -45,7 +45,7 @@ namespace Google.Cloud.Dlp.V2
         /// <see cref="OrganizationName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="organizationName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="organizationName">The organization resource name in string form. Must not be <c>null</c>.</param>
@@ -108,7 +108,7 @@ namespace Google.Cloud.Dlp.V2
     /// <summary>
     /// Resource name for the 'organization_deidentify_template' resource.
     /// </summary>
-    public sealed partial class OrganizationDeidentifyTemplateName : gax::IResourceName, s::IEquatable<OrganizationDeidentifyTemplateName>
+    public sealed partial class OrganizationDeidentifyTemplateName : gax::IResourceName, sys::IEquatable<OrganizationDeidentifyTemplateName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/deidentifyTemplates/{deidentify_template}");
 
@@ -130,7 +130,7 @@ namespace Google.Cloud.Dlp.V2
         /// <see cref="OrganizationDeidentifyTemplateName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="organizationDeidentifyTemplateName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationDeidentifyTemplateName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="organizationDeidentifyTemplateName">The organization_deidentify_template resource name in string form. Must not be <c>null</c>.</param>
@@ -200,7 +200,7 @@ namespace Google.Cloud.Dlp.V2
     /// <summary>
     /// Resource name for the 'project_deidentify_template' resource.
     /// </summary>
-    public sealed partial class ProjectDeidentifyTemplateName : gax::IResourceName, s::IEquatable<ProjectDeidentifyTemplateName>
+    public sealed partial class ProjectDeidentifyTemplateName : gax::IResourceName, sys::IEquatable<ProjectDeidentifyTemplateName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/deidentifyTemplates/{deidentify_template}");
 
@@ -222,7 +222,7 @@ namespace Google.Cloud.Dlp.V2
         /// <see cref="ProjectDeidentifyTemplateName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectDeidentifyTemplateName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectDeidentifyTemplateName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectDeidentifyTemplateName">The project_deidentify_template resource name in string form. Must not be <c>null</c>.</param>
@@ -292,7 +292,7 @@ namespace Google.Cloud.Dlp.V2
     /// <summary>
     /// Resource name for the 'organization_inspect_template' resource.
     /// </summary>
-    public sealed partial class OrganizationInspectTemplateName : gax::IResourceName, s::IEquatable<OrganizationInspectTemplateName>
+    public sealed partial class OrganizationInspectTemplateName : gax::IResourceName, sys::IEquatable<OrganizationInspectTemplateName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/inspectTemplates/{inspect_template}");
 
@@ -314,7 +314,7 @@ namespace Google.Cloud.Dlp.V2
         /// <see cref="OrganizationInspectTemplateName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="organizationInspectTemplateName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationInspectTemplateName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="organizationInspectTemplateName">The organization_inspect_template resource name in string form. Must not be <c>null</c>.</param>
@@ -384,7 +384,7 @@ namespace Google.Cloud.Dlp.V2
     /// <summary>
     /// Resource name for the 'project_inspect_template' resource.
     /// </summary>
-    public sealed partial class ProjectInspectTemplateName : gax::IResourceName, s::IEquatable<ProjectInspectTemplateName>
+    public sealed partial class ProjectInspectTemplateName : gax::IResourceName, sys::IEquatable<ProjectInspectTemplateName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/inspectTemplates/{inspect_template}");
 
@@ -406,7 +406,7 @@ namespace Google.Cloud.Dlp.V2
         /// <see cref="ProjectInspectTemplateName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectInspectTemplateName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectInspectTemplateName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectInspectTemplateName">The project_inspect_template resource name in string form. Must not be <c>null</c>.</param>
@@ -476,7 +476,7 @@ namespace Google.Cloud.Dlp.V2
     /// <summary>
     /// Resource name for the 'project_job_trigger' resource.
     /// </summary>
-    public sealed partial class ProjectJobTriggerName : gax::IResourceName, s::IEquatable<ProjectJobTriggerName>
+    public sealed partial class ProjectJobTriggerName : gax::IResourceName, sys::IEquatable<ProjectJobTriggerName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/jobTriggers/{job_trigger}");
 
@@ -498,7 +498,7 @@ namespace Google.Cloud.Dlp.V2
         /// <see cref="ProjectJobTriggerName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectJobTriggerName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectJobTriggerName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectJobTriggerName">The project_job_trigger resource name in string form. Must not be <c>null</c>.</param>
@@ -568,7 +568,7 @@ namespace Google.Cloud.Dlp.V2
     /// <summary>
     /// Resource name for the 'project' resource.
     /// </summary>
-    public sealed partial class ProjectName : gax::IResourceName, s::IEquatable<ProjectName>
+    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
 
@@ -590,7 +590,7 @@ namespace Google.Cloud.Dlp.V2
         /// <see cref="ProjectName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
@@ -653,7 +653,7 @@ namespace Google.Cloud.Dlp.V2
     /// <summary>
     /// Resource name for the 'dlp_job' resource.
     /// </summary>
-    public sealed partial class DlpJobName : gax::IResourceName, s::IEquatable<DlpJobName>
+    public sealed partial class DlpJobName : gax::IResourceName, sys::IEquatable<DlpJobName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/dlpJobs/{dlp_job}");
 
@@ -675,7 +675,7 @@ namespace Google.Cloud.Dlp.V2
         /// <see cref="DlpJobName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="dlpJobName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="dlpJobName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="dlpJobName">The dlp_job resource name in string form. Must not be <c>null</c>.</param>
@@ -752,7 +752,7 @@ namespace Google.Cloud.Dlp.V2
     /// <item><description>ProjectDeidentifyTemplateName: A resource of type 'project_deidentify_template'.</description></item>
     /// </list>
     /// </remarks>
-    public sealed partial class DeidentifyTemplateNameOneof : gax::IResourceName, s::IEquatable<DeidentifyTemplateNameOneof>
+    public sealed partial class DeidentifyTemplateNameOneof : gax::IResourceName, sys::IEquatable<DeidentifyTemplateNameOneof>
     {
         /// <summary>
         /// The possible contents of <see cref="DeidentifyTemplateNameOneof"/>.
@@ -789,7 +789,7 @@ namespace Google.Cloud.Dlp.V2
         /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
         /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="s::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
         /// <returns>The parsed <see cref="DeidentifyTemplateNameOneof"/> if successful.</returns>
         public static DeidentifyTemplateNameOneof Parse(string name, bool allowUnknown)
         {
@@ -798,7 +798,7 @@ namespace Google.Cloud.Dlp.V2
             {
                 return result;
             }
-            throw new s::ArgumentException("Invalid name", nameof(name));
+            throw new sys::ArgumentException("Invalid name", nameof(name));
         }
 
         /// <summary>
@@ -883,7 +883,7 @@ namespace Google.Cloud.Dlp.V2
             Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
             if (!IsValid(type, name))
             {
-                throw new s::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
             }
         }
 
@@ -901,7 +901,7 @@ namespace Google.Cloud.Dlp.V2
         {
             if (Type != type)
             {
-                throw new s::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
             }
             return (T)Name;
         }
@@ -910,7 +910,7 @@ namespace Google.Cloud.Dlp.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="OrganizationDeidentifyTemplateName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="OrganizationDeidentifyTemplateName"/>.
         /// </remarks>
         public OrganizationDeidentifyTemplateName OrganizationDeidentifyTemplateName => CheckAndReturn<OrganizationDeidentifyTemplateName>(OneofType.OrganizationDeidentifyTemplateName);
@@ -919,7 +919,7 @@ namespace Google.Cloud.Dlp.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="ProjectDeidentifyTemplateName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="ProjectDeidentifyTemplateName"/>.
         /// </remarks>
         public ProjectDeidentifyTemplateName ProjectDeidentifyTemplateName => CheckAndReturn<ProjectDeidentifyTemplateName>(OneofType.ProjectDeidentifyTemplateName);
@@ -956,7 +956,7 @@ namespace Google.Cloud.Dlp.V2
     /// <item><description>ProjectInspectTemplateName: A resource of type 'project_inspect_template'.</description></item>
     /// </list>
     /// </remarks>
-    public sealed partial class InspectTemplateNameOneof : gax::IResourceName, s::IEquatable<InspectTemplateNameOneof>
+    public sealed partial class InspectTemplateNameOneof : gax::IResourceName, sys::IEquatable<InspectTemplateNameOneof>
     {
         /// <summary>
         /// The possible contents of <see cref="InspectTemplateNameOneof"/>.
@@ -993,7 +993,7 @@ namespace Google.Cloud.Dlp.V2
         /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
         /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="s::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
         /// <returns>The parsed <see cref="InspectTemplateNameOneof"/> if successful.</returns>
         public static InspectTemplateNameOneof Parse(string name, bool allowUnknown)
         {
@@ -1002,7 +1002,7 @@ namespace Google.Cloud.Dlp.V2
             {
                 return result;
             }
-            throw new s::ArgumentException("Invalid name", nameof(name));
+            throw new sys::ArgumentException("Invalid name", nameof(name));
         }
 
         /// <summary>
@@ -1087,7 +1087,7 @@ namespace Google.Cloud.Dlp.V2
             Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
             if (!IsValid(type, name))
             {
-                throw new s::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
             }
         }
 
@@ -1105,7 +1105,7 @@ namespace Google.Cloud.Dlp.V2
         {
             if (Type != type)
             {
-                throw new s::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
             }
             return (T)Name;
         }
@@ -1114,7 +1114,7 @@ namespace Google.Cloud.Dlp.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="OrganizationInspectTemplateName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="OrganizationInspectTemplateName"/>.
         /// </remarks>
         public OrganizationInspectTemplateName OrganizationInspectTemplateName => CheckAndReturn<OrganizationInspectTemplateName>(OneofType.OrganizationInspectTemplateName);
@@ -1123,7 +1123,7 @@ namespace Google.Cloud.Dlp.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="ProjectInspectTemplateName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="ProjectInspectTemplateName"/>.
         /// </remarks>
         public ProjectInspectTemplateName ProjectInspectTemplateName => CheckAndReturn<ProjectInspectTemplateName>(OneofType.ProjectInspectTemplateName);
@@ -1154,9 +1154,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class CancelDlpJobRequest
     {
         /// <summary>
-        /// <see cref="DlpJobName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.DlpJobName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public DlpJobName DlpJobName
+        public Google.Cloud.Dlp.V2.DlpJobName DlpJobName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Dlp.V2.DlpJobName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1167,9 +1167,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class CreateDeidentifyTemplateRequest
     {
         /// <summary>
-        /// <see cref="OrganizationName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.OrganizationName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public OrganizationName ParentAsOrganizationName
+        public Google.Cloud.Dlp.V2.OrganizationName ParentAsOrganizationName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dlp.V2.OrganizationName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1180,9 +1180,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class CreateDlpJobRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ProjectName ParentAsProjectName
+        public Google.Cloud.Dlp.V2.ProjectName ParentAsProjectName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dlp.V2.ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1193,9 +1193,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class CreateInspectTemplateRequest
     {
         /// <summary>
-        /// <see cref="OrganizationName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.OrganizationName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public OrganizationName ParentAsOrganizationName
+        public Google.Cloud.Dlp.V2.OrganizationName ParentAsOrganizationName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dlp.V2.OrganizationName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1206,9 +1206,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class CreateJobTriggerRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ProjectName ParentAsProjectName
+        public Google.Cloud.Dlp.V2.ProjectName ParentAsProjectName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dlp.V2.ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1219,9 +1219,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class DeidentifyContentRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ProjectName ParentAsProjectName
+        public Google.Cloud.Dlp.V2.ProjectName ParentAsProjectName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dlp.V2.ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1232,9 +1232,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class DeleteDeidentifyTemplateRequest
     {
         /// <summary>
-        /// <see cref="DeidentifyTemplateNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.DeidentifyTemplateNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public DeidentifyTemplateNameOneof DeidentifyTemplateNameOneof
+        public Google.Cloud.Dlp.V2.DeidentifyTemplateNameOneof DeidentifyTemplateNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Dlp.V2.DeidentifyTemplateNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1245,9 +1245,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class DeleteDlpJobRequest
     {
         /// <summary>
-        /// <see cref="DlpJobName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.DlpJobName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public DlpJobName DlpJobName
+        public Google.Cloud.Dlp.V2.DlpJobName DlpJobName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Dlp.V2.DlpJobName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1258,9 +1258,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class DeleteInspectTemplateRequest
     {
         /// <summary>
-        /// <see cref="InspectTemplateNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.InspectTemplateNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public InspectTemplateNameOneof InspectTemplateNameOneof
+        public Google.Cloud.Dlp.V2.InspectTemplateNameOneof InspectTemplateNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Dlp.V2.InspectTemplateNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1271,9 +1271,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class DeleteJobTriggerRequest
     {
         /// <summary>
-        /// <see cref="ProjectJobTriggerName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.ProjectJobTriggerName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectJobTriggerName ProjectJobTriggerName
+        public Google.Cloud.Dlp.V2.ProjectJobTriggerName ProjectJobTriggerName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Dlp.V2.ProjectJobTriggerName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1284,9 +1284,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class GetDeidentifyTemplateRequest
     {
         /// <summary>
-        /// <see cref="DeidentifyTemplateNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.DeidentifyTemplateNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public DeidentifyTemplateNameOneof DeidentifyTemplateNameOneof
+        public Google.Cloud.Dlp.V2.DeidentifyTemplateNameOneof DeidentifyTemplateNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Dlp.V2.DeidentifyTemplateNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1297,9 +1297,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class GetDlpJobRequest
     {
         /// <summary>
-        /// <see cref="DlpJobName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.DlpJobName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public DlpJobName DlpJobName
+        public Google.Cloud.Dlp.V2.DlpJobName DlpJobName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Dlp.V2.DlpJobName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1310,9 +1310,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class GetInspectTemplateRequest
     {
         /// <summary>
-        /// <see cref="InspectTemplateNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.InspectTemplateNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public InspectTemplateNameOneof InspectTemplateNameOneof
+        public Google.Cloud.Dlp.V2.InspectTemplateNameOneof InspectTemplateNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Dlp.V2.InspectTemplateNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1323,9 +1323,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class GetJobTriggerRequest
     {
         /// <summary>
-        /// <see cref="ProjectJobTriggerName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.ProjectJobTriggerName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectJobTriggerName ProjectJobTriggerName
+        public Google.Cloud.Dlp.V2.ProjectJobTriggerName ProjectJobTriggerName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Dlp.V2.ProjectJobTriggerName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1336,9 +1336,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class InspectContentRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ProjectName ParentAsProjectName
+        public Google.Cloud.Dlp.V2.ProjectName ParentAsProjectName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dlp.V2.ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1349,9 +1349,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class ListDeidentifyTemplatesRequest
     {
         /// <summary>
-        /// <see cref="OrganizationName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.OrganizationName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public OrganizationName ParentAsOrganizationName
+        public Google.Cloud.Dlp.V2.OrganizationName ParentAsOrganizationName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dlp.V2.OrganizationName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1362,9 +1362,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class ListDlpJobsRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ProjectName ParentAsProjectName
+        public Google.Cloud.Dlp.V2.ProjectName ParentAsProjectName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dlp.V2.ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1375,9 +1375,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class ListInspectTemplatesRequest
     {
         /// <summary>
-        /// <see cref="OrganizationName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.OrganizationName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public OrganizationName ParentAsOrganizationName
+        public Google.Cloud.Dlp.V2.OrganizationName ParentAsOrganizationName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dlp.V2.OrganizationName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1388,9 +1388,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class ListJobTriggersRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ProjectName ParentAsProjectName
+        public Google.Cloud.Dlp.V2.ProjectName ParentAsProjectName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dlp.V2.ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1401,9 +1401,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class RedactImageRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ProjectName ParentAsProjectName
+        public Google.Cloud.Dlp.V2.ProjectName ParentAsProjectName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dlp.V2.ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1414,9 +1414,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class ReidentifyContentRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ProjectName ParentAsProjectName
+        public Google.Cloud.Dlp.V2.ProjectName ParentAsProjectName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dlp.V2.ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -1427,9 +1427,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class UpdateDeidentifyTemplateRequest
     {
         /// <summary>
-        /// <see cref="DeidentifyTemplateNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.DeidentifyTemplateNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public DeidentifyTemplateNameOneof DeidentifyTemplateNameOneof
+        public Google.Cloud.Dlp.V2.DeidentifyTemplateNameOneof DeidentifyTemplateNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Dlp.V2.DeidentifyTemplateNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1440,9 +1440,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class UpdateInspectTemplateRequest
     {
         /// <summary>
-        /// <see cref="InspectTemplateNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.InspectTemplateNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public InspectTemplateNameOneof InspectTemplateNameOneof
+        public Google.Cloud.Dlp.V2.InspectTemplateNameOneof InspectTemplateNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Dlp.V2.InspectTemplateNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1453,9 +1453,9 @@ namespace Google.Cloud.Dlp.V2
     public partial class UpdateJobTriggerRequest
     {
         /// <summary>
-        /// <see cref="ProjectJobTriggerName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Dlp.V2.ProjectJobTriggerName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectJobTriggerName ProjectJobTriggerName
+        public Google.Cloud.Dlp.V2.ProjectJobTriggerName ProjectJobTriggerName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Dlp.V2.ProjectJobTriggerName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceClient.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -67,7 +67,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -95,8 +95,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -115,8 +115,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(20000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(20000),
             delayMultiplier: 1.0
         );
 
@@ -146,7 +146,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -176,7 +176,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -276,7 +276,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </summary>
         public virtual ErrorGroupService.ErrorGroupServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -376,7 +376,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             GetGroupRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -413,7 +413,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             GetGroupRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -496,7 +496,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             UpdateGroupRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -535,7 +535,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             UpdateGroupRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -574,8 +574,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -68,7 +68,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -96,8 +96,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -116,8 +116,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(20000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(20000),
             delayMultiplier: 1.0
         );
 
@@ -147,7 +147,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -177,7 +177,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -207,7 +207,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -307,7 +307,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </summary>
         public virtual ErrorStatsService.ErrorStatsServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -424,7 +424,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             ListGroupStatsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -443,7 +443,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             ListGroupStatsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -546,7 +546,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             ListEventsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -565,7 +565,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             ListEventsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -656,7 +656,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             DeleteEventsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -693,7 +693,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             DeleteEventsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -737,8 +737,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceClient.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -66,7 +66,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -94,8 +94,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -114,8 +114,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(20000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(20000),
             delayMultiplier: 1.0
         );
 
@@ -144,7 +144,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -244,7 +244,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </summary>
         public virtual ReportErrorsService.ReportErrorsServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -375,7 +375,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             ReportErrorEventRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -426,7 +426,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             ReportErrorEventRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -460,8 +460,8 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ResourceNames.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ResourceNames.cs
@@ -15,15 +15,15 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.ErrorReporting.V1Beta1
 {
     /// <summary>
     /// Resource name for the 'project' resource.
     /// </summary>
-    public sealed partial class ProjectName : gax::IResourceName, s::IEquatable<ProjectName>
+    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
 
@@ -45,7 +45,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <see cref="ProjectName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
@@ -108,7 +108,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
     /// <summary>
     /// Resource name for the 'group' resource.
     /// </summary>
-    public sealed partial class GroupName : gax::IResourceName, s::IEquatable<GroupName>
+    public sealed partial class GroupName : gax::IResourceName, sys::IEquatable<GroupName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/groups/{group}");
 
@@ -130,7 +130,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <see cref="GroupName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="groupName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="groupName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="groupName">The group resource name in string form. Must not be <c>null</c>.</param>
@@ -201,9 +201,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
     public partial class DeleteEventsRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="ProjectName"/> resource name property.
+        /// <see cref="Google.Cloud.ErrorReporting.V1Beta1.ProjectName"/>-typed view over the <see cref="ProjectName"/> resource name property.
         /// </summary>
-        public ProjectName ProjectNameAsProjectName
+        public Google.Cloud.ErrorReporting.V1Beta1.ProjectName ProjectNameAsProjectName
         {
             get { return string.IsNullOrEmpty(ProjectName) ? null : Google.Cloud.ErrorReporting.V1Beta1.ProjectName.Parse(ProjectName); }
             set { ProjectName = value != null ? value.ToString() : ""; }
@@ -214,9 +214,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
     public partial class ErrorGroup
     {
         /// <summary>
-        /// <see cref="GroupName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.ErrorReporting.V1Beta1.GroupName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public GroupName GroupName
+        public Google.Cloud.ErrorReporting.V1Beta1.GroupName GroupName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.ErrorReporting.V1Beta1.GroupName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -227,9 +227,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
     public partial class GetGroupRequest
     {
         /// <summary>
-        /// <see cref="GroupName"/>-typed view over the <see cref="GroupName"/> resource name property.
+        /// <see cref="Google.Cloud.ErrorReporting.V1Beta1.GroupName"/>-typed view over the <see cref="GroupName"/> resource name property.
         /// </summary>
-        public GroupName GroupNameAsGroupName
+        public Google.Cloud.ErrorReporting.V1Beta1.GroupName GroupNameAsGroupName
         {
             get { return string.IsNullOrEmpty(GroupName) ? null : Google.Cloud.ErrorReporting.V1Beta1.GroupName.Parse(GroupName); }
             set { GroupName = value != null ? value.ToString() : ""; }
@@ -240,9 +240,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
     public partial class ListEventsRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="ProjectName"/> resource name property.
+        /// <see cref="Google.Cloud.ErrorReporting.V1Beta1.ProjectName"/>-typed view over the <see cref="ProjectName"/> resource name property.
         /// </summary>
-        public ProjectName ProjectNameAsProjectName
+        public Google.Cloud.ErrorReporting.V1Beta1.ProjectName ProjectNameAsProjectName
         {
             get { return string.IsNullOrEmpty(ProjectName) ? null : Google.Cloud.ErrorReporting.V1Beta1.ProjectName.Parse(ProjectName); }
             set { ProjectName = value != null ? value.ToString() : ""; }
@@ -253,9 +253,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
     public partial class ListGroupStatsRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="ProjectName"/> resource name property.
+        /// <see cref="Google.Cloud.ErrorReporting.V1Beta1.ProjectName"/>-typed view over the <see cref="ProjectName"/> resource name property.
         /// </summary>
-        public ProjectName ProjectNameAsProjectName
+        public Google.Cloud.ErrorReporting.V1Beta1.ProjectName ProjectNameAsProjectName
         {
             get { return string.IsNullOrEmpty(ProjectName) ? null : Google.Cloud.ErrorReporting.V1Beta1.ProjectName.Parse(ProjectName); }
             set { ProjectName = value != null ? value.ToString() : ""; }
@@ -266,9 +266,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
     public partial class ReportErrorEventRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="ProjectName"/> resource name property.
+        /// <see cref="Google.Cloud.ErrorReporting.V1Beta1.ProjectName"/>-typed view over the <see cref="ProjectName"/> resource name property.
         /// </summary>
-        public ProjectName ProjectNameAsProjectName
+        public Google.Cloud.ErrorReporting.V1Beta1.ProjectName ProjectNameAsProjectName
         {
             get { return string.IsNullOrEmpty(ProjectName) ? null : Google.Cloud.ErrorReporting.V1Beta1.ProjectName.Parse(ProjectName); }
             set { ProjectName = value != null ? value.ToString() : ""; }

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Snippets/FirestoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Snippets/FirestoreClientSnippets.g.cs
@@ -484,7 +484,7 @@ namespace Google.Cloud.Firestore.V1Beta1.Snippets
             FirestoreClient firestoreClient = await FirestoreClient.CreateAsync();
             // Initialize request argument(s)
             string formattedDatabase = new DatabaseRootName("[PROJECT]", "[DATABASE]").ToString();
-            ByteString transaction = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString transaction = ByteString.Empty;
             // Make the request
             await firestoreClient.RollbackAsync(formattedDatabase, transaction);
             // End snippet
@@ -498,7 +498,7 @@ namespace Google.Cloud.Firestore.V1Beta1.Snippets
             FirestoreClient firestoreClient = FirestoreClient.Create();
             // Initialize request argument(s)
             string formattedDatabase = new DatabaseRootName("[PROJECT]", "[DATABASE]").ToString();
-            ByteString transaction = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString transaction = ByteString.Empty;
             // Make the request
             firestoreClient.Rollback(formattedDatabase, transaction);
             // End snippet
@@ -515,7 +515,7 @@ namespace Google.Cloud.Firestore.V1Beta1.Snippets
             RollbackRequest request = new RollbackRequest
             {
                 Database = new DatabaseRootName("[PROJECT]", "[DATABASE]").ToString(),
-                Transaction = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                Transaction = ByteString.Empty,
             };
             // Make the request
             await firestoreClient.RollbackAsync(request);
@@ -532,7 +532,7 @@ namespace Google.Cloud.Firestore.V1Beta1.Snippets
             RollbackRequest request = new RollbackRequest
             {
                 Database = new DatabaseRootName("[PROJECT]", "[DATABASE]").ToString(),
-                Transaction = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                Transaction = ByteString.Empty,
             };
             // Make the request
             firestoreClient.Rollback(request);

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/FirestoreClient.cs
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/FirestoreClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -80,7 +80,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -108,8 +108,8 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -128,8 +128,8 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(20000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(20000),
             delayMultiplier: 1.0
         );
 
@@ -148,8 +148,8 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetStreamingRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -168,8 +168,8 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetStreamingTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(300000),
-            maxDelay: s::TimeSpan.FromMilliseconds(300000),
+            delay: sys::TimeSpan.FromMilliseconds(300000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(300000),
             delayMultiplier: 1.0
         );
 
@@ -199,7 +199,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -229,7 +229,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -258,7 +258,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -287,7 +287,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -317,7 +317,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -328,7 +328,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings BatchGetDocumentsSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
-            gaxgrpc::CallTiming.FromTimeout(s::TimeSpan.FromMilliseconds(600000)));
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)));
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
@@ -356,7 +356,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -385,7 +385,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -415,7 +415,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -426,7 +426,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings RunQuerySettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
-            gaxgrpc::CallTiming.FromTimeout(s::TimeSpan.FromMilliseconds(600000)));
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)));
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for calls to <c>FirestoreClient.Write</c>.
@@ -435,7 +435,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings WriteSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
-            gaxgrpc::CallTiming.FromTimeout(s::TimeSpan.FromMilliseconds(600000)));
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)));
 
         /// <summary>
         /// <see cref="gaxgrpc::BidirectionalStreamingSettings"/> for calls to
@@ -454,7 +454,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings ListenSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
-            gaxgrpc::CallTiming.FromTimeout(s::TimeSpan.FromMilliseconds(600000)));
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)));
 
         /// <summary>
         /// <see cref="gaxgrpc::BidirectionalStreamingSettings"/> for calls to
@@ -492,7 +492,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -594,7 +594,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// </summary>
         public virtual Firestore.FirestoreClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -613,7 +613,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             GetDocumentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -650,7 +650,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             GetDocumentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -669,7 +669,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             ListDocumentsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -688,7 +688,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             ListDocumentsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -707,7 +707,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             CreateDocumentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -744,7 +744,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             CreateDocumentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -859,7 +859,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             UpdateDocumentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -896,7 +896,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             UpdateDocumentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -975,7 +975,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             DeleteDocumentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1009,7 +1009,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             DeleteDocumentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1031,7 +1031,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             BatchGetDocumentsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1120,7 +1120,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             BeginTransactionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1157,7 +1157,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             BeginTransactionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1260,7 +1260,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             CommitRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1297,7 +1297,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             CommitRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1318,7 +1318,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// </returns>
         public virtual stt::Task RollbackAsync(
             string database,
-            proto::ByteString transaction,
+            pb::ByteString transaction,
             gaxgrpc::CallSettings callSettings = null) => RollbackAsync(
                 new RollbackRequest
                 {
@@ -1345,7 +1345,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// </returns>
         public virtual stt::Task RollbackAsync(
             string database,
-            proto::ByteString transaction,
+            pb::ByteString transaction,
             st::CancellationToken cancellationToken) => RollbackAsync(
                 database,
                 transaction,
@@ -1366,7 +1366,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// </param>
         public virtual void Rollback(
             string database,
-            proto::ByteString transaction,
+            pb::ByteString transaction,
             gaxgrpc::CallSettings callSettings = null) => Rollback(
                 new RollbackRequest
                 {
@@ -1391,7 +1391,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             RollbackRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1425,7 +1425,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             RollbackRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1444,7 +1444,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             RunQueryRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1470,7 +1470,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             gaxgrpc::CallSettings callSettings = null,
             gaxgrpc::BidirectionalStreamingSettings streamingSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1496,7 +1496,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             gaxgrpc::CallSettings callSettings = null,
             gaxgrpc::BidirectionalStreamingSettings streamingSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1594,7 +1594,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             ListCollectionIdsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1613,7 +1613,7 @@ namespace Google.Cloud.Firestore.V1Beta1
             ListCollectionIdsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1627,11 +1627,11 @@ namespace Google.Cloud.Firestore.V1Beta1
         private readonly gaxgrpc::ApiCall<ListDocumentsRequest, ListDocumentsResponse> _callListDocuments;
         private readonly gaxgrpc::ApiCall<CreateDocumentRequest, Document> _callCreateDocument;
         private readonly gaxgrpc::ApiCall<UpdateDocumentRequest, Document> _callUpdateDocument;
-        private readonly gaxgrpc::ApiCall<DeleteDocumentRequest, protowkt::Empty> _callDeleteDocument;
+        private readonly gaxgrpc::ApiCall<DeleteDocumentRequest, pbwkt::Empty> _callDeleteDocument;
         private readonly gaxgrpc::ApiServerStreamingCall<BatchGetDocumentsRequest, BatchGetDocumentsResponse> _callBatchGetDocuments;
         private readonly gaxgrpc::ApiCall<BeginTransactionRequest, BeginTransactionResponse> _callBeginTransaction;
         private readonly gaxgrpc::ApiCall<CommitRequest, CommitResponse> _callCommit;
-        private readonly gaxgrpc::ApiCall<RollbackRequest, protowkt::Empty> _callRollback;
+        private readonly gaxgrpc::ApiCall<RollbackRequest, pbwkt::Empty> _callRollback;
         private readonly gaxgrpc::ApiServerStreamingCall<RunQueryRequest, RunQueryResponse> _callRunQuery;
         private readonly gaxgrpc::ApiBidirectionalStreamingCall<WriteRequest, WriteResponse> _callWrite;
         private readonly gaxgrpc::ApiBidirectionalStreamingCall<ListenRequest, ListenResponse> _callListen;
@@ -1655,7 +1655,7 @@ namespace Google.Cloud.Firestore.V1Beta1
                 GrpcClient.CreateDocumentAsync, GrpcClient.CreateDocument, effectiveSettings.CreateDocumentSettings);
             _callUpdateDocument = clientHelper.BuildApiCall<UpdateDocumentRequest, Document>(
                 GrpcClient.UpdateDocumentAsync, GrpcClient.UpdateDocument, effectiveSettings.UpdateDocumentSettings);
-            _callDeleteDocument = clientHelper.BuildApiCall<DeleteDocumentRequest, protowkt::Empty>(
+            _callDeleteDocument = clientHelper.BuildApiCall<DeleteDocumentRequest, pbwkt::Empty>(
                 GrpcClient.DeleteDocumentAsync, GrpcClient.DeleteDocument, effectiveSettings.DeleteDocumentSettings);
             _callBatchGetDocuments = clientHelper.BuildApiCall<BatchGetDocumentsRequest, BatchGetDocumentsResponse>(
                 GrpcClient.BatchGetDocuments, effectiveSettings.BatchGetDocumentsSettings);
@@ -1663,7 +1663,7 @@ namespace Google.Cloud.Firestore.V1Beta1
                 GrpcClient.BeginTransactionAsync, GrpcClient.BeginTransaction, effectiveSettings.BeginTransactionSettings);
             _callCommit = clientHelper.BuildApiCall<CommitRequest, CommitResponse>(
                 GrpcClient.CommitAsync, GrpcClient.Commit, effectiveSettings.CommitSettings);
-            _callRollback = clientHelper.BuildApiCall<RollbackRequest, protowkt::Empty>(
+            _callRollback = clientHelper.BuildApiCall<RollbackRequest, pbwkt::Empty>(
                 GrpcClient.RollbackAsync, GrpcClient.Rollback, effectiveSettings.RollbackSettings);
             _callRunQuery = clientHelper.BuildApiCall<RunQueryRequest, RunQueryResponse>(
                 GrpcClient.RunQuery, effectiveSettings.RunQuerySettings);
@@ -1707,14 +1707,14 @@ namespace Google.Cloud.Firestore.V1Beta1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiServerStreamingCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiBidirectionalStreamingCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -1722,11 +1722,11 @@ namespace Google.Cloud.Firestore.V1Beta1
         partial void Modify_ListDocumentsApiCall(ref gaxgrpc::ApiCall<ListDocumentsRequest, ListDocumentsResponse> call);
         partial void Modify_CreateDocumentApiCall(ref gaxgrpc::ApiCall<CreateDocumentRequest, Document> call);
         partial void Modify_UpdateDocumentApiCall(ref gaxgrpc::ApiCall<UpdateDocumentRequest, Document> call);
-        partial void Modify_DeleteDocumentApiCall(ref gaxgrpc::ApiCall<DeleteDocumentRequest, protowkt::Empty> call);
+        partial void Modify_DeleteDocumentApiCall(ref gaxgrpc::ApiCall<DeleteDocumentRequest, pbwkt::Empty> call);
         partial void Modify_BatchGetDocumentsApiCall(ref gaxgrpc::ApiServerStreamingCall<BatchGetDocumentsRequest, BatchGetDocumentsResponse> call);
         partial void Modify_BeginTransactionApiCall(ref gaxgrpc::ApiCall<BeginTransactionRequest, BeginTransactionResponse> call);
         partial void Modify_CommitApiCall(ref gaxgrpc::ApiCall<CommitRequest, CommitResponse> call);
-        partial void Modify_RollbackApiCall(ref gaxgrpc::ApiCall<RollbackRequest, protowkt::Empty> call);
+        partial void Modify_RollbackApiCall(ref gaxgrpc::ApiCall<RollbackRequest, pbwkt::Empty> call);
         partial void Modify_RunQueryApiCall(ref gaxgrpc::ApiServerStreamingCall<RunQueryRequest, RunQueryResponse> call);
         partial void Modify_WriteApiCall(ref gaxgrpc::ApiBidirectionalStreamingCall<WriteRequest, WriteResponse> call);
         partial void Modify_ListenApiCall(ref gaxgrpc::ApiBidirectionalStreamingCall<ListenRequest, ListenResponse> call);

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/ResourceNames.cs
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/ResourceNames.cs
@@ -15,15 +15,15 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Firestore.V1Beta1
 {
     /// <summary>
     /// Resource name for the 'database_root' resource.
     /// </summary>
-    public sealed partial class DatabaseRootName : gax::IResourceName, s::IEquatable<DatabaseRootName>
+    public sealed partial class DatabaseRootName : gax::IResourceName, sys::IEquatable<DatabaseRootName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/databases/{database}");
 
@@ -45,7 +45,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// <see cref="DatabaseRootName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="databaseRootName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="databaseRootName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="databaseRootName">The database_root resource name in string form. Must not be <c>null</c>.</param>
@@ -115,7 +115,7 @@ namespace Google.Cloud.Firestore.V1Beta1
     /// <summary>
     /// Resource name for the 'document_root' resource.
     /// </summary>
-    public sealed partial class DocumentRootName : gax::IResourceName, s::IEquatable<DocumentRootName>
+    public sealed partial class DocumentRootName : gax::IResourceName, sys::IEquatable<DocumentRootName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/databases/{database}/documents");
 
@@ -137,7 +137,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// <see cref="DocumentRootName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="documentRootName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="documentRootName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="documentRootName">The document_root resource name in string form. Must not be <c>null</c>.</param>
@@ -207,7 +207,7 @@ namespace Google.Cloud.Firestore.V1Beta1
     /// <summary>
     /// Resource name for the 'document_path' resource.
     /// </summary>
-    public sealed partial class DocumentPathName : gax::IResourceName, s::IEquatable<DocumentPathName>
+    public sealed partial class DocumentPathName : gax::IResourceName, sys::IEquatable<DocumentPathName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/databases/{database}/documents/{document_path=**}");
 
@@ -229,7 +229,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// <see cref="DocumentPathName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="documentPathName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="documentPathName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="documentPathName">The document_path resource name in string form. Must not be <c>null</c>.</param>
@@ -306,7 +306,7 @@ namespace Google.Cloud.Firestore.V1Beta1
     /// <summary>
     /// Resource name for the 'any_path' resource.
     /// </summary>
-    public sealed partial class AnyPathName : gax::IResourceName, s::IEquatable<AnyPathName>
+    public sealed partial class AnyPathName : gax::IResourceName, sys::IEquatable<AnyPathName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/databases/{database}/documents/{document}/{any_path=**}");
 
@@ -328,7 +328,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// <see cref="AnyPathName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="anyPathName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="anyPathName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="anyPathName">The any_path resource name in string form. Must not be <c>null</c>.</param>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -71,7 +71,7 @@ namespace Google.Cloud.Language.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace Google.Cloud.Language.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -99,8 +99,8 @@ namespace Google.Cloud.Language.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -119,8 +119,8 @@ namespace Google.Cloud.Language.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(60000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(60000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.0
         );
 
@@ -150,7 +150,7 @@ namespace Google.Cloud.Language.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -180,7 +180,7 @@ namespace Google.Cloud.Language.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -210,7 +210,7 @@ namespace Google.Cloud.Language.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -240,7 +240,7 @@ namespace Google.Cloud.Language.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -270,7 +270,7 @@ namespace Google.Cloud.Language.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -300,7 +300,7 @@ namespace Google.Cloud.Language.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -400,7 +400,7 @@ namespace Google.Cloud.Language.V1
         /// </summary>
         public virtual LanguageService.LanguageServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -479,7 +479,7 @@ namespace Google.Cloud.Language.V1
             AnalyzeSentimentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -516,7 +516,7 @@ namespace Google.Cloud.Language.V1
             AnalyzeSentimentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -618,7 +618,7 @@ namespace Google.Cloud.Language.V1
             AnalyzeEntitiesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -659,7 +659,7 @@ namespace Google.Cloud.Language.V1
             AnalyzeEntitiesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -757,7 +757,7 @@ namespace Google.Cloud.Language.V1
             AnalyzeEntitySentimentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -796,7 +796,7 @@ namespace Google.Cloud.Language.V1
             AnalyzeEntitySentimentRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -898,7 +898,7 @@ namespace Google.Cloud.Language.V1
             AnalyzeSyntaxRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -939,7 +939,7 @@ namespace Google.Cloud.Language.V1
             AnalyzeSyntaxRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1018,7 +1018,7 @@ namespace Google.Cloud.Language.V1
             ClassifyTextRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1055,7 +1055,7 @@ namespace Google.Cloud.Language.V1
             ClassifyTextRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1168,7 +1168,7 @@ namespace Google.Cloud.Language.V1
             AnnotateTextRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1207,7 +1207,7 @@ namespace Google.Cloud.Language.V1
             AnnotateTextRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1266,8 +1266,8 @@ namespace Google.Cloud.Language.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/ResourceNames.cs
@@ -15,8 +15,8 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Language.V1
 {

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ConfigServiceV2Client.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ConfigServiceV2Client.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -76,7 +76,7 @@ namespace Google.Cloud.Logging.V2
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Internal, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace Google.Cloud.Logging.V2
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -104,8 +104,8 @@ namespace Google.Cloud.Logging.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(1000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(1000),
             delayMultiplier: 1.2
         );
 
@@ -124,8 +124,8 @@ namespace Google.Cloud.Logging.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(30000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(30000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.5
         );
 
@@ -144,8 +144,8 @@ namespace Google.Cloud.Logging.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetWriteSinkRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(1000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(1000),
             delayMultiplier: 1.2
         );
 
@@ -164,8 +164,8 @@ namespace Google.Cloud.Logging.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetWriteSinkTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(30000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(30000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.5
         );
 
@@ -196,7 +196,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -227,7 +227,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -256,7 +256,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -285,7 +285,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -316,7 +316,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -347,7 +347,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -378,7 +378,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -407,7 +407,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -436,7 +436,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -467,7 +467,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -575,7 +575,7 @@ namespace Google.Cloud.Logging.V2
         /// </summary>
         public virtual ConfigServiceV2.ConfigServiceV2Client GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -670,7 +670,7 @@ namespace Google.Cloud.Logging.V2
             ListSinksRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -689,7 +689,7 @@ namespace Google.Cloud.Logging.V2
             ListSinksRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -789,7 +789,7 @@ namespace Google.Cloud.Logging.V2
             GetSinkRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -826,7 +826,7 @@ namespace Google.Cloud.Logging.V2
             GetSinkRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -956,7 +956,7 @@ namespace Google.Cloud.Logging.V2
             CreateSinkRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -999,7 +999,7 @@ namespace Google.Cloud.Logging.V2
             CreateSinkRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1132,7 +1132,7 @@ namespace Google.Cloud.Logging.V2
             UpdateSinkRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1175,7 +1175,7 @@ namespace Google.Cloud.Logging.V2
             UpdateSinkRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1279,7 +1279,7 @@ namespace Google.Cloud.Logging.V2
             DeleteSinkRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1315,7 +1315,7 @@ namespace Google.Cloud.Logging.V2
             DeleteSinkRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1410,7 +1410,7 @@ namespace Google.Cloud.Logging.V2
             ListExclusionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1429,7 +1429,7 @@ namespace Google.Cloud.Logging.V2
             ListExclusionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1529,7 +1529,7 @@ namespace Google.Cloud.Logging.V2
             GetExclusionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1566,7 +1566,7 @@ namespace Google.Cloud.Logging.V2
             GetExclusionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1692,7 +1692,7 @@ namespace Google.Cloud.Logging.V2
             CreateExclusionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1733,7 +1733,7 @@ namespace Google.Cloud.Logging.V2
             CreateExclusionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1771,7 +1771,7 @@ namespace Google.Cloud.Logging.V2
         public virtual stt::Task<LogExclusion> UpdateExclusionAsync(
             ExclusionNameOneof name,
             LogExclusion exclusion,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             gaxgrpc::CallSettings callSettings = null) => UpdateExclusionAsync(
                 new UpdateExclusionRequest
                 {
@@ -1816,7 +1816,7 @@ namespace Google.Cloud.Logging.V2
         public virtual stt::Task<LogExclusion> UpdateExclusionAsync(
             ExclusionNameOneof name,
             LogExclusion exclusion,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             st::CancellationToken cancellationToken) => UpdateExclusionAsync(
                 name,
                 exclusion,
@@ -1858,7 +1858,7 @@ namespace Google.Cloud.Logging.V2
         public virtual LogExclusion UpdateExclusion(
             ExclusionNameOneof name,
             LogExclusion exclusion,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             gaxgrpc::CallSettings callSettings = null) => UpdateExclusion(
                 new UpdateExclusionRequest
                 {
@@ -1884,7 +1884,7 @@ namespace Google.Cloud.Logging.V2
             UpdateExclusionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1921,7 +1921,7 @@ namespace Google.Cloud.Logging.V2
             UpdateExclusionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2018,7 +2018,7 @@ namespace Google.Cloud.Logging.V2
             DeleteExclusionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2052,7 +2052,7 @@ namespace Google.Cloud.Logging.V2
             DeleteExclusionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -2066,12 +2066,12 @@ namespace Google.Cloud.Logging.V2
         private readonly gaxgrpc::ApiCall<GetSinkRequest, LogSink> _callGetSink;
         private readonly gaxgrpc::ApiCall<CreateSinkRequest, LogSink> _callCreateSink;
         private readonly gaxgrpc::ApiCall<UpdateSinkRequest, LogSink> _callUpdateSink;
-        private readonly gaxgrpc::ApiCall<DeleteSinkRequest, protowkt::Empty> _callDeleteSink;
+        private readonly gaxgrpc::ApiCall<DeleteSinkRequest, pbwkt::Empty> _callDeleteSink;
         private readonly gaxgrpc::ApiCall<ListExclusionsRequest, ListExclusionsResponse> _callListExclusions;
         private readonly gaxgrpc::ApiCall<GetExclusionRequest, LogExclusion> _callGetExclusion;
         private readonly gaxgrpc::ApiCall<CreateExclusionRequest, LogExclusion> _callCreateExclusion;
         private readonly gaxgrpc::ApiCall<UpdateExclusionRequest, LogExclusion> _callUpdateExclusion;
-        private readonly gaxgrpc::ApiCall<DeleteExclusionRequest, protowkt::Empty> _callDeleteExclusion;
+        private readonly gaxgrpc::ApiCall<DeleteExclusionRequest, pbwkt::Empty> _callDeleteExclusion;
 
         /// <summary>
         /// Constructs a client wrapper for the ConfigServiceV2 service, with the specified gRPC client and settings.
@@ -2091,7 +2091,7 @@ namespace Google.Cloud.Logging.V2
                 GrpcClient.CreateSinkAsync, GrpcClient.CreateSink, effectiveSettings.CreateSinkSettings);
             _callUpdateSink = clientHelper.BuildApiCall<UpdateSinkRequest, LogSink>(
                 GrpcClient.UpdateSinkAsync, GrpcClient.UpdateSink, effectiveSettings.UpdateSinkSettings);
-            _callDeleteSink = clientHelper.BuildApiCall<DeleteSinkRequest, protowkt::Empty>(
+            _callDeleteSink = clientHelper.BuildApiCall<DeleteSinkRequest, pbwkt::Empty>(
                 GrpcClient.DeleteSinkAsync, GrpcClient.DeleteSink, effectiveSettings.DeleteSinkSettings);
             _callListExclusions = clientHelper.BuildApiCall<ListExclusionsRequest, ListExclusionsResponse>(
                 GrpcClient.ListExclusionsAsync, GrpcClient.ListExclusions, effectiveSettings.ListExclusionsSettings);
@@ -2101,7 +2101,7 @@ namespace Google.Cloud.Logging.V2
                 GrpcClient.CreateExclusionAsync, GrpcClient.CreateExclusion, effectiveSettings.CreateExclusionSettings);
             _callUpdateExclusion = clientHelper.BuildApiCall<UpdateExclusionRequest, LogExclusion>(
                 GrpcClient.UpdateExclusionAsync, GrpcClient.UpdateExclusion, effectiveSettings.UpdateExclusionSettings);
-            _callDeleteExclusion = clientHelper.BuildApiCall<DeleteExclusionRequest, protowkt::Empty>(
+            _callDeleteExclusion = clientHelper.BuildApiCall<DeleteExclusionRequest, pbwkt::Empty>(
                 GrpcClient.DeleteExclusionAsync, GrpcClient.DeleteExclusion, effectiveSettings.DeleteExclusionSettings);
             Modify_ApiCall(ref _callListSinks);
             Modify_ListSinksApiCall(ref _callListSinks);
@@ -2131,8 +2131,8 @@ namespace Google.Cloud.Logging.V2
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -2140,12 +2140,12 @@ namespace Google.Cloud.Logging.V2
         partial void Modify_GetSinkApiCall(ref gaxgrpc::ApiCall<GetSinkRequest, LogSink> call);
         partial void Modify_CreateSinkApiCall(ref gaxgrpc::ApiCall<CreateSinkRequest, LogSink> call);
         partial void Modify_UpdateSinkApiCall(ref gaxgrpc::ApiCall<UpdateSinkRequest, LogSink> call);
-        partial void Modify_DeleteSinkApiCall(ref gaxgrpc::ApiCall<DeleteSinkRequest, protowkt::Empty> call);
+        partial void Modify_DeleteSinkApiCall(ref gaxgrpc::ApiCall<DeleteSinkRequest, pbwkt::Empty> call);
         partial void Modify_ListExclusionsApiCall(ref gaxgrpc::ApiCall<ListExclusionsRequest, ListExclusionsResponse> call);
         partial void Modify_GetExclusionApiCall(ref gaxgrpc::ApiCall<GetExclusionRequest, LogExclusion> call);
         partial void Modify_CreateExclusionApiCall(ref gaxgrpc::ApiCall<CreateExclusionRequest, LogExclusion> call);
         partial void Modify_UpdateExclusionApiCall(ref gaxgrpc::ApiCall<UpdateExclusionRequest, LogExclusion> call);
-        partial void Modify_DeleteExclusionApiCall(ref gaxgrpc::ApiCall<DeleteExclusionRequest, protowkt::Empty> call);
+        partial void Modify_DeleteExclusionApiCall(ref gaxgrpc::ApiCall<DeleteExclusionRequest, pbwkt::Empty> call);
         partial void OnConstruction(ConfigServiceV2.ConfigServiceV2Client grpcClient, ConfigServiceV2Settings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
         /// <summary>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingServiceV2Client.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingServiceV2Client.cs
@@ -17,10 +17,10 @@
 using Google.Api;
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -72,7 +72,7 @@ namespace Google.Cloud.Logging.V2
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Internal, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Google.Cloud.Logging.V2
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -100,8 +100,8 @@ namespace Google.Cloud.Logging.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(1000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(1000),
             delayMultiplier: 1.2
         );
 
@@ -120,8 +120,8 @@ namespace Google.Cloud.Logging.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.5
         );
 
@@ -140,8 +140,8 @@ namespace Google.Cloud.Logging.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetListRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(1000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(1000),
             delayMultiplier: 1.2
         );
 
@@ -160,8 +160,8 @@ namespace Google.Cloud.Logging.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetListTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(2000),
-            maxDelay: s::TimeSpan.FromMilliseconds(10000),
+            delay: sys::TimeSpan.FromMilliseconds(2000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(10000),
             delayMultiplier: 1.5
         );
 
@@ -192,7 +192,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -221,7 +221,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -252,7 +252,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetListRetryBackoff(),
                 timeoutBackoff: GetListTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(20000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(20000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -283,7 +283,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -314,7 +314,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -422,7 +422,7 @@ namespace Google.Cloud.Logging.V2
         /// </summary>
         public virtual LoggingServiceV2.LoggingServiceV2Client GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -543,7 +543,7 @@ namespace Google.Cloud.Logging.V2
             DeleteLogRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -583,7 +583,7 @@ namespace Google.Cloud.Logging.V2
             DeleteLogRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -857,7 +857,7 @@ namespace Google.Cloud.Logging.V2
             WriteLogEntriesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -906,7 +906,7 @@ namespace Google.Cloud.Logging.V2
             WriteLogEntriesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1055,7 +1055,7 @@ namespace Google.Cloud.Logging.V2
             ListLogEntriesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1076,7 +1076,7 @@ namespace Google.Cloud.Logging.V2
             ListLogEntriesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1096,7 +1096,7 @@ namespace Google.Cloud.Logging.V2
             ListMonitoredResourceDescriptorsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1116,7 +1116,7 @@ namespace Google.Cloud.Logging.V2
             ListMonitoredResourceDescriptorsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1214,7 +1214,7 @@ namespace Google.Cloud.Logging.V2
             ListLogsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1234,7 +1234,7 @@ namespace Google.Cloud.Logging.V2
             ListLogsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1244,7 +1244,7 @@ namespace Google.Cloud.Logging.V2
     /// </summary>
     public sealed partial class LoggingServiceV2ClientImpl : LoggingServiceV2Client
     {
-        private readonly gaxgrpc::ApiCall<DeleteLogRequest, protowkt::Empty> _callDeleteLog;
+        private readonly gaxgrpc::ApiCall<DeleteLogRequest, pbwkt::Empty> _callDeleteLog;
         private readonly gaxgrpc::ApiCall<WriteLogEntriesRequest, WriteLogEntriesResponse> _callWriteLogEntries;
         private readonly gaxgrpc::ApiCall<ListLogEntriesRequest, ListLogEntriesResponse> _callListLogEntries;
         private readonly gaxgrpc::ApiCall<ListMonitoredResourceDescriptorsRequest, ListMonitoredResourceDescriptorsResponse> _callListMonitoredResourceDescriptors;
@@ -1260,7 +1260,7 @@ namespace Google.Cloud.Logging.V2
             GrpcClient = grpcClient;
             LoggingServiceV2Settings effectiveSettings = settings ?? LoggingServiceV2Settings.GetDefault();
             gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callDeleteLog = clientHelper.BuildApiCall<DeleteLogRequest, protowkt::Empty>(
+            _callDeleteLog = clientHelper.BuildApiCall<DeleteLogRequest, pbwkt::Empty>(
                 GrpcClient.DeleteLogAsync, GrpcClient.DeleteLog, effectiveSettings.DeleteLogSettings);
             _callWriteLogEntries = clientHelper.BuildApiCall<WriteLogEntriesRequest, WriteLogEntriesResponse>(
                 GrpcClient.WriteLogEntriesAsync, GrpcClient.WriteLogEntries, effectiveSettings.WriteLogEntriesSettings);
@@ -1288,12 +1288,12 @@ namespace Google.Cloud.Logging.V2
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
-        partial void Modify_DeleteLogApiCall(ref gaxgrpc::ApiCall<DeleteLogRequest, protowkt::Empty> call);
+        partial void Modify_DeleteLogApiCall(ref gaxgrpc::ApiCall<DeleteLogRequest, pbwkt::Empty> call);
         partial void Modify_WriteLogEntriesApiCall(ref gaxgrpc::ApiCall<WriteLogEntriesRequest, WriteLogEntriesResponse> call);
         partial void Modify_ListLogEntriesApiCall(ref gaxgrpc::ApiCall<ListLogEntriesRequest, ListLogEntriesResponse> call);
         partial void Modify_ListMonitoredResourceDescriptorsApiCall(ref gaxgrpc::ApiCall<ListMonitoredResourceDescriptorsRequest, ListMonitoredResourceDescriptorsResponse> call);

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/MetricsServiceV2Client.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/MetricsServiceV2Client.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -71,7 +71,7 @@ namespace Google.Cloud.Logging.V2
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Internal, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace Google.Cloud.Logging.V2
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -99,8 +99,8 @@ namespace Google.Cloud.Logging.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(1000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(1000),
             delayMultiplier: 1.2
         );
 
@@ -119,8 +119,8 @@ namespace Google.Cloud.Logging.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.5
         );
 
@@ -151,7 +151,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -182,7 +182,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -211,7 +211,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -240,7 +240,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -271,7 +271,7 @@ namespace Google.Cloud.Logging.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(90000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(90000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -379,7 +379,7 @@ namespace Google.Cloud.Logging.V2
         /// </summary>
         public virtual MetricsServiceV2.MetricsServiceV2Client GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -468,7 +468,7 @@ namespace Google.Cloud.Logging.V2
             ListLogMetricsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -487,7 +487,7 @@ namespace Google.Cloud.Logging.V2
             ListLogMetricsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -572,7 +572,7 @@ namespace Google.Cloud.Logging.V2
             GetLogMetricRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -609,7 +609,7 @@ namespace Google.Cloud.Logging.V2
             GetLogMetricRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -718,7 +718,7 @@ namespace Google.Cloud.Logging.V2
             CreateLogMetricRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -755,7 +755,7 @@ namespace Google.Cloud.Logging.V2
             CreateLogMetricRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -867,7 +867,7 @@ namespace Google.Cloud.Logging.V2
             UpdateLogMetricRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -904,7 +904,7 @@ namespace Google.Cloud.Logging.V2
             UpdateLogMetricRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -986,7 +986,7 @@ namespace Google.Cloud.Logging.V2
             DeleteLogMetricRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1020,7 +1020,7 @@ namespace Google.Cloud.Logging.V2
             DeleteLogMetricRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1034,7 +1034,7 @@ namespace Google.Cloud.Logging.V2
         private readonly gaxgrpc::ApiCall<GetLogMetricRequest, LogMetric> _callGetLogMetric;
         private readonly gaxgrpc::ApiCall<CreateLogMetricRequest, LogMetric> _callCreateLogMetric;
         private readonly gaxgrpc::ApiCall<UpdateLogMetricRequest, LogMetric> _callUpdateLogMetric;
-        private readonly gaxgrpc::ApiCall<DeleteLogMetricRequest, protowkt::Empty> _callDeleteLogMetric;
+        private readonly gaxgrpc::ApiCall<DeleteLogMetricRequest, pbwkt::Empty> _callDeleteLogMetric;
 
         /// <summary>
         /// Constructs a client wrapper for the MetricsServiceV2 service, with the specified gRPC client and settings.
@@ -1054,7 +1054,7 @@ namespace Google.Cloud.Logging.V2
                 GrpcClient.CreateLogMetricAsync, GrpcClient.CreateLogMetric, effectiveSettings.CreateLogMetricSettings);
             _callUpdateLogMetric = clientHelper.BuildApiCall<UpdateLogMetricRequest, LogMetric>(
                 GrpcClient.UpdateLogMetricAsync, GrpcClient.UpdateLogMetric, effectiveSettings.UpdateLogMetricSettings);
-            _callDeleteLogMetric = clientHelper.BuildApiCall<DeleteLogMetricRequest, protowkt::Empty>(
+            _callDeleteLogMetric = clientHelper.BuildApiCall<DeleteLogMetricRequest, pbwkt::Empty>(
                 GrpcClient.DeleteLogMetricAsync, GrpcClient.DeleteLogMetric, effectiveSettings.DeleteLogMetricSettings);
             Modify_ApiCall(ref _callListLogMetrics);
             Modify_ListLogMetricsApiCall(ref _callListLogMetrics);
@@ -1074,8 +1074,8 @@ namespace Google.Cloud.Logging.V2
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -1083,7 +1083,7 @@ namespace Google.Cloud.Logging.V2
         partial void Modify_GetLogMetricApiCall(ref gaxgrpc::ApiCall<GetLogMetricRequest, LogMetric> call);
         partial void Modify_CreateLogMetricApiCall(ref gaxgrpc::ApiCall<CreateLogMetricRequest, LogMetric> call);
         partial void Modify_UpdateLogMetricApiCall(ref gaxgrpc::ApiCall<UpdateLogMetricRequest, LogMetric> call);
-        partial void Modify_DeleteLogMetricApiCall(ref gaxgrpc::ApiCall<DeleteLogMetricRequest, protowkt::Empty> call);
+        partial void Modify_DeleteLogMetricApiCall(ref gaxgrpc::ApiCall<DeleteLogMetricRequest, pbwkt::Empty> call);
         partial void OnConstruction(MetricsServiceV2.MetricsServiceV2Client grpcClient, MetricsServiceV2Settings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
         /// <summary>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ResourceNames.cs
@@ -15,15 +15,15 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Logging.V2
 {
     /// <summary>
     /// Resource name for the 'project' resource.
     /// </summary>
-    public sealed partial class ProjectName : gax::IResourceName, s::IEquatable<ProjectName>
+    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
 
@@ -45,7 +45,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="ProjectName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
@@ -108,7 +108,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'log' resource.
     /// </summary>
-    public sealed partial class LogName : gax::IResourceName, s::IEquatable<LogName>
+    public sealed partial class LogName : gax::IResourceName, sys::IEquatable<LogName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/logs/{log}");
 
@@ -130,7 +130,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="LogName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="logName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="logName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="logName">The log resource name in string form. Must not be <c>null</c>.</param>
@@ -200,7 +200,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'sink' resource.
     /// </summary>
-    public sealed partial class SinkName : gax::IResourceName, s::IEquatable<SinkName>
+    public sealed partial class SinkName : gax::IResourceName, sys::IEquatable<SinkName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/sinks/{sink}");
 
@@ -222,7 +222,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="SinkName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="sinkName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="sinkName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="sinkName">The sink resource name in string form. Must not be <c>null</c>.</param>
@@ -292,7 +292,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'metric' resource.
     /// </summary>
-    public sealed partial class MetricName : gax::IResourceName, s::IEquatable<MetricName>
+    public sealed partial class MetricName : gax::IResourceName, sys::IEquatable<MetricName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/metrics/{metric}");
 
@@ -314,7 +314,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="MetricName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="metricName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="metricName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="metricName">The metric resource name in string form. Must not be <c>null</c>.</param>
@@ -384,7 +384,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'exclusion' resource.
     /// </summary>
-    public sealed partial class ExclusionName : gax::IResourceName, s::IEquatable<ExclusionName>
+    public sealed partial class ExclusionName : gax::IResourceName, sys::IEquatable<ExclusionName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/exclusions/{exclusion}");
 
@@ -406,7 +406,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="ExclusionName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="exclusionName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="exclusionName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="exclusionName">The exclusion resource name in string form. Must not be <c>null</c>.</param>
@@ -476,7 +476,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'organization' resource.
     /// </summary>
-    public sealed partial class OrganizationName : gax::IResourceName, s::IEquatable<OrganizationName>
+    public sealed partial class OrganizationName : gax::IResourceName, sys::IEquatable<OrganizationName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}");
 
@@ -498,7 +498,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="OrganizationName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="organizationName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="organizationName">The organization resource name in string form. Must not be <c>null</c>.</param>
@@ -561,7 +561,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'organization_log' resource.
     /// </summary>
-    public sealed partial class OrganizationLogName : gax::IResourceName, s::IEquatable<OrganizationLogName>
+    public sealed partial class OrganizationLogName : gax::IResourceName, sys::IEquatable<OrganizationLogName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/logs/{log}");
 
@@ -583,7 +583,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="OrganizationLogName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="organizationLogName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationLogName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="organizationLogName">The organization_log resource name in string form. Must not be <c>null</c>.</param>
@@ -653,7 +653,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'organization_sink' resource.
     /// </summary>
-    public sealed partial class OrganizationSinkName : gax::IResourceName, s::IEquatable<OrganizationSinkName>
+    public sealed partial class OrganizationSinkName : gax::IResourceName, sys::IEquatable<OrganizationSinkName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/sinks/{sink}");
 
@@ -675,7 +675,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="OrganizationSinkName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="organizationSinkName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationSinkName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="organizationSinkName">The organization_sink resource name in string form. Must not be <c>null</c>.</param>
@@ -745,7 +745,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'organization_exclusion' resource.
     /// </summary>
-    public sealed partial class OrganizationExclusionName : gax::IResourceName, s::IEquatable<OrganizationExclusionName>
+    public sealed partial class OrganizationExclusionName : gax::IResourceName, sys::IEquatable<OrganizationExclusionName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/exclusions/{exclusion}");
 
@@ -767,7 +767,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="OrganizationExclusionName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="organizationExclusionName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationExclusionName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="organizationExclusionName">The organization_exclusion resource name in string form. Must not be <c>null</c>.</param>
@@ -837,7 +837,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'folder' resource.
     /// </summary>
-    public sealed partial class FolderName : gax::IResourceName, s::IEquatable<FolderName>
+    public sealed partial class FolderName : gax::IResourceName, sys::IEquatable<FolderName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("folders/{folder}");
 
@@ -859,7 +859,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="FolderName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="folderName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="folderName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="folderName">The folder resource name in string form. Must not be <c>null</c>.</param>
@@ -922,7 +922,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'folder_log' resource.
     /// </summary>
-    public sealed partial class FolderLogName : gax::IResourceName, s::IEquatable<FolderLogName>
+    public sealed partial class FolderLogName : gax::IResourceName, sys::IEquatable<FolderLogName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("folders/{folder}/logs/{log}");
 
@@ -944,7 +944,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="FolderLogName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="folderLogName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="folderLogName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="folderLogName">The folder_log resource name in string form. Must not be <c>null</c>.</param>
@@ -1014,7 +1014,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'folder_sink' resource.
     /// </summary>
-    public sealed partial class FolderSinkName : gax::IResourceName, s::IEquatable<FolderSinkName>
+    public sealed partial class FolderSinkName : gax::IResourceName, sys::IEquatable<FolderSinkName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("folders/{folder}/sinks/{sink}");
 
@@ -1036,7 +1036,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="FolderSinkName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="folderSinkName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="folderSinkName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="folderSinkName">The folder_sink resource name in string form. Must not be <c>null</c>.</param>
@@ -1106,7 +1106,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'folder_exclusion' resource.
     /// </summary>
-    public sealed partial class FolderExclusionName : gax::IResourceName, s::IEquatable<FolderExclusionName>
+    public sealed partial class FolderExclusionName : gax::IResourceName, sys::IEquatable<FolderExclusionName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("folders/{folder}/exclusions/{exclusion}");
 
@@ -1128,7 +1128,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="FolderExclusionName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="folderExclusionName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="folderExclusionName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="folderExclusionName">The folder_exclusion resource name in string form. Must not be <c>null</c>.</param>
@@ -1198,7 +1198,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'billing' resource.
     /// </summary>
-    public sealed partial class BillingName : gax::IResourceName, s::IEquatable<BillingName>
+    public sealed partial class BillingName : gax::IResourceName, sys::IEquatable<BillingName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("billingAccounts/{billing_account}");
 
@@ -1220,7 +1220,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="BillingName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="billingName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="billingName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="billingName">The billing resource name in string form. Must not be <c>null</c>.</param>
@@ -1283,7 +1283,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'billing_log' resource.
     /// </summary>
-    public sealed partial class BillingLogName : gax::IResourceName, s::IEquatable<BillingLogName>
+    public sealed partial class BillingLogName : gax::IResourceName, sys::IEquatable<BillingLogName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("billingAccounts/{billing_account}/logs/{log}");
 
@@ -1305,7 +1305,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="BillingLogName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="billingLogName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="billingLogName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="billingLogName">The billing_log resource name in string form. Must not be <c>null</c>.</param>
@@ -1375,7 +1375,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'billing_sink' resource.
     /// </summary>
-    public sealed partial class BillingSinkName : gax::IResourceName, s::IEquatable<BillingSinkName>
+    public sealed partial class BillingSinkName : gax::IResourceName, sys::IEquatable<BillingSinkName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("billingAccounts/{billing_account}/sinks/{sink}");
 
@@ -1397,7 +1397,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="BillingSinkName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="billingSinkName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="billingSinkName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="billingSinkName">The billing_sink resource name in string form. Must not be <c>null</c>.</param>
@@ -1467,7 +1467,7 @@ namespace Google.Cloud.Logging.V2
     /// <summary>
     /// Resource name for the 'billing_exclusion' resource.
     /// </summary>
-    public sealed partial class BillingExclusionName : gax::IResourceName, s::IEquatable<BillingExclusionName>
+    public sealed partial class BillingExclusionName : gax::IResourceName, sys::IEquatable<BillingExclusionName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("billingAccounts/{billing_account}/exclusions/{exclusion}");
 
@@ -1489,7 +1489,7 @@ namespace Google.Cloud.Logging.V2
         /// <see cref="BillingExclusionName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="billingExclusionName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="billingExclusionName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="billingExclusionName">The billing_exclusion resource name in string form. Must not be <c>null</c>.</param>
@@ -1568,7 +1568,7 @@ namespace Google.Cloud.Logging.V2
     /// <item><description>BillingName: A resource of type 'billing'.</description></item>
     /// </list>
     /// </remarks>
-    public sealed partial class ParentNameOneof : gax::IResourceName, s::IEquatable<ParentNameOneof>
+    public sealed partial class ParentNameOneof : gax::IResourceName, sys::IEquatable<ParentNameOneof>
     {
         /// <summary>
         /// The possible contents of <see cref="ParentNameOneof"/>.
@@ -1617,7 +1617,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
         /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="s::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
         /// <returns>The parsed <see cref="ParentNameOneof"/> if successful.</returns>
         public static ParentNameOneof Parse(string name, bool allowUnknown)
         {
@@ -1626,7 +1626,7 @@ namespace Google.Cloud.Logging.V2
             {
                 return result;
             }
-            throw new s::ArgumentException("Invalid name", nameof(name));
+            throw new sys::ArgumentException("Invalid name", nameof(name));
         }
 
         /// <summary>
@@ -1743,7 +1743,7 @@ namespace Google.Cloud.Logging.V2
             Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
             if (!IsValid(type, name))
             {
-                throw new s::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
             }
         }
 
@@ -1761,7 +1761,7 @@ namespace Google.Cloud.Logging.V2
         {
             if (Type != type)
             {
-                throw new s::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
             }
             return (T)Name;
         }
@@ -1770,7 +1770,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="ProjectName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="ProjectName"/>.
         /// </remarks>
         public ProjectName ProjectName => CheckAndReturn<ProjectName>(OneofType.ProjectName);
@@ -1779,7 +1779,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="OrganizationName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="OrganizationName"/>.
         /// </remarks>
         public OrganizationName OrganizationName => CheckAndReturn<OrganizationName>(OneofType.OrganizationName);
@@ -1788,7 +1788,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="FolderName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="FolderName"/>.
         /// </remarks>
         public FolderName FolderName => CheckAndReturn<FolderName>(OneofType.FolderName);
@@ -1797,7 +1797,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="BillingName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="BillingName"/>.
         /// </remarks>
         public BillingName BillingName => CheckAndReturn<BillingName>(OneofType.BillingName);
@@ -1836,7 +1836,7 @@ namespace Google.Cloud.Logging.V2
     /// <item><description>BillingSinkName: A resource of type 'billing_sink'.</description></item>
     /// </list>
     /// </remarks>
-    public sealed partial class SinkNameOneof : gax::IResourceName, s::IEquatable<SinkNameOneof>
+    public sealed partial class SinkNameOneof : gax::IResourceName, sys::IEquatable<SinkNameOneof>
     {
         /// <summary>
         /// The possible contents of <see cref="SinkNameOneof"/>.
@@ -1885,7 +1885,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
         /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="s::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
         /// <returns>The parsed <see cref="SinkNameOneof"/> if successful.</returns>
         public static SinkNameOneof Parse(string name, bool allowUnknown)
         {
@@ -1894,7 +1894,7 @@ namespace Google.Cloud.Logging.V2
             {
                 return result;
             }
-            throw new s::ArgumentException("Invalid name", nameof(name));
+            throw new sys::ArgumentException("Invalid name", nameof(name));
         }
 
         /// <summary>
@@ -2011,7 +2011,7 @@ namespace Google.Cloud.Logging.V2
             Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
             if (!IsValid(type, name))
             {
-                throw new s::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
             }
         }
 
@@ -2029,7 +2029,7 @@ namespace Google.Cloud.Logging.V2
         {
             if (Type != type)
             {
-                throw new s::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
             }
             return (T)Name;
         }
@@ -2038,7 +2038,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="SinkName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="SinkName"/>.
         /// </remarks>
         public SinkName SinkName => CheckAndReturn<SinkName>(OneofType.SinkName);
@@ -2047,7 +2047,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="OrganizationSinkName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="OrganizationSinkName"/>.
         /// </remarks>
         public OrganizationSinkName OrganizationSinkName => CheckAndReturn<OrganizationSinkName>(OneofType.OrganizationSinkName);
@@ -2056,7 +2056,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="FolderSinkName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="FolderSinkName"/>.
         /// </remarks>
         public FolderSinkName FolderSinkName => CheckAndReturn<FolderSinkName>(OneofType.FolderSinkName);
@@ -2065,7 +2065,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="BillingSinkName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="BillingSinkName"/>.
         /// </remarks>
         public BillingSinkName BillingSinkName => CheckAndReturn<BillingSinkName>(OneofType.BillingSinkName);
@@ -2104,7 +2104,7 @@ namespace Google.Cloud.Logging.V2
     /// <item><description>BillingExclusionName: A resource of type 'billing_exclusion'.</description></item>
     /// </list>
     /// </remarks>
-    public sealed partial class ExclusionNameOneof : gax::IResourceName, s::IEquatable<ExclusionNameOneof>
+    public sealed partial class ExclusionNameOneof : gax::IResourceName, sys::IEquatable<ExclusionNameOneof>
     {
         /// <summary>
         /// The possible contents of <see cref="ExclusionNameOneof"/>.
@@ -2153,7 +2153,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
         /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="s::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
         /// <returns>The parsed <see cref="ExclusionNameOneof"/> if successful.</returns>
         public static ExclusionNameOneof Parse(string name, bool allowUnknown)
         {
@@ -2162,7 +2162,7 @@ namespace Google.Cloud.Logging.V2
             {
                 return result;
             }
-            throw new s::ArgumentException("Invalid name", nameof(name));
+            throw new sys::ArgumentException("Invalid name", nameof(name));
         }
 
         /// <summary>
@@ -2279,7 +2279,7 @@ namespace Google.Cloud.Logging.V2
             Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
             if (!IsValid(type, name))
             {
-                throw new s::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
             }
         }
 
@@ -2297,7 +2297,7 @@ namespace Google.Cloud.Logging.V2
         {
             if (Type != type)
             {
-                throw new s::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
             }
             return (T)Name;
         }
@@ -2306,7 +2306,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="ExclusionName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="ExclusionName"/>.
         /// </remarks>
         public ExclusionName ExclusionName => CheckAndReturn<ExclusionName>(OneofType.ExclusionName);
@@ -2315,7 +2315,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="OrganizationExclusionName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="OrganizationExclusionName"/>.
         /// </remarks>
         public OrganizationExclusionName OrganizationExclusionName => CheckAndReturn<OrganizationExclusionName>(OneofType.OrganizationExclusionName);
@@ -2324,7 +2324,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="FolderExclusionName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="FolderExclusionName"/>.
         /// </remarks>
         public FolderExclusionName FolderExclusionName => CheckAndReturn<FolderExclusionName>(OneofType.FolderExclusionName);
@@ -2333,7 +2333,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="BillingExclusionName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="BillingExclusionName"/>.
         /// </remarks>
         public BillingExclusionName BillingExclusionName => CheckAndReturn<BillingExclusionName>(OneofType.BillingExclusionName);
@@ -2372,7 +2372,7 @@ namespace Google.Cloud.Logging.V2
     /// <item><description>BillingLogName: A resource of type 'billing_log'.</description></item>
     /// </list>
     /// </remarks>
-    public sealed partial class LogNameOneof : gax::IResourceName, s::IEquatable<LogNameOneof>
+    public sealed partial class LogNameOneof : gax::IResourceName, sys::IEquatable<LogNameOneof>
     {
         /// <summary>
         /// The possible contents of <see cref="LogNameOneof"/>.
@@ -2421,7 +2421,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
         /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="s::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
         /// <returns>The parsed <see cref="LogNameOneof"/> if successful.</returns>
         public static LogNameOneof Parse(string name, bool allowUnknown)
         {
@@ -2430,7 +2430,7 @@ namespace Google.Cloud.Logging.V2
             {
                 return result;
             }
-            throw new s::ArgumentException("Invalid name", nameof(name));
+            throw new sys::ArgumentException("Invalid name", nameof(name));
         }
 
         /// <summary>
@@ -2547,7 +2547,7 @@ namespace Google.Cloud.Logging.V2
             Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
             if (!IsValid(type, name))
             {
-                throw new s::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
             }
         }
 
@@ -2565,7 +2565,7 @@ namespace Google.Cloud.Logging.V2
         {
             if (Type != type)
             {
-                throw new s::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
             }
             return (T)Name;
         }
@@ -2574,7 +2574,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="LogName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="LogName"/>.
         /// </remarks>
         public LogName LogName => CheckAndReturn<LogName>(OneofType.LogName);
@@ -2583,7 +2583,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="OrganizationLogName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="OrganizationLogName"/>.
         /// </remarks>
         public OrganizationLogName OrganizationLogName => CheckAndReturn<OrganizationLogName>(OneofType.OrganizationLogName);
@@ -2592,7 +2592,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="FolderLogName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="FolderLogName"/>.
         /// </remarks>
         public FolderLogName FolderLogName => CheckAndReturn<FolderLogName>(OneofType.FolderLogName);
@@ -2601,7 +2601,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="BillingLogName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="BillingLogName"/>.
         /// </remarks>
         public BillingLogName BillingLogName => CheckAndReturn<BillingLogName>(OneofType.BillingLogName);
@@ -2637,7 +2637,7 @@ namespace Google.Cloud.Logging.V2
     /// <item><description>MetricName: A resource of type 'metric'.</description></item>
     /// </list>
     /// </remarks>
-    public sealed partial class MetricNameOneof : gax::IResourceName, s::IEquatable<MetricNameOneof>
+    public sealed partial class MetricNameOneof : gax::IResourceName, sys::IEquatable<MetricNameOneof>
     {
         /// <summary>
         /// The possible contents of <see cref="MetricNameOneof"/>.
@@ -2668,7 +2668,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
         /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="s::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
         /// <returns>The parsed <see cref="MetricNameOneof"/> if successful.</returns>
         public static MetricNameOneof Parse(string name, bool allowUnknown)
         {
@@ -2677,7 +2677,7 @@ namespace Google.Cloud.Logging.V2
             {
                 return result;
             }
-            throw new s::ArgumentException("Invalid name", nameof(name));
+            throw new sys::ArgumentException("Invalid name", nameof(name));
         }
 
         /// <summary>
@@ -2746,7 +2746,7 @@ namespace Google.Cloud.Logging.V2
             Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
             if (!IsValid(type, name))
             {
-                throw new s::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
             }
         }
 
@@ -2764,7 +2764,7 @@ namespace Google.Cloud.Logging.V2
         {
             if (Type != type)
             {
-                throw new s::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
             }
             return (T)Name;
         }
@@ -2773,7 +2773,7 @@ namespace Google.Cloud.Logging.V2
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="MetricName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="MetricName"/>.
         /// </remarks>
         public MetricName MetricName => CheckAndReturn<MetricName>(OneofType.MetricName);
@@ -2804,9 +2804,9 @@ namespace Google.Cloud.Logging.V2
     public partial class CreateExclusionRequest
     {
         /// <summary>
-        /// <see cref="ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ParentNameOneof ParentAsParentNameOneof
+        public Google.Cloud.Logging.V2.ParentNameOneof ParentAsParentNameOneof
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Logging.V2.ParentNameOneof.Parse(Parent, true); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -2817,9 +2817,9 @@ namespace Google.Cloud.Logging.V2
     public partial class CreateLogMetricRequest
     {
         /// <summary>
-        /// <see cref="ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ParentNameOneof ParentAsParentNameOneof
+        public Google.Cloud.Logging.V2.ParentNameOneof ParentAsParentNameOneof
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Logging.V2.ParentNameOneof.Parse(Parent, true); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -2830,9 +2830,9 @@ namespace Google.Cloud.Logging.V2
     public partial class CreateSinkRequest
     {
         /// <summary>
-        /// <see cref="ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ParentNameOneof ParentAsParentNameOneof
+        public Google.Cloud.Logging.V2.ParentNameOneof ParentAsParentNameOneof
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Logging.V2.ParentNameOneof.Parse(Parent, true); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -2843,9 +2843,9 @@ namespace Google.Cloud.Logging.V2
     public partial class DeleteExclusionRequest
     {
         /// <summary>
-        /// <see cref="ExclusionNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.ExclusionNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ExclusionNameOneof ExclusionNameOneof
+        public Google.Cloud.Logging.V2.ExclusionNameOneof ExclusionNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Logging.V2.ExclusionNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -2856,9 +2856,9 @@ namespace Google.Cloud.Logging.V2
     public partial class DeleteLogMetricRequest
     {
         /// <summary>
-        /// <see cref="MetricNameOneof"/>-typed view over the <see cref="MetricName"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.MetricNameOneof"/>-typed view over the <see cref="MetricName"/> resource name property.
         /// </summary>
-        public MetricNameOneof MetricNameAsMetricNameOneof
+        public Google.Cloud.Logging.V2.MetricNameOneof MetricNameAsMetricNameOneof
         {
             get { return string.IsNullOrEmpty(MetricName) ? null : Google.Cloud.Logging.V2.MetricNameOneof.Parse(MetricName, true); }
             set { MetricName = value != null ? value.ToString() : ""; }
@@ -2869,9 +2869,9 @@ namespace Google.Cloud.Logging.V2
     public partial class DeleteLogRequest
     {
         /// <summary>
-        /// <see cref="LogNameOneof"/>-typed view over the <see cref="LogName"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.LogNameOneof"/>-typed view over the <see cref="LogName"/> resource name property.
         /// </summary>
-        public LogNameOneof LogNameAsLogNameOneof
+        public Google.Cloud.Logging.V2.LogNameOneof LogNameAsLogNameOneof
         {
             get { return string.IsNullOrEmpty(LogName) ? null : Google.Cloud.Logging.V2.LogNameOneof.Parse(LogName, true); }
             set { LogName = value != null ? value.ToString() : ""; }
@@ -2882,9 +2882,9 @@ namespace Google.Cloud.Logging.V2
     public partial class DeleteSinkRequest
     {
         /// <summary>
-        /// <see cref="SinkNameOneof"/>-typed view over the <see cref="SinkName"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.SinkNameOneof"/>-typed view over the <see cref="SinkName"/> resource name property.
         /// </summary>
-        public SinkNameOneof SinkNameAsSinkNameOneof
+        public Google.Cloud.Logging.V2.SinkNameOneof SinkNameAsSinkNameOneof
         {
             get { return string.IsNullOrEmpty(SinkName) ? null : Google.Cloud.Logging.V2.SinkNameOneof.Parse(SinkName, true); }
             set { SinkName = value != null ? value.ToString() : ""; }
@@ -2895,9 +2895,9 @@ namespace Google.Cloud.Logging.V2
     public partial class GetExclusionRequest
     {
         /// <summary>
-        /// <see cref="ExclusionNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.ExclusionNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ExclusionNameOneof ExclusionNameOneof
+        public Google.Cloud.Logging.V2.ExclusionNameOneof ExclusionNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Logging.V2.ExclusionNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -2908,9 +2908,9 @@ namespace Google.Cloud.Logging.V2
     public partial class GetLogMetricRequest
     {
         /// <summary>
-        /// <see cref="MetricNameOneof"/>-typed view over the <see cref="MetricName"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.MetricNameOneof"/>-typed view over the <see cref="MetricName"/> resource name property.
         /// </summary>
-        public MetricNameOneof MetricNameAsMetricNameOneof
+        public Google.Cloud.Logging.V2.MetricNameOneof MetricNameAsMetricNameOneof
         {
             get { return string.IsNullOrEmpty(MetricName) ? null : Google.Cloud.Logging.V2.MetricNameOneof.Parse(MetricName, true); }
             set { MetricName = value != null ? value.ToString() : ""; }
@@ -2921,9 +2921,9 @@ namespace Google.Cloud.Logging.V2
     public partial class GetSinkRequest
     {
         /// <summary>
-        /// <see cref="SinkNameOneof"/>-typed view over the <see cref="SinkName"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.SinkNameOneof"/>-typed view over the <see cref="SinkName"/> resource name property.
         /// </summary>
-        public SinkNameOneof SinkNameAsSinkNameOneof
+        public Google.Cloud.Logging.V2.SinkNameOneof SinkNameAsSinkNameOneof
         {
             get { return string.IsNullOrEmpty(SinkName) ? null : Google.Cloud.Logging.V2.SinkNameOneof.Parse(SinkName, true); }
             set { SinkName = value != null ? value.ToString() : ""; }
@@ -2934,9 +2934,9 @@ namespace Google.Cloud.Logging.V2
     public partial class ListExclusionsRequest
     {
         /// <summary>
-        /// <see cref="ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ParentNameOneof ParentAsParentNameOneof
+        public Google.Cloud.Logging.V2.ParentNameOneof ParentAsParentNameOneof
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Logging.V2.ParentNameOneof.Parse(Parent, true); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -2947,9 +2947,9 @@ namespace Google.Cloud.Logging.V2
     public partial class ListLogMetricsRequest
     {
         /// <summary>
-        /// <see cref="ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ParentNameOneof ParentAsParentNameOneof
+        public Google.Cloud.Logging.V2.ParentNameOneof ParentAsParentNameOneof
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Logging.V2.ParentNameOneof.Parse(Parent, true); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -2960,9 +2960,9 @@ namespace Google.Cloud.Logging.V2
     public partial class ListLogsRequest
     {
         /// <summary>
-        /// <see cref="ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ParentNameOneof ParentAsParentNameOneof
+        public Google.Cloud.Logging.V2.ParentNameOneof ParentAsParentNameOneof
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Logging.V2.ParentNameOneof.Parse(Parent, true); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -2973,9 +2973,9 @@ namespace Google.Cloud.Logging.V2
     public partial class ListSinksRequest
     {
         /// <summary>
-        /// <see cref="ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.ParentNameOneof"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ParentNameOneof ParentAsParentNameOneof
+        public Google.Cloud.Logging.V2.ParentNameOneof ParentAsParentNameOneof
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Logging.V2.ParentNameOneof.Parse(Parent, true); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -2986,9 +2986,9 @@ namespace Google.Cloud.Logging.V2
     public partial class LogEntry
     {
         /// <summary>
-        /// <see cref="LogNameOneof"/>-typed view over the <see cref="LogName"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.LogNameOneof"/>-typed view over the <see cref="LogName"/> resource name property.
         /// </summary>
-        public LogNameOneof LogNameAsLogNameOneof
+        public Google.Cloud.Logging.V2.LogNameOneof LogNameAsLogNameOneof
         {
             get { return string.IsNullOrEmpty(LogName) ? null : Google.Cloud.Logging.V2.LogNameOneof.Parse(LogName, true); }
             set { LogName = value != null ? value.ToString() : ""; }
@@ -3012,9 +3012,9 @@ namespace Google.Cloud.Logging.V2
     public partial class UpdateExclusionRequest
     {
         /// <summary>
-        /// <see cref="ExclusionNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.ExclusionNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ExclusionNameOneof ExclusionNameOneof
+        public Google.Cloud.Logging.V2.ExclusionNameOneof ExclusionNameOneof
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Logging.V2.ExclusionNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -3025,9 +3025,9 @@ namespace Google.Cloud.Logging.V2
     public partial class UpdateLogMetricRequest
     {
         /// <summary>
-        /// <see cref="MetricNameOneof"/>-typed view over the <see cref="MetricName"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.MetricNameOneof"/>-typed view over the <see cref="MetricName"/> resource name property.
         /// </summary>
-        public MetricNameOneof MetricNameAsMetricNameOneof
+        public Google.Cloud.Logging.V2.MetricNameOneof MetricNameAsMetricNameOneof
         {
             get { return string.IsNullOrEmpty(MetricName) ? null : Google.Cloud.Logging.V2.MetricNameOneof.Parse(MetricName, true); }
             set { MetricName = value != null ? value.ToString() : ""; }
@@ -3038,9 +3038,9 @@ namespace Google.Cloud.Logging.V2
     public partial class UpdateSinkRequest
     {
         /// <summary>
-        /// <see cref="SinkNameOneof"/>-typed view over the <see cref="SinkName"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.SinkNameOneof"/>-typed view over the <see cref="SinkName"/> resource name property.
         /// </summary>
-        public SinkNameOneof SinkNameAsSinkNameOneof
+        public Google.Cloud.Logging.V2.SinkNameOneof SinkNameAsSinkNameOneof
         {
             get { return string.IsNullOrEmpty(SinkName) ? null : Google.Cloud.Logging.V2.SinkNameOneof.Parse(SinkName, true); }
             set { SinkName = value != null ? value.ToString() : ""; }
@@ -3051,9 +3051,9 @@ namespace Google.Cloud.Logging.V2
     public partial class WriteLogEntriesRequest
     {
         /// <summary>
-        /// <see cref="LogNameOneof"/>-typed view over the <see cref="LogName"/> resource name property.
+        /// <see cref="Google.Cloud.Logging.V2.LogNameOneof"/>-typed view over the <see cref="LogName"/> resource name property.
         /// </summary>
-        public LogNameOneof LogNameAsLogNameOneof
+        public Google.Cloud.Logging.V2.LogNameOneof LogNameAsLogNameOneof
         {
             get { return string.IsNullOrEmpty(LogName) ? null : Google.Cloud.Logging.V2.LogNameOneof.Parse(LogName, true); }
             set { LogName = value != null ? value.ToString() : ""; }

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertPolicyServiceClient.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertPolicyServiceClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -70,7 +70,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -98,8 +98,8 @@ namespace Google.Cloud.Monitoring.V3
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -118,8 +118,8 @@ namespace Google.Cloud.Monitoring.V3
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(20000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(20000),
             delayMultiplier: 1.0
         );
 
@@ -149,7 +149,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -179,7 +179,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -208,7 +208,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -238,7 +238,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -267,7 +267,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -373,7 +373,7 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public virtual AlertPolicyService.AlertPolicyServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -474,7 +474,7 @@ namespace Google.Cloud.Monitoring.V3
             ListAlertPoliciesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -493,7 +493,7 @@ namespace Google.Cloud.Monitoring.V3
             ListAlertPoliciesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -578,7 +578,7 @@ namespace Google.Cloud.Monitoring.V3
             GetAlertPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -615,7 +615,7 @@ namespace Google.Cloud.Monitoring.V3
             GetAlertPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -736,7 +736,7 @@ namespace Google.Cloud.Monitoring.V3
             CreateAlertPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -773,7 +773,7 @@ namespace Google.Cloud.Monitoring.V3
             CreateAlertPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -861,7 +861,7 @@ namespace Google.Cloud.Monitoring.V3
             DeleteAlertPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -895,7 +895,7 @@ namespace Google.Cloud.Monitoring.V3
             DeleteAlertPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -940,7 +940,7 @@ namespace Google.Cloud.Monitoring.V3
         /// A Task containing the RPC response.
         /// </returns>
         public virtual stt::Task<AlertPolicy> UpdateAlertPolicyAsync(
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             AlertPolicy alertPolicy,
             gaxgrpc::CallSettings callSettings = null) => UpdateAlertPolicyAsync(
                 new UpdateAlertPolicyRequest
@@ -992,7 +992,7 @@ namespace Google.Cloud.Monitoring.V3
         /// A Task containing the RPC response.
         /// </returns>
         public virtual stt::Task<AlertPolicy> UpdateAlertPolicyAsync(
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             AlertPolicy alertPolicy,
             st::CancellationToken cancellationToken) => UpdateAlertPolicyAsync(
                 updateMask,
@@ -1041,7 +1041,7 @@ namespace Google.Cloud.Monitoring.V3
         /// The RPC response.
         /// </returns>
         public virtual AlertPolicy UpdateAlertPolicy(
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             AlertPolicy alertPolicy,
             gaxgrpc::CallSettings callSettings = null) => UpdateAlertPolicy(
                 new UpdateAlertPolicyRequest
@@ -1070,7 +1070,7 @@ namespace Google.Cloud.Monitoring.V3
             UpdateAlertPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1113,7 +1113,7 @@ namespace Google.Cloud.Monitoring.V3
             UpdateAlertPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1126,7 +1126,7 @@ namespace Google.Cloud.Monitoring.V3
         private readonly gaxgrpc::ApiCall<ListAlertPoliciesRequest, ListAlertPoliciesResponse> _callListAlertPolicies;
         private readonly gaxgrpc::ApiCall<GetAlertPolicyRequest, AlertPolicy> _callGetAlertPolicy;
         private readonly gaxgrpc::ApiCall<CreateAlertPolicyRequest, AlertPolicy> _callCreateAlertPolicy;
-        private readonly gaxgrpc::ApiCall<DeleteAlertPolicyRequest, protowkt::Empty> _callDeleteAlertPolicy;
+        private readonly gaxgrpc::ApiCall<DeleteAlertPolicyRequest, pbwkt::Empty> _callDeleteAlertPolicy;
         private readonly gaxgrpc::ApiCall<UpdateAlertPolicyRequest, AlertPolicy> _callUpdateAlertPolicy;
 
         /// <summary>
@@ -1145,7 +1145,7 @@ namespace Google.Cloud.Monitoring.V3
                 GrpcClient.GetAlertPolicyAsync, GrpcClient.GetAlertPolicy, effectiveSettings.GetAlertPolicySettings);
             _callCreateAlertPolicy = clientHelper.BuildApiCall<CreateAlertPolicyRequest, AlertPolicy>(
                 GrpcClient.CreateAlertPolicyAsync, GrpcClient.CreateAlertPolicy, effectiveSettings.CreateAlertPolicySettings);
-            _callDeleteAlertPolicy = clientHelper.BuildApiCall<DeleteAlertPolicyRequest, protowkt::Empty>(
+            _callDeleteAlertPolicy = clientHelper.BuildApiCall<DeleteAlertPolicyRequest, pbwkt::Empty>(
                 GrpcClient.DeleteAlertPolicyAsync, GrpcClient.DeleteAlertPolicy, effectiveSettings.DeleteAlertPolicySettings);
             _callUpdateAlertPolicy = clientHelper.BuildApiCall<UpdateAlertPolicyRequest, AlertPolicy>(
                 GrpcClient.UpdateAlertPolicyAsync, GrpcClient.UpdateAlertPolicy, effectiveSettings.UpdateAlertPolicySettings);
@@ -1167,15 +1167,15 @@ namespace Google.Cloud.Monitoring.V3
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
         partial void Modify_ListAlertPoliciesApiCall(ref gaxgrpc::ApiCall<ListAlertPoliciesRequest, ListAlertPoliciesResponse> call);
         partial void Modify_GetAlertPolicyApiCall(ref gaxgrpc::ApiCall<GetAlertPolicyRequest, AlertPolicy> call);
         partial void Modify_CreateAlertPolicyApiCall(ref gaxgrpc::ApiCall<CreateAlertPolicyRequest, AlertPolicy> call);
-        partial void Modify_DeleteAlertPolicyApiCall(ref gaxgrpc::ApiCall<DeleteAlertPolicyRequest, protowkt::Empty> call);
+        partial void Modify_DeleteAlertPolicyApiCall(ref gaxgrpc::ApiCall<DeleteAlertPolicyRequest, pbwkt::Empty> call);
         partial void Modify_UpdateAlertPolicyApiCall(ref gaxgrpc::ApiCall<UpdateAlertPolicyRequest, AlertPolicy> call);
         partial void OnConstruction(AlertPolicyService.AlertPolicyServiceClient grpcClient, AlertPolicyServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceClient.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceClient.cs
@@ -17,10 +17,10 @@
 using Google.Api;
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -72,7 +72,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -100,8 +100,8 @@ namespace Google.Cloud.Monitoring.V3
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -120,8 +120,8 @@ namespace Google.Cloud.Monitoring.V3
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(20000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(20000),
             delayMultiplier: 1.0
         );
 
@@ -151,7 +151,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -181,7 +181,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -210,7 +210,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -240,7 +240,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -270,7 +270,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -300,7 +300,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -406,7 +406,7 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public virtual GroupService.GroupServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -425,7 +425,7 @@ namespace Google.Cloud.Monitoring.V3
             ListGroupsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -444,7 +444,7 @@ namespace Google.Cloud.Monitoring.V3
             ListGroupsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -526,7 +526,7 @@ namespace Google.Cloud.Monitoring.V3
             GetGroupRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -563,7 +563,7 @@ namespace Google.Cloud.Monitoring.V3
             GetGroupRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -663,7 +663,7 @@ namespace Google.Cloud.Monitoring.V3
             CreateGroupRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -700,7 +700,7 @@ namespace Google.Cloud.Monitoring.V3
             CreateGroupRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -786,7 +786,7 @@ namespace Google.Cloud.Monitoring.V3
             UpdateGroupRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -825,7 +825,7 @@ namespace Google.Cloud.Monitoring.V3
             UpdateGroupRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -904,7 +904,7 @@ namespace Google.Cloud.Monitoring.V3
             DeleteGroupRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -938,7 +938,7 @@ namespace Google.Cloud.Monitoring.V3
             DeleteGroupRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1025,7 +1025,7 @@ namespace Google.Cloud.Monitoring.V3
             ListGroupMembersRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1044,7 +1044,7 @@ namespace Google.Cloud.Monitoring.V3
             ListGroupMembersRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1058,7 +1058,7 @@ namespace Google.Cloud.Monitoring.V3
         private readonly gaxgrpc::ApiCall<GetGroupRequest, Group> _callGetGroup;
         private readonly gaxgrpc::ApiCall<CreateGroupRequest, Group> _callCreateGroup;
         private readonly gaxgrpc::ApiCall<UpdateGroupRequest, Group> _callUpdateGroup;
-        private readonly gaxgrpc::ApiCall<DeleteGroupRequest, protowkt::Empty> _callDeleteGroup;
+        private readonly gaxgrpc::ApiCall<DeleteGroupRequest, pbwkt::Empty> _callDeleteGroup;
         private readonly gaxgrpc::ApiCall<ListGroupMembersRequest, ListGroupMembersResponse> _callListGroupMembers;
 
         /// <summary>
@@ -1079,7 +1079,7 @@ namespace Google.Cloud.Monitoring.V3
                 GrpcClient.CreateGroupAsync, GrpcClient.CreateGroup, effectiveSettings.CreateGroupSettings);
             _callUpdateGroup = clientHelper.BuildApiCall<UpdateGroupRequest, Group>(
                 GrpcClient.UpdateGroupAsync, GrpcClient.UpdateGroup, effectiveSettings.UpdateGroupSettings);
-            _callDeleteGroup = clientHelper.BuildApiCall<DeleteGroupRequest, protowkt::Empty>(
+            _callDeleteGroup = clientHelper.BuildApiCall<DeleteGroupRequest, pbwkt::Empty>(
                 GrpcClient.DeleteGroupAsync, GrpcClient.DeleteGroup, effectiveSettings.DeleteGroupSettings);
             _callListGroupMembers = clientHelper.BuildApiCall<ListGroupMembersRequest, ListGroupMembersResponse>(
                 GrpcClient.ListGroupMembersAsync, GrpcClient.ListGroupMembers, effectiveSettings.ListGroupMembersSettings);
@@ -1103,8 +1103,8 @@ namespace Google.Cloud.Monitoring.V3
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -1112,7 +1112,7 @@ namespace Google.Cloud.Monitoring.V3
         partial void Modify_GetGroupApiCall(ref gaxgrpc::ApiCall<GetGroupRequest, Group> call);
         partial void Modify_CreateGroupApiCall(ref gaxgrpc::ApiCall<CreateGroupRequest, Group> call);
         partial void Modify_UpdateGroupApiCall(ref gaxgrpc::ApiCall<UpdateGroupRequest, Group> call);
-        partial void Modify_DeleteGroupApiCall(ref gaxgrpc::ApiCall<DeleteGroupRequest, protowkt::Empty> call);
+        partial void Modify_DeleteGroupApiCall(ref gaxgrpc::ApiCall<DeleteGroupRequest, pbwkt::Empty> call);
         partial void Modify_ListGroupMembersApiCall(ref gaxgrpc::ApiCall<ListGroupMembersRequest, ListGroupMembersResponse> call);
         partial void OnConstruction(GroupService.GroupServiceClient grpcClient, GroupServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceClient.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceClient.cs
@@ -17,10 +17,10 @@
 using Google.Api;
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -74,7 +74,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -102,8 +102,8 @@ namespace Google.Cloud.Monitoring.V3
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -122,8 +122,8 @@ namespace Google.Cloud.Monitoring.V3
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(20000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(20000),
             delayMultiplier: 1.0
         );
 
@@ -153,7 +153,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -183,7 +183,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -213,7 +213,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -243,7 +243,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -272,7 +272,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -302,7 +302,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -332,7 +332,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -361,7 +361,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -467,7 +467,7 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public virtual MetricService.MetricServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -554,7 +554,7 @@ namespace Google.Cloud.Monitoring.V3
             ListMonitoredResourceDescriptorsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -573,7 +573,7 @@ namespace Google.Cloud.Monitoring.V3
             ListMonitoredResourceDescriptorsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -661,7 +661,7 @@ namespace Google.Cloud.Monitoring.V3
             GetMonitoredResourceDescriptorRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -698,7 +698,7 @@ namespace Google.Cloud.Monitoring.V3
             GetMonitoredResourceDescriptorRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -785,7 +785,7 @@ namespace Google.Cloud.Monitoring.V3
             ListMetricDescriptorsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -804,7 +804,7 @@ namespace Google.Cloud.Monitoring.V3
             ListMetricDescriptorsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -892,7 +892,7 @@ namespace Google.Cloud.Monitoring.V3
             GetMetricDescriptorRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -929,7 +929,7 @@ namespace Google.Cloud.Monitoring.V3
             GetMetricDescriptorRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1037,7 +1037,7 @@ namespace Google.Cloud.Monitoring.V3
             CreateMetricDescriptorRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1078,7 +1078,7 @@ namespace Google.Cloud.Monitoring.V3
             CreateMetricDescriptorRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1167,7 +1167,7 @@ namespace Google.Cloud.Monitoring.V3
             DeleteMetricDescriptorRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1203,7 +1203,7 @@ namespace Google.Cloud.Monitoring.V3
             DeleteMetricDescriptorRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1336,7 +1336,7 @@ namespace Google.Cloud.Monitoring.V3
             ListTimeSeriesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1355,7 +1355,7 @@ namespace Google.Cloud.Monitoring.V3
             ListTimeSeriesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1473,7 +1473,7 @@ namespace Google.Cloud.Monitoring.V3
             CreateTimeSeriesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1513,7 +1513,7 @@ namespace Google.Cloud.Monitoring.V3
             CreateTimeSeriesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1528,9 +1528,9 @@ namespace Google.Cloud.Monitoring.V3
         private readonly gaxgrpc::ApiCall<ListMetricDescriptorsRequest, ListMetricDescriptorsResponse> _callListMetricDescriptors;
         private readonly gaxgrpc::ApiCall<GetMetricDescriptorRequest, MetricDescriptor> _callGetMetricDescriptor;
         private readonly gaxgrpc::ApiCall<CreateMetricDescriptorRequest, MetricDescriptor> _callCreateMetricDescriptor;
-        private readonly gaxgrpc::ApiCall<DeleteMetricDescriptorRequest, protowkt::Empty> _callDeleteMetricDescriptor;
+        private readonly gaxgrpc::ApiCall<DeleteMetricDescriptorRequest, pbwkt::Empty> _callDeleteMetricDescriptor;
         private readonly gaxgrpc::ApiCall<ListTimeSeriesRequest, ListTimeSeriesResponse> _callListTimeSeries;
-        private readonly gaxgrpc::ApiCall<CreateTimeSeriesRequest, protowkt::Empty> _callCreateTimeSeries;
+        private readonly gaxgrpc::ApiCall<CreateTimeSeriesRequest, pbwkt::Empty> _callCreateTimeSeries;
 
         /// <summary>
         /// Constructs a client wrapper for the MetricService service, with the specified gRPC client and settings.
@@ -1552,11 +1552,11 @@ namespace Google.Cloud.Monitoring.V3
                 GrpcClient.GetMetricDescriptorAsync, GrpcClient.GetMetricDescriptor, effectiveSettings.GetMetricDescriptorSettings);
             _callCreateMetricDescriptor = clientHelper.BuildApiCall<CreateMetricDescriptorRequest, MetricDescriptor>(
                 GrpcClient.CreateMetricDescriptorAsync, GrpcClient.CreateMetricDescriptor, effectiveSettings.CreateMetricDescriptorSettings);
-            _callDeleteMetricDescriptor = clientHelper.BuildApiCall<DeleteMetricDescriptorRequest, protowkt::Empty>(
+            _callDeleteMetricDescriptor = clientHelper.BuildApiCall<DeleteMetricDescriptorRequest, pbwkt::Empty>(
                 GrpcClient.DeleteMetricDescriptorAsync, GrpcClient.DeleteMetricDescriptor, effectiveSettings.DeleteMetricDescriptorSettings);
             _callListTimeSeries = clientHelper.BuildApiCall<ListTimeSeriesRequest, ListTimeSeriesResponse>(
                 GrpcClient.ListTimeSeriesAsync, GrpcClient.ListTimeSeries, effectiveSettings.ListTimeSeriesSettings);
-            _callCreateTimeSeries = clientHelper.BuildApiCall<CreateTimeSeriesRequest, protowkt::Empty>(
+            _callCreateTimeSeries = clientHelper.BuildApiCall<CreateTimeSeriesRequest, pbwkt::Empty>(
                 GrpcClient.CreateTimeSeriesAsync, GrpcClient.CreateTimeSeries, effectiveSettings.CreateTimeSeriesSettings);
             Modify_ApiCall(ref _callListMonitoredResourceDescriptors);
             Modify_ListMonitoredResourceDescriptorsApiCall(ref _callListMonitoredResourceDescriptors);
@@ -1582,8 +1582,8 @@ namespace Google.Cloud.Monitoring.V3
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -1592,9 +1592,9 @@ namespace Google.Cloud.Monitoring.V3
         partial void Modify_ListMetricDescriptorsApiCall(ref gaxgrpc::ApiCall<ListMetricDescriptorsRequest, ListMetricDescriptorsResponse> call);
         partial void Modify_GetMetricDescriptorApiCall(ref gaxgrpc::ApiCall<GetMetricDescriptorRequest, MetricDescriptor> call);
         partial void Modify_CreateMetricDescriptorApiCall(ref gaxgrpc::ApiCall<CreateMetricDescriptorRequest, MetricDescriptor> call);
-        partial void Modify_DeleteMetricDescriptorApiCall(ref gaxgrpc::ApiCall<DeleteMetricDescriptorRequest, protowkt::Empty> call);
+        partial void Modify_DeleteMetricDescriptorApiCall(ref gaxgrpc::ApiCall<DeleteMetricDescriptorRequest, pbwkt::Empty> call);
         partial void Modify_ListTimeSeriesApiCall(ref gaxgrpc::ApiCall<ListTimeSeriesRequest, ListTimeSeriesResponse> call);
-        partial void Modify_CreateTimeSeriesApiCall(ref gaxgrpc::ApiCall<CreateTimeSeriesRequest, protowkt::Empty> call);
+        partial void Modify_CreateTimeSeriesApiCall(ref gaxgrpc::ApiCall<CreateTimeSeriesRequest, pbwkt::Empty> call);
         partial void OnConstruction(MetricService.MetricServiceClient grpcClient, MetricServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
         /// <summary>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationChannelServiceClient.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationChannelServiceClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -72,7 +72,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -100,8 +100,8 @@ namespace Google.Cloud.Monitoring.V3
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -120,8 +120,8 @@ namespace Google.Cloud.Monitoring.V3
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(20000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(20000),
             delayMultiplier: 1.0
         );
 
@@ -151,7 +151,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -181,7 +181,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -211,7 +211,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -241,7 +241,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -270,7 +270,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -299,7 +299,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -329,7 +329,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -435,7 +435,7 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public virtual NotificationChannelService.NotificationChannelServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -539,7 +539,7 @@ namespace Google.Cloud.Monitoring.V3
             ListNotificationChannelDescriptorsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -559,7 +559,7 @@ namespace Google.Cloud.Monitoring.V3
             ListNotificationChannelDescriptorsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -645,7 +645,7 @@ namespace Google.Cloud.Monitoring.V3
             GetNotificationChannelDescriptorRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -684,7 +684,7 @@ namespace Google.Cloud.Monitoring.V3
             GetNotificationChannelDescriptorRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -779,7 +779,7 @@ namespace Google.Cloud.Monitoring.V3
             ListNotificationChannelsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -798,7 +798,7 @@ namespace Google.Cloud.Monitoring.V3
             ListNotificationChannelsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -896,7 +896,7 @@ namespace Google.Cloud.Monitoring.V3
             GetNotificationChannelRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -941,7 +941,7 @@ namespace Google.Cloud.Monitoring.V3
             GetNotificationChannelRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1060,7 +1060,7 @@ namespace Google.Cloud.Monitoring.V3
             CreateNotificationChannelRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1099,7 +1099,7 @@ namespace Google.Cloud.Monitoring.V3
             CreateNotificationChannelRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1122,7 +1122,7 @@ namespace Google.Cloud.Monitoring.V3
         /// A Task containing the RPC response.
         /// </returns>
         public virtual stt::Task<NotificationChannel> UpdateNotificationChannelAsync(
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             NotificationChannel notificationChannel,
             gaxgrpc::CallSettings callSettings = null) => UpdateNotificationChannelAsync(
                 new UpdateNotificationChannelRequest
@@ -1152,7 +1152,7 @@ namespace Google.Cloud.Monitoring.V3
         /// A Task containing the RPC response.
         /// </returns>
         public virtual stt::Task<NotificationChannel> UpdateNotificationChannelAsync(
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             NotificationChannel notificationChannel,
             st::CancellationToken cancellationToken) => UpdateNotificationChannelAsync(
                 updateMask,
@@ -1179,7 +1179,7 @@ namespace Google.Cloud.Monitoring.V3
         /// The RPC response.
         /// </returns>
         public virtual NotificationChannel UpdateNotificationChannel(
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             NotificationChannel notificationChannel,
             gaxgrpc::CallSettings callSettings = null) => UpdateNotificationChannel(
                 new UpdateNotificationChannelRequest
@@ -1206,7 +1206,7 @@ namespace Google.Cloud.Monitoring.V3
             UpdateNotificationChannelRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1245,7 +1245,7 @@ namespace Google.Cloud.Monitoring.V3
             UpdateNotificationChannelRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1348,7 +1348,7 @@ namespace Google.Cloud.Monitoring.V3
             DeleteNotificationChannelRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1382,7 +1382,7 @@ namespace Google.Cloud.Monitoring.V3
             DeleteNotificationChannelRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1398,7 +1398,7 @@ namespace Google.Cloud.Monitoring.V3
         private readonly gaxgrpc::ApiCall<GetNotificationChannelRequest, NotificationChannel> _callGetNotificationChannel;
         private readonly gaxgrpc::ApiCall<CreateNotificationChannelRequest, NotificationChannel> _callCreateNotificationChannel;
         private readonly gaxgrpc::ApiCall<UpdateNotificationChannelRequest, NotificationChannel> _callUpdateNotificationChannel;
-        private readonly gaxgrpc::ApiCall<DeleteNotificationChannelRequest, protowkt::Empty> _callDeleteNotificationChannel;
+        private readonly gaxgrpc::ApiCall<DeleteNotificationChannelRequest, pbwkt::Empty> _callDeleteNotificationChannel;
 
         /// <summary>
         /// Constructs a client wrapper for the NotificationChannelService service, with the specified gRPC client and settings.
@@ -1422,7 +1422,7 @@ namespace Google.Cloud.Monitoring.V3
                 GrpcClient.CreateNotificationChannelAsync, GrpcClient.CreateNotificationChannel, effectiveSettings.CreateNotificationChannelSettings);
             _callUpdateNotificationChannel = clientHelper.BuildApiCall<UpdateNotificationChannelRequest, NotificationChannel>(
                 GrpcClient.UpdateNotificationChannelAsync, GrpcClient.UpdateNotificationChannel, effectiveSettings.UpdateNotificationChannelSettings);
-            _callDeleteNotificationChannel = clientHelper.BuildApiCall<DeleteNotificationChannelRequest, protowkt::Empty>(
+            _callDeleteNotificationChannel = clientHelper.BuildApiCall<DeleteNotificationChannelRequest, pbwkt::Empty>(
                 GrpcClient.DeleteNotificationChannelAsync, GrpcClient.DeleteNotificationChannel, effectiveSettings.DeleteNotificationChannelSettings);
             Modify_ApiCall(ref _callListNotificationChannelDescriptors);
             Modify_ListNotificationChannelDescriptorsApiCall(ref _callListNotificationChannelDescriptors);
@@ -1446,8 +1446,8 @@ namespace Google.Cloud.Monitoring.V3
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -1457,7 +1457,7 @@ namespace Google.Cloud.Monitoring.V3
         partial void Modify_GetNotificationChannelApiCall(ref gaxgrpc::ApiCall<GetNotificationChannelRequest, NotificationChannel> call);
         partial void Modify_CreateNotificationChannelApiCall(ref gaxgrpc::ApiCall<CreateNotificationChannelRequest, NotificationChannel> call);
         partial void Modify_UpdateNotificationChannelApiCall(ref gaxgrpc::ApiCall<UpdateNotificationChannelRequest, NotificationChannel> call);
-        partial void Modify_DeleteNotificationChannelApiCall(ref gaxgrpc::ApiCall<DeleteNotificationChannelRequest, protowkt::Empty> call);
+        partial void Modify_DeleteNotificationChannelApiCall(ref gaxgrpc::ApiCall<DeleteNotificationChannelRequest, pbwkt::Empty> call);
         partial void OnConstruction(NotificationChannelService.NotificationChannelServiceClient grpcClient, NotificationChannelServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
         /// <summary>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ResourceNames.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ResourceNames.cs
@@ -15,15 +15,15 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Monitoring.V3
 {
     /// <summary>
     /// Resource name for the 'project' resource.
     /// </summary>
-    public sealed partial class ProjectName : gax::IResourceName, s::IEquatable<ProjectName>
+    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
 
@@ -45,7 +45,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <see cref="ProjectName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
@@ -108,7 +108,7 @@ namespace Google.Cloud.Monitoring.V3
     /// <summary>
     /// Resource name for the 'alert_policy' resource.
     /// </summary>
-    public sealed partial class AlertPolicyName : gax::IResourceName, s::IEquatable<AlertPolicyName>
+    public sealed partial class AlertPolicyName : gax::IResourceName, sys::IEquatable<AlertPolicyName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/alertPolicies/{alert_policy}");
 
@@ -130,7 +130,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <see cref="AlertPolicyName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="alertPolicyName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="alertPolicyName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="alertPolicyName">The alert_policy resource name in string form. Must not be <c>null</c>.</param>
@@ -200,7 +200,7 @@ namespace Google.Cloud.Monitoring.V3
     /// <summary>
     /// Resource name for the 'alert_policy_condition' resource.
     /// </summary>
-    public sealed partial class AlertPolicyConditionName : gax::IResourceName, s::IEquatable<AlertPolicyConditionName>
+    public sealed partial class AlertPolicyConditionName : gax::IResourceName, sys::IEquatable<AlertPolicyConditionName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/alertPolicies/{alert_policy}/conditions/{condition}");
 
@@ -222,7 +222,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <see cref="AlertPolicyConditionName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="alertPolicyConditionName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="alertPolicyConditionName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="alertPolicyConditionName">The alert_policy_condition resource name in string form. Must not be <c>null</c>.</param>
@@ -299,7 +299,7 @@ namespace Google.Cloud.Monitoring.V3
     /// <summary>
     /// Resource name for the 'group' resource.
     /// </summary>
-    public sealed partial class GroupName : gax::IResourceName, s::IEquatable<GroupName>
+    public sealed partial class GroupName : gax::IResourceName, sys::IEquatable<GroupName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/groups/{group}");
 
@@ -321,7 +321,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <see cref="GroupName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="groupName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="groupName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="groupName">The group resource name in string form. Must not be <c>null</c>.</param>
@@ -391,7 +391,7 @@ namespace Google.Cloud.Monitoring.V3
     /// <summary>
     /// Resource name for the 'metric_descriptor' resource.
     /// </summary>
-    public sealed partial class MetricDescriptorName : gax::IResourceName, s::IEquatable<MetricDescriptorName>
+    public sealed partial class MetricDescriptorName : gax::IResourceName, sys::IEquatable<MetricDescriptorName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/metricDescriptors/{metric_descriptor=**}");
 
@@ -413,7 +413,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <see cref="MetricDescriptorName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="metricDescriptorName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="metricDescriptorName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="metricDescriptorName">The metric_descriptor resource name in string form. Must not be <c>null</c>.</param>
@@ -483,7 +483,7 @@ namespace Google.Cloud.Monitoring.V3
     /// <summary>
     /// Resource name for the 'monitored_resource_descriptor' resource.
     /// </summary>
-    public sealed partial class MonitoredResourceDescriptorName : gax::IResourceName, s::IEquatable<MonitoredResourceDescriptorName>
+    public sealed partial class MonitoredResourceDescriptorName : gax::IResourceName, sys::IEquatable<MonitoredResourceDescriptorName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/monitoredResourceDescriptors/{monitored_resource_descriptor}");
 
@@ -505,7 +505,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <see cref="MonitoredResourceDescriptorName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="monitoredResourceDescriptorName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="monitoredResourceDescriptorName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="monitoredResourceDescriptorName">The monitored_resource_descriptor resource name in string form. Must not be <c>null</c>.</param>
@@ -575,7 +575,7 @@ namespace Google.Cloud.Monitoring.V3
     /// <summary>
     /// Resource name for the 'notification_channel' resource.
     /// </summary>
-    public sealed partial class NotificationChannelName : gax::IResourceName, s::IEquatable<NotificationChannelName>
+    public sealed partial class NotificationChannelName : gax::IResourceName, sys::IEquatable<NotificationChannelName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/notificationChannels/{notification_channel}");
 
@@ -597,7 +597,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <see cref="NotificationChannelName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="notificationChannelName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="notificationChannelName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="notificationChannelName">The notification_channel resource name in string form. Must not be <c>null</c>.</param>
@@ -667,7 +667,7 @@ namespace Google.Cloud.Monitoring.V3
     /// <summary>
     /// Resource name for the 'notification_channel_descriptor' resource.
     /// </summary>
-    public sealed partial class NotificationChannelDescriptorName : gax::IResourceName, s::IEquatable<NotificationChannelDescriptorName>
+    public sealed partial class NotificationChannelDescriptorName : gax::IResourceName, sys::IEquatable<NotificationChannelDescriptorName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/notificationChannelDescriptors/{channel_descriptor}");
 
@@ -689,7 +689,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <see cref="NotificationChannelDescriptorName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="notificationChannelDescriptorName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="notificationChannelDescriptorName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="notificationChannelDescriptorName">The notification_channel_descriptor resource name in string form. Must not be <c>null</c>.</param>
@@ -759,7 +759,7 @@ namespace Google.Cloud.Monitoring.V3
     /// <summary>
     /// Resource name for the 'uptime_check_config' resource.
     /// </summary>
-    public sealed partial class UptimeCheckConfigName : gax::IResourceName, s::IEquatable<UptimeCheckConfigName>
+    public sealed partial class UptimeCheckConfigName : gax::IResourceName, sys::IEquatable<UptimeCheckConfigName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/uptimeCheckConfigs/{uptime_check_config}");
 
@@ -781,7 +781,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <see cref="UptimeCheckConfigName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="uptimeCheckConfigName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="uptimeCheckConfigName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="uptimeCheckConfigName">The uptime_check_config resource name in string form. Must not be <c>null</c>.</param>
@@ -852,9 +852,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class CreateAlertPolicyRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.Monitoring.V3.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -865,9 +865,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class CreateGroupRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.Monitoring.V3.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -878,9 +878,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class CreateMetricDescriptorRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.Monitoring.V3.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -891,9 +891,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class CreateNotificationChannelRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.Monitoring.V3.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -904,9 +904,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class CreateTimeSeriesRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.Monitoring.V3.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -917,9 +917,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class DeleteAlertPolicyRequest
     {
         /// <summary>
-        /// <see cref="AlertPolicyName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.AlertPolicyName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public AlertPolicyName AlertPolicyName
+        public Google.Cloud.Monitoring.V3.AlertPolicyName AlertPolicyName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.AlertPolicyName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -930,9 +930,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class DeleteGroupRequest
     {
         /// <summary>
-        /// <see cref="GroupName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.GroupName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public GroupName GroupName
+        public Google.Cloud.Monitoring.V3.GroupName GroupName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.GroupName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -943,9 +943,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class DeleteMetricDescriptorRequest
     {
         /// <summary>
-        /// <see cref="MetricDescriptorName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.MetricDescriptorName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public MetricDescriptorName MetricDescriptorName
+        public Google.Cloud.Monitoring.V3.MetricDescriptorName MetricDescriptorName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.MetricDescriptorName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -956,9 +956,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class DeleteNotificationChannelRequest
     {
         /// <summary>
-        /// <see cref="NotificationChannelName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.NotificationChannelName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public NotificationChannelName NotificationChannelName
+        public Google.Cloud.Monitoring.V3.NotificationChannelName NotificationChannelName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.NotificationChannelName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -969,9 +969,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class GetAlertPolicyRequest
     {
         /// <summary>
-        /// <see cref="AlertPolicyName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.AlertPolicyName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public AlertPolicyName AlertPolicyName
+        public Google.Cloud.Monitoring.V3.AlertPolicyName AlertPolicyName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.AlertPolicyName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -982,9 +982,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class GetGroupRequest
     {
         /// <summary>
-        /// <see cref="GroupName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.GroupName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public GroupName GroupName
+        public Google.Cloud.Monitoring.V3.GroupName GroupName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.GroupName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -995,9 +995,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class GetMetricDescriptorRequest
     {
         /// <summary>
-        /// <see cref="MetricDescriptorName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.MetricDescriptorName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public MetricDescriptorName MetricDescriptorName
+        public Google.Cloud.Monitoring.V3.MetricDescriptorName MetricDescriptorName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.MetricDescriptorName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1008,9 +1008,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class GetMonitoredResourceDescriptorRequest
     {
         /// <summary>
-        /// <see cref="MonitoredResourceDescriptorName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.MonitoredResourceDescriptorName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public MonitoredResourceDescriptorName MonitoredResourceDescriptorName
+        public Google.Cloud.Monitoring.V3.MonitoredResourceDescriptorName MonitoredResourceDescriptorName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.MonitoredResourceDescriptorName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1021,9 +1021,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class GetNotificationChannelDescriptorRequest
     {
         /// <summary>
-        /// <see cref="NotificationChannelDescriptorName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.NotificationChannelDescriptorName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public NotificationChannelDescriptorName NotificationChannelDescriptorName
+        public Google.Cloud.Monitoring.V3.NotificationChannelDescriptorName NotificationChannelDescriptorName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.NotificationChannelDescriptorName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1034,9 +1034,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class GetNotificationChannelRequest
     {
         /// <summary>
-        /// <see cref="NotificationChannelName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.NotificationChannelName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public NotificationChannelName NotificationChannelName
+        public Google.Cloud.Monitoring.V3.NotificationChannelName NotificationChannelName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.NotificationChannelName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1047,9 +1047,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class GetNotificationChannelVerificationCodeRequest
     {
         /// <summary>
-        /// <see cref="NotificationChannelName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.NotificationChannelName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public NotificationChannelName NotificationChannelName
+        public Google.Cloud.Monitoring.V3.NotificationChannelName NotificationChannelName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.NotificationChannelName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1060,18 +1060,18 @@ namespace Google.Cloud.Monitoring.V3
     public partial class Group
     {
         /// <summary>
-        /// <see cref="GroupName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.GroupName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public GroupName GroupName
+        public Google.Cloud.Monitoring.V3.GroupName GroupName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.GroupName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="GroupName"/>-typed view over the <see cref="ParentName"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.GroupName"/>-typed view over the <see cref="ParentName"/> resource name property.
         /// </summary>
-        public GroupName ParentNameAsGroupName
+        public Google.Cloud.Monitoring.V3.GroupName ParentNameAsGroupName
         {
             get { return string.IsNullOrEmpty(ParentName) ? null : Google.Cloud.Monitoring.V3.GroupName.Parse(ParentName); }
             set { ParentName = value != null ? value.ToString() : ""; }
@@ -1082,9 +1082,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class ListAlertPoliciesRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.Monitoring.V3.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1095,9 +1095,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class ListGroupMembersRequest
     {
         /// <summary>
-        /// <see cref="GroupName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.GroupName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public GroupName GroupName
+        public Google.Cloud.Monitoring.V3.GroupName GroupName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.GroupName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1108,36 +1108,36 @@ namespace Google.Cloud.Monitoring.V3
     public partial class ListGroupsRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.Monitoring.V3.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="GroupName"/>-typed view over the <see cref="ChildrenOfGroup"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.GroupName"/>-typed view over the <see cref="ChildrenOfGroup"/> resource name property.
         /// </summary>
-        public GroupName ChildrenOfGroupAsGroupName
+        public Google.Cloud.Monitoring.V3.GroupName ChildrenOfGroupAsGroupName
         {
             get { return string.IsNullOrEmpty(ChildrenOfGroup) ? null : Google.Cloud.Monitoring.V3.GroupName.Parse(ChildrenOfGroup); }
             set { ChildrenOfGroup = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="GroupName"/>-typed view over the <see cref="AncestorsOfGroup"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.GroupName"/>-typed view over the <see cref="AncestorsOfGroup"/> resource name property.
         /// </summary>
-        public GroupName AncestorsOfGroupAsGroupName
+        public Google.Cloud.Monitoring.V3.GroupName AncestorsOfGroupAsGroupName
         {
             get { return string.IsNullOrEmpty(AncestorsOfGroup) ? null : Google.Cloud.Monitoring.V3.GroupName.Parse(AncestorsOfGroup); }
             set { AncestorsOfGroup = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="GroupName"/>-typed view over the <see cref="DescendantsOfGroup"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.GroupName"/>-typed view over the <see cref="DescendantsOfGroup"/> resource name property.
         /// </summary>
-        public GroupName DescendantsOfGroupAsGroupName
+        public Google.Cloud.Monitoring.V3.GroupName DescendantsOfGroupAsGroupName
         {
             get { return string.IsNullOrEmpty(DescendantsOfGroup) ? null : Google.Cloud.Monitoring.V3.GroupName.Parse(DescendantsOfGroup); }
             set { DescendantsOfGroup = value != null ? value.ToString() : ""; }
@@ -1148,9 +1148,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class ListMetricDescriptorsRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.Monitoring.V3.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1161,9 +1161,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class ListMonitoredResourceDescriptorsRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.Monitoring.V3.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1174,9 +1174,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class ListNotificationChannelDescriptorsRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.Monitoring.V3.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1187,9 +1187,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class ListNotificationChannelsRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.Monitoring.V3.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1200,9 +1200,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class ListTimeSeriesRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.Monitoring.V3.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1213,9 +1213,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class SendNotificationChannelVerificationCodeRequest
     {
         /// <summary>
-        /// <see cref="NotificationChannelName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.NotificationChannelName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public NotificationChannelName NotificationChannelName
+        public Google.Cloud.Monitoring.V3.NotificationChannelName NotificationChannelName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.NotificationChannelName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -1226,9 +1226,9 @@ namespace Google.Cloud.Monitoring.V3
     public partial class VerifyNotificationChannelRequest
     {
         /// <summary>
-        /// <see cref="NotificationChannelName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Monitoring.V3.NotificationChannelName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public NotificationChannelName NotificationChannelName
+        public Google.Cloud.Monitoring.V3.NotificationChannelName NotificationChannelName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Monitoring.V3.NotificationChannelName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeCheckServiceClient.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeCheckServiceClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -71,7 +71,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -99,8 +99,8 @@ namespace Google.Cloud.Monitoring.V3
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -119,8 +119,8 @@ namespace Google.Cloud.Monitoring.V3
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(20000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(20000),
             delayMultiplier: 1.0
         );
 
@@ -150,7 +150,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -180,7 +180,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -209,7 +209,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -238,7 +238,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -268,7 +268,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -298,7 +298,7 @@ namespace Google.Cloud.Monitoring.V3
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -404,7 +404,7 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public virtual UptimeCheckService.UptimeCheckServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -496,7 +496,7 @@ namespace Google.Cloud.Monitoring.V3
             ListUptimeCheckConfigsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -516,7 +516,7 @@ namespace Google.Cloud.Monitoring.V3
             ListUptimeCheckConfigsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -601,7 +601,7 @@ namespace Google.Cloud.Monitoring.V3
             GetUptimeCheckConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -638,7 +638,7 @@ namespace Google.Cloud.Monitoring.V3
             GetUptimeCheckConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -738,7 +738,7 @@ namespace Google.Cloud.Monitoring.V3
             CreateUptimeCheckConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -775,7 +775,7 @@ namespace Google.Cloud.Monitoring.V3
             CreateUptimeCheckConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -884,7 +884,7 @@ namespace Google.Cloud.Monitoring.V3
             UpdateUptimeCheckConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -927,7 +927,7 @@ namespace Google.Cloud.Monitoring.V3
             UpdateUptimeCheckConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1017,7 +1017,7 @@ namespace Google.Cloud.Monitoring.V3
             DeleteUptimeCheckConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1055,7 +1055,7 @@ namespace Google.Cloud.Monitoring.V3
             DeleteUptimeCheckConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1074,7 +1074,7 @@ namespace Google.Cloud.Monitoring.V3
             ListUptimeCheckIpsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1093,7 +1093,7 @@ namespace Google.Cloud.Monitoring.V3
             ListUptimeCheckIpsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1107,7 +1107,7 @@ namespace Google.Cloud.Monitoring.V3
         private readonly gaxgrpc::ApiCall<GetUptimeCheckConfigRequest, UptimeCheckConfig> _callGetUptimeCheckConfig;
         private readonly gaxgrpc::ApiCall<CreateUptimeCheckConfigRequest, UptimeCheckConfig> _callCreateUptimeCheckConfig;
         private readonly gaxgrpc::ApiCall<UpdateUptimeCheckConfigRequest, UptimeCheckConfig> _callUpdateUptimeCheckConfig;
-        private readonly gaxgrpc::ApiCall<DeleteUptimeCheckConfigRequest, protowkt::Empty> _callDeleteUptimeCheckConfig;
+        private readonly gaxgrpc::ApiCall<DeleteUptimeCheckConfigRequest, pbwkt::Empty> _callDeleteUptimeCheckConfig;
         private readonly gaxgrpc::ApiCall<ListUptimeCheckIpsRequest, ListUptimeCheckIpsResponse> _callListUptimeCheckIps;
 
         /// <summary>
@@ -1128,7 +1128,7 @@ namespace Google.Cloud.Monitoring.V3
                 GrpcClient.CreateUptimeCheckConfigAsync, GrpcClient.CreateUptimeCheckConfig, effectiveSettings.CreateUptimeCheckConfigSettings);
             _callUpdateUptimeCheckConfig = clientHelper.BuildApiCall<UpdateUptimeCheckConfigRequest, UptimeCheckConfig>(
                 GrpcClient.UpdateUptimeCheckConfigAsync, GrpcClient.UpdateUptimeCheckConfig, effectiveSettings.UpdateUptimeCheckConfigSettings);
-            _callDeleteUptimeCheckConfig = clientHelper.BuildApiCall<DeleteUptimeCheckConfigRequest, protowkt::Empty>(
+            _callDeleteUptimeCheckConfig = clientHelper.BuildApiCall<DeleteUptimeCheckConfigRequest, pbwkt::Empty>(
                 GrpcClient.DeleteUptimeCheckConfigAsync, GrpcClient.DeleteUptimeCheckConfig, effectiveSettings.DeleteUptimeCheckConfigSettings);
             _callListUptimeCheckIps = clientHelper.BuildApiCall<ListUptimeCheckIpsRequest, ListUptimeCheckIpsResponse>(
                 GrpcClient.ListUptimeCheckIpsAsync, GrpcClient.ListUptimeCheckIps, effectiveSettings.ListUptimeCheckIpsSettings);
@@ -1152,8 +1152,8 @@ namespace Google.Cloud.Monitoring.V3
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -1161,7 +1161,7 @@ namespace Google.Cloud.Monitoring.V3
         partial void Modify_GetUptimeCheckConfigApiCall(ref gaxgrpc::ApiCall<GetUptimeCheckConfigRequest, UptimeCheckConfig> call);
         partial void Modify_CreateUptimeCheckConfigApiCall(ref gaxgrpc::ApiCall<CreateUptimeCheckConfigRequest, UptimeCheckConfig> call);
         partial void Modify_UpdateUptimeCheckConfigApiCall(ref gaxgrpc::ApiCall<UpdateUptimeCheckConfigRequest, UptimeCheckConfig> call);
-        partial void Modify_DeleteUptimeCheckConfigApiCall(ref gaxgrpc::ApiCall<DeleteUptimeCheckConfigRequest, protowkt::Empty> call);
+        partial void Modify_DeleteUptimeCheckConfigApiCall(ref gaxgrpc::ApiCall<DeleteUptimeCheckConfigRequest, pbwkt::Empty> call);
         partial void Modify_ListUptimeCheckIpsApiCall(ref gaxgrpc::ApiCall<ListUptimeCheckIpsRequest, ListUptimeCheckIpsResponse> call);
         partial void OnConstruction(UptimeCheckService.UptimeCheckServiceClient grpcClient, UptimeCheckServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/OsLoginServiceClient.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/OsLoginServiceClient.cs
@@ -17,10 +17,10 @@
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using Google.Cloud.OsLogin.Common;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -72,7 +72,7 @@ namespace Google.Cloud.OsLogin.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Google.Cloud.OsLogin.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -100,8 +100,8 @@ namespace Google.Cloud.OsLogin.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -120,8 +120,8 @@ namespace Google.Cloud.OsLogin.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(10000),
-            maxDelay: s::TimeSpan.FromMilliseconds(10000),
+            delay: sys::TimeSpan.FromMilliseconds(10000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(10000),
             delayMultiplier: 1.0
         );
 
@@ -151,7 +151,7 @@ namespace Google.Cloud.OsLogin.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -181,7 +181,7 @@ namespace Google.Cloud.OsLogin.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -211,7 +211,7 @@ namespace Google.Cloud.OsLogin.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -241,7 +241,7 @@ namespace Google.Cloud.OsLogin.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -271,7 +271,7 @@ namespace Google.Cloud.OsLogin.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -301,7 +301,7 @@ namespace Google.Cloud.OsLogin.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -407,7 +407,7 @@ namespace Google.Cloud.OsLogin.V1
         /// </summary>
         public virtual OsLoginService.OsLoginServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -489,7 +489,7 @@ namespace Google.Cloud.OsLogin.V1
             DeletePosixAccountRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -523,7 +523,7 @@ namespace Google.Cloud.OsLogin.V1
             DeletePosixAccountRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -605,7 +605,7 @@ namespace Google.Cloud.OsLogin.V1
             DeleteSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -639,7 +639,7 @@ namespace Google.Cloud.OsLogin.V1
             DeleteSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -722,7 +722,7 @@ namespace Google.Cloud.OsLogin.V1
             GetLoginProfileRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -761,7 +761,7 @@ namespace Google.Cloud.OsLogin.V1
             GetLoginProfileRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -846,7 +846,7 @@ namespace Google.Cloud.OsLogin.V1
             GetSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -883,7 +883,7 @@ namespace Google.Cloud.OsLogin.V1
             GetSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1081,7 +1081,7 @@ namespace Google.Cloud.OsLogin.V1
             ImportSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1122,7 +1122,7 @@ namespace Google.Cloud.OsLogin.V1
             ImportSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1233,7 +1233,7 @@ namespace Google.Cloud.OsLogin.V1
         public virtual stt::Task<SshPublicKey> UpdateSshPublicKeyAsync(
             FingerprintName name,
             SshPublicKey sshPublicKey,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             gaxgrpc::CallSettings callSettings = null) => UpdateSshPublicKeyAsync(
                 new UpdateSshPublicKeyRequest
                 {
@@ -1267,7 +1267,7 @@ namespace Google.Cloud.OsLogin.V1
         public virtual stt::Task<SshPublicKey> UpdateSshPublicKeyAsync(
             FingerprintName name,
             SshPublicKey sshPublicKey,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             st::CancellationToken cancellationToken) => UpdateSshPublicKeyAsync(
                 name,
                 sshPublicKey,
@@ -1298,7 +1298,7 @@ namespace Google.Cloud.OsLogin.V1
         public virtual SshPublicKey UpdateSshPublicKey(
             FingerprintName name,
             SshPublicKey sshPublicKey,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             gaxgrpc::CallSettings callSettings = null) => UpdateSshPublicKey(
                 new UpdateSshPublicKeyRequest
                 {
@@ -1325,7 +1325,7 @@ namespace Google.Cloud.OsLogin.V1
             UpdateSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1364,7 +1364,7 @@ namespace Google.Cloud.OsLogin.V1
             UpdateSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1374,8 +1374,8 @@ namespace Google.Cloud.OsLogin.V1
     /// </summary>
     public sealed partial class OsLoginServiceClientImpl : OsLoginServiceClient
     {
-        private readonly gaxgrpc::ApiCall<DeletePosixAccountRequest, protowkt::Empty> _callDeletePosixAccount;
-        private readonly gaxgrpc::ApiCall<DeleteSshPublicKeyRequest, protowkt::Empty> _callDeleteSshPublicKey;
+        private readonly gaxgrpc::ApiCall<DeletePosixAccountRequest, pbwkt::Empty> _callDeletePosixAccount;
+        private readonly gaxgrpc::ApiCall<DeleteSshPublicKeyRequest, pbwkt::Empty> _callDeleteSshPublicKey;
         private readonly gaxgrpc::ApiCall<GetLoginProfileRequest, LoginProfile> _callGetLoginProfile;
         private readonly gaxgrpc::ApiCall<GetSshPublicKeyRequest, SshPublicKey> _callGetSshPublicKey;
         private readonly gaxgrpc::ApiCall<ImportSshPublicKeyRequest, ImportSshPublicKeyResponse> _callImportSshPublicKey;
@@ -1391,9 +1391,9 @@ namespace Google.Cloud.OsLogin.V1
             GrpcClient = grpcClient;
             OsLoginServiceSettings effectiveSettings = settings ?? OsLoginServiceSettings.GetDefault();
             gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callDeletePosixAccount = clientHelper.BuildApiCall<DeletePosixAccountRequest, protowkt::Empty>(
+            _callDeletePosixAccount = clientHelper.BuildApiCall<DeletePosixAccountRequest, pbwkt::Empty>(
                 GrpcClient.DeletePosixAccountAsync, GrpcClient.DeletePosixAccount, effectiveSettings.DeletePosixAccountSettings);
-            _callDeleteSshPublicKey = clientHelper.BuildApiCall<DeleteSshPublicKeyRequest, protowkt::Empty>(
+            _callDeleteSshPublicKey = clientHelper.BuildApiCall<DeleteSshPublicKeyRequest, pbwkt::Empty>(
                 GrpcClient.DeleteSshPublicKeyAsync, GrpcClient.DeleteSshPublicKey, effectiveSettings.DeleteSshPublicKeySettings);
             _callGetLoginProfile = clientHelper.BuildApiCall<GetLoginProfileRequest, LoginProfile>(
                 GrpcClient.GetLoginProfileAsync, GrpcClient.GetLoginProfile, effectiveSettings.GetLoginProfileSettings);
@@ -1423,13 +1423,13 @@ namespace Google.Cloud.OsLogin.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
-        partial void Modify_DeletePosixAccountApiCall(ref gaxgrpc::ApiCall<DeletePosixAccountRequest, protowkt::Empty> call);
-        partial void Modify_DeleteSshPublicKeyApiCall(ref gaxgrpc::ApiCall<DeleteSshPublicKeyRequest, protowkt::Empty> call);
+        partial void Modify_DeletePosixAccountApiCall(ref gaxgrpc::ApiCall<DeletePosixAccountRequest, pbwkt::Empty> call);
+        partial void Modify_DeleteSshPublicKeyApiCall(ref gaxgrpc::ApiCall<DeleteSshPublicKeyRequest, pbwkt::Empty> call);
         partial void Modify_GetLoginProfileApiCall(ref gaxgrpc::ApiCall<GetLoginProfileRequest, LoginProfile> call);
         partial void Modify_GetSshPublicKeyApiCall(ref gaxgrpc::ApiCall<GetSshPublicKeyRequest, SshPublicKey> call);
         partial void Modify_ImportSshPublicKeyApiCall(ref gaxgrpc::ApiCall<ImportSshPublicKeyRequest, ImportSshPublicKeyResponse> call);

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/ResourceNames.cs
@@ -15,15 +15,15 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.OsLogin.V1
 {
     /// <summary>
     /// Resource name for the 'user' resource.
     /// </summary>
-    public sealed partial class UserName : gax::IResourceName, s::IEquatable<UserName>
+    public sealed partial class UserName : gax::IResourceName, sys::IEquatable<UserName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("users/{user}");
 
@@ -45,7 +45,7 @@ namespace Google.Cloud.OsLogin.V1
         /// <see cref="UserName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="userName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="userName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="userName">The user resource name in string form. Must not be <c>null</c>.</param>
@@ -108,7 +108,7 @@ namespace Google.Cloud.OsLogin.V1
     /// <summary>
     /// Resource name for the 'project' resource.
     /// </summary>
-    public sealed partial class ProjectName : gax::IResourceName, s::IEquatable<ProjectName>
+    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("users/{user}/projects/{project}");
 
@@ -130,7 +130,7 @@ namespace Google.Cloud.OsLogin.V1
         /// <see cref="ProjectName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
@@ -200,7 +200,7 @@ namespace Google.Cloud.OsLogin.V1
     /// <summary>
     /// Resource name for the 'fingerprint' resource.
     /// </summary>
-    public sealed partial class FingerprintName : gax::IResourceName, s::IEquatable<FingerprintName>
+    public sealed partial class FingerprintName : gax::IResourceName, sys::IEquatable<FingerprintName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("users/{user}/sshPublicKeys/{fingerprint}");
 
@@ -222,7 +222,7 @@ namespace Google.Cloud.OsLogin.V1
         /// <see cref="FingerprintName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="fingerprintName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="fingerprintName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="fingerprintName">The fingerprint resource name in string form. Must not be <c>null</c>.</param>
@@ -293,9 +293,9 @@ namespace Google.Cloud.OsLogin.V1
     public partial class DeletePosixAccountRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.OsLogin.V1.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.OsLogin.V1.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.OsLogin.V1.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -306,9 +306,9 @@ namespace Google.Cloud.OsLogin.V1
     public partial class DeleteSshPublicKeyRequest
     {
         /// <summary>
-        /// <see cref="FingerprintName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.OsLogin.V1.FingerprintName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public FingerprintName FingerprintName
+        public Google.Cloud.OsLogin.V1.FingerprintName FingerprintName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.OsLogin.V1.FingerprintName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -319,9 +319,9 @@ namespace Google.Cloud.OsLogin.V1
     public partial class GetLoginProfileRequest
     {
         /// <summary>
-        /// <see cref="UserName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.OsLogin.V1.UserName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public UserName UserName
+        public Google.Cloud.OsLogin.V1.UserName UserName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.OsLogin.V1.UserName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -332,9 +332,9 @@ namespace Google.Cloud.OsLogin.V1
     public partial class GetSshPublicKeyRequest
     {
         /// <summary>
-        /// <see cref="FingerprintName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.OsLogin.V1.FingerprintName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public FingerprintName FingerprintName
+        public Google.Cloud.OsLogin.V1.FingerprintName FingerprintName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.OsLogin.V1.FingerprintName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -345,9 +345,9 @@ namespace Google.Cloud.OsLogin.V1
     public partial class ImportSshPublicKeyRequest
     {
         /// <summary>
-        /// <see cref="UserName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.OsLogin.V1.UserName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public UserName ParentAsUserName
+        public Google.Cloud.OsLogin.V1.UserName ParentAsUserName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.OsLogin.V1.UserName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -358,9 +358,9 @@ namespace Google.Cloud.OsLogin.V1
     public partial class UpdateSshPublicKeyRequest
     {
         /// <summary>
-        /// <see cref="FingerprintName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.OsLogin.V1.FingerprintName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public FingerprintName FingerprintName
+        public Google.Cloud.OsLogin.V1.FingerprintName FingerprintName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.OsLogin.V1.FingerprintName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/OsLoginServiceClient.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/OsLoginServiceClient.cs
@@ -17,10 +17,10 @@
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using Google.Cloud.OsLogin.Common;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -72,7 +72,7 @@ namespace Google.Cloud.OsLogin.V1Beta
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Google.Cloud.OsLogin.V1Beta
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -100,8 +100,8 @@ namespace Google.Cloud.OsLogin.V1Beta
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -120,8 +120,8 @@ namespace Google.Cloud.OsLogin.V1Beta
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(10000),
-            maxDelay: s::TimeSpan.FromMilliseconds(10000),
+            delay: sys::TimeSpan.FromMilliseconds(10000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(10000),
             delayMultiplier: 1.0
         );
 
@@ -151,7 +151,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -181,7 +181,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -211,7 +211,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -241,7 +241,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -271,7 +271,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -301,7 +301,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -407,7 +407,7 @@ namespace Google.Cloud.OsLogin.V1Beta
         /// </summary>
         public virtual OsLoginService.OsLoginServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -489,7 +489,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             DeletePosixAccountRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -523,7 +523,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             DeletePosixAccountRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -605,7 +605,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             DeleteSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -639,7 +639,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             DeleteSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -722,7 +722,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             GetLoginProfileRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -761,7 +761,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             GetLoginProfileRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -846,7 +846,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             GetSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -883,7 +883,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             GetSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1081,7 +1081,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             ImportSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1122,7 +1122,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             ImportSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1233,7 +1233,7 @@ namespace Google.Cloud.OsLogin.V1Beta
         public virtual stt::Task<SshPublicKey> UpdateSshPublicKeyAsync(
             FingerprintName name,
             SshPublicKey sshPublicKey,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             gaxgrpc::CallSettings callSettings = null) => UpdateSshPublicKeyAsync(
                 new UpdateSshPublicKeyRequest
                 {
@@ -1267,7 +1267,7 @@ namespace Google.Cloud.OsLogin.V1Beta
         public virtual stt::Task<SshPublicKey> UpdateSshPublicKeyAsync(
             FingerprintName name,
             SshPublicKey sshPublicKey,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             st::CancellationToken cancellationToken) => UpdateSshPublicKeyAsync(
                 name,
                 sshPublicKey,
@@ -1298,7 +1298,7 @@ namespace Google.Cloud.OsLogin.V1Beta
         public virtual SshPublicKey UpdateSshPublicKey(
             FingerprintName name,
             SshPublicKey sshPublicKey,
-            protowkt::FieldMask updateMask,
+            pbwkt::FieldMask updateMask,
             gaxgrpc::CallSettings callSettings = null) => UpdateSshPublicKey(
                 new UpdateSshPublicKeyRequest
                 {
@@ -1325,7 +1325,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             UpdateSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1364,7 +1364,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             UpdateSshPublicKeyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1374,8 +1374,8 @@ namespace Google.Cloud.OsLogin.V1Beta
     /// </summary>
     public sealed partial class OsLoginServiceClientImpl : OsLoginServiceClient
     {
-        private readonly gaxgrpc::ApiCall<DeletePosixAccountRequest, protowkt::Empty> _callDeletePosixAccount;
-        private readonly gaxgrpc::ApiCall<DeleteSshPublicKeyRequest, protowkt::Empty> _callDeleteSshPublicKey;
+        private readonly gaxgrpc::ApiCall<DeletePosixAccountRequest, pbwkt::Empty> _callDeletePosixAccount;
+        private readonly gaxgrpc::ApiCall<DeleteSshPublicKeyRequest, pbwkt::Empty> _callDeleteSshPublicKey;
         private readonly gaxgrpc::ApiCall<GetLoginProfileRequest, LoginProfile> _callGetLoginProfile;
         private readonly gaxgrpc::ApiCall<GetSshPublicKeyRequest, SshPublicKey> _callGetSshPublicKey;
         private readonly gaxgrpc::ApiCall<ImportSshPublicKeyRequest, ImportSshPublicKeyResponse> _callImportSshPublicKey;
@@ -1391,9 +1391,9 @@ namespace Google.Cloud.OsLogin.V1Beta
             GrpcClient = grpcClient;
             OsLoginServiceSettings effectiveSettings = settings ?? OsLoginServiceSettings.GetDefault();
             gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callDeletePosixAccount = clientHelper.BuildApiCall<DeletePosixAccountRequest, protowkt::Empty>(
+            _callDeletePosixAccount = clientHelper.BuildApiCall<DeletePosixAccountRequest, pbwkt::Empty>(
                 GrpcClient.DeletePosixAccountAsync, GrpcClient.DeletePosixAccount, effectiveSettings.DeletePosixAccountSettings);
-            _callDeleteSshPublicKey = clientHelper.BuildApiCall<DeleteSshPublicKeyRequest, protowkt::Empty>(
+            _callDeleteSshPublicKey = clientHelper.BuildApiCall<DeleteSshPublicKeyRequest, pbwkt::Empty>(
                 GrpcClient.DeleteSshPublicKeyAsync, GrpcClient.DeleteSshPublicKey, effectiveSettings.DeleteSshPublicKeySettings);
             _callGetLoginProfile = clientHelper.BuildApiCall<GetLoginProfileRequest, LoginProfile>(
                 GrpcClient.GetLoginProfileAsync, GrpcClient.GetLoginProfile, effectiveSettings.GetLoginProfileSettings);
@@ -1423,13 +1423,13 @@ namespace Google.Cloud.OsLogin.V1Beta
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
-        partial void Modify_DeletePosixAccountApiCall(ref gaxgrpc::ApiCall<DeletePosixAccountRequest, protowkt::Empty> call);
-        partial void Modify_DeleteSshPublicKeyApiCall(ref gaxgrpc::ApiCall<DeleteSshPublicKeyRequest, protowkt::Empty> call);
+        partial void Modify_DeletePosixAccountApiCall(ref gaxgrpc::ApiCall<DeletePosixAccountRequest, pbwkt::Empty> call);
+        partial void Modify_DeleteSshPublicKeyApiCall(ref gaxgrpc::ApiCall<DeleteSshPublicKeyRequest, pbwkt::Empty> call);
         partial void Modify_GetLoginProfileApiCall(ref gaxgrpc::ApiCall<GetLoginProfileRequest, LoginProfile> call);
         partial void Modify_GetSshPublicKeyApiCall(ref gaxgrpc::ApiCall<GetSshPublicKeyRequest, SshPublicKey> call);
         partial void Modify_ImportSshPublicKeyApiCall(ref gaxgrpc::ApiCall<ImportSshPublicKeyRequest, ImportSshPublicKeyResponse> call);

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/ResourceNames.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/ResourceNames.cs
@@ -15,15 +15,15 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.OsLogin.V1Beta
 {
     /// <summary>
     /// Resource name for the 'user' resource.
     /// </summary>
-    public sealed partial class UserName : gax::IResourceName, s::IEquatable<UserName>
+    public sealed partial class UserName : gax::IResourceName, sys::IEquatable<UserName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("users/{user}");
 
@@ -45,7 +45,7 @@ namespace Google.Cloud.OsLogin.V1Beta
         /// <see cref="UserName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="userName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="userName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="userName">The user resource name in string form. Must not be <c>null</c>.</param>
@@ -108,7 +108,7 @@ namespace Google.Cloud.OsLogin.V1Beta
     /// <summary>
     /// Resource name for the 'project' resource.
     /// </summary>
-    public sealed partial class ProjectName : gax::IResourceName, s::IEquatable<ProjectName>
+    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("users/{user}/projects/{project}");
 
@@ -130,7 +130,7 @@ namespace Google.Cloud.OsLogin.V1Beta
         /// <see cref="ProjectName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
@@ -200,7 +200,7 @@ namespace Google.Cloud.OsLogin.V1Beta
     /// <summary>
     /// Resource name for the 'fingerprint' resource.
     /// </summary>
-    public sealed partial class FingerprintName : gax::IResourceName, s::IEquatable<FingerprintName>
+    public sealed partial class FingerprintName : gax::IResourceName, sys::IEquatable<FingerprintName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("users/{user}/sshPublicKeys/{fingerprint}");
 
@@ -222,7 +222,7 @@ namespace Google.Cloud.OsLogin.V1Beta
         /// <see cref="FingerprintName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="fingerprintName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="fingerprintName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="fingerprintName">The fingerprint resource name in string form. Must not be <c>null</c>.</param>
@@ -293,9 +293,9 @@ namespace Google.Cloud.OsLogin.V1Beta
     public partial class DeletePosixAccountRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.OsLogin.V1Beta.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.OsLogin.V1Beta.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.OsLogin.V1Beta.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -306,9 +306,9 @@ namespace Google.Cloud.OsLogin.V1Beta
     public partial class DeleteSshPublicKeyRequest
     {
         /// <summary>
-        /// <see cref="FingerprintName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.OsLogin.V1Beta.FingerprintName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public FingerprintName FingerprintName
+        public Google.Cloud.OsLogin.V1Beta.FingerprintName FingerprintName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.OsLogin.V1Beta.FingerprintName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -319,9 +319,9 @@ namespace Google.Cloud.OsLogin.V1Beta
     public partial class GetLoginProfileRequest
     {
         /// <summary>
-        /// <see cref="UserName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.OsLogin.V1Beta.UserName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public UserName UserName
+        public Google.Cloud.OsLogin.V1Beta.UserName UserName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.OsLogin.V1Beta.UserName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -332,9 +332,9 @@ namespace Google.Cloud.OsLogin.V1Beta
     public partial class GetSshPublicKeyRequest
     {
         /// <summary>
-        /// <see cref="FingerprintName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.OsLogin.V1Beta.FingerprintName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public FingerprintName FingerprintName
+        public Google.Cloud.OsLogin.V1Beta.FingerprintName FingerprintName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.OsLogin.V1Beta.FingerprintName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -345,9 +345,9 @@ namespace Google.Cloud.OsLogin.V1Beta
     public partial class ImportSshPublicKeyRequest
     {
         /// <summary>
-        /// <see cref="UserName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.OsLogin.V1Beta.UserName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public UserName ParentAsUserName
+        public Google.Cloud.OsLogin.V1Beta.UserName ParentAsUserName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.OsLogin.V1Beta.UserName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -358,9 +358,9 @@ namespace Google.Cloud.OsLogin.V1Beta
     public partial class UpdateSshPublicKeyRequest
     {
         /// <summary>
-        /// <see cref="FingerprintName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.OsLogin.V1Beta.FingerprintName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public FingerprintName FingerprintName
+        public Google.Cloud.OsLogin.V1Beta.FingerprintName FingerprintName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.OsLogin.V1Beta.FingerprintName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/PublisherServiceApiClientSnippets.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/PublisherServiceApiClientSnippets.g.cs
@@ -142,7 +142,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             {
                 new PubsubMessage
                 {
-                    Data = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                    Data = ByteString.Empty,
                 },
             };
             // Make the request
@@ -162,7 +162,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             {
                 new PubsubMessage
                 {
-                    Data = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                    Data = ByteString.Empty,
                 },
             };
             // Make the request
@@ -184,7 +184,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
                 Messages = {
                                new PubsubMessage
                                {
-                                   Data = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                                   Data = ByteString.Empty,
                                },
                            },
             };
@@ -206,7 +206,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
                 Messages = {
                                new PubsubMessage
                                {
-                                   Data = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                                   Data = ByteString.Empty,
                                },
                            },
             };

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherServiceApiClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherServiceApiClient.cs
@@ -17,10 +17,10 @@
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using iam = Google.Cloud.Iam.V1;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -76,7 +76,7 @@ namespace Google.Cloud.PubSub.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Google.Cloud.PubSub.V1
         /// <item><description><see cref="grpccore::StatusCode.Unknown"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> OnePlusDeliveryRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> OnePlusDeliveryRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.Aborted, grpccore::StatusCode.Cancelled, grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Internal, grpccore::StatusCode.ResourceExhausted, grpccore::StatusCode.Unavailable, grpccore::StatusCode.Unknown);
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace Google.Cloud.PubSub.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -123,8 +123,8 @@ namespace Google.Cloud.PubSub.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -143,8 +143,8 @@ namespace Google.Cloud.PubSub.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(60000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(60000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.0
         );
 
@@ -163,8 +163,8 @@ namespace Google.Cloud.PubSub.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetMessagingRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -183,8 +183,8 @@ namespace Google.Cloud.PubSub.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetMessagingTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(12000),
-            maxDelay: s::TimeSpan.FromMilliseconds(30000),
+            delay: sys::TimeSpan.FromMilliseconds(12000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(30000),
             delayMultiplier: 1.0
         );
 
@@ -214,7 +214,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -244,7 +244,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -279,7 +279,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetMessagingRetryBackoff(),
                 timeoutBackoff: GetMessagingTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: OnePlusDeliveryRetryFilter
             )));
 
@@ -309,7 +309,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -339,7 +339,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -369,7 +369,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -399,7 +399,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -428,7 +428,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -458,7 +458,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -487,7 +487,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -589,7 +589,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         public virtual Publisher.PublisherClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -683,7 +683,7 @@ namespace Google.Cloud.PubSub.V1
             Topic request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -720,7 +720,7 @@ namespace Google.Cloud.PubSub.V1
             Topic request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -744,7 +744,7 @@ namespace Google.Cloud.PubSub.V1
             UpdateTopicRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -791,7 +791,7 @@ namespace Google.Cloud.PubSub.V1
             UpdateTopicRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -896,7 +896,7 @@ namespace Google.Cloud.PubSub.V1
             PublishRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -937,7 +937,7 @@ namespace Google.Cloud.PubSub.V1
             PublishRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1019,7 +1019,7 @@ namespace Google.Cloud.PubSub.V1
             GetTopicRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1056,7 +1056,7 @@ namespace Google.Cloud.PubSub.V1
             GetTopicRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1143,7 +1143,7 @@ namespace Google.Cloud.PubSub.V1
             ListTopicsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1162,7 +1162,7 @@ namespace Google.Cloud.PubSub.V1
             ListTopicsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1249,7 +1249,7 @@ namespace Google.Cloud.PubSub.V1
             ListTopicSubscriptionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1268,7 +1268,7 @@ namespace Google.Cloud.PubSub.V1
             ListTopicSubscriptionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1363,7 +1363,7 @@ namespace Google.Cloud.PubSub.V1
             DeleteTopicRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1405,7 +1405,7 @@ namespace Google.Cloud.PubSub.V1
             DeleteTopicRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1518,7 +1518,7 @@ namespace Google.Cloud.PubSub.V1
             iam::SetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1557,7 +1557,7 @@ namespace Google.Cloud.PubSub.V1
             iam::SetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1650,7 +1650,7 @@ namespace Google.Cloud.PubSub.V1
             iam::GetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1691,7 +1691,7 @@ namespace Google.Cloud.PubSub.V1
             iam::GetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1808,7 +1808,7 @@ namespace Google.Cloud.PubSub.V1
             iam::TestIamPermissionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1849,7 +1849,7 @@ namespace Google.Cloud.PubSub.V1
             iam::TestIamPermissionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1865,7 +1865,7 @@ namespace Google.Cloud.PubSub.V1
         private readonly gaxgrpc::ApiCall<GetTopicRequest, Topic> _callGetTopic;
         private readonly gaxgrpc::ApiCall<ListTopicsRequest, ListTopicsResponse> _callListTopics;
         private readonly gaxgrpc::ApiCall<ListTopicSubscriptionsRequest, ListTopicSubscriptionsResponse> _callListTopicSubscriptions;
-        private readonly gaxgrpc::ApiCall<DeleteTopicRequest, protowkt::Empty> _callDeleteTopic;
+        private readonly gaxgrpc::ApiCall<DeleteTopicRequest, pbwkt::Empty> _callDeleteTopic;
         private readonly gaxgrpc::ApiCall<iam::SetIamPolicyRequest, iam::Policy> _callSetIamPolicy;
         private readonly gaxgrpc::ApiCall<iam::GetIamPolicyRequest, iam::Policy> _callGetIamPolicy;
         private readonly gaxgrpc::ApiCall<iam::TestIamPermissionsRequest, iam::TestIamPermissionsResponse> _callTestIamPermissions;
@@ -1893,7 +1893,7 @@ namespace Google.Cloud.PubSub.V1
                 GrpcClient.ListTopicsAsync, GrpcClient.ListTopics, effectiveSettings.ListTopicsSettings);
             _callListTopicSubscriptions = clientHelper.BuildApiCall<ListTopicSubscriptionsRequest, ListTopicSubscriptionsResponse>(
                 GrpcClient.ListTopicSubscriptionsAsync, GrpcClient.ListTopicSubscriptions, effectiveSettings.ListTopicSubscriptionsSettings);
-            _callDeleteTopic = clientHelper.BuildApiCall<DeleteTopicRequest, protowkt::Empty>(
+            _callDeleteTopic = clientHelper.BuildApiCall<DeleteTopicRequest, pbwkt::Empty>(
                 GrpcClient.DeleteTopicAsync, GrpcClient.DeleteTopic, effectiveSettings.DeleteTopicSettings);
             _callSetIamPolicy = clientHelper.BuildApiCall<iam::SetIamPolicyRequest, iam::Policy>(
                 grpcIAMPolicyClient.SetIamPolicyAsync, grpcIAMPolicyClient.SetIamPolicy, effectiveSettings.SetIamPolicySettings);
@@ -1929,8 +1929,8 @@ namespace Google.Cloud.PubSub.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -1940,7 +1940,7 @@ namespace Google.Cloud.PubSub.V1
         partial void Modify_GetTopicApiCall(ref gaxgrpc::ApiCall<GetTopicRequest, Topic> call);
         partial void Modify_ListTopicsApiCall(ref gaxgrpc::ApiCall<ListTopicsRequest, ListTopicsResponse> call);
         partial void Modify_ListTopicSubscriptionsApiCall(ref gaxgrpc::ApiCall<ListTopicSubscriptionsRequest, ListTopicSubscriptionsResponse> call);
-        partial void Modify_DeleteTopicApiCall(ref gaxgrpc::ApiCall<DeleteTopicRequest, protowkt::Empty> call);
+        partial void Modify_DeleteTopicApiCall(ref gaxgrpc::ApiCall<DeleteTopicRequest, pbwkt::Empty> call);
         partial void Modify_SetIamPolicyApiCall(ref gaxgrpc::ApiCall<iam::SetIamPolicyRequest, iam::Policy> call);
         partial void Modify_GetIamPolicyApiCall(ref gaxgrpc::ApiCall<iam::GetIamPolicyRequest, iam::Policy> call);
         partial void Modify_TestIamPermissionsApiCall(ref gaxgrpc::ApiCall<iam::TestIamPermissionsRequest, iam::TestIamPermissionsResponse> call);

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/ResourceNames.cs
@@ -15,16 +15,16 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
+using sys = System;
 using scg = System.Collections.Generic;
-using System.Linq;
+using linq = System.Linq;
 
 namespace Google.Cloud.PubSub.V1
 {
     /// <summary>
     /// Resource name for the 'project' resource.
     /// </summary>
-    public sealed partial class ProjectName : gax::IResourceName, s::IEquatable<ProjectName>
+    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
 
@@ -46,7 +46,7 @@ namespace Google.Cloud.PubSub.V1
         /// <see cref="ProjectName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
@@ -109,7 +109,7 @@ namespace Google.Cloud.PubSub.V1
     /// <summary>
     /// Resource name for the 'snapshot' resource.
     /// </summary>
-    public sealed partial class SnapshotName : gax::IResourceName, s::IEquatable<SnapshotName>
+    public sealed partial class SnapshotName : gax::IResourceName, sys::IEquatable<SnapshotName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/snapshots/{snapshot}");
 
@@ -131,7 +131,7 @@ namespace Google.Cloud.PubSub.V1
         /// <see cref="SnapshotName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="snapshotName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="snapshotName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="snapshotName">The snapshot resource name in string form. Must not be <c>null</c>.</param>
@@ -201,7 +201,7 @@ namespace Google.Cloud.PubSub.V1
     /// <summary>
     /// Resource name for the 'subscription' resource.
     /// </summary>
-    public sealed partial class SubscriptionName : gax::IResourceName, s::IEquatable<SubscriptionName>
+    public sealed partial class SubscriptionName : gax::IResourceName, sys::IEquatable<SubscriptionName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/subscriptions/{subscription}");
 
@@ -223,7 +223,7 @@ namespace Google.Cloud.PubSub.V1
         /// <see cref="SubscriptionName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="subscriptionName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="subscriptionName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="subscriptionName">The subscription resource name in string form. Must not be <c>null</c>.</param>
@@ -293,7 +293,7 @@ namespace Google.Cloud.PubSub.V1
     /// <summary>
     /// Resource name for the 'topic' resource.
     /// </summary>
-    public sealed partial class TopicName : gax::IResourceName, s::IEquatable<TopicName>
+    public sealed partial class TopicName : gax::IResourceName, sys::IEquatable<TopicName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/topics/{topic}");
 
@@ -315,7 +315,7 @@ namespace Google.Cloud.PubSub.V1
         /// <see cref="TopicName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="topicName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="topicName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="topicName">The topic resource name in string form. Must not be <c>null</c>.</param>
@@ -392,7 +392,7 @@ namespace Google.Cloud.PubSub.V1
     /// <item><description>DeletedTopicNameFixed: A resource of type 'deleted_topic'.</description></item>
     /// </list>
     /// </remarks>
-    public sealed partial class TopicNameOneof : gax::IResourceName, s::IEquatable<TopicNameOneof>
+    public sealed partial class TopicNameOneof : gax::IResourceName, sys::IEquatable<TopicNameOneof>
     {
         /// <summary>
         /// The possible contents of <see cref="TopicNameOneof"/>.
@@ -429,7 +429,7 @@ namespace Google.Cloud.PubSub.V1
         /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
         /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="s::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
         /// <returns>The parsed <see cref="TopicNameOneof"/> if successful.</returns>
         public static TopicNameOneof Parse(string name, bool allowUnknown)
         {
@@ -438,7 +438,7 @@ namespace Google.Cloud.PubSub.V1
             {
                 return result;
             }
-            throw new s::ArgumentException("Invalid name", nameof(name));
+            throw new sys::ArgumentException("Invalid name", nameof(name));
         }
 
         /// <summary>
@@ -523,7 +523,7 @@ namespace Google.Cloud.PubSub.V1
             Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
             if (!IsValid(type, name))
             {
-                throw new s::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
             }
         }
 
@@ -541,7 +541,7 @@ namespace Google.Cloud.PubSub.V1
         {
             if (Type != type)
             {
-                throw new s::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
             }
             return (T)Name;
         }
@@ -550,7 +550,7 @@ namespace Google.Cloud.PubSub.V1
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="TopicName"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="TopicName"/>.
         /// </remarks>
         public TopicName TopicName => CheckAndReturn<TopicName>(OneofType.TopicName);
@@ -559,7 +559,7 @@ namespace Google.Cloud.PubSub.V1
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="DeletedTopicNameFixed"/>.
         /// </summary>
         /// <remarks>
-        /// An <see cref="s::InvalidOperationException"/> will be thrown if this does not
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
         /// contain an instance of <see cref="DeletedTopicNameFixed"/>.
         /// </remarks>
         public DeletedTopicNameFixed DeletedTopicNameFixed => CheckAndReturn<DeletedTopicNameFixed>(OneofType.DeletedTopicNameFixed);
@@ -589,7 +589,7 @@ namespace Google.Cloud.PubSub.V1
     /// <summary>
     /// Resource name to represent the fixed string "_deleted-topic_".
     /// </summary>
-    public sealed partial class DeletedTopicNameFixed : gax::IResourceName, s::IEquatable<DeletedTopicNameFixed>
+    public sealed partial class DeletedTopicNameFixed : gax::IResourceName, sys::IEquatable<DeletedTopicNameFixed>
     {
         /// <summary>
         /// The fixed string value: "_deleted-topic_".
@@ -610,7 +610,7 @@ namespace Google.Cloud.PubSub.V1
             DeletedTopicNameFixed result;
             if (!TryParse(deletedTopicNameFixed, out result))
             {
-                throw new s::ArgumentException($"Invalid resource name, must be \"{FixedValue}\"", nameof(deletedTopicNameFixed));
+                throw new sys::ArgumentException($"Invalid resource name, must be \"{FixedValue}\"", nameof(deletedTopicNameFixed));
             }
             return result;
         }
@@ -662,9 +662,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class AcknowledgeRequest
     {
         /// <summary>
-        /// <see cref="SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
         /// </summary>
-        public SubscriptionName SubscriptionAsSubscriptionName
+        public Google.Cloud.PubSub.V1.SubscriptionName SubscriptionAsSubscriptionName
         {
             get { return string.IsNullOrEmpty(Subscription) ? null : Google.Cloud.PubSub.V1.SubscriptionName.Parse(Subscription); }
             set { Subscription = value != null ? value.ToString() : ""; }
@@ -675,18 +675,18 @@ namespace Google.Cloud.PubSub.V1
     public partial class CreateSnapshotRequest
     {
         /// <summary>
-        /// <see cref="SnapshotName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.SnapshotName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public SnapshotName SnapshotName
+        public Google.Cloud.PubSub.V1.SnapshotName SnapshotName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.PubSub.V1.SnapshotName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
         /// </summary>
-        public SubscriptionName SubscriptionAsSubscriptionName
+        public Google.Cloud.PubSub.V1.SubscriptionName SubscriptionAsSubscriptionName
         {
             get { return string.IsNullOrEmpty(Subscription) ? null : Google.Cloud.PubSub.V1.SubscriptionName.Parse(Subscription); }
             set { Subscription = value != null ? value.ToString() : ""; }
@@ -697,9 +697,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class DeleteSnapshotRequest
     {
         /// <summary>
-        /// <see cref="SnapshotName"/>-typed view over the <see cref="Snapshot"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.SnapshotName"/>-typed view over the <see cref="Snapshot"/> resource name property.
         /// </summary>
-        public SnapshotName SnapshotAsSnapshotName
+        public Google.Cloud.PubSub.V1.SnapshotName SnapshotAsSnapshotName
         {
             get { return string.IsNullOrEmpty(Snapshot) ? null : Google.Cloud.PubSub.V1.SnapshotName.Parse(Snapshot); }
             set { Snapshot = value != null ? value.ToString() : ""; }
@@ -710,9 +710,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class DeleteSubscriptionRequest
     {
         /// <summary>
-        /// <see cref="SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
         /// </summary>
-        public SubscriptionName SubscriptionAsSubscriptionName
+        public Google.Cloud.PubSub.V1.SubscriptionName SubscriptionAsSubscriptionName
         {
             get { return string.IsNullOrEmpty(Subscription) ? null : Google.Cloud.PubSub.V1.SubscriptionName.Parse(Subscription); }
             set { Subscription = value != null ? value.ToString() : ""; }
@@ -723,9 +723,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class DeleteTopicRequest
     {
         /// <summary>
-        /// <see cref="TopicName"/>-typed view over the <see cref="Topic"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.TopicName"/>-typed view over the <see cref="Topic"/> resource name property.
         /// </summary>
-        public TopicName TopicAsTopicName
+        public Google.Cloud.PubSub.V1.TopicName TopicAsTopicName
         {
             get { return string.IsNullOrEmpty(Topic) ? null : Google.Cloud.PubSub.V1.TopicName.Parse(Topic); }
             set { Topic = value != null ? value.ToString() : ""; }
@@ -736,9 +736,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class GetSubscriptionRequest
     {
         /// <summary>
-        /// <see cref="SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
         /// </summary>
-        public SubscriptionName SubscriptionAsSubscriptionName
+        public Google.Cloud.PubSub.V1.SubscriptionName SubscriptionAsSubscriptionName
         {
             get { return string.IsNullOrEmpty(Subscription) ? null : Google.Cloud.PubSub.V1.SubscriptionName.Parse(Subscription); }
             set { Subscription = value != null ? value.ToString() : ""; }
@@ -749,9 +749,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class GetTopicRequest
     {
         /// <summary>
-        /// <see cref="TopicName"/>-typed view over the <see cref="Topic"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.TopicName"/>-typed view over the <see cref="Topic"/> resource name property.
         /// </summary>
-        public TopicName TopicAsTopicName
+        public Google.Cloud.PubSub.V1.TopicName TopicAsTopicName
         {
             get { return string.IsNullOrEmpty(Topic) ? null : Google.Cloud.PubSub.V1.TopicName.Parse(Topic); }
             set { Topic = value != null ? value.ToString() : ""; }
@@ -762,9 +762,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class ListSnapshotsRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Project"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.ProjectName"/>-typed view over the <see cref="Project"/> resource name property.
         /// </summary>
-        public ProjectName ProjectAsProjectName
+        public Google.Cloud.PubSub.V1.ProjectName ProjectAsProjectName
         {
             get { return string.IsNullOrEmpty(Project) ? null : Google.Cloud.PubSub.V1.ProjectName.Parse(Project); }
             set { Project = value != null ? value.ToString() : ""; }
@@ -775,9 +775,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class ListSubscriptionsRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Project"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.ProjectName"/>-typed view over the <see cref="Project"/> resource name property.
         /// </summary>
-        public ProjectName ProjectAsProjectName
+        public Google.Cloud.PubSub.V1.ProjectName ProjectAsProjectName
         {
             get { return string.IsNullOrEmpty(Project) ? null : Google.Cloud.PubSub.V1.ProjectName.Parse(Project); }
             set { Project = value != null ? value.ToString() : ""; }
@@ -788,9 +788,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class ListTopicSubscriptionsRequest
     {
         /// <summary>
-        /// <see cref="TopicName"/>-typed view over the <see cref="Topic"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.TopicName"/>-typed view over the <see cref="Topic"/> resource name property.
         /// </summary>
-        public TopicName TopicAsTopicName
+        public Google.Cloud.PubSub.V1.TopicName TopicAsTopicName
         {
             get { return string.IsNullOrEmpty(Topic) ? null : Google.Cloud.PubSub.V1.TopicName.Parse(Topic); }
             set { Topic = value != null ? value.ToString() : ""; }
@@ -812,9 +812,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class ListTopicsRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Project"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.ProjectName"/>-typed view over the <see cref="Project"/> resource name property.
         /// </summary>
-        public ProjectName ProjectAsProjectName
+        public Google.Cloud.PubSub.V1.ProjectName ProjectAsProjectName
         {
             get { return string.IsNullOrEmpty(Project) ? null : Google.Cloud.PubSub.V1.ProjectName.Parse(Project); }
             set { Project = value != null ? value.ToString() : ""; }
@@ -825,9 +825,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class ModifyAckDeadlineRequest
     {
         /// <summary>
-        /// <see cref="SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
         /// </summary>
-        public SubscriptionName SubscriptionAsSubscriptionName
+        public Google.Cloud.PubSub.V1.SubscriptionName SubscriptionAsSubscriptionName
         {
             get { return string.IsNullOrEmpty(Subscription) ? null : Google.Cloud.PubSub.V1.SubscriptionName.Parse(Subscription); }
             set { Subscription = value != null ? value.ToString() : ""; }
@@ -838,9 +838,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class ModifyPushConfigRequest
     {
         /// <summary>
-        /// <see cref="SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
         /// </summary>
-        public SubscriptionName SubscriptionAsSubscriptionName
+        public Google.Cloud.PubSub.V1.SubscriptionName SubscriptionAsSubscriptionName
         {
             get { return string.IsNullOrEmpty(Subscription) ? null : Google.Cloud.PubSub.V1.SubscriptionName.Parse(Subscription); }
             set { Subscription = value != null ? value.ToString() : ""; }
@@ -851,9 +851,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class PublishRequest
     {
         /// <summary>
-        /// <see cref="TopicName"/>-typed view over the <see cref="Topic"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.TopicName"/>-typed view over the <see cref="Topic"/> resource name property.
         /// </summary>
-        public TopicName TopicAsTopicName
+        public Google.Cloud.PubSub.V1.TopicName TopicAsTopicName
         {
             get { return string.IsNullOrEmpty(Topic) ? null : Google.Cloud.PubSub.V1.TopicName.Parse(Topic); }
             set { Topic = value != null ? value.ToString() : ""; }
@@ -864,9 +864,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class PullRequest
     {
         /// <summary>
-        /// <see cref="SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
         /// </summary>
-        public SubscriptionName SubscriptionAsSubscriptionName
+        public Google.Cloud.PubSub.V1.SubscriptionName SubscriptionAsSubscriptionName
         {
             get { return string.IsNullOrEmpty(Subscription) ? null : Google.Cloud.PubSub.V1.SubscriptionName.Parse(Subscription); }
             set { Subscription = value != null ? value.ToString() : ""; }
@@ -877,18 +877,18 @@ namespace Google.Cloud.PubSub.V1
     public partial class SeekRequest
     {
         /// <summary>
-        /// <see cref="SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
         /// </summary>
-        public SubscriptionName SubscriptionAsSubscriptionName
+        public Google.Cloud.PubSub.V1.SubscriptionName SubscriptionAsSubscriptionName
         {
             get { return string.IsNullOrEmpty(Subscription) ? null : Google.Cloud.PubSub.V1.SubscriptionName.Parse(Subscription); }
             set { Subscription = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="SnapshotName"/>-typed view over the <see cref="Snapshot"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.SnapshotName"/>-typed view over the <see cref="Snapshot"/> resource name property.
         /// </summary>
-        public SnapshotName SnapshotAsSnapshotName
+        public Google.Cloud.PubSub.V1.SnapshotName SnapshotAsSnapshotName
         {
             get { return string.IsNullOrEmpty(Snapshot) ? null : Google.Cloud.PubSub.V1.SnapshotName.Parse(Snapshot); }
             set { Snapshot = value != null ? value.ToString() : ""; }
@@ -899,18 +899,18 @@ namespace Google.Cloud.PubSub.V1
     public partial class Snapshot
     {
         /// <summary>
-        /// <see cref="SnapshotName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.SnapshotName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public SnapshotName SnapshotName
+        public Google.Cloud.PubSub.V1.SnapshotName SnapshotName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.PubSub.V1.SnapshotName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="TopicName"/>-typed view over the <see cref="Topic"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.TopicName"/>-typed view over the <see cref="Topic"/> resource name property.
         /// </summary>
-        public TopicName TopicAsTopicName
+        public Google.Cloud.PubSub.V1.TopicName TopicAsTopicName
         {
             get { return string.IsNullOrEmpty(Topic) ? null : Google.Cloud.PubSub.V1.TopicName.Parse(Topic); }
             set { Topic = value != null ? value.ToString() : ""; }
@@ -921,9 +921,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class StreamingPullRequest
     {
         /// <summary>
-        /// <see cref="SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.SubscriptionName"/>-typed view over the <see cref="Subscription"/> resource name property.
         /// </summary>
-        public SubscriptionName SubscriptionAsSubscriptionName
+        public Google.Cloud.PubSub.V1.SubscriptionName SubscriptionAsSubscriptionName
         {
             get { return string.IsNullOrEmpty(Subscription) ? null : Google.Cloud.PubSub.V1.SubscriptionName.Parse(Subscription); }
             set { Subscription = value != null ? value.ToString() : ""; }
@@ -934,18 +934,18 @@ namespace Google.Cloud.PubSub.V1
     public partial class Subscription
     {
         /// <summary>
-        /// <see cref="SubscriptionName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.SubscriptionName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public SubscriptionName SubscriptionName
+        public Google.Cloud.PubSub.V1.SubscriptionName SubscriptionName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.PubSub.V1.SubscriptionName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="TopicNameOneof"/>-typed view over the <see cref="Topic"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.TopicNameOneof"/>-typed view over the <see cref="Topic"/> resource name property.
         /// </summary>
-        public TopicNameOneof TopicAsTopicNameOneof
+        public Google.Cloud.PubSub.V1.TopicNameOneof TopicAsTopicNameOneof
         {
             get { return string.IsNullOrEmpty(Topic) ? null : Google.Cloud.PubSub.V1.TopicNameOneof.Parse(Topic, true); }
             set { Topic = value != null ? value.ToString() : ""; }
@@ -956,9 +956,9 @@ namespace Google.Cloud.PubSub.V1
     public partial class Topic
     {
         /// <summary>
-        /// <see cref="TopicName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.PubSub.V1.TopicName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public TopicName TopicName
+        public Google.Cloud.PubSub.V1.TopicName TopicName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.PubSub.V1.TopicName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClient.cs
@@ -17,10 +17,10 @@
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using iam = Google.Cloud.Iam.V1;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -85,7 +85,7 @@ namespace Google.Cloud.PubSub.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Google.Cloud.PubSub.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Google.Cloud.PubSub.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> PullRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> PullRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.Cancelled, grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Internal, grpccore::StatusCode.ResourceExhausted, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -130,8 +130,8 @@ namespace Google.Cloud.PubSub.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -150,8 +150,8 @@ namespace Google.Cloud.PubSub.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(60000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(60000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.0
         );
 
@@ -170,8 +170,8 @@ namespace Google.Cloud.PubSub.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetMessagingRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -190,8 +190,8 @@ namespace Google.Cloud.PubSub.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetMessagingTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(12000),
-            maxDelay: s::TimeSpan.FromMilliseconds(12000),
+            delay: sys::TimeSpan.FromMilliseconds(12000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(12000),
             delayMultiplier: 1.0
         );
 
@@ -210,8 +210,8 @@ namespace Google.Cloud.PubSub.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetStreamingMessagingRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -230,8 +230,8 @@ namespace Google.Cloud.PubSub.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetStreamingMessagingTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(600000),
-            maxDelay: s::TimeSpan.FromMilliseconds(600000),
+            delay: sys::TimeSpan.FromMilliseconds(600000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(600000),
             delayMultiplier: 1.0
         );
 
@@ -261,7 +261,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -291,7 +291,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -321,7 +321,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -351,7 +351,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -381,7 +381,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -410,7 +410,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -439,7 +439,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetMessagingRetryBackoff(),
                 timeoutBackoff: GetMessagingTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -472,7 +472,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetMessagingRetryBackoff(),
                 timeoutBackoff: GetMessagingTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: PullRetryFilter
             )));
 
@@ -483,7 +483,7 @@ namespace Google.Cloud.PubSub.V1
         /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings StreamingPullSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
-            gaxgrpc::CallTiming.FromTimeout(s::TimeSpan.FromMilliseconds(600000)));
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)));
 
         /// <summary>
         /// <see cref="gaxgrpc::BidirectionalStreamingSettings"/> for calls to
@@ -520,7 +520,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -550,7 +550,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -580,7 +580,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -610,7 +610,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -640,7 +640,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -669,7 +669,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -698,7 +698,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -728,7 +728,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -757,7 +757,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -859,7 +859,7 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         public virtual Subscriber.SubscriberClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -1103,7 +1103,7 @@ namespace Google.Cloud.PubSub.V1
             Subscription request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1158,7 +1158,7 @@ namespace Google.Cloud.PubSub.V1
             Subscription request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1240,7 +1240,7 @@ namespace Google.Cloud.PubSub.V1
             GetSubscriptionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1277,7 +1277,7 @@ namespace Google.Cloud.PubSub.V1
             GetSubscriptionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1301,7 +1301,7 @@ namespace Google.Cloud.PubSub.V1
             UpdateSubscriptionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1348,7 +1348,7 @@ namespace Google.Cloud.PubSub.V1
             UpdateSubscriptionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1435,7 +1435,7 @@ namespace Google.Cloud.PubSub.V1
             ListSubscriptionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1454,7 +1454,7 @@ namespace Google.Cloud.PubSub.V1
             ListSubscriptionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1549,7 +1549,7 @@ namespace Google.Cloud.PubSub.V1
             DeleteSubscriptionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1591,7 +1591,7 @@ namespace Google.Cloud.PubSub.V1
             DeleteSubscriptionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1734,7 +1734,7 @@ namespace Google.Cloud.PubSub.V1
             ModifyAckDeadlineRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1776,7 +1776,7 @@ namespace Google.Cloud.PubSub.V1
             ModifyAckDeadlineRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1897,7 +1897,7 @@ namespace Google.Cloud.PubSub.V1
             AcknowledgeRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1943,7 +1943,7 @@ namespace Google.Cloud.PubSub.V1
             AcknowledgeRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2085,7 +2085,7 @@ namespace Google.Cloud.PubSub.V1
             PullRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2128,7 +2128,7 @@ namespace Google.Cloud.PubSub.V1
             PullRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2158,7 +2158,7 @@ namespace Google.Cloud.PubSub.V1
             gaxgrpc::CallSettings callSettings = null,
             gaxgrpc::BidirectionalStreamingSettings streamingSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2294,7 +2294,7 @@ namespace Google.Cloud.PubSub.V1
             ModifyPushConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2338,7 +2338,7 @@ namespace Google.Cloud.PubSub.V1
             ModifyPushConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2425,7 +2425,7 @@ namespace Google.Cloud.PubSub.V1
             ListSnapshotsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2444,7 +2444,7 @@ namespace Google.Cloud.PubSub.V1
             ListSnapshotsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2610,7 +2610,7 @@ namespace Google.Cloud.PubSub.V1
             CreateSnapshotRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2665,7 +2665,7 @@ namespace Google.Cloud.PubSub.V1
             CreateSnapshotRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2689,7 +2689,7 @@ namespace Google.Cloud.PubSub.V1
             UpdateSnapshotRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2736,7 +2736,7 @@ namespace Google.Cloud.PubSub.V1
             UpdateSnapshotRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2827,7 +2827,7 @@ namespace Google.Cloud.PubSub.V1
             DeleteSnapshotRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2867,7 +2867,7 @@ namespace Google.Cloud.PubSub.V1
             DeleteSnapshotRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2887,7 +2887,7 @@ namespace Google.Cloud.PubSub.V1
             SeekRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2926,7 +2926,7 @@ namespace Google.Cloud.PubSub.V1
             SeekRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3039,7 +3039,7 @@ namespace Google.Cloud.PubSub.V1
             iam::SetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3078,7 +3078,7 @@ namespace Google.Cloud.PubSub.V1
             iam::SetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3171,7 +3171,7 @@ namespace Google.Cloud.PubSub.V1
             iam::GetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3212,7 +3212,7 @@ namespace Google.Cloud.PubSub.V1
             iam::GetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3329,7 +3329,7 @@ namespace Google.Cloud.PubSub.V1
             iam::TestIamPermissionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -3370,7 +3370,7 @@ namespace Google.Cloud.PubSub.V1
             iam::TestIamPermissionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -3384,16 +3384,16 @@ namespace Google.Cloud.PubSub.V1
         private readonly gaxgrpc::ApiCall<GetSubscriptionRequest, Subscription> _callGetSubscription;
         private readonly gaxgrpc::ApiCall<UpdateSubscriptionRequest, Subscription> _callUpdateSubscription;
         private readonly gaxgrpc::ApiCall<ListSubscriptionsRequest, ListSubscriptionsResponse> _callListSubscriptions;
-        private readonly gaxgrpc::ApiCall<DeleteSubscriptionRequest, protowkt::Empty> _callDeleteSubscription;
-        private readonly gaxgrpc::ApiCall<ModifyAckDeadlineRequest, protowkt::Empty> _callModifyAckDeadline;
-        private readonly gaxgrpc::ApiCall<AcknowledgeRequest, protowkt::Empty> _callAcknowledge;
+        private readonly gaxgrpc::ApiCall<DeleteSubscriptionRequest, pbwkt::Empty> _callDeleteSubscription;
+        private readonly gaxgrpc::ApiCall<ModifyAckDeadlineRequest, pbwkt::Empty> _callModifyAckDeadline;
+        private readonly gaxgrpc::ApiCall<AcknowledgeRequest, pbwkt::Empty> _callAcknowledge;
         private readonly gaxgrpc::ApiCall<PullRequest, PullResponse> _callPull;
         private readonly gaxgrpc::ApiBidirectionalStreamingCall<StreamingPullRequest, StreamingPullResponse> _callStreamingPull;
-        private readonly gaxgrpc::ApiCall<ModifyPushConfigRequest, protowkt::Empty> _callModifyPushConfig;
+        private readonly gaxgrpc::ApiCall<ModifyPushConfigRequest, pbwkt::Empty> _callModifyPushConfig;
         private readonly gaxgrpc::ApiCall<ListSnapshotsRequest, ListSnapshotsResponse> _callListSnapshots;
         private readonly gaxgrpc::ApiCall<CreateSnapshotRequest, Snapshot> _callCreateSnapshot;
         private readonly gaxgrpc::ApiCall<UpdateSnapshotRequest, Snapshot> _callUpdateSnapshot;
-        private readonly gaxgrpc::ApiCall<DeleteSnapshotRequest, protowkt::Empty> _callDeleteSnapshot;
+        private readonly gaxgrpc::ApiCall<DeleteSnapshotRequest, pbwkt::Empty> _callDeleteSnapshot;
         private readonly gaxgrpc::ApiCall<SeekRequest, SeekResponse> _callSeek;
         private readonly gaxgrpc::ApiCall<iam::SetIamPolicyRequest, iam::Policy> _callSetIamPolicy;
         private readonly gaxgrpc::ApiCall<iam::GetIamPolicyRequest, iam::Policy> _callGetIamPolicy;
@@ -3418,17 +3418,17 @@ namespace Google.Cloud.PubSub.V1
                 GrpcClient.UpdateSubscriptionAsync, GrpcClient.UpdateSubscription, effectiveSettings.UpdateSubscriptionSettings);
             _callListSubscriptions = clientHelper.BuildApiCall<ListSubscriptionsRequest, ListSubscriptionsResponse>(
                 GrpcClient.ListSubscriptionsAsync, GrpcClient.ListSubscriptions, effectiveSettings.ListSubscriptionsSettings);
-            _callDeleteSubscription = clientHelper.BuildApiCall<DeleteSubscriptionRequest, protowkt::Empty>(
+            _callDeleteSubscription = clientHelper.BuildApiCall<DeleteSubscriptionRequest, pbwkt::Empty>(
                 GrpcClient.DeleteSubscriptionAsync, GrpcClient.DeleteSubscription, effectiveSettings.DeleteSubscriptionSettings);
-            _callModifyAckDeadline = clientHelper.BuildApiCall<ModifyAckDeadlineRequest, protowkt::Empty>(
+            _callModifyAckDeadline = clientHelper.BuildApiCall<ModifyAckDeadlineRequest, pbwkt::Empty>(
                 GrpcClient.ModifyAckDeadlineAsync, GrpcClient.ModifyAckDeadline, effectiveSettings.ModifyAckDeadlineSettings);
-            _callAcknowledge = clientHelper.BuildApiCall<AcknowledgeRequest, protowkt::Empty>(
+            _callAcknowledge = clientHelper.BuildApiCall<AcknowledgeRequest, pbwkt::Empty>(
                 GrpcClient.AcknowledgeAsync, GrpcClient.Acknowledge, effectiveSettings.AcknowledgeSettings);
             _callPull = clientHelper.BuildApiCall<PullRequest, PullResponse>(
                 GrpcClient.PullAsync, GrpcClient.Pull, effectiveSettings.PullSettings);
             _callStreamingPull = clientHelper.BuildApiCall<StreamingPullRequest, StreamingPullResponse>(
                 GrpcClient.StreamingPull, effectiveSettings.StreamingPullSettings, effectiveSettings.StreamingPullStreamingSettings);
-            _callModifyPushConfig = clientHelper.BuildApiCall<ModifyPushConfigRequest, protowkt::Empty>(
+            _callModifyPushConfig = clientHelper.BuildApiCall<ModifyPushConfigRequest, pbwkt::Empty>(
                 GrpcClient.ModifyPushConfigAsync, GrpcClient.ModifyPushConfig, effectiveSettings.ModifyPushConfigSettings);
             _callListSnapshots = clientHelper.BuildApiCall<ListSnapshotsRequest, ListSnapshotsResponse>(
                 GrpcClient.ListSnapshotsAsync, GrpcClient.ListSnapshots, effectiveSettings.ListSnapshotsSettings);
@@ -3436,7 +3436,7 @@ namespace Google.Cloud.PubSub.V1
                 GrpcClient.CreateSnapshotAsync, GrpcClient.CreateSnapshot, effectiveSettings.CreateSnapshotSettings);
             _callUpdateSnapshot = clientHelper.BuildApiCall<UpdateSnapshotRequest, Snapshot>(
                 GrpcClient.UpdateSnapshotAsync, GrpcClient.UpdateSnapshot, effectiveSettings.UpdateSnapshotSettings);
-            _callDeleteSnapshot = clientHelper.BuildApiCall<DeleteSnapshotRequest, protowkt::Empty>(
+            _callDeleteSnapshot = clientHelper.BuildApiCall<DeleteSnapshotRequest, pbwkt::Empty>(
                 GrpcClient.DeleteSnapshotAsync, GrpcClient.DeleteSnapshot, effectiveSettings.DeleteSnapshotSettings);
             _callSeek = clientHelper.BuildApiCall<SeekRequest, SeekResponse>(
                 GrpcClient.SeekAsync, GrpcClient.Seek, effectiveSettings.SeekSettings);
@@ -3490,11 +3490,11 @@ namespace Google.Cloud.PubSub.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiBidirectionalStreamingCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -3502,16 +3502,16 @@ namespace Google.Cloud.PubSub.V1
         partial void Modify_GetSubscriptionApiCall(ref gaxgrpc::ApiCall<GetSubscriptionRequest, Subscription> call);
         partial void Modify_UpdateSubscriptionApiCall(ref gaxgrpc::ApiCall<UpdateSubscriptionRequest, Subscription> call);
         partial void Modify_ListSubscriptionsApiCall(ref gaxgrpc::ApiCall<ListSubscriptionsRequest, ListSubscriptionsResponse> call);
-        partial void Modify_DeleteSubscriptionApiCall(ref gaxgrpc::ApiCall<DeleteSubscriptionRequest, protowkt::Empty> call);
-        partial void Modify_ModifyAckDeadlineApiCall(ref gaxgrpc::ApiCall<ModifyAckDeadlineRequest, protowkt::Empty> call);
-        partial void Modify_AcknowledgeApiCall(ref gaxgrpc::ApiCall<AcknowledgeRequest, protowkt::Empty> call);
+        partial void Modify_DeleteSubscriptionApiCall(ref gaxgrpc::ApiCall<DeleteSubscriptionRequest, pbwkt::Empty> call);
+        partial void Modify_ModifyAckDeadlineApiCall(ref gaxgrpc::ApiCall<ModifyAckDeadlineRequest, pbwkt::Empty> call);
+        partial void Modify_AcknowledgeApiCall(ref gaxgrpc::ApiCall<AcknowledgeRequest, pbwkt::Empty> call);
         partial void Modify_PullApiCall(ref gaxgrpc::ApiCall<PullRequest, PullResponse> call);
         partial void Modify_StreamingPullApiCall(ref gaxgrpc::ApiBidirectionalStreamingCall<StreamingPullRequest, StreamingPullResponse> call);
-        partial void Modify_ModifyPushConfigApiCall(ref gaxgrpc::ApiCall<ModifyPushConfigRequest, protowkt::Empty> call);
+        partial void Modify_ModifyPushConfigApiCall(ref gaxgrpc::ApiCall<ModifyPushConfigRequest, pbwkt::Empty> call);
         partial void Modify_ListSnapshotsApiCall(ref gaxgrpc::ApiCall<ListSnapshotsRequest, ListSnapshotsResponse> call);
         partial void Modify_CreateSnapshotApiCall(ref gaxgrpc::ApiCall<CreateSnapshotRequest, Snapshot> call);
         partial void Modify_UpdateSnapshotApiCall(ref gaxgrpc::ApiCall<UpdateSnapshotRequest, Snapshot> call);
-        partial void Modify_DeleteSnapshotApiCall(ref gaxgrpc::ApiCall<DeleteSnapshotRequest, protowkt::Empty> call);
+        partial void Modify_DeleteSnapshotApiCall(ref gaxgrpc::ApiCall<DeleteSnapshotRequest, pbwkt::Empty> call);
         partial void Modify_SeekApiCall(ref gaxgrpc::ApiCall<SeekRequest, SeekResponse> call);
         partial void Modify_SetIamPolicyApiCall(ref gaxgrpc::ApiCall<iam::SetIamPolicyRequest, iam::Policy> call);
         partial void Modify_GetIamPolicyApiCall(ref gaxgrpc::ApiCall<iam::GetIamPolicyRequest, iam::Policy> call);

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.cs
@@ -18,10 +18,10 @@ using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using iam = Google.Cloud.Iam.V1;
 using lro = Google.LongRunning;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -78,7 +78,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -106,8 +106,8 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(1000),
-            maxDelay: s::TimeSpan.FromMilliseconds(32000),
+            delay: sys::TimeSpan.FromMilliseconds(1000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(32000),
             delayMultiplier: 1.3
         );
 
@@ -126,8 +126,8 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(60000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(60000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.0
         );
 
@@ -157,7 +157,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -186,7 +186,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -205,10 +205,10 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         public lro::OperationsSettings CreateDatabaseOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(86400000L)),
-                s::TimeSpan.FromMilliseconds(20000L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(86400000L)),
+                sys::TimeSpan.FromMilliseconds(20000L),
                 1.5,
-                s::TimeSpan.FromMilliseconds(45000L))
+                sys::TimeSpan.FromMilliseconds(45000L))
         };
 
         /// <summary>
@@ -237,7 +237,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -267,7 +267,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -286,10 +286,10 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         public lro::OperationsSettings UpdateDatabaseDdlOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(86400000L)),
-                s::TimeSpan.FromMilliseconds(20000L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(86400000L)),
+                sys::TimeSpan.FromMilliseconds(20000L),
                 1.5,
-                s::TimeSpan.FromMilliseconds(45000L))
+                sys::TimeSpan.FromMilliseconds(45000L))
         };
 
         /// <summary>
@@ -318,7 +318,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -348,7 +348,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -377,7 +377,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -407,7 +407,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -436,7 +436,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -538,7 +538,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// </summary>
         public virtual DatabaseAdmin.DatabaseAdminClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -625,7 +625,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             ListDatabasesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -644,7 +644,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             ListDatabasesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -781,7 +781,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             CreateDatabaseRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -820,7 +820,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             CreateDatabaseRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -828,7 +828,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// </summary>
         public virtual lro::OperationsClient CreateDatabaseOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -923,7 +923,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             GetDatabaseRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -960,7 +960,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             GetDatabaseRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -984,7 +984,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual stt::Task<lro::Operation<protowkt::Empty, UpdateDatabaseDdlMetadata>> UpdateDatabaseDdlAsync(
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, UpdateDatabaseDdlMetadata>> UpdateDatabaseDdlAsync(
             DatabaseName database,
             scg::IEnumerable<string> statements,
             gaxgrpc::CallSettings callSettings = null) => UpdateDatabaseDdlAsync(
@@ -1016,7 +1016,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual stt::Task<lro::Operation<protowkt::Empty, UpdateDatabaseDdlMetadata>> UpdateDatabaseDdlAsync(
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, UpdateDatabaseDdlMetadata>> UpdateDatabaseDdlAsync(
             DatabaseName database,
             scg::IEnumerable<string> statements,
             st::CancellationToken cancellationToken) => UpdateDatabaseDdlAsync(
@@ -1045,7 +1045,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual lro::Operation<protowkt::Empty, UpdateDatabaseDdlMetadata> UpdateDatabaseDdl(
+        public virtual lro::Operation<pbwkt::Empty, UpdateDatabaseDdlMetadata> UpdateDatabaseDdl(
             DatabaseName database,
             scg::IEnumerable<string> statements,
             gaxgrpc::CallSettings callSettings = null) => UpdateDatabaseDdl(
@@ -1074,11 +1074,11 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public virtual stt::Task<lro::Operation<protowkt::Empty, UpdateDatabaseDdlMetadata>> UpdateDatabaseDdlAsync(
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, UpdateDatabaseDdlMetadata>> UpdateDatabaseDdlAsync(
             UpdateDatabaseDdlRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1087,9 +1087,9 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A task representing the result of polling the operation.</returns>
-        public virtual stt::Task<lro::Operation<protowkt::Empty, UpdateDatabaseDdlMetadata>> PollOnceUpdateDatabaseDdlAsync(
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, UpdateDatabaseDdlMetadata>> PollOnceUpdateDatabaseDdlAsync(
             string operationName,
-            gaxgrpc::CallSettings callSettings = null) => lro::Operation<protowkt::Empty, UpdateDatabaseDdlMetadata>.PollOnceFromNameAsync(
+            gaxgrpc::CallSettings callSettings = null) => lro::Operation<pbwkt::Empty, UpdateDatabaseDdlMetadata>.PollOnceFromNameAsync(
                 gax::GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 UpdateDatabaseDdlOperationsClient,
                 callSettings);
@@ -1112,11 +1112,11 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public virtual lro::Operation<protowkt::Empty, UpdateDatabaseDdlMetadata> UpdateDatabaseDdl(
+        public virtual lro::Operation<pbwkt::Empty, UpdateDatabaseDdlMetadata> UpdateDatabaseDdl(
             UpdateDatabaseDdlRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1124,7 +1124,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// </summary>
         public virtual lro::OperationsClient UpdateDatabaseDdlOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -1133,9 +1133,9 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The result of polling the operation.</returns>
-        public virtual lro::Operation<protowkt::Empty, UpdateDatabaseDdlMetadata> PollOnceUpdateDatabaseDdl(
+        public virtual lro::Operation<pbwkt::Empty, UpdateDatabaseDdlMetadata> PollOnceUpdateDatabaseDdl(
             string operationName,
-            gaxgrpc::CallSettings callSettings = null) => lro::Operation<protowkt::Empty, UpdateDatabaseDdlMetadata>.PollOnceFromName(
+            gaxgrpc::CallSettings callSettings = null) => lro::Operation<pbwkt::Empty, UpdateDatabaseDdlMetadata>.PollOnceFromName(
                 gax::GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 UpdateDatabaseDdlOperationsClient,
                 callSettings);
@@ -1213,7 +1213,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             DropDatabaseRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1247,7 +1247,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             DropDatabaseRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1334,7 +1334,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             GetDatabaseDdlRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1375,7 +1375,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             GetDatabaseDdlRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1500,7 +1500,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             iam::SetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1545,7 +1545,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             iam::SetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1646,7 +1646,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             iam::GetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1691,7 +1691,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             iam::GetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1820,7 +1820,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             iam::TestIamPermissionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1867,7 +1867,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             iam::TestIamPermissionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -1881,7 +1881,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         private readonly gaxgrpc::ApiCall<CreateDatabaseRequest, lro::Operation> _callCreateDatabase;
         private readonly gaxgrpc::ApiCall<GetDatabaseRequest, Database> _callGetDatabase;
         private readonly gaxgrpc::ApiCall<UpdateDatabaseDdlRequest, lro::Operation> _callUpdateDatabaseDdl;
-        private readonly gaxgrpc::ApiCall<DropDatabaseRequest, protowkt::Empty> _callDropDatabase;
+        private readonly gaxgrpc::ApiCall<DropDatabaseRequest, pbwkt::Empty> _callDropDatabase;
         private readonly gaxgrpc::ApiCall<GetDatabaseDdlRequest, GetDatabaseDdlResponse> _callGetDatabaseDdl;
         private readonly gaxgrpc::ApiCall<iam::SetIamPolicyRequest, iam::Policy> _callSetIamPolicy;
         private readonly gaxgrpc::ApiCall<iam::GetIamPolicyRequest, iam::Policy> _callGetIamPolicy;
@@ -1909,7 +1909,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
                 GrpcClient.GetDatabaseAsync, GrpcClient.GetDatabase, effectiveSettings.GetDatabaseSettings);
             _callUpdateDatabaseDdl = clientHelper.BuildApiCall<UpdateDatabaseDdlRequest, lro::Operation>(
                 GrpcClient.UpdateDatabaseDdlAsync, GrpcClient.UpdateDatabaseDdl, effectiveSettings.UpdateDatabaseDdlSettings);
-            _callDropDatabase = clientHelper.BuildApiCall<DropDatabaseRequest, protowkt::Empty>(
+            _callDropDatabase = clientHelper.BuildApiCall<DropDatabaseRequest, pbwkt::Empty>(
                 GrpcClient.DropDatabaseAsync, GrpcClient.DropDatabase, effectiveSettings.DropDatabaseSettings);
             _callGetDatabaseDdl = clientHelper.BuildApiCall<GetDatabaseDdlRequest, GetDatabaseDdlResponse>(
                 GrpcClient.GetDatabaseDdlAsync, GrpcClient.GetDatabaseDdl, effectiveSettings.GetDatabaseDdlSettings);
@@ -1945,8 +1945,8 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -1954,7 +1954,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         partial void Modify_CreateDatabaseApiCall(ref gaxgrpc::ApiCall<CreateDatabaseRequest, lro::Operation> call);
         partial void Modify_GetDatabaseApiCall(ref gaxgrpc::ApiCall<GetDatabaseRequest, Database> call);
         partial void Modify_UpdateDatabaseDdlApiCall(ref gaxgrpc::ApiCall<UpdateDatabaseDdlRequest, lro::Operation> call);
-        partial void Modify_DropDatabaseApiCall(ref gaxgrpc::ApiCall<DropDatabaseRequest, protowkt::Empty> call);
+        partial void Modify_DropDatabaseApiCall(ref gaxgrpc::ApiCall<DropDatabaseRequest, pbwkt::Empty> call);
         partial void Modify_GetDatabaseDdlApiCall(ref gaxgrpc::ApiCall<GetDatabaseDdlRequest, GetDatabaseDdlResponse> call);
         partial void Modify_SetIamPolicyApiCall(ref gaxgrpc::ApiCall<iam::SetIamPolicyRequest, iam::Policy> call);
         partial void Modify_GetIamPolicyApiCall(ref gaxgrpc::ApiCall<iam::GetIamPolicyRequest, iam::Policy> call);
@@ -2138,12 +2138,12 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// A Task containing the RPC response.
         /// </returns>
-        public override async stt::Task<lro::Operation<protowkt::Empty, UpdateDatabaseDdlMetadata>> UpdateDatabaseDdlAsync(
+        public override async stt::Task<lro::Operation<pbwkt::Empty, UpdateDatabaseDdlMetadata>> UpdateDatabaseDdlAsync(
             UpdateDatabaseDdlRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
             Modify_UpdateDatabaseDdlRequest(ref request, ref callSettings);
-            return new lro::Operation<protowkt::Empty, UpdateDatabaseDdlMetadata>(
+            return new lro::Operation<pbwkt::Empty, UpdateDatabaseDdlMetadata>(
                 await _callUpdateDatabaseDdl.Async(request, callSettings).ConfigureAwait(false), UpdateDatabaseDdlOperationsClient);
         }
 
@@ -2165,12 +2165,12 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <returns>
         /// The RPC response.
         /// </returns>
-        public override lro::Operation<protowkt::Empty, UpdateDatabaseDdlMetadata> UpdateDatabaseDdl(
+        public override lro::Operation<pbwkt::Empty, UpdateDatabaseDdlMetadata> UpdateDatabaseDdl(
             UpdateDatabaseDdlRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
             Modify_UpdateDatabaseDdlRequest(ref request, ref callSettings);
-            return new lro::Operation<protowkt::Empty, UpdateDatabaseDdlMetadata>(
+            return new lro::Operation<pbwkt::Empty, UpdateDatabaseDdlMetadata>(
                 _callUpdateDatabaseDdl.Sync(request, callSettings), UpdateDatabaseDdlOperationsClient);
         }
 

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/ResourceNames.cs
@@ -15,15 +15,15 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Spanner.Admin.Database.V1
 {
     /// <summary>
     /// Resource name for the 'instance' resource.
     /// </summary>
-    public sealed partial class InstanceName : gax::IResourceName, s::IEquatable<InstanceName>
+    public sealed partial class InstanceName : gax::IResourceName, sys::IEquatable<InstanceName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}");
 
@@ -45,7 +45,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <see cref="InstanceName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="instanceName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="instanceName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="instanceName">The instance resource name in string form. Must not be <c>null</c>.</param>
@@ -115,7 +115,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
     /// <summary>
     /// Resource name for the 'database' resource.
     /// </summary>
-    public sealed partial class DatabaseName : gax::IResourceName, s::IEquatable<DatabaseName>
+    public sealed partial class DatabaseName : gax::IResourceName, sys::IEquatable<DatabaseName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}/databases/{database}");
 
@@ -137,7 +137,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <see cref="DatabaseName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="databaseName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="databaseName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="databaseName">The database resource name in string form. Must not be <c>null</c>.</param>
@@ -215,9 +215,9 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
     public partial class CreateDatabaseMetadata
     {
         /// <summary>
-        /// <see cref="DatabaseName"/>-typed view over the <see cref="Database"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Database.V1.DatabaseName"/>-typed view over the <see cref="Database"/> resource name property.
         /// </summary>
-        public DatabaseName DatabaseAsDatabaseName
+        public Google.Cloud.Spanner.Admin.Database.V1.DatabaseName DatabaseAsDatabaseName
         {
             get { return string.IsNullOrEmpty(Database) ? null : Google.Cloud.Spanner.Admin.Database.V1.DatabaseName.Parse(Database); }
             set { Database = value != null ? value.ToString() : ""; }
@@ -228,9 +228,9 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
     public partial class CreateDatabaseRequest
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Database.V1.InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public InstanceName ParentAsInstanceName
+        public Google.Cloud.Spanner.Admin.Database.V1.InstanceName ParentAsInstanceName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Spanner.Admin.Database.V1.InstanceName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -241,9 +241,9 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
     public partial class DropDatabaseRequest
     {
         /// <summary>
-        /// <see cref="DatabaseName"/>-typed view over the <see cref="Database"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Database.V1.DatabaseName"/>-typed view over the <see cref="Database"/> resource name property.
         /// </summary>
-        public DatabaseName DatabaseAsDatabaseName
+        public Google.Cloud.Spanner.Admin.Database.V1.DatabaseName DatabaseAsDatabaseName
         {
             get { return string.IsNullOrEmpty(Database) ? null : Google.Cloud.Spanner.Admin.Database.V1.DatabaseName.Parse(Database); }
             set { Database = value != null ? value.ToString() : ""; }
@@ -254,9 +254,9 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
     public partial class GetDatabaseDdlRequest
     {
         /// <summary>
-        /// <see cref="DatabaseName"/>-typed view over the <see cref="Database"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Database.V1.DatabaseName"/>-typed view over the <see cref="Database"/> resource name property.
         /// </summary>
-        public DatabaseName DatabaseAsDatabaseName
+        public Google.Cloud.Spanner.Admin.Database.V1.DatabaseName DatabaseAsDatabaseName
         {
             get { return string.IsNullOrEmpty(Database) ? null : Google.Cloud.Spanner.Admin.Database.V1.DatabaseName.Parse(Database); }
             set { Database = value != null ? value.ToString() : ""; }
@@ -267,9 +267,9 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
     public partial class GetDatabaseRequest
     {
         /// <summary>
-        /// <see cref="DatabaseName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Database.V1.DatabaseName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public DatabaseName DatabaseName
+        public Google.Cloud.Spanner.Admin.Database.V1.DatabaseName DatabaseName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Spanner.Admin.Database.V1.DatabaseName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -280,9 +280,9 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
     public partial class ListDatabasesRequest
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Database.V1.InstanceName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public InstanceName ParentAsInstanceName
+        public Google.Cloud.Spanner.Admin.Database.V1.InstanceName ParentAsInstanceName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Spanner.Admin.Database.V1.InstanceName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -293,9 +293,9 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
     public partial class UpdateDatabaseDdlMetadata
     {
         /// <summary>
-        /// <see cref="DatabaseName"/>-typed view over the <see cref="Database"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Database.V1.DatabaseName"/>-typed view over the <see cref="Database"/> resource name property.
         /// </summary>
-        public DatabaseName DatabaseAsDatabaseName
+        public Google.Cloud.Spanner.Admin.Database.V1.DatabaseName DatabaseAsDatabaseName
         {
             get { return string.IsNullOrEmpty(Database) ? null : Google.Cloud.Spanner.Admin.Database.V1.DatabaseName.Parse(Database); }
             set { Database = value != null ? value.ToString() : ""; }
@@ -306,9 +306,9 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
     public partial class UpdateDatabaseDdlRequest
     {
         /// <summary>
-        /// <see cref="DatabaseName"/>-typed view over the <see cref="Database"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Database.V1.DatabaseName"/>-typed view over the <see cref="Database"/> resource name property.
         /// </summary>
-        public DatabaseName DatabaseAsDatabaseName
+        public Google.Cloud.Spanner.Admin.Database.V1.DatabaseName DatabaseAsDatabaseName
         {
             get { return string.IsNullOrEmpty(Database) ? null : Google.Cloud.Spanner.Admin.Database.V1.DatabaseName.Parse(Database); }
             set { Database = value != null ? value.ToString() : ""; }

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClient.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClient.cs
@@ -18,10 +18,10 @@ using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using iam = Google.Cloud.Iam.V1;
 using lro = Google.LongRunning;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -79,7 +79,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -107,8 +107,8 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(1000),
-            maxDelay: s::TimeSpan.FromMilliseconds(32000),
+            delay: sys::TimeSpan.FromMilliseconds(1000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(32000),
             delayMultiplier: 1.3
         );
 
@@ -127,8 +127,8 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(60000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(60000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.0
         );
 
@@ -158,7 +158,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -188,7 +188,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -218,7 +218,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -248,7 +248,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -277,7 +277,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -296,10 +296,10 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         public lro::OperationsSettings CreateInstanceOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(86400000L)),
-                s::TimeSpan.FromMilliseconds(20000L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(86400000L)),
+                sys::TimeSpan.FromMilliseconds(20000L),
                 1.5,
-                s::TimeSpan.FromMilliseconds(45000L))
+                sys::TimeSpan.FromMilliseconds(45000L))
         };
 
         /// <summary>
@@ -327,7 +327,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -346,10 +346,10 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         public lro::OperationsSettings UpdateInstanceOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(86400000L)),
-                s::TimeSpan.FromMilliseconds(20000L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(86400000L)),
+                sys::TimeSpan.FromMilliseconds(20000L),
                 1.5,
-                s::TimeSpan.FromMilliseconds(45000L))
+                sys::TimeSpan.FromMilliseconds(45000L))
         };
 
         /// <summary>
@@ -378,7 +378,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -407,7 +407,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -437,7 +437,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -466,7 +466,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -568,7 +568,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// </summary>
         public virtual InstanceAdmin.InstanceAdminClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -657,7 +657,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             ListInstanceConfigsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -676,7 +676,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             ListInstanceConfigsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -758,7 +758,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             GetInstanceConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -795,7 +795,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             GetInstanceConfigRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -882,7 +882,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             ListInstancesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -901,7 +901,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             ListInstancesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -983,7 +983,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             GetInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1020,7 +1020,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             GetInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1273,7 +1273,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             CreateInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1338,7 +1338,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             CreateInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1346,7 +1346,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// </summary>
         public virtual lro::OperationsClient CreateInstanceOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -1422,7 +1422,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// </returns>
         public virtual stt::Task<lro::Operation<Instance, UpdateInstanceMetadata>> UpdateInstanceAsync(
             Instance instance,
-            protowkt::FieldMask fieldMask,
+            pbwkt::FieldMask fieldMask,
             gaxgrpc::CallSettings callSettings = null) => UpdateInstanceAsync(
                 new UpdateInstanceRequest
                 {
@@ -1491,7 +1491,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// </returns>
         public virtual stt::Task<lro::Operation<Instance, UpdateInstanceMetadata>> UpdateInstanceAsync(
             Instance instance,
-            protowkt::FieldMask fieldMask,
+            pbwkt::FieldMask fieldMask,
             st::CancellationToken cancellationToken) => UpdateInstanceAsync(
                 instance,
                 fieldMask,
@@ -1557,7 +1557,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// </returns>
         public virtual lro::Operation<Instance, UpdateInstanceMetadata> UpdateInstance(
             Instance instance,
-            protowkt::FieldMask fieldMask,
+            pbwkt::FieldMask fieldMask,
             gaxgrpc::CallSettings callSettings = null) => UpdateInstance(
                 new UpdateInstanceRequest
                 {
@@ -1621,7 +1621,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             UpdateInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1692,7 +1692,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             UpdateInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1700,7 +1700,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// </summary>
         public virtual lro::OperationsClient UpdateInstanceOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -1832,7 +1832,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             DeleteInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1886,7 +1886,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             DeleteInstanceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2011,7 +2011,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             iam::SetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2056,7 +2056,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             iam::SetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2157,7 +2157,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             iam::GetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2202,7 +2202,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             iam::GetIamPolicyRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2331,7 +2331,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             iam::TestIamPermissionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2378,7 +2378,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             iam::TestIamPermissionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -2394,7 +2394,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         private readonly gaxgrpc::ApiCall<GetInstanceRequest, Instance> _callGetInstance;
         private readonly gaxgrpc::ApiCall<CreateInstanceRequest, lro::Operation> _callCreateInstance;
         private readonly gaxgrpc::ApiCall<UpdateInstanceRequest, lro::Operation> _callUpdateInstance;
-        private readonly gaxgrpc::ApiCall<DeleteInstanceRequest, protowkt::Empty> _callDeleteInstance;
+        private readonly gaxgrpc::ApiCall<DeleteInstanceRequest, pbwkt::Empty> _callDeleteInstance;
         private readonly gaxgrpc::ApiCall<iam::SetIamPolicyRequest, iam::Policy> _callSetIamPolicy;
         private readonly gaxgrpc::ApiCall<iam::GetIamPolicyRequest, iam::Policy> _callGetIamPolicy;
         private readonly gaxgrpc::ApiCall<iam::TestIamPermissionsRequest, iam::TestIamPermissionsResponse> _callTestIamPermissions;
@@ -2425,7 +2425,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
                 GrpcClient.CreateInstanceAsync, GrpcClient.CreateInstance, effectiveSettings.CreateInstanceSettings);
             _callUpdateInstance = clientHelper.BuildApiCall<UpdateInstanceRequest, lro::Operation>(
                 GrpcClient.UpdateInstanceAsync, GrpcClient.UpdateInstance, effectiveSettings.UpdateInstanceSettings);
-            _callDeleteInstance = clientHelper.BuildApiCall<DeleteInstanceRequest, protowkt::Empty>(
+            _callDeleteInstance = clientHelper.BuildApiCall<DeleteInstanceRequest, pbwkt::Empty>(
                 GrpcClient.DeleteInstanceAsync, GrpcClient.DeleteInstance, effectiveSettings.DeleteInstanceSettings);
             _callSetIamPolicy = clientHelper.BuildApiCall<iam::SetIamPolicyRequest, iam::Policy>(
                 GrpcClient.SetIamPolicyAsync, GrpcClient.SetIamPolicy, effectiveSettings.SetIamPolicySettings);
@@ -2461,8 +2461,8 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
@@ -2472,7 +2472,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         partial void Modify_GetInstanceApiCall(ref gaxgrpc::ApiCall<GetInstanceRequest, Instance> call);
         partial void Modify_CreateInstanceApiCall(ref gaxgrpc::ApiCall<CreateInstanceRequest, lro::Operation> call);
         partial void Modify_UpdateInstanceApiCall(ref gaxgrpc::ApiCall<UpdateInstanceRequest, lro::Operation> call);
-        partial void Modify_DeleteInstanceApiCall(ref gaxgrpc::ApiCall<DeleteInstanceRequest, protowkt::Empty> call);
+        partial void Modify_DeleteInstanceApiCall(ref gaxgrpc::ApiCall<DeleteInstanceRequest, pbwkt::Empty> call);
         partial void Modify_SetIamPolicyApiCall(ref gaxgrpc::ApiCall<iam::SetIamPolicyRequest, iam::Policy> call);
         partial void Modify_GetIamPolicyApiCall(ref gaxgrpc::ApiCall<iam::GetIamPolicyRequest, iam::Policy> call);
         partial void Modify_TestIamPermissionsApiCall(ref gaxgrpc::ApiCall<iam::TestIamPermissionsRequest, iam::TestIamPermissionsResponse> call);

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/ResourceNames.cs
@@ -15,15 +15,15 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Spanner.Admin.Instance.V1
 {
     /// <summary>
     /// Resource name for the 'project' resource.
     /// </summary>
-    public sealed partial class ProjectName : gax::IResourceName, s::IEquatable<ProjectName>
+    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
 
@@ -45,7 +45,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <see cref="ProjectName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
@@ -108,7 +108,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
     /// <summary>
     /// Resource name for the 'instance_config' resource.
     /// </summary>
-    public sealed partial class InstanceConfigName : gax::IResourceName, s::IEquatable<InstanceConfigName>
+    public sealed partial class InstanceConfigName : gax::IResourceName, sys::IEquatable<InstanceConfigName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instanceConfigs/{instance_config}");
 
@@ -130,7 +130,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <see cref="InstanceConfigName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="instanceConfigName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="instanceConfigName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="instanceConfigName">The instance_config resource name in string form. Must not be <c>null</c>.</param>
@@ -200,7 +200,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
     /// <summary>
     /// Resource name for the 'instance' resource.
     /// </summary>
-    public sealed partial class InstanceName : gax::IResourceName, s::IEquatable<InstanceName>
+    public sealed partial class InstanceName : gax::IResourceName, sys::IEquatable<InstanceName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}");
 
@@ -222,7 +222,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <see cref="InstanceName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="instanceName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="instanceName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="instanceName">The instance resource name in string form. Must not be <c>null</c>.</param>
@@ -293,18 +293,18 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
     public partial class CreateInstanceRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Instance.V1.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ProjectName ParentAsProjectName
+        public Google.Cloud.Spanner.Admin.Instance.V1.ProjectName ParentAsProjectName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Spanner.Admin.Instance.V1.ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="InstanceId"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Instance.V1.InstanceName"/>-typed view over the <see cref="InstanceId"/> resource name property.
         /// </summary>
-        public InstanceName InstanceIdAsInstanceName
+        public Google.Cloud.Spanner.Admin.Instance.V1.InstanceName InstanceIdAsInstanceName
         {
             get { return string.IsNullOrEmpty(InstanceId) ? null : Google.Cloud.Spanner.Admin.Instance.V1.InstanceName.Parse(InstanceId); }
             set { InstanceId = value != null ? value.ToString() : ""; }
@@ -315,9 +315,9 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
     public partial class DeleteInstanceRequest
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Instance.V1.InstanceName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public InstanceName InstanceName
+        public Google.Cloud.Spanner.Admin.Instance.V1.InstanceName InstanceName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Spanner.Admin.Instance.V1.InstanceName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -328,9 +328,9 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
     public partial class GetInstanceConfigRequest
     {
         /// <summary>
-        /// <see cref="InstanceConfigName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Instance.V1.InstanceConfigName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public InstanceConfigName InstanceConfigName
+        public Google.Cloud.Spanner.Admin.Instance.V1.InstanceConfigName InstanceConfigName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Spanner.Admin.Instance.V1.InstanceConfigName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -341,9 +341,9 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
     public partial class GetInstanceRequest
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Instance.V1.InstanceName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public InstanceName InstanceName
+        public Google.Cloud.Spanner.Admin.Instance.V1.InstanceName InstanceName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Spanner.Admin.Instance.V1.InstanceName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -354,18 +354,18 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
     public partial class Instance
     {
         /// <summary>
-        /// <see cref="InstanceName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Instance.V1.InstanceName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public InstanceName InstanceName
+        public Google.Cloud.Spanner.Admin.Instance.V1.InstanceName InstanceName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Spanner.Admin.Instance.V1.InstanceName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="InstanceConfigName"/>-typed view over the <see cref="Config"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Instance.V1.InstanceConfigName"/>-typed view over the <see cref="Config"/> resource name property.
         /// </summary>
-        public InstanceConfigName ConfigAsInstanceConfigName
+        public Google.Cloud.Spanner.Admin.Instance.V1.InstanceConfigName ConfigAsInstanceConfigName
         {
             get { return string.IsNullOrEmpty(Config) ? null : Google.Cloud.Spanner.Admin.Instance.V1.InstanceConfigName.Parse(Config); }
             set { Config = value != null ? value.ToString() : ""; }
@@ -376,9 +376,9 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
     public partial class InstanceConfig
     {
         /// <summary>
-        /// <see cref="InstanceConfigName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Instance.V1.InstanceConfigName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public InstanceConfigName InstanceConfigName
+        public Google.Cloud.Spanner.Admin.Instance.V1.InstanceConfigName InstanceConfigName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Spanner.Admin.Instance.V1.InstanceConfigName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -389,9 +389,9 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
     public partial class ListInstanceConfigsRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Instance.V1.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ProjectName ParentAsProjectName
+        public Google.Cloud.Spanner.Admin.Instance.V1.ProjectName ParentAsProjectName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Spanner.Admin.Instance.V1.ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
@@ -402,9 +402,9 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
     public partial class ListInstancesRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.Admin.Instance.V1.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public ProjectName ParentAsProjectName
+        public Google.Cloud.Spanner.Admin.Instance.V1.ProjectName ParentAsProjectName
         {
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Spanner.Admin.Instance.V1.ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/SpannerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/SpannerClientSnippets.g.cs
@@ -596,7 +596,7 @@ namespace Google.Cloud.Spanner.V1.Snippets
             SpannerClient spannerClient = await SpannerClient.CreateAsync();
             // Initialize request argument(s)
             SessionName session = new SessionName("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
-            ByteString transactionId = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString transactionId = ByteString.Empty;
             IEnumerable<Mutation> mutations = new List<Mutation>();
             // Make the request
             CommitResponse response = await spannerClient.CommitAsync(session, transactionId, mutations);
@@ -611,7 +611,7 @@ namespace Google.Cloud.Spanner.V1.Snippets
             SpannerClient spannerClient = SpannerClient.Create();
             // Initialize request argument(s)
             SessionName session = new SessionName("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
-            ByteString transactionId = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString transactionId = ByteString.Empty;
             IEnumerable<Mutation> mutations = new List<Mutation>();
             // Make the request
             CommitResponse response = spannerClient.Commit(session, transactionId, mutations);
@@ -693,7 +693,7 @@ namespace Google.Cloud.Spanner.V1.Snippets
             SpannerClient spannerClient = await SpannerClient.CreateAsync();
             // Initialize request argument(s)
             SessionName session = new SessionName("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
-            ByteString transactionId = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString transactionId = ByteString.Empty;
             // Make the request
             await spannerClient.RollbackAsync(session, transactionId);
             // End snippet
@@ -707,7 +707,7 @@ namespace Google.Cloud.Spanner.V1.Snippets
             SpannerClient spannerClient = SpannerClient.Create();
             // Initialize request argument(s)
             SessionName session = new SessionName("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]");
-            ByteString transactionId = Google.Protobuf.ByteString.CopyFromUtf8("");
+            ByteString transactionId = ByteString.Empty;
             // Make the request
             spannerClient.Rollback(session, transactionId);
             // End snippet
@@ -724,7 +724,7 @@ namespace Google.Cloud.Spanner.V1.Snippets
             RollbackRequest request = new RollbackRequest
             {
                 SessionAsSessionName = new SessionName("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]"),
-                TransactionId = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                TransactionId = ByteString.Empty,
             };
             // Make the request
             await spannerClient.RollbackAsync(request);
@@ -741,7 +741,7 @@ namespace Google.Cloud.Spanner.V1.Snippets
             RollbackRequest request = new RollbackRequest
             {
                 SessionAsSessionName = new SessionName("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]"),
-                TransactionId = Google.Protobuf.ByteString.CopyFromUtf8(""),
+                TransactionId = ByteString.Empty,
             };
             // Make the request
             spannerClient.Rollback(request);

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ResourceNames.cs
@@ -15,15 +15,15 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Spanner.V1
 {
     /// <summary>
     /// Resource name for the 'database' resource.
     /// </summary>
-    public sealed partial class DatabaseName : gax::IResourceName, s::IEquatable<DatabaseName>
+    public sealed partial class DatabaseName : gax::IResourceName, sys::IEquatable<DatabaseName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}/databases/{database}");
 
@@ -45,7 +45,7 @@ namespace Google.Cloud.Spanner.V1
         /// <see cref="DatabaseName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="databaseName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="databaseName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="databaseName">The database resource name in string form. Must not be <c>null</c>.</param>
@@ -122,7 +122,7 @@ namespace Google.Cloud.Spanner.V1
     /// <summary>
     /// Resource name for the 'session' resource.
     /// </summary>
-    public sealed partial class SessionName : gax::IResourceName, s::IEquatable<SessionName>
+    public sealed partial class SessionName : gax::IResourceName, sys::IEquatable<SessionName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}/databases/{database}/sessions/{session}");
 
@@ -144,7 +144,7 @@ namespace Google.Cloud.Spanner.V1
         /// <see cref="SessionName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="sessionName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="sessionName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="sessionName">The session resource name in string form. Must not be <c>null</c>.</param>
@@ -229,9 +229,9 @@ namespace Google.Cloud.Spanner.V1
     public partial class BeginTransactionRequest
     {
         /// <summary>
-        /// <see cref="SessionName"/>-typed view over the <see cref="Session"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.V1.SessionName"/>-typed view over the <see cref="Session"/> resource name property.
         /// </summary>
-        public SessionName SessionAsSessionName
+        public Google.Cloud.Spanner.V1.SessionName SessionAsSessionName
         {
             get { return string.IsNullOrEmpty(Session) ? null : Google.Cloud.Spanner.V1.SessionName.Parse(Session); }
             set { Session = value != null ? value.ToString() : ""; }
@@ -242,9 +242,9 @@ namespace Google.Cloud.Spanner.V1
     public partial class CommitRequest
     {
         /// <summary>
-        /// <see cref="SessionName"/>-typed view over the <see cref="Session"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.V1.SessionName"/>-typed view over the <see cref="Session"/> resource name property.
         /// </summary>
-        public SessionName SessionAsSessionName
+        public Google.Cloud.Spanner.V1.SessionName SessionAsSessionName
         {
             get { return string.IsNullOrEmpty(Session) ? null : Google.Cloud.Spanner.V1.SessionName.Parse(Session); }
             set { Session = value != null ? value.ToString() : ""; }
@@ -255,9 +255,9 @@ namespace Google.Cloud.Spanner.V1
     public partial class CreateSessionRequest
     {
         /// <summary>
-        /// <see cref="DatabaseName"/>-typed view over the <see cref="Database"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.V1.DatabaseName"/>-typed view over the <see cref="Database"/> resource name property.
         /// </summary>
-        public DatabaseName DatabaseAsDatabaseName
+        public Google.Cloud.Spanner.V1.DatabaseName DatabaseAsDatabaseName
         {
             get { return string.IsNullOrEmpty(Database) ? null : Google.Cloud.Spanner.V1.DatabaseName.Parse(Database); }
             set { Database = value != null ? value.ToString() : ""; }
@@ -268,9 +268,9 @@ namespace Google.Cloud.Spanner.V1
     public partial class DeleteSessionRequest
     {
         /// <summary>
-        /// <see cref="SessionName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.V1.SessionName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public SessionName SessionName
+        public Google.Cloud.Spanner.V1.SessionName SessionName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Spanner.V1.SessionName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -281,9 +281,9 @@ namespace Google.Cloud.Spanner.V1
     public partial class ExecuteSqlRequest
     {
         /// <summary>
-        /// <see cref="SessionName"/>-typed view over the <see cref="Session"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.V1.SessionName"/>-typed view over the <see cref="Session"/> resource name property.
         /// </summary>
-        public SessionName SessionAsSessionName
+        public Google.Cloud.Spanner.V1.SessionName SessionAsSessionName
         {
             get { return string.IsNullOrEmpty(Session) ? null : Google.Cloud.Spanner.V1.SessionName.Parse(Session); }
             set { Session = value != null ? value.ToString() : ""; }
@@ -294,9 +294,9 @@ namespace Google.Cloud.Spanner.V1
     public partial class GetSessionRequest
     {
         /// <summary>
-        /// <see cref="SessionName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.V1.SessionName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public SessionName SessionName
+        public Google.Cloud.Spanner.V1.SessionName SessionName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Spanner.V1.SessionName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -307,9 +307,9 @@ namespace Google.Cloud.Spanner.V1
     public partial class ReadRequest
     {
         /// <summary>
-        /// <see cref="SessionName"/>-typed view over the <see cref="Session"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.V1.SessionName"/>-typed view over the <see cref="Session"/> resource name property.
         /// </summary>
-        public SessionName SessionAsSessionName
+        public Google.Cloud.Spanner.V1.SessionName SessionAsSessionName
         {
             get { return string.IsNullOrEmpty(Session) ? null : Google.Cloud.Spanner.V1.SessionName.Parse(Session); }
             set { Session = value != null ? value.ToString() : ""; }
@@ -320,9 +320,9 @@ namespace Google.Cloud.Spanner.V1
     public partial class RollbackRequest
     {
         /// <summary>
-        /// <see cref="SessionName"/>-typed view over the <see cref="Session"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.V1.SessionName"/>-typed view over the <see cref="Session"/> resource name property.
         /// </summary>
-        public SessionName SessionAsSessionName
+        public Google.Cloud.Spanner.V1.SessionName SessionAsSessionName
         {
             get { return string.IsNullOrEmpty(Session) ? null : Google.Cloud.Spanner.V1.SessionName.Parse(Session); }
             set { Session = value != null ? value.ToString() : ""; }
@@ -333,9 +333,9 @@ namespace Google.Cloud.Spanner.V1
     public partial class Session
     {
         /// <summary>
-        /// <see cref="SessionName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Spanner.V1.SessionName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public SessionName SessionName
+        public Google.Cloud.Spanner.V1.SessionName SessionName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Spanner.V1.SessionName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -78,7 +78,7 @@ namespace Google.Cloud.Spanner.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace Google.Cloud.Spanner.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace Google.Cloud.Spanner.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> LongRunningRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> LongRunningRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -119,8 +119,8 @@ namespace Google.Cloud.Spanner.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(1000),
-            maxDelay: s::TimeSpan.FromMilliseconds(32000),
+            delay: sys::TimeSpan.FromMilliseconds(1000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(32000),
             delayMultiplier: 1.3
         );
 
@@ -139,8 +139,8 @@ namespace Google.Cloud.Spanner.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(60000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(60000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.0
         );
 
@@ -159,8 +159,8 @@ namespace Google.Cloud.Spanner.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetLongRunningRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(1000),
-            maxDelay: s::TimeSpan.FromMilliseconds(32000),
+            delay: sys::TimeSpan.FromMilliseconds(1000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(32000),
             delayMultiplier: 1.3
         );
 
@@ -179,8 +179,8 @@ namespace Google.Cloud.Spanner.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetLongRunningTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(3600000),
-            maxDelay: s::TimeSpan.FromMilliseconds(3600000),
+            delay: sys::TimeSpan.FromMilliseconds(3600000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(3600000),
             delayMultiplier: 1.0
         );
 
@@ -210,7 +210,7 @@ namespace Google.Cloud.Spanner.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -240,7 +240,7 @@ namespace Google.Cloud.Spanner.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -270,7 +270,7 @@ namespace Google.Cloud.Spanner.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -300,7 +300,7 @@ namespace Google.Cloud.Spanner.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -330,7 +330,7 @@ namespace Google.Cloud.Spanner.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -341,7 +341,7 @@ namespace Google.Cloud.Spanner.V1
         /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings ExecuteStreamingSqlSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
-            gaxgrpc::CallTiming.FromTimeout(s::TimeSpan.FromMilliseconds(600000)));
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)));
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
@@ -369,7 +369,7 @@ namespace Google.Cloud.Spanner.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -380,7 +380,7 @@ namespace Google.Cloud.Spanner.V1
         /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings StreamingReadSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
-            gaxgrpc::CallTiming.FromTimeout(s::TimeSpan.FromMilliseconds(600000)));
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)));
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
@@ -408,7 +408,7 @@ namespace Google.Cloud.Spanner.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -437,7 +437,7 @@ namespace Google.Cloud.Spanner.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetLongRunningRetryBackoff(),
                 timeoutBackoff: GetLongRunningTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(3600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(3600000)),
                 retryFilter: LongRunningRetryFilter
             )));
 
@@ -467,7 +467,7 @@ namespace Google.Cloud.Spanner.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -497,7 +497,7 @@ namespace Google.Cloud.Spanner.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -527,7 +527,7 @@ namespace Google.Cloud.Spanner.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -629,7 +629,7 @@ namespace Google.Cloud.Spanner.V1
         /// </summary>
         public virtual Spanner.SpannerClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -780,7 +780,7 @@ namespace Google.Cloud.Spanner.V1
             CreateSessionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -853,7 +853,7 @@ namespace Google.Cloud.Spanner.V1
             CreateSessionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -940,7 +940,7 @@ namespace Google.Cloud.Spanner.V1
             GetSessionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -981,7 +981,7 @@ namespace Google.Cloud.Spanner.V1
             GetSessionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1066,7 +1066,7 @@ namespace Google.Cloud.Spanner.V1
             ListSessionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1085,7 +1085,7 @@ namespace Google.Cloud.Spanner.V1
             ListSessionsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1161,7 +1161,7 @@ namespace Google.Cloud.Spanner.V1
             DeleteSessionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1195,7 +1195,7 @@ namespace Google.Cloud.Spanner.V1
             DeleteSessionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1224,7 +1224,7 @@ namespace Google.Cloud.Spanner.V1
             ExecuteSqlRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1281,7 +1281,7 @@ namespace Google.Cloud.Spanner.V1
             ExecuteSqlRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1304,7 +1304,7 @@ namespace Google.Cloud.Spanner.V1
             ExecuteSqlRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1342,7 +1342,7 @@ namespace Google.Cloud.Spanner.V1
             ReadRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1403,7 +1403,7 @@ namespace Google.Cloud.Spanner.V1
             ReadRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1426,7 +1426,7 @@ namespace Google.Cloud.Spanner.V1
             ReadRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1539,7 +1539,7 @@ namespace Google.Cloud.Spanner.V1
             BeginTransactionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1582,7 +1582,7 @@ namespace Google.Cloud.Spanner.V1
             BeginTransactionRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1614,13 +1614,13 @@ namespace Google.Cloud.Spanner.V1
         /// </returns>
         public virtual stt::Task<CommitResponse> CommitAsync(
             SessionName session,
-            proto::ByteString transactionId,
+            pb::ByteString transactionId,
             scg::IEnumerable<Mutation> mutations,
             gaxgrpc::CallSettings callSettings = null) => CommitAsync(
                 new CommitRequest
                 {
                     SessionAsSessionName = gax::GaxPreconditions.CheckNotNull(session, nameof(session)),
-                    TransactionId = transactionId ?? Google.Protobuf.ByteString.Empty, // Optional
+                    TransactionId = transactionId ?? pb::ByteString.Empty, // Optional
                     Mutations = { gax::GaxPreconditions.CheckNotNull(mutations, nameof(mutations)) },
                 },
                 callSettings);
@@ -1654,7 +1654,7 @@ namespace Google.Cloud.Spanner.V1
         /// </returns>
         public virtual stt::Task<CommitResponse> CommitAsync(
             SessionName session,
-            proto::ByteString transactionId,
+            pb::ByteString transactionId,
             scg::IEnumerable<Mutation> mutations,
             st::CancellationToken cancellationToken) => CommitAsync(
                 session,
@@ -1691,13 +1691,13 @@ namespace Google.Cloud.Spanner.V1
         /// </returns>
         public virtual CommitResponse Commit(
             SessionName session,
-            proto::ByteString transactionId,
+            pb::ByteString transactionId,
             scg::IEnumerable<Mutation> mutations,
             gaxgrpc::CallSettings callSettings = null) => Commit(
                 new CommitRequest
                 {
                     SessionAsSessionName = gax::GaxPreconditions.CheckNotNull(session, nameof(session)),
-                    TransactionId = transactionId ?? Google.Protobuf.ByteString.Empty, // Optional
+                    TransactionId = transactionId ?? pb::ByteString.Empty, // Optional
                     Mutations = { gax::GaxPreconditions.CheckNotNull(mutations, nameof(mutations)) },
                 },
                 callSettings);
@@ -1866,7 +1866,7 @@ namespace Google.Cloud.Spanner.V1
             CommitRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1917,7 +1917,7 @@ namespace Google.Cloud.Spanner.V1
             CommitRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -1944,7 +1944,7 @@ namespace Google.Cloud.Spanner.V1
         /// </returns>
         public virtual stt::Task RollbackAsync(
             SessionName session,
-            proto::ByteString transactionId,
+            pb::ByteString transactionId,
             gaxgrpc::CallSettings callSettings = null) => RollbackAsync(
                 new RollbackRequest
                 {
@@ -1977,7 +1977,7 @@ namespace Google.Cloud.Spanner.V1
         /// </returns>
         public virtual stt::Task RollbackAsync(
             SessionName session,
-            proto::ByteString transactionId,
+            pb::ByteString transactionId,
             st::CancellationToken cancellationToken) => RollbackAsync(
                 session,
                 transactionId,
@@ -2004,7 +2004,7 @@ namespace Google.Cloud.Spanner.V1
         /// </param>
         public virtual void Rollback(
             SessionName session,
-            proto::ByteString transactionId,
+            pb::ByteString transactionId,
             gaxgrpc::CallSettings callSettings = null) => Rollback(
                 new RollbackRequest
                 {
@@ -2036,7 +2036,7 @@ namespace Google.Cloud.Spanner.V1
             RollbackRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2084,7 +2084,7 @@ namespace Google.Cloud.Spanner.V1
             RollbackRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2110,7 +2110,7 @@ namespace Google.Cloud.Spanner.V1
             PartitionQueryRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2161,7 +2161,7 @@ namespace Google.Cloud.Spanner.V1
             PartitionQueryRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2187,7 +2187,7 @@ namespace Google.Cloud.Spanner.V1
             PartitionReadRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -2238,7 +2238,7 @@ namespace Google.Cloud.Spanner.V1
             PartitionReadRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -2251,14 +2251,14 @@ namespace Google.Cloud.Spanner.V1
         private readonly gaxgrpc::ApiCall<CreateSessionRequest, Session> _callCreateSession;
         private readonly gaxgrpc::ApiCall<GetSessionRequest, Session> _callGetSession;
         private readonly gaxgrpc::ApiCall<ListSessionsRequest, ListSessionsResponse> _callListSessions;
-        private readonly gaxgrpc::ApiCall<DeleteSessionRequest, protowkt::Empty> _callDeleteSession;
+        private readonly gaxgrpc::ApiCall<DeleteSessionRequest, pbwkt::Empty> _callDeleteSession;
         private readonly gaxgrpc::ApiCall<ExecuteSqlRequest, ResultSet> _callExecuteSql;
         private readonly gaxgrpc::ApiServerStreamingCall<ExecuteSqlRequest, PartialResultSet> _callExecuteStreamingSql;
         private readonly gaxgrpc::ApiCall<ReadRequest, ResultSet> _callRead;
         private readonly gaxgrpc::ApiServerStreamingCall<ReadRequest, PartialResultSet> _callStreamingRead;
         private readonly gaxgrpc::ApiCall<BeginTransactionRequest, Transaction> _callBeginTransaction;
         private readonly gaxgrpc::ApiCall<CommitRequest, CommitResponse> _callCommit;
-        private readonly gaxgrpc::ApiCall<RollbackRequest, protowkt::Empty> _callRollback;
+        private readonly gaxgrpc::ApiCall<RollbackRequest, pbwkt::Empty> _callRollback;
         private readonly gaxgrpc::ApiCall<PartitionQueryRequest, PartitionResponse> _callPartitionQuery;
         private readonly gaxgrpc::ApiCall<PartitionReadRequest, PartitionResponse> _callPartitionRead;
 
@@ -2278,7 +2278,7 @@ namespace Google.Cloud.Spanner.V1
                 GrpcClient.GetSessionAsync, GrpcClient.GetSession, effectiveSettings.GetSessionSettings);
             _callListSessions = clientHelper.BuildApiCall<ListSessionsRequest, ListSessionsResponse>(
                 GrpcClient.ListSessionsAsync, GrpcClient.ListSessions, effectiveSettings.ListSessionsSettings);
-            _callDeleteSession = clientHelper.BuildApiCall<DeleteSessionRequest, protowkt::Empty>(
+            _callDeleteSession = clientHelper.BuildApiCall<DeleteSessionRequest, pbwkt::Empty>(
                 GrpcClient.DeleteSessionAsync, GrpcClient.DeleteSession, effectiveSettings.DeleteSessionSettings);
             _callExecuteSql = clientHelper.BuildApiCall<ExecuteSqlRequest, ResultSet>(
                 GrpcClient.ExecuteSqlAsync, GrpcClient.ExecuteSql, effectiveSettings.ExecuteSqlSettings);
@@ -2292,7 +2292,7 @@ namespace Google.Cloud.Spanner.V1
                 GrpcClient.BeginTransactionAsync, GrpcClient.BeginTransaction, effectiveSettings.BeginTransactionSettings);
             _callCommit = clientHelper.BuildApiCall<CommitRequest, CommitResponse>(
                 GrpcClient.CommitAsync, GrpcClient.Commit, effectiveSettings.CommitSettings);
-            _callRollback = clientHelper.BuildApiCall<RollbackRequest, protowkt::Empty>(
+            _callRollback = clientHelper.BuildApiCall<RollbackRequest, pbwkt::Empty>(
                 GrpcClient.RollbackAsync, GrpcClient.Rollback, effectiveSettings.RollbackSettings);
             _callPartitionQuery = clientHelper.BuildApiCall<PartitionQueryRequest, PartitionResponse>(
                 GrpcClient.PartitionQueryAsync, GrpcClient.PartitionQuery, effectiveSettings.PartitionQuerySettings);
@@ -2332,25 +2332,25 @@ namespace Google.Cloud.Spanner.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiServerStreamingCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
         partial void Modify_CreateSessionApiCall(ref gaxgrpc::ApiCall<CreateSessionRequest, Session> call);
         partial void Modify_GetSessionApiCall(ref gaxgrpc::ApiCall<GetSessionRequest, Session> call);
         partial void Modify_ListSessionsApiCall(ref gaxgrpc::ApiCall<ListSessionsRequest, ListSessionsResponse> call);
-        partial void Modify_DeleteSessionApiCall(ref gaxgrpc::ApiCall<DeleteSessionRequest, protowkt::Empty> call);
+        partial void Modify_DeleteSessionApiCall(ref gaxgrpc::ApiCall<DeleteSessionRequest, pbwkt::Empty> call);
         partial void Modify_ExecuteSqlApiCall(ref gaxgrpc::ApiCall<ExecuteSqlRequest, ResultSet> call);
         partial void Modify_ExecuteStreamingSqlApiCall(ref gaxgrpc::ApiServerStreamingCall<ExecuteSqlRequest, PartialResultSet> call);
         partial void Modify_ReadApiCall(ref gaxgrpc::ApiCall<ReadRequest, ResultSet> call);
         partial void Modify_StreamingReadApiCall(ref gaxgrpc::ApiServerStreamingCall<ReadRequest, PartialResultSet> call);
         partial void Modify_BeginTransactionApiCall(ref gaxgrpc::ApiCall<BeginTransactionRequest, Transaction> call);
         partial void Modify_CommitApiCall(ref gaxgrpc::ApiCall<CommitRequest, CommitResponse> call);
-        partial void Modify_RollbackApiCall(ref gaxgrpc::ApiCall<RollbackRequest, protowkt::Empty> call);
+        partial void Modify_RollbackApiCall(ref gaxgrpc::ApiCall<RollbackRequest, pbwkt::Empty> call);
         partial void Modify_PartitionQueryApiCall(ref gaxgrpc::ApiCall<PartitionQueryRequest, PartitionResponse> call);
         partial void Modify_PartitionReadApiCall(ref gaxgrpc::ApiCall<PartitionReadRequest, PartitionResponse> call);
         partial void OnConstruction(Spanner.SpannerClient grpcClient, SpannerSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/ResourceNames.cs
@@ -15,8 +15,8 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Speech.V1
 {

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.cs
@@ -17,10 +17,10 @@
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using lro = Google.LongRunning;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -71,7 +71,7 @@ namespace Google.Cloud.Speech.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace Google.Cloud.Speech.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -99,8 +99,8 @@ namespace Google.Cloud.Speech.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -119,8 +119,8 @@ namespace Google.Cloud.Speech.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(1000000),
-            maxDelay: s::TimeSpan.FromMilliseconds(1000000),
+            delay: sys::TimeSpan.FromMilliseconds(1000000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(1000000),
             delayMultiplier: 1.0
         );
 
@@ -150,7 +150,7 @@ namespace Google.Cloud.Speech.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(5000000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(5000000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -179,7 +179,7 @@ namespace Google.Cloud.Speech.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(5000000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(5000000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -198,10 +198,10 @@ namespace Google.Cloud.Speech.V1
         public lro::OperationsSettings LongRunningRecognizeOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(86400000L)),
-                s::TimeSpan.FromMilliseconds(20000L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(86400000L)),
+                sys::TimeSpan.FromMilliseconds(20000L),
                 1.5,
-                s::TimeSpan.FromMilliseconds(45000L))
+                sys::TimeSpan.FromMilliseconds(45000L))
         };
 
         /// <summary>
@@ -211,7 +211,7 @@ namespace Google.Cloud.Speech.V1
         /// Default RPC expiration is 5000000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings StreamingRecognizeSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
-            gaxgrpc::CallTiming.FromTimeout(s::TimeSpan.FromMilliseconds(5000000)));
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(5000000)));
 
         /// <summary>
         /// <see cref="gaxgrpc::BidirectionalStreamingSettings"/> for calls to
@@ -319,7 +319,7 @@ namespace Google.Cloud.Speech.V1
         /// </summary>
         public virtual Speech.SpeechClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -420,7 +420,7 @@ namespace Google.Cloud.Speech.V1
             RecognizeRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -459,7 +459,7 @@ namespace Google.Cloud.Speech.V1
             RecognizeRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -568,7 +568,7 @@ namespace Google.Cloud.Speech.V1
             LongRunningRecognizeRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -603,7 +603,7 @@ namespace Google.Cloud.Speech.V1
             LongRunningRecognizeRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -611,7 +611,7 @@ namespace Google.Cloud.Speech.V1
         /// </summary>
         public virtual lro::OperationsClient LongRunningRecognizeOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -644,7 +644,7 @@ namespace Google.Cloud.Speech.V1
             gaxgrpc::CallSettings callSettings = null,
             gaxgrpc::BidirectionalStreamingSettings streamingSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -697,11 +697,11 @@ namespace Google.Cloud.Speech.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiBidirectionalStreamingCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/ResourceNames.cs
@@ -15,8 +15,8 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Trace.V1
 {

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/TraceServiceClient.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/TraceServiceClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -68,7 +68,7 @@ namespace Google.Cloud.Trace.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Google.Cloud.Trace.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -96,8 +96,8 @@ namespace Google.Cloud.Trace.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(1000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(1000),
             delayMultiplier: 1.2
         );
 
@@ -116,8 +116,8 @@ namespace Google.Cloud.Trace.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(20000),
-            maxDelay: s::TimeSpan.FromMilliseconds(30000),
+            delay: sys::TimeSpan.FromMilliseconds(20000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(30000),
             delayMultiplier: 1.5
         );
 
@@ -147,7 +147,7 @@ namespace Google.Cloud.Trace.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(45000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(45000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -177,7 +177,7 @@ namespace Google.Cloud.Trace.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(45000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(45000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -207,7 +207,7 @@ namespace Google.Cloud.Trace.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(45000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(45000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -311,7 +311,7 @@ namespace Google.Cloud.Trace.V1
         /// </summary>
         public virtual TraceService.TraceServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -418,7 +418,7 @@ namespace Google.Cloud.Trace.V1
             PatchTracesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -460,7 +460,7 @@ namespace Google.Cloud.Trace.V1
             PatchTracesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -554,7 +554,7 @@ namespace Google.Cloud.Trace.V1
             GetTraceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -591,7 +591,7 @@ namespace Google.Cloud.Trace.V1
             GetTraceRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -676,7 +676,7 @@ namespace Google.Cloud.Trace.V1
             ListTracesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -695,7 +695,7 @@ namespace Google.Cloud.Trace.V1
             ListTracesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -705,7 +705,7 @@ namespace Google.Cloud.Trace.V1
     /// </summary>
     public sealed partial class TraceServiceClientImpl : TraceServiceClient
     {
-        private readonly gaxgrpc::ApiCall<PatchTracesRequest, protowkt::Empty> _callPatchTraces;
+        private readonly gaxgrpc::ApiCall<PatchTracesRequest, pbwkt::Empty> _callPatchTraces;
         private readonly gaxgrpc::ApiCall<GetTraceRequest, Trace> _callGetTrace;
         private readonly gaxgrpc::ApiCall<ListTracesRequest, ListTracesResponse> _callListTraces;
 
@@ -719,7 +719,7 @@ namespace Google.Cloud.Trace.V1
             GrpcClient = grpcClient;
             TraceServiceSettings effectiveSettings = settings ?? TraceServiceSettings.GetDefault();
             gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callPatchTraces = clientHelper.BuildApiCall<PatchTracesRequest, protowkt::Empty>(
+            _callPatchTraces = clientHelper.BuildApiCall<PatchTracesRequest, pbwkt::Empty>(
                 GrpcClient.PatchTracesAsync, GrpcClient.PatchTraces, effectiveSettings.PatchTracesSettings);
             _callGetTrace = clientHelper.BuildApiCall<GetTraceRequest, Trace>(
                 GrpcClient.GetTraceAsync, GrpcClient.GetTrace, effectiveSettings.GetTraceSettings);
@@ -739,12 +739,12 @@ namespace Google.Cloud.Trace.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
-        partial void Modify_PatchTracesApiCall(ref gaxgrpc::ApiCall<PatchTracesRequest, protowkt::Empty> call);
+        partial void Modify_PatchTracesApiCall(ref gaxgrpc::ApiCall<PatchTracesRequest, pbwkt::Empty> call);
         partial void Modify_GetTraceApiCall(ref gaxgrpc::ApiCall<GetTraceRequest, Trace> call);
         partial void Modify_ListTracesApiCall(ref gaxgrpc::ApiCall<ListTracesRequest, ListTracesResponse> call);
         partial void OnConstruction(TraceService.TraceServiceClient grpcClient, TraceServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/ResourceNames.cs
@@ -15,15 +15,15 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Trace.V2
 {
     /// <summary>
     /// Resource name for the 'project' resource.
     /// </summary>
-    public sealed partial class ProjectName : gax::IResourceName, s::IEquatable<ProjectName>
+    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
 
@@ -45,7 +45,7 @@ namespace Google.Cloud.Trace.V2
         /// <see cref="ProjectName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
@@ -108,7 +108,7 @@ namespace Google.Cloud.Trace.V2
     /// <summary>
     /// Resource name for the 'span' resource.
     /// </summary>
-    public sealed partial class SpanName : gax::IResourceName, s::IEquatable<SpanName>
+    public sealed partial class SpanName : gax::IResourceName, sys::IEquatable<SpanName>
     {
         private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/traces/{trace}/spans/{span}");
 
@@ -130,7 +130,7 @@ namespace Google.Cloud.Trace.V2
         /// <see cref="SpanName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="spanName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="spanName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="spanName">The span resource name in string form. Must not be <c>null</c>.</param>
@@ -208,9 +208,9 @@ namespace Google.Cloud.Trace.V2
     public partial class BatchWriteSpansRequest
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Trace.V2.ProjectName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ProjectName ProjectName
+        public Google.Cloud.Trace.V2.ProjectName ProjectName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Trace.V2.ProjectName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
@@ -221,9 +221,9 @@ namespace Google.Cloud.Trace.V2
     public partial class Span
     {
         /// <summary>
-        /// <see cref="SpanName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Cloud.Trace.V2.SpanName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public SpanName SpanName
+        public Google.Cloud.Trace.V2.SpanName SpanName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Cloud.Trace.V2.SpanName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceServiceClient.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceServiceClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -67,7 +67,7 @@ namespace Google.Cloud.Trace.V2
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace Google.Cloud.Trace.V2
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -95,8 +95,8 @@ namespace Google.Cloud.Trace.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(1000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(1000),
             delayMultiplier: 1.2
         );
 
@@ -115,8 +115,8 @@ namespace Google.Cloud.Trace.V2
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(30000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(30000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.5
         );
 
@@ -145,7 +145,7 @@ namespace Google.Cloud.Trace.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(120000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(120000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
 
@@ -175,7 +175,7 @@ namespace Google.Cloud.Trace.V2
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(120000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(120000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -277,7 +277,7 @@ namespace Google.Cloud.Trace.V2
         /// </summary>
         public virtual TraceService.TraceServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -378,7 +378,7 @@ namespace Google.Cloud.Trace.V2
             BatchWriteSpansRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace Google.Cloud.Trace.V2
             BatchWriteSpansRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -433,7 +433,7 @@ namespace Google.Cloud.Trace.V2
             Span request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -470,7 +470,7 @@ namespace Google.Cloud.Trace.V2
             Span request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -480,7 +480,7 @@ namespace Google.Cloud.Trace.V2
     /// </summary>
     public sealed partial class TraceServiceClientImpl : TraceServiceClient
     {
-        private readonly gaxgrpc::ApiCall<BatchWriteSpansRequest, protowkt::Empty> _callBatchWriteSpans;
+        private readonly gaxgrpc::ApiCall<BatchWriteSpansRequest, pbwkt::Empty> _callBatchWriteSpans;
         private readonly gaxgrpc::ApiCall<Span, Span> _callCreateSpan;
 
         /// <summary>
@@ -493,7 +493,7 @@ namespace Google.Cloud.Trace.V2
             GrpcClient = grpcClient;
             TraceServiceSettings effectiveSettings = settings ?? TraceServiceSettings.GetDefault();
             gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callBatchWriteSpans = clientHelper.BuildApiCall<BatchWriteSpansRequest, protowkt::Empty>(
+            _callBatchWriteSpans = clientHelper.BuildApiCall<BatchWriteSpansRequest, pbwkt::Empty>(
                 GrpcClient.BatchWriteSpansAsync, GrpcClient.BatchWriteSpans, effectiveSettings.BatchWriteSpansSettings);
             _callCreateSpan = clientHelper.BuildApiCall<Span, Span>(
                 GrpcClient.CreateSpanAsync, GrpcClient.CreateSpan, effectiveSettings.CreateSpanSettings);
@@ -509,12 +509,12 @@ namespace Google.Cloud.Trace.V2
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
-        partial void Modify_BatchWriteSpansApiCall(ref gaxgrpc::ApiCall<BatchWriteSpansRequest, protowkt::Empty> call);
+        partial void Modify_BatchWriteSpansApiCall(ref gaxgrpc::ApiCall<BatchWriteSpansRequest, pbwkt::Empty> call);
         partial void Modify_CreateSpanApiCall(ref gaxgrpc::ApiCall<Span, Span> call);
         partial void OnConstruction(TraceService.TraceServiceClient grpcClient, TraceServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/ResourceNames.cs
@@ -15,8 +15,8 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.VideoIntelligence.V1
 {

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/VideoIntelligenceServiceClient.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/VideoIntelligenceServiceClient.cs
@@ -17,14 +17,14 @@
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using lro = Google.LongRunning;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
-using System.Linq;
+using linq = System.Linq;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
 
@@ -69,7 +69,7 @@ namespace Google.Cloud.VideoIntelligence.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace Google.Cloud.VideoIntelligence.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -97,8 +97,8 @@ namespace Google.Cloud.VideoIntelligence.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(1000),
-            maxDelay: s::TimeSpan.FromMilliseconds(120000),
+            delay: sys::TimeSpan.FromMilliseconds(1000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(120000),
             delayMultiplier: 2.5
         );
 
@@ -117,8 +117,8 @@ namespace Google.Cloud.VideoIntelligence.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(120000),
-            maxDelay: s::TimeSpan.FromMilliseconds(120000),
+            delay: sys::TimeSpan.FromMilliseconds(120000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(120000),
             delayMultiplier: 1.0
         );
 
@@ -148,7 +148,7 @@ namespace Google.Cloud.VideoIntelligence.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -167,10 +167,10 @@ namespace Google.Cloud.VideoIntelligence.V1
         public lro::OperationsSettings AnnotateVideoOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(86400000L)),
-                s::TimeSpan.FromMilliseconds(20000L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(86400000L)),
+                sys::TimeSpan.FromMilliseconds(20000L),
                 1.5,
-                s::TimeSpan.FromMilliseconds(45000L))
+                sys::TimeSpan.FromMilliseconds(45000L))
         };
 
         /// <summary>
@@ -269,7 +269,7 @@ namespace Google.Cloud.VideoIntelligence.V1
         /// </summary>
         public virtual VideoIntelligenceService.VideoIntelligenceServiceClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -306,7 +306,7 @@ namespace Google.Cloud.VideoIntelligence.V1
                 new AnnotateVideoRequest
                 {
                     InputUri = inputUri ?? "", // Optional
-                    Features = { features ?? Enumerable.Empty<Feature>() }, // Optional
+                    Features = { features ?? linq::Enumerable.Empty<Feature>() }, // Optional
                 },
                 callSettings);
 
@@ -379,7 +379,7 @@ namespace Google.Cloud.VideoIntelligence.V1
                 new AnnotateVideoRequest
                 {
                     InputUri = inputUri ?? "", // Optional
-                    Features = { features ?? Enumerable.Empty<Feature>() }, // Optional
+                    Features = { features ?? linq::Enumerable.Empty<Feature>() }, // Optional
                 },
                 callSettings);
 
@@ -402,7 +402,7 @@ namespace Google.Cloud.VideoIntelligence.V1
             AnnotateVideoRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -437,7 +437,7 @@ namespace Google.Cloud.VideoIntelligence.V1
             AnnotateVideoRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -445,7 +445,7 @@ namespace Google.Cloud.VideoIntelligence.V1
         /// </summary>
         public virtual lro::OperationsClient AnnotateVideoOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -494,8 +494,8 @@ namespace Google.Cloud.VideoIntelligence.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -66,7 +66,7 @@ namespace Google.Cloud.Vision.V1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Google.Cloud.Vision.V1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -94,8 +94,8 @@ namespace Google.Cloud.Vision.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -114,8 +114,8 @@ namespace Google.Cloud.Vision.V1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(60000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(60000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.0
         );
 
@@ -145,7 +145,7 @@ namespace Google.Cloud.Vision.V1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -247,7 +247,7 @@ namespace Google.Cloud.Vision.V1
         /// </summary>
         public virtual ImageAnnotator.ImageAnnotatorClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -326,7 +326,7 @@ namespace Google.Cloud.Vision.V1
             BatchAnnotateImagesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -363,7 +363,7 @@ namespace Google.Cloud.Vision.V1
             BatchAnnotateImagesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -397,8 +397,8 @@ namespace Google.Cloud.Vision.V1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ResourceNames.cs
@@ -15,8 +15,8 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Vision.V1
 {

--- a/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1/ImageAnnotatorClient.cs
+++ b/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1/ImageAnnotatorClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -66,7 +66,7 @@ namespace Google.Cloud.Vision.V1P1Beta1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Google.Cloud.Vision.V1P1Beta1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -94,8 +94,8 @@ namespace Google.Cloud.Vision.V1P1Beta1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -114,8 +114,8 @@ namespace Google.Cloud.Vision.V1P1Beta1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(60000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(60000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.0
         );
 
@@ -145,7 +145,7 @@ namespace Google.Cloud.Vision.V1P1Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -247,7 +247,7 @@ namespace Google.Cloud.Vision.V1P1Beta1
         /// </summary>
         public virtual ImageAnnotator.ImageAnnotatorClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -326,7 +326,7 @@ namespace Google.Cloud.Vision.V1P1Beta1
             BatchAnnotateImagesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -363,7 +363,7 @@ namespace Google.Cloud.Vision.V1P1Beta1
             BatchAnnotateImagesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -397,8 +397,8 @@ namespace Google.Cloud.Vision.V1P1Beta1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.

--- a/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1/ResourceNames.cs
+++ b/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1/ResourceNames.cs
@@ -15,8 +15,8 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Vision.V1P1Beta1
 {

--- a/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1/ImageAnnotatorClient.cs
+++ b/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1/ImageAnnotatorClient.cs
@@ -17,10 +17,10 @@
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using lro = Google.LongRunning;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -69,7 +69,7 @@ namespace Google.Cloud.Vision.V1P2Beta1
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace Google.Cloud.Vision.V1P2Beta1
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -97,8 +97,8 @@ namespace Google.Cloud.Vision.V1P2Beta1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -117,8 +117,8 @@ namespace Google.Cloud.Vision.V1P2Beta1
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(60000),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(60000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.0
         );
 
@@ -148,7 +148,7 @@ namespace Google.Cloud.Vision.V1P2Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -178,7 +178,7 @@ namespace Google.Cloud.Vision.V1P2Beta1
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -197,10 +197,10 @@ namespace Google.Cloud.Vision.V1P2Beta1
         public lro::OperationsSettings AsyncBatchAnnotateFilesOperationsSettings { get; set; } = new lro::OperationsSettings
         {
             DefaultPollSettings = new gax::PollSettings(
-                gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(86400000L)),
-                s::TimeSpan.FromMilliseconds(20000L),
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(86400000L)),
+                sys::TimeSpan.FromMilliseconds(20000L),
                 1.5,
-                s::TimeSpan.FromMilliseconds(45000L))
+                sys::TimeSpan.FromMilliseconds(45000L))
         };
 
         /// <summary>
@@ -301,7 +301,7 @@ namespace Google.Cloud.Vision.V1P2Beta1
         /// </summary>
         public virtual ImageAnnotator.ImageAnnotatorClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -380,7 +380,7 @@ namespace Google.Cloud.Vision.V1P2Beta1
             BatchAnnotateImagesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -417,7 +417,7 @@ namespace Google.Cloud.Vision.V1P2Beta1
             BatchAnnotateImagesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -516,7 +516,7 @@ namespace Google.Cloud.Vision.V1P2Beta1
             AsyncBatchAnnotateFilesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -553,7 +553,7 @@ namespace Google.Cloud.Vision.V1P2Beta1
             AsyncBatchAnnotateFilesRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -561,7 +561,7 @@ namespace Google.Cloud.Vision.V1P2Beta1
         /// </summary>
         public virtual lro::OperationsClient AsyncBatchAnnotateFilesOperationsClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -615,8 +615,8 @@ namespace Google.Cloud.Vision.V1P2Beta1
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.

--- a/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1/ResourceNames.cs
+++ b/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1/ResourceNames.cs
@@ -15,8 +15,8 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.Cloud.Vision.V1P2Beta1
 {

--- a/apis/Google.LongRunning/Google.LongRunning/OperationsClient.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/OperationsClient.cs
@@ -16,10 +16,10 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
-using protowkt = Google.Protobuf.WellKnownTypes;
+using pb = Google.Protobuf;
+using pbwkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
-using s = System;
+using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -69,7 +69,7 @@ namespace Google.LongRunning
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace Google.LongRunning
         /// <remarks>
         /// There are no RPC <see cref="grpccore::StatusCode"/>s eligible for retry for "NonIdempotent" RPC methods.
         /// </remarks>
-        public static s::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
+        public static sys::Predicate<grpccore::RpcException> NonIdempotentRetryFilter { get; } =
             gaxgrpc::RetrySettings.FilterForStatusCodes();
 
         /// <summary>
@@ -97,8 +97,8 @@ namespace Google.LongRunning
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultRetryBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(100),
-            maxDelay: s::TimeSpan.FromMilliseconds(60000),
+            delay: sys::TimeSpan.FromMilliseconds(100),
+            maxDelay: sys::TimeSpan.FromMilliseconds(60000),
             delayMultiplier: 1.3
         );
 
@@ -117,8 +117,8 @@ namespace Google.LongRunning
         /// </list>
         /// </remarks>
         public static gaxgrpc::BackoffSettings GetDefaultTimeoutBackoff() => new gaxgrpc::BackoffSettings(
-            delay: s::TimeSpan.FromMilliseconds(90000),
-            maxDelay: s::TimeSpan.FromMilliseconds(90000),
+            delay: sys::TimeSpan.FromMilliseconds(90000),
+            maxDelay: sys::TimeSpan.FromMilliseconds(90000),
             delayMultiplier: 1.0
         );
 
@@ -148,7 +148,7 @@ namespace Google.LongRunning
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -178,7 +178,7 @@ namespace Google.LongRunning
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -208,7 +208,7 @@ namespace Google.LongRunning
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -238,7 +238,7 @@ namespace Google.LongRunning
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
-                totalExpiration: gax::Expiration.FromTimeout(s::TimeSpan.FromMilliseconds(600000)),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
 
@@ -336,7 +336,7 @@ namespace Google.LongRunning
         /// </summary>
         public virtual Operations.OperationsClient GrpcClient
         {
-            get { throw new s::NotImplementedException(); }
+            get { throw new sys::NotImplementedException(); }
         }
 
         /// <summary>
@@ -423,7 +423,7 @@ namespace Google.LongRunning
             GetOperationRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -464,7 +464,7 @@ namespace Google.LongRunning
             GetOperationRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -571,7 +571,7 @@ namespace Google.LongRunning
             ListOperationsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -594,7 +594,7 @@ namespace Google.LongRunning
             ListOperationsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -706,7 +706,7 @@ namespace Google.LongRunning
             CancelOperationRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -758,7 +758,7 @@ namespace Google.LongRunning
             CancelOperationRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -846,7 +846,7 @@ namespace Google.LongRunning
             DeleteOperationRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
         /// <summary>
@@ -886,7 +886,7 @@ namespace Google.LongRunning
             DeleteOperationRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            throw new s::NotImplementedException();
+            throw new sys::NotImplementedException();
         }
 
     }
@@ -898,8 +898,8 @@ namespace Google.LongRunning
     {
         private readonly gaxgrpc::ApiCall<GetOperationRequest, Operation> _callGetOperation;
         private readonly gaxgrpc::ApiCall<ListOperationsRequest, ListOperationsResponse> _callListOperations;
-        private readonly gaxgrpc::ApiCall<CancelOperationRequest, protowkt::Empty> _callCancelOperation;
-        private readonly gaxgrpc::ApiCall<DeleteOperationRequest, protowkt::Empty> _callDeleteOperation;
+        private readonly gaxgrpc::ApiCall<CancelOperationRequest, pbwkt::Empty> _callCancelOperation;
+        private readonly gaxgrpc::ApiCall<DeleteOperationRequest, pbwkt::Empty> _callDeleteOperation;
 
         /// <summary>
         /// Constructs a client wrapper for the Operations service, with the specified gRPC client and settings.
@@ -915,9 +915,9 @@ namespace Google.LongRunning
                 GrpcClient.GetOperationAsync, GrpcClient.GetOperation, effectiveSettings.GetOperationSettings);
             _callListOperations = clientHelper.BuildApiCall<ListOperationsRequest, ListOperationsResponse>(
                 GrpcClient.ListOperationsAsync, GrpcClient.ListOperations, effectiveSettings.ListOperationsSettings);
-            _callCancelOperation = clientHelper.BuildApiCall<CancelOperationRequest, protowkt::Empty>(
+            _callCancelOperation = clientHelper.BuildApiCall<CancelOperationRequest, pbwkt::Empty>(
                 GrpcClient.CancelOperationAsync, GrpcClient.CancelOperation, effectiveSettings.CancelOperationSettings);
-            _callDeleteOperation = clientHelper.BuildApiCall<DeleteOperationRequest, protowkt::Empty>(
+            _callDeleteOperation = clientHelper.BuildApiCall<DeleteOperationRequest, pbwkt::Empty>(
                 GrpcClient.DeleteOperationAsync, GrpcClient.DeleteOperation, effectiveSettings.DeleteOperationSettings);
             Modify_ApiCall(ref _callGetOperation);
             Modify_GetOperationApiCall(ref _callGetOperation);
@@ -935,15 +935,15 @@ namespace Google.LongRunning
         // Partial methods called for every ApiCall on construction.
         // Allows modification of all the underlying ApiCall objects.
         partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call)
-            where TRequest : class, proto::IMessage<TRequest>
-            where TResponse : class, proto::IMessage<TResponse>;
+            where TRequest : class, pb::IMessage<TRequest>
+            where TResponse : class, pb::IMessage<TResponse>;
 
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
         partial void Modify_GetOperationApiCall(ref gaxgrpc::ApiCall<GetOperationRequest, Operation> call);
         partial void Modify_ListOperationsApiCall(ref gaxgrpc::ApiCall<ListOperationsRequest, ListOperationsResponse> call);
-        partial void Modify_CancelOperationApiCall(ref gaxgrpc::ApiCall<CancelOperationRequest, protowkt::Empty> call);
-        partial void Modify_DeleteOperationApiCall(ref gaxgrpc::ApiCall<DeleteOperationRequest, protowkt::Empty> call);
+        partial void Modify_CancelOperationApiCall(ref gaxgrpc::ApiCall<CancelOperationRequest, pbwkt::Empty> call);
+        partial void Modify_DeleteOperationApiCall(ref gaxgrpc::ApiCall<DeleteOperationRequest, pbwkt::Empty> call);
         partial void OnConstruction(Operations.OperationsClient grpcClient, OperationsSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
         /// <summary>

--- a/apis/Google.LongRunning/Google.LongRunning/ResourceNames.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/ResourceNames.cs
@@ -15,8 +15,8 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
-using s = System;
-using System.Linq;
+using sys = System;
+using linq = System.Linq;
 
 namespace Google.LongRunning
 {

--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -28,9 +28,7 @@ build_api_docs() {
     dotnet run --no-build --no-restore -p ../tools/Google.Cloud.Tools.GenerateDocfxSources -- $api
   fi
   cp filterConfig.yml output/$api
-  $DOCFX metadata --logLevel Warning -f output/$api/docfx.json | tee errors.txt \
-      | grep -v "Invalid file link" \
-      | grep -v "Invalid cref value \"s::"
+  $DOCFX metadata --logLevel Warning -f output/$api/docfx.json | tee errors.txt | grep -v "Invalid file link"
   (! grep --quiet 'Build failed.' errors.txt)
   dotnet run --no-build --no-restore -p ../tools/Google.Cloud.Tools.GenerateSnippetMarkdown -- $api
   


### PR DESCRIPTION
I'm doing a docs build locally to check that moving away from a single-character namespace alias has the desired effect.

Will also skim the diff to make sure the changes are what we expect.