### PR TITLE
Remove codecov from pull requests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,8 +5,3 @@ coverage:
       default:
         # Allow coverage to drop by 2% before complaining
         threshold: 2
-    # For pull requests
-    patch:
-      default:
-        # Allow coverage to drop by 2% before complaining
-        threshold: 2


### PR DESCRIPTION
It isn't useful (for various reasons) and we always ignore it when
looking at the PR, so let's kill it. Keep the "after merge" overall
coverage though.