### PR TITLE
(Not for submission) Remove all optional parameters from Google.Cloud.Firestore

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/CodeHealthTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/CodeHealthTest.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using Google.Cloud.ClientTesting;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace Google.Cloud.Firestore.Tests
@@ -31,6 +33,17 @@ namespace Google.Cloud.Firestore.Tests
             // Query is neither sealed nor abstract, deliberately: CollectionReference derives from it, and
             // it creates new instances of itself.
             CodeHealthTester.AssertClassesAreSealedOrAbstract(typeof(FirestoreDb), new[] { typeof(Query) });
+        }
+
+        [Fact]
+        public void NoOptionalParameters()
+        {
+            string[] allowedMethods = { "FirestoreDb.Create", "FirestoreDb.CreateAsync" };
+            var methods = from type in typeof(FirestoreDb).GetTypeInfo().Assembly.GetTypes()
+                          from method in type.GetTypeInfo().GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
+                          where method.GetParameters().Any(p => p.IsOptional)
+                          select $"{type.Name}.{method.Name}";
+            Assert.Empty(methods.Except(allowedMethods));
         }
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FirestoreDbTest.RunTransactionAsync.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FirestoreDbTest.RunTransactionAsync.cs
@@ -127,7 +127,7 @@ namespace Google.Cloud.Firestore.Tests
         public async Task RunTransactionAsync_TooManyRetries(int? userSpecifiedAttempts)
         {
             int actualAttempts = userSpecifiedAttempts ?? TransactionOptions.Default.MaxAttempts;
-            var options = userSpecifiedAttempts == null ? null : TransactionOptions.Create(userSpecifiedAttempts.Value);
+            var options = TransactionOptions.Create(actualAttempts);
 
             var client = new TransactionTestingClient(actualAttempts, CreateRpcException(StatusCode.Aborted));
             var db = FirestoreDb.Create("proj", "db", client);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/PathUtilitiesTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/PathUtilitiesTest.cs
@@ -40,7 +40,7 @@ namespace Google.Cloud.Firestore.Tests
         [InlineData("a/b")]
         public void ValidateId_Invalid(string id)
         {
-            Assert.Throws<ArgumentException>(() => PathUtilities.ValidateId(id));
+            Assert.Throws<ArgumentException>(() => PathUtilities.ValidateId(id, nameof(id)));
         }
 
         [Theory]
@@ -49,7 +49,7 @@ namespace Google.Cloud.Firestore.Tests
         [InlineData("a-b")]
         public void ValidateId_Valid(string id)
         {
-            PathUtilities.ValidateId(id);
+            PathUtilities.ValidateId(id, nameof(id));
         }
 
         [Theory]

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Proto/ProtoTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Proto/ProtoTest.cs
@@ -208,7 +208,7 @@ namespace Google.Cloud.Firestore.Tests.Proto
             {
                 DocumentReference doc = GetDocumentReference(test.DocRefPath);
                 object documentData = DeserializeJson(test.JsonData);
-                var setOptions = test.Option == null ? null :
+                var setOptions = test.Option == null ? SetOptions.Overwrite : // Overwrite is the effective default
                     test.Option.All ? SetOptions.MergeAll :
                     SetOptions.MergeFields(test.Option.Fields.Select(ConvertFieldPath).ToArray());
                 batch.Set(doc, documentData, setOptions);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WriteBatchTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WriteBatchTest.cs
@@ -182,17 +182,14 @@ namespace Google.Cloud.Firestore.Tests
             AssertWrites(batch, (expectedWrite, true));
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Set_Overwrite(bool explicitOptions)
+        [Fact]
+        public void Set_Overwrite()
         {
-            var options = explicitOptions ? SetOptions.Overwrite : null;
             var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
             var batch = db.StartBatch();
             var doc = db.Document("col/doc");
             var data = new { Name = "Test", Nested = new { Value1 = 10, Value2 = 20 }, Score = 30 };
-            batch.Set(doc, data, options);
+            batch.Set(doc, data, SetOptions.Overwrite);
 
             var expectedWrite = new Write
             {

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/CollectionReference.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/CollectionReference.cs
@@ -88,9 +88,20 @@ namespace Google.Cloud.Firestore
         /// instead of this method.
         /// </remarks>
         /// <param name="documentData">The data for the document. Must not be null.</param>
+        /// <returns>The reference for the newly-created document.</returns>
+        public Task<DocumentReference> AddAsync(object documentData) => AddAsync(documentData, default);
+
+        /// <summary>
+        /// Asynchronously creates a document with the given data in this collection. The document has a randomly generated ID.
+        /// </summary>
+        /// <remarks>
+        /// If the <see cref="WriteResult"/> for the operation is required, use <see cref="DocumentReference.CreateAsync(object, CancellationToken)"/>
+        /// instead of this method.
+        /// </remarks>
+        /// <param name="documentData">The data for the document. Must not be null.</param>
         /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
         /// <returns>The reference for the newly-created document.</returns>
-        public async Task<DocumentReference> AddAsync(object documentData, CancellationToken cancellationToken = default)
+        public async Task<DocumentReference> AddAsync(object documentData, CancellationToken cancellationToken)
         {
             var docRef = Document();
             var result = await docRef.CreateAsync(documentData, cancellationToken).ConfigureAwait(false);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentReference.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentReference.cs
@@ -93,9 +93,16 @@ namespace Google.Cloud.Firestore
         /// Asynchronously creates a document on the server with the given data. The document must not exist beforehand.
         /// </summary>
         /// <param name="documentData">The data for the document. Must not be null.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> CreateAsync(object documentData) => CreateAsync(documentData, default);
+
+        /// <summary>
+        /// Asynchronously creates a document on the server with the given data. The document must not exist beforehand.
+        /// </summary>
+        /// <param name="documentData">The data for the document. Must not be null.</param>
         /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
         /// <returns>The write result of the server operation.</returns>
-        public async Task<WriteResult> CreateAsync(object documentData, CancellationToken cancellationToken = default)
+        public async Task<WriteResult> CreateAsync(object documentData, CancellationToken cancellationToken)
         {
             var batch = Database.StartBatch();
             var results = await batch.Create(this, documentData).CommitAsync(cancellationToken).ConfigureAwait(false);
@@ -103,58 +110,162 @@ namespace Google.Cloud.Firestore
         }
 
         /// <summary>
-        /// Asynchronously deletes the document referred to by this path, with an optional precondition.
+        /// Asynchronously deletes the document referred to by this path.
+        /// </summary>
+        /// <remarks>
+        /// If the document doesn't exist, this returned task will still succeed.
+        /// </remarks>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> DeleteAsync() => DeleteAsync(Precondition.None, default);
+
+        /// <summary>
+        /// Asynchronously deletes the document referred to by this path, with a cancellation token.
+        /// </summary>
+        /// <remarks>
+        /// If the document doesn't exist, this returned task will still succeed.
+        /// </remarks>
+        /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> DeleteAsync(CancellationToken cancellationToken) => DeleteAsync(Precondition.None, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously deletes the document referred to by this path, with a precondition.
         /// </summary>
         /// <remarks>
         /// If no precondition is specified and the document doesn't exist, this returned task will succeed. If a precondition
         /// is specified and not met, the returned task will fail with an <see cref="RpcException"/>.
         /// </remarks>
-        /// <param name="precondition">Optional precondition for deletion. May be null, in which case the deletion is unconditional.</param>
+        /// <param name="precondition">Precondition for deletion. Must not be null.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> DeleteAsync(Precondition precondition) => DeleteAsync(precondition, default);
+
+        /// <summary>
+        /// Asynchronously deletes the document referred to by this path, with a precondition.
+        /// </summary>
+        /// <remarks>
+        /// If <see cref="Precondition.None">Precondition.None</see> is specified and the document doesn't exist, this returned task
+        /// will succeed. If any other precondition is specified and not met, the returned task will fail with an <see cref="RpcException"/>.
+        /// </remarks>
+        /// <param name="precondition">Precondition for deletion. Must not be null.</param>
         /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
         /// <returns>The write result of the server operation.</returns>
-        public async Task<WriteResult> DeleteAsync(Precondition precondition = null, CancellationToken cancellationToken = default)
+        public async Task<WriteResult> DeleteAsync(Precondition precondition, CancellationToken cancellationToken)
         {
+            GaxPreconditions.CheckNotNull(precondition, nameof(precondition));
             var batch = Database.StartBatch();
             batch.Delete(this, precondition);
             var results = await batch.CommitAsync(cancellationToken).ConfigureAwait(false);
             return results[0];
         }
-        
+
         /// <summary>
-        /// Asynchronously performs a set of updates on the document referred to by this path, with an optional precondition.
+        /// Asynchronously performs a set of updates on the document referred to by this path. A precondition of <see cref="Precondition.MustExist" /> is applied.
         /// </summary>
         /// <param name="updates">The updates to perform on the document, keyed by the dot-separated field path to update. Fields not present in this dictionary are not updated. Must not be null or empty.</param>
-        /// <param name="precondition">Optional precondition for updating the document. May be null, which is equivalent to <see cref="Precondition.MustExist"/>.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> UpdateAsync(IDictionary<string, object> updates) => UpdateAsync(updates, Precondition.MustExist, default);
+
+        /// <summary>
+        /// Asynchronously performs a set of updates on the document referred to by this path. A precondition of <see cref="Precondition.MustExist" /> is applied.
+        /// </summary>
+        /// <param name="updates">The updates to perform on the document, keyed by the dot-separated field path to update. Fields not present in this dictionary are not updated. Must not be null or empty.</param>
         /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
         /// <returns>The write result of the server operation.</returns>
-        public Task<WriteResult> UpdateAsync(IDictionary<string, object> updates, Precondition precondition = null, CancellationToken cancellationToken = default)
+        public Task<WriteResult> UpdateAsync(IDictionary<string, object> updates, CancellationToken cancellationToken) => UpdateAsync(updates, Precondition.MustExist, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously performs a set of updates on the document referred to by this path, with a precondition.
+        /// </summary>
+        /// <param name="updates">The updates to perform on the document, keyed by the dot-separated field path to update. Fields not present in this dictionary are not updated. Must not be null or empty.</param>
+        /// <param name="precondition">Precondition for updating the document. Must not be null.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> UpdateAsync(IDictionary<string, object> updates, Precondition precondition) => UpdateAsync(updates, precondition, default);
+
+        /// <summary>
+        /// Asynchronously performs a set of updates on the document referred to by this path, with a precondition.
+        /// </summary>
+        /// <param name="updates">The updates to perform on the document, keyed by the dot-separated field path to update. Fields not present in this dictionary are not updated. Must not be null or empty.</param>
+        /// <param name="precondition">Precondition for updating the document. Must not be null.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> UpdateAsync(IDictionary<string, object> updates, Precondition precondition, CancellationToken cancellationToken)
         {
             GaxPreconditions.CheckNotNull(updates, nameof(updates));
+            GaxPreconditions.CheckNotNull(precondition, nameof(precondition));
             return UpdateAsync(updates.ToDictionary(pair => FieldPath.FromDotSeparatedString(pair.Key), pair => pair.Value), precondition, cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously performs a single field update on the document referred to by this path, with an optional precondition.
+        /// Asynchronously performs a single field update on the document referred to by this path. A precondition of <see cref="Precondition.MustExist" /> is applied.
         /// </summary>
         /// <param name="field">The dot-separated name of the field to update. Must not be null.</param>
         /// <param name="value">The new value for the field. May be null.</param>
-        /// <param name="precondition">Optional precondition for updating the document. May be null, which is equivalent to <see cref="Precondition.MustExist"/>.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> UpdateAsync(string field, object value) => UpdateAsync(field, value, Precondition.MustExist, default);
+
+        /// <summary>
+        /// Asynchronously performs a single field update on the document referred to by this path. A precondition of <see cref="Precondition.MustExist" /> is applied.
+        /// </summary>
+        /// <param name="field">The dot-separated name of the field to update. Must not be null.</param>
+        /// <param name="value">The new value for the field. May be null.</param>
         /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
         /// <returns>The write result of the server operation.</returns>
-        public Task<WriteResult> UpdateAsync(string field, object value, Precondition precondition = null, CancellationToken cancellationToken = default)
+        public Task<WriteResult> UpdateAsync(string field, object value, CancellationToken cancellationToken) => UpdateAsync(field, value, Precondition.MustExist, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously performs a single field update on the document referred to by this path, with a precondition.
+        /// </summary>
+        /// <param name="field">The dot-separated name of the field to update. Must not be null.</param>
+        /// <param name="value">The new value for the field. May be null.</param>
+        /// <param name="precondition">Optional precondition for updating the document. Must not be null.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> UpdateAsync(string field, object value, Precondition precondition) => UpdateAsync(field, value, precondition, default);
+
+        /// <summary>
+        /// Asynchronously performs a single field update on the document referred to by this path, with a precondition.
+        /// </summary>
+        /// <param name="field">The dot-separated name of the field to update. Must not be null.</param>
+        /// <param name="value">The new value for the field. May be null.</param>
+        /// <param name="precondition">Optional precondition for updating the document. Must not be null.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> UpdateAsync(string field, object value, Precondition precondition, CancellationToken cancellationToken)
         {
             GaxPreconditions.CheckNotNull(field, nameof(field));
             return UpdateAsync(new Dictionary<string, object> { { field, value } }, precondition, cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously performs a set of updates on the document referred to by this path, with an optional precondition.
+        /// Asynchronously performs a set of updates on the document referred to by this path. A precondition of <see cref="Precondition.MustExist" /> is applied.
         /// </summary>
         /// <param name="updates">The updates to perform on the document, keyed by the field path to update. Fields not present in this dictionary are not updated. Must not be null or empty.</param>
-        /// <param name="precondition">Optional precondition for updating the document. May be null, which is equivalent to <see cref="Precondition.MustExist"/>.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> UpdateAsync(IDictionary<FieldPath, object> updates) => UpdateAsync(updates, Precondition.MustExist, default);
+
+        /// <summary>
+        /// Asynchronously performs a set of updates on the document referred to by this path. A precondition of <see cref="Precondition.MustExist" /> is applied.
+        /// </summary>
+        /// <param name="updates">The updates to perform on the document, keyed by the field path to update. Fields not present in this dictionary are not updated. Must not be null or empty.</param>
         /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
         /// <returns>The write result of the server operation.</returns>
-        public async Task<WriteResult> UpdateAsync(IDictionary<FieldPath, object> updates, Precondition precondition = null, CancellationToken cancellationToken = default)
+        public Task<WriteResult> UpdateAsync(IDictionary<FieldPath, object> updates, CancellationToken cancellationToken) => UpdateAsync(updates, Precondition.MustExist, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously performs a set of updates on the document referred to by this path, with a precondition.
+        /// </summary>
+        /// <param name="updates">The updates to perform on the document, keyed by the field path to update. Fields not present in this dictionary are not updated. Must not be null or empty.</param>
+        /// <param name="precondition">Optional precondition for updating the document. Must not be null.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> UpdateAsync(IDictionary<FieldPath, object> updates, Precondition precondition) => UpdateAsync(updates, precondition, default);
+
+        /// <summary>
+        /// Asynchronously performs a set of updates on the document referred to by this path, with a precondition.
+        /// </summary>
+        /// <param name="updates">The updates to perform on the document, keyed by the field path to update. Fields not present in this dictionary are not updated. Must not be null or empty.</param>
+        /// <param name="precondition">Optional precondition for updating the document. Must not be null.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public async Task<WriteResult> UpdateAsync(IDictionary<FieldPath, object> updates, Precondition precondition, CancellationToken cancellationToken)
         {
             var batch = Database.StartBatch();
             batch.Update(this, updates, precondition);
@@ -163,13 +274,36 @@ namespace Google.Cloud.Firestore
         }
 
         /// <summary>
+        /// Asynchronously sets data in the document, replacing it completely.
+        /// </summary>
+        /// <param name="documentData">The data to store in the document. Must not be null.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> SetAsync(object documentData) => SetAsync(documentData, SetOptions.Overwrite, default);
+
+        /// <summary>
+        /// Asynchronously sets data in the document, replacing it completely.
+        /// </summary>
+        /// <param name="documentData">The data to store in the document. Must not be null.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> SetAsync(object documentData, CancellationToken cancellationToken) => SetAsync(documentData, SetOptions.Overwrite, cancellationToken);
+
+        /// <summary>
         /// Asynchronously sets data in the document, either replacing it completely or merging fields.
         /// </summary>
         /// <param name="documentData">The data to store in the document. Must not be null.</param>
-        /// <param name="options">The options to use when updating the document. May be null, which is equivalent to <see cref="SetOptions.Overwrite"/>.</param>
+        /// <param name="options">The options to use when updating the document. Must not be null.</param>
+        /// <returns>The write result of the server operation.</returns>
+        public Task<WriteResult> SetAsync(object documentData, SetOptions options) => SetAsync(documentData, options, default);
+
+        /// <summary>
+        /// Asynchronously sets data in the document, either replacing it completely or merging fields.
+        /// </summary>
+        /// <param name="documentData">The data to store in the document. Must not be null.</param>
+        /// <param name="options">The options to use when updating the document. Must not be null.</param>
         /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
         /// <returns>The write result of the server operation.</returns>
-        public async Task<WriteResult> SetAsync(object documentData, SetOptions options = null, CancellationToken cancellationToken = default)
+        public async Task<WriteResult> SetAsync(object documentData, SetOptions options, CancellationToken cancellationToken)
         {
             var batch = Database.StartBatch();
             batch.Set(this, documentData, options);
@@ -181,7 +315,14 @@ namespace Google.Cloud.Firestore
         /// Asynchronously fetches a snapshot of the document.
         /// </summary>
         /// <returns>A snapshot of the document. The snapshot may represent a missing document.</returns>
-        public Task<DocumentSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default) =>
+        public Task<DocumentSnapshot> GetSnapshotAsync() => GetSnapshotAsync(default);
+
+        /// <summary>
+        /// Asynchronously fetches a snapshot of the document.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
+        /// <returns>A snapshot of the document. The snapshot may represent a missing document.</returns>
+        public Task<DocumentSnapshot> GetSnapshotAsync(CancellationToken cancellationToken) =>
             GetSnapshotAsync(null, cancellationToken);
 
         /// <summary>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/PathUtilities.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/PathUtilities.cs
@@ -42,7 +42,7 @@ namespace Google.Cloud.Firestore
             return elements;
         }
 
-        internal static string ValidateId(string id, string paramName = "id")
+        internal static string ValidateId(string id, string paramName)
         {
             GaxPreconditions.CheckNotNullOrEmpty(id, paramName);
             GaxPreconditions.CheckArgument(!id.Contains('/'), paramName, "ID cannot contain a '/' character.");

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Query.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Query.cs
@@ -508,9 +508,15 @@ namespace Google.Cloud.Firestore
         /// <summary>
         /// Asynchronously takes a snapshot of all documents matching the query.
         /// </summary>
+        /// <returns>A snapshot of documents matching the query.</returns>
+        public Task<QuerySnapshot> GetSnapshotAsync() => GetSnapshotAsync(default);
+
+        /// <summary>
+        /// Asynchronously takes a snapshot of all documents matching the query.
+        /// </summary>
         /// <param name="cancellationToken">A cancellation token for the operation.</param>
         /// <returns>A snapshot of documents matching the query.</returns>
-        public Task<QuerySnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default) => GetSnapshotAsync(null, cancellationToken);
+        public Task<QuerySnapshot> GetSnapshotAsync(CancellationToken cancellationToken) => GetSnapshotAsync(null, cancellationToken);
 
         internal async Task<QuerySnapshot> GetSnapshotAsync(ByteString transactionId, CancellationToken cancellationToken)
         {
@@ -540,9 +546,18 @@ namespace Google.Cloud.Firestore
         /// <remarks>
         /// Each time you iterate over the sequence, a new query will be performed.
         /// </remarks>
+        /// <returns>An asynchronous sequence of document snapshots matching the query.</returns>
+        public IAsyncEnumerable<DocumentSnapshot> StreamAsync() => StreamAsync(default);
+
+        /// <summary>
+        /// Returns an asynchronous sequence of snapshots matching the query.
+        /// </summary>
+        /// <remarks>
+        /// Each time you iterate over the sequence, a new query will be performed.
+        /// </remarks>
         /// <param name="cancellationToken">A cancellation token for the operation.</param>
         /// <returns>An asynchronous sequence of document snapshots matching the query.</returns>
-        public IAsyncEnumerable<DocumentSnapshot> StreamAsync(CancellationToken cancellationToken = default) => StreamAsync(null, cancellationToken);
+        public IAsyncEnumerable<DocumentSnapshot> StreamAsync(CancellationToken cancellationToken) => StreamAsync(null, cancellationToken);
 
         internal IAsyncEnumerable<DocumentSnapshot> StreamAsync(ByteString transactionId, CancellationToken cancellationToken) =>
              StreamResponsesAsync(transactionId, cancellationToken)

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WriteBatch.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WriteBatch.cs
@@ -69,12 +69,19 @@ namespace Google.Cloud.Firestore
         }
 
         /// <summary>
-        /// Adds a write operation that deletes the specified document, with an optional precondition.
+        /// Adds a write operation that unconditionally deletes the specified document.
         /// </summary>
         /// <param name="documentReference">A document reference indicating the path of the document to delete. Must not be null.</param>
-        /// <param name="precondition">Optional precondition for deletion. May be null, in which case the deletion is unconditional.</param>
         /// <returns>This batch, for the purposes of method chaining.</returns>
-        public WriteBatch Delete(DocumentReference documentReference, Precondition precondition = null)
+        public WriteBatch Delete(DocumentReference documentReference) => Delete(documentReference, Precondition.None);
+
+        /// <summary>
+        /// Adds a write operation that deletes the specified document, with a precondition.
+        /// </summary>
+        /// <param name="documentReference">A document reference indicating the path of the document to delete. Must not be null.</param>
+        /// <param name="precondition">Optional precondition for deletion. Must not be null</param>
+        /// <returns>This batch, for the purposes of method chaining.</returns>
+        public WriteBatch Delete(DocumentReference documentReference, Precondition precondition)
         {
             GaxPreconditions.CheckNotNull(documentReference, nameof(documentReference));
             var write = new Write
@@ -87,17 +94,34 @@ namespace Google.Cloud.Firestore
         }
 
         /// <summary>
+        /// Adds an update operation that updates just the specified fields paths in the document, with the corresponding values. A precondition of <see cref="Precondition.MustExist" /> is applied.
+        /// </summary>
+        /// <param name="documentReference">A document reference indicating the path of the document to update. Must not be null.</param>
+        /// <param name="updates">The updates to perform on the document, keyed by the dot-separated field path to update. Fields not present in this dictionary are not updated. Must not be null or empty.</param>
+        /// <returns>This batch, for the purposes of method chaining.</returns>
+        public WriteBatch Update(DocumentReference documentReference, IDictionary<string, object> updates) => Update(documentReference, updates, Precondition.MustExist);
+
+        /// <summary>
         /// Adds an update operation that updates just the specified fields paths in the document, with the corresponding values.
         /// </summary>
         /// <param name="documentReference">A document reference indicating the path of the document to update. Must not be null.</param>
         /// <param name="updates">The updates to perform on the document, keyed by the dot-separated field path to update. Fields not present in this dictionary are not updated. Must not be null or empty.</param>
-        /// <param name="precondition">Optional precondition for updating the document. May be null, which is equivalent to <see cref="Precondition.MustExist"/>.</param>
+        /// <param name="precondition">Precondition for updating the document. Must not be null.</param>
         /// <returns>This batch, for the purposes of method chaining.</returns>
-        public WriteBatch Update(DocumentReference documentReference, IDictionary<string, object> updates, Precondition precondition = null)
+        public WriteBatch Update(DocumentReference documentReference, IDictionary<string, object> updates, Precondition precondition)
         {
             GaxPreconditions.CheckNotNull(updates, nameof(updates));
             return Update(documentReference, updates.ToDictionary(pair => FieldPath.FromDotSeparatedString(pair.Key), pair => pair.Value), precondition);
         }
+
+        /// <summary>
+        /// Adds an update operation that updates just the specified field in the document, with the corresponding values. A precondition of <see cref="Precondition.MustExist" /> is applied.
+        /// </summary>
+        /// <param name="documentReference">A document reference indicating the path of the document to update. Must not be null.</param>
+        /// <param name="field">The dot-separated name of the field to update. Must not be null.</param>
+        /// <param name="value">The new value for the field. May be null.</param>
+        /// <returns>This batch, for the purposes of method chaining.</returns>
+        public WriteBatch Update(DocumentReference documentReference, string field, object value) => Update(documentReference, field, value, Precondition.MustExist);
 
         /// <summary>
         /// Adds an update operation that updates just the specified field in the document, with the corresponding values.
@@ -105,27 +129,34 @@ namespace Google.Cloud.Firestore
         /// <param name="documentReference">A document reference indicating the path of the document to update. Must not be null.</param>
         /// <param name="field">The dot-separated name of the field to update. Must not be null.</param>
         /// <param name="value">The new value for the field. May be null.</param>
-        /// <param name="precondition">Optional precondition for updating the document. May be null, which is equivalent to <see cref="Precondition.MustExist"/>.</param>
+        /// <param name="precondition">Precondition for updating the document. Must not be null.</param>
         /// <returns>This batch, for the purposes of method chaining.</returns>
-        public WriteBatch Update(DocumentReference documentReference, string field, object value, Precondition precondition = null)
+        public WriteBatch Update(DocumentReference documentReference, string field, object value, Precondition precondition)
         {
             GaxPreconditions.CheckNotNull(field, nameof(field));
             return Update(documentReference, new Dictionary<string, object> { { field, value } }, precondition);
         }
 
         /// <summary>
+        /// Adds an update operation that updates just the specified fields paths in the document, with the corresponding values. A precondition of <see cref="Precondition.MustExist" /> is applied.
+        /// </summary>
+        /// <param name="documentReference">A document reference indicating the path of the document to update. Must not be null.</param>
+        /// <param name="updates">The updates to perform on the document, keyed by the field path to update. Fields not present in this dictionary are not updated. Must not be null or empty.</param>
+        /// <returns>This batch, for the purposes of method chaining.</returns>
+        public WriteBatch Update(DocumentReference documentReference, IDictionary<FieldPath, object> updates) => Update(documentReference, updates, Precondition.MustExist);
+
+        /// <summary>
         /// Adds an update operation that updates just the specified fields paths in the document, with the corresponding values.
         /// </summary>
         /// <param name="documentReference">A document reference indicating the path of the document to update. Must not be null.</param>
         /// <param name="updates">The updates to perform on the document, keyed by the field path to update. Fields not present in this dictionary are not updated. Must not be null or empty.</param>
-        /// <param name="precondition">Optional precondition for updating the document. May be null, which is equivalent to <see cref="Precondition.MustExist"/>.</param>
+        /// <param name="precondition">Precondition for updating the document. Must not be null.</param>
         /// <returns>This batch, for the purposes of method chaining.</returns>
-        public WriteBatch Update(DocumentReference documentReference, IDictionary<FieldPath, object> updates, Precondition precondition = null)
+        public WriteBatch Update(DocumentReference documentReference, IDictionary<FieldPath, object> updates, Precondition precondition)
         {
             GaxPreconditions.CheckNotNull(documentReference, nameof(documentReference));
             GaxPreconditions.CheckNotNull(updates, nameof(updates));
             GaxPreconditions.CheckArgument(updates.Count != 0, nameof(updates), "Empty set of updates specified");
-            GaxPreconditions.CheckArgument(precondition?.Proto.Exists != true, nameof(precondition), "Cannot specify a must-exist precondition for update");
 
             var serializedUpdates = updates.ToDictionary(pair => pair.Key, pair => ValueSerializer.Serialize(pair.Value));
             var expanded = ExpandObject(serializedUpdates);
@@ -144,19 +175,27 @@ namespace Google.Cloud.Firestore
         }
 
         /// <summary>
+        /// Adds an operation that sets data in a document, replacing it completely.
+        /// </summary>
+        /// <param name="documentReference">A document reference indicating the path of the document to update. Must not be null.</param>
+        /// <param name="documentData">The data to store in the document. Must not be null.</param>
+        /// <returns>This batch, for the purposes of method chaining.</returns>
+        public WriteBatch Set(DocumentReference documentReference, object documentData) => Set(documentReference, documentData, SetOptions.Overwrite);
+
+        /// <summary>
         /// Adds an operation that sets data in a document, either replacing it completely or merging fields.
         /// </summary>
         /// <param name="documentReference">A document reference indicating the path of the document to update. Must not be null.</param>
         /// <param name="documentData">The data to store in the document. Must not be null.</param>
-        /// <param name="options">The options to use when setting data in the document. May be null, which is equivalent to <see cref="SetOptions.Overwrite"/>.</param>
+        /// <param name="options">The options to use when setting data in the document. Must not be null.</param>
         /// <returns>This batch, for the purposes of method chaining.</returns>
-        public WriteBatch Set(DocumentReference documentReference, object documentData, SetOptions options = null)
+        public WriteBatch Set(DocumentReference documentReference, object documentData, SetOptions options)
         {
             GaxPreconditions.CheckNotNull(documentReference, nameof(documentReference));
             GaxPreconditions.CheckNotNull(documentData, nameof(documentData));
+            GaxPreconditions.CheckNotNull(options, nameof(options));
 
             var fields = ValueSerializer.SerializeMap(documentData);
-            options = options ?? SetOptions.Overwrite;
             var serverTimestamps = new List<FieldPath>();
             var deletes = new List<FieldPath>();
             FindSentinels(fields, FieldPath.Empty, serverTimestamps, deletes);
@@ -221,7 +260,14 @@ namespace Google.Cloud.Firestore
         /// Commits the batch on the server.
         /// </summary>
         /// <returns>The write results from the commit.</returns>
-        public Task<IList<WriteResult>> CommitAsync(CancellationToken cancellationToken = default) =>
+        public Task<IList<WriteResult>> CommitAsync() => CommitAsync(default);
+
+        /// <summary>
+        /// Commits the batch on the server.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
+        /// <returns>The write results from the commit.</returns>
+        public Task<IList<WriteResult>> CommitAsync(CancellationToken cancellationToken) =>
             CommitAsync(ByteString.Empty, cancellationToken);
 
         internal async Task<IList<WriteResult>> CommitAsync(ByteString transactionId, CancellationToken cancellationToken)


### PR DESCRIPTION
(Except for FirestoreDb.Create and FirestoreDb.CreateAsync.)

This is for the purpose of being able to add more overloads later on
without breaking compatibility (or at least, reducing the impact).

Currently two proto conformance tests fail, because we "shouldn't"
be able to specify a precondition of MustExist explicitly, although
that was the default behaviour. I've left the tests failing rather
than skipping them, as we probably want to think carefully about this.