### PR TITLE
Deflake some diagnostic integration tests

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
@@ -109,7 +109,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         private static async Task TestTrace(string testId, DateTime startTime, HttpClient client)
         {
             var response = await client.GetAsync($"/Trace/Trace/{testId}");
-            Thread.Sleep(TimeSpan.FromSeconds(5));
 
             var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Google.Api;
 using Google.Cloud.Diagnostics.Common;
@@ -108,10 +109,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         private static async Task TestTrace(string testId, DateTime startTime, HttpClient client)
         {
             var response = await client.GetAsync($"/Trace/Trace/{testId}");
+            Thread.Sleep(TimeSpan.FromSeconds(5));
 
             var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);
 
-            var polling = new TraceEntryPolling();
+            // Give the polling a little extra time to find the trace as
+            // trace processing can sometimes take time and the default buffer is a 
+            // timed buffer.
+            var polling = new TraceEntryPolling(TimeSpan.FromSeconds(20));
             var trace = polling.GetTrace(spanName, Timestamp.FromDateTime(startTime));
 
             Assert.NotNull(trace);

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 {
     public class LoggingTest
     {
-        private readonly LogEntryPolling _polling = new LogEntryPolling(TimeSpan.FromSeconds(60));
+        private readonly LogEntryPolling _polling = new LogEntryPolling(TimeSpan.FromSeconds(120));
 
         [Fact]
         public async Task Logging_SizedBufferNoLogs()
@@ -161,7 +161,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
                 await client.GetAsync($"/Main/Error/{testId}");
                 await client.GetAsync($"/Main/Critical/{testId}");
-                Thread.Sleep(TimeSpan.FromSeconds(10));
+                Thread.Sleep(TimeSpan.FromSeconds(20));
 
                 var results = _polling.GetEntries(startTime, testId, 4, LogSeverity.Warning);
                 Assert.Equal(4, results.Count());

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceEntryPolling.cs
@@ -15,6 +15,7 @@
 using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Cloud.Trace.V1;
 using Google.Protobuf.WellKnownTypes;
+using System;
 using System.Linq;
 
 using TraceProto = Google.Cloud.Trace.V1.Trace;
@@ -31,6 +32,10 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
 
         /// <summary>Client to use to send RPCs.</summary>
         private readonly TraceServiceClient _client = TraceServiceClient.Create();
+
+        internal TraceEntryPolling() : base() { }
+
+        internal TraceEntryPolling(TimeSpan timeout = default, TimeSpan sleepInterval = default) : base(timeout, sleepInterval) { }
 
         /// <summary>
         /// Gets a trace that contains a span with the given name.

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceEntryPolling.cs
@@ -33,8 +33,6 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         /// <summary>Client to use to send RPCs.</summary>
         private readonly TraceServiceClient _client = TraceServiceClient.Create();
 
-        internal TraceEntryPolling() : base() { }
-
         internal TraceEntryPolling(TimeSpan timeout = default, TimeSpan sleepInterval = default) : base(timeout, sleepInterval) { }
 
         /// <summary>


### PR DESCRIPTION
- Add extra timeout for when polling for tracing as the buffer being used (default) is the timed buffer. That plus the time it sometimes take to process traces can cause flakes.
-Increase the timeout when looking for logs, this extra time normally won't be used and will only cause extra delay when failing in most cases.
- Increase the timeout during the TimedBuffer test as the buffer flush time was higher than the wait time.

Fixes #2083