### PR TITLE
Fix root snippets to use common resource names

### DIFF
--- a/tools/Google.Cloud.Docs.Snippets/FaqSnippets.cs
+++ b/tools/Google.Cloud.Docs.Snippets/FaqSnippets.cs
@@ -18,6 +18,7 @@ using Google.Cloud.Translation.V2;
 using static Google.Apis.Http.ConfigurableMessageHandler;
 using Grpc.Core;
 using System;
+using Google.Api.Gax.ResourceNames;
 
 namespace Google.Cloud.Tools.Snippets
 {

--- a/tools/Google.Cloud.Docs.Snippets/PageStreamingSnippets.cs
+++ b/tools/Google.Cloud.Docs.Snippets/PageStreamingSnippets.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using Google.Api.Gax.ResourceNames;
 using Google.Cloud.PubSub.V1;
 using System;
 using System.Collections.Generic;

--- a/tools/Google.Cloud.Docs.Snippets/ResourceNameSnippets.cs
+++ b/tools/Google.Cloud.Docs.Snippets/ResourceNameSnippets.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using Google.Api.Gax.ResourceNames;
 using Google.Cloud.PubSub.V1;
 using System;
 using Xunit;

--- a/tools/Google.Cloud.Docs.Snippets/SnippetFixture.cs
+++ b/tools/Google.Cloud.Docs.Snippets/SnippetFixture.cs
@@ -1,4 +1,5 @@
-﻿using Google.Cloud.PubSub.V1;
+﻿using Google.Api.Gax.ResourceNames;
+using Google.Cloud.PubSub.V1;
 using System;
 using System.Linq;
 using Xunit;


### PR DESCRIPTION
(We can decide later whether or not this is appropriate; we may well
want more documentation about common vs API-specific resource names,
but let's fix the build first.)