### PR TITLE
Make the AppVeyor build differ more between PR and merge

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+dotnet --info
+echo "Regenerating projects: if this fails, run generateprojects.sh and commit changes"
+bash generateprojects.sh && git diff --exit-code
+
+if [[ -z "$APPVEYOR_PULL_REQUEST_NUMBER" ]]
+then
+  # Not in a pull request. Run the build without tests,
+  # then test with code coverage.
+  choco install codecov
+  bash build.sh --notests --diff
+  bash createcoveragereport.sh
+  if [[ -f "coverage/coverage-filtered.xml" ]]
+  then
+    codecov -f "coverage/coverage-filtered.xml"
+  fi
+else
+  # We're in a pull request. Don't do any coverage; just
+  # build and run tests.
+  bash build.sh --diff
+fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,23 +23,7 @@ install:
 
 # Perform the build.
 build_script:
-  - dotnet --info
-  - echo "Regenerating projects: if this fails, run generateprojects.sh and commit changes"
-  - bash generateprojects.sh && git diff --exit-code
-  - bash build.sh --notests --diff
+  - bash appveyor.sh
 
-# Scripts to run before tests
-before_test:
-  - choco install codecov
-
-# Run the tests with coverage
-test_script:
-  - bash runcoverage.sh
-  
-# Create and upload code coverage report.
-# As we only build changed APIs, and some APIs don't have unit tests,
-# we need to handle the possibility of there being no coverage to
-# report on.
-after_test:
-  - bash createcoveragereport.sh
-  - if exist coverage/coverage-filtered.xml codecov -f "coverage/coverage-filtered.xml"
+test: off
+deploy: off


### PR DESCRIPTION
On a PR, we just run the build without coverage.
After a merge, run the build with code coverage as well.

It's easier to do this conditional work in a shell script, and we
don't really care much about the different build phases, so do it
all in a script.