### PR TITLE
Prune the root directory of unnecessary files

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,9 +1,0 @@
-<Project>
-  <!-- See https://github.com/Microsoft/msbuild/issues/1786 for details -->
-  <Target Name="WorkaroundAppConfigPathTooLong"
-          BeforeTargets="GenerateBindingRedirects">
-    <PropertyGroup>
-      <_GenerateBindingRedirectsIntermediateAppConfig>$(IntermediateOutputPath)$(TargetFileName).config</_GenerateBindingRedirectsIntermediateAppConfig>
-    </PropertyGroup>
-  </Target>
-</Project>

--- a/myget.bat
+++ b/myget.bat
@@ -1,1 +1,0 @@
-bash build.sh


### PR DESCRIPTION
- .gitmodules is now empty, and has been for a while
- We haven't used myget for a long time
- Directory.Build.targets is now obsolete as the issue has been
  fixed in the .NET Core SDK