### PR TITLE
Implement comparisons for DocumentReference and CollectionReference

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ComparisonTester.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ComparisonTester.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2018, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace Google.Cloud.Firestore.Tests
+{
+    internal static class ComparisonTester
+    {
+        internal static void AssertComparison<T>(T smaller, T larger, IComparer<T> comparer = null)
+        {
+            comparer = comparer ?? Comparer<T>.Default;
+            Assert.InRange(comparer.Compare(smaller, larger), int.MinValue, -1);
+            Assert.InRange(comparer.Compare(larger, smaller), 1, int.MaxValue);
+            Assert.Equal(0, comparer.Compare(smaller, smaller));
+            Assert.Equal(0, comparer.Compare(larger, larger));
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/DocumentReferenceTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/DocumentReferenceTest.cs
@@ -107,5 +107,35 @@ namespace Google.Cloud.Firestore.Tests
             var document = db.Document("root/doc");
             Assert.Throws<ArgumentException>(() => document.Collection(id));
         }
+
+        [Theory]
+        // Vary one property at a time
+        [InlineData("p1", "d1", "col1/doc1", "p2", "d1", "col1/doc1")]
+        [InlineData("p1", "d1", "col1/doc1", "p1", "d2", "col1/doc1")]
+        [InlineData("p1", "d1", "col1/doc1", "p1", "d1", "col2/doc1")]
+        [InlineData("p1", "d1", "col1/doc1", "p1", "d1", "col1/doc2")]
+
+        // Precedence of properties
+        [InlineData("p1", "d2", "col1/doc1", "p2", "d1", "col1/doc1")] // Project before database
+        [InlineData("p1", "d1", "col9/doc9", "p1", "d2", "col1/doc1")] // Database before path
+        [InlineData("p1", "d1", "col1/doc2", "p1", "d1", "col2/doc1")] // Collection before document
+        // (More details path tests in PathComparerTest)
+        public void CompareTo(
+            string smallerProject, string smallerDb, string smallerPath,
+            string largerProject, string largerDb, string largerPath)
+        {
+            var client = new FakeFirestoreClient();
+            var smaller = FirestoreDb.Create(smallerProject, smallerDb, client).Document(smallerPath);
+            var larger = FirestoreDb.Create(largerProject, largerDb, client).Document(largerPath);
+            ComparisonTester.AssertComparison(smaller, larger);
+        }
+
+        [Fact]
+        public void CompareTo_Null()
+        {
+            var db = FirestoreDb.Create("proj", "db", new FakeFirestoreClient());
+            var document = db.Document("root/doc");
+            ComparisonTester.AssertComparison(null, document);
+        }
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/PathComparerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/PathComparerTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2018, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Google.Cloud.Firestore.Tests
+{
+    public class PathComparerTest
+    {
+        [Theory]
+        [InlineData("", "x")]
+        [InlineData("a/b", "a/c")]
+        [InlineData("a/b", "a/bx")]
+        [InlineData("a/b", "b/a")]
+        [InlineData("a/b", "a+/a")] // Prevents simple ordinal comparison: + comes before /
+        [InlineData("a/b", "a/b/c")]
+        public void CompareTo(string smaller, string larger) =>
+            ComparisonTester.AssertComparison(smaller, larger, PathComparer.Instance);
+    }
+}

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/CollectionReference.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/CollectionReference.cs
@@ -24,7 +24,7 @@ namespace Google.Cloud.Firestore
     /// A reference to a collection in a Firestore database. The existence of
     /// this object does not imply that the collection currently exists in storage.
     /// </summary>
-    public sealed class CollectionReference : Query, IEquatable<CollectionReference>
+    public sealed class CollectionReference : Query, IEquatable<CollectionReference>, IComparable<CollectionReference>
     {
         /// <summary>
         /// The final part of the complete collection path; this is the identity of
@@ -108,5 +108,10 @@ namespace Google.Cloud.Firestore
 
         /// <inheritdoc />
         public override string ToString() => Path;
+
+        // Note: this implementation wastefully compares the characters in "projects" and "databases" but means we don't need
+        // to keep a database-relative path or perform more complex comparisons.
+        /// <inheritdoc />
+        public int CompareTo(CollectionReference other) => other == null ? 1 : PathComparer.Instance.Compare(Path, other.Path);
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentReference.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentReference.cs
@@ -27,7 +27,7 @@ namespace Google.Cloud.Firestore
     /// A reference to a document in a Firestore database. The existence of
     /// this object does not imply that the document currently exists in storage.
     /// </summary>
-    public sealed class DocumentReference : IEquatable<DocumentReference>
+    public sealed class DocumentReference : IEquatable<DocumentReference>, IComparable<DocumentReference>
     {
         /// <summary>
         /// The database which contains the document.
@@ -89,6 +89,11 @@ namespace Google.Cloud.Firestore
         /// <inheritdoc />
         public override string ToString() => Path;
 
+        // Note: this implementation wastefully compares the characters in "projects" and "databases" but means we don't need
+        // to keep a database-relative path or perform more complex comparisons.
+        /// <inheritdoc />
+        public int CompareTo(DocumentReference other) => other == null ? 1 : PathComparer.Instance.Compare(Path, other.Path);
+        
         /// <summary>
         /// Asynchronously creates a document on the server with the given data. The document must not exist beforehand.
         /// </summary>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/PathComparer.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/PathComparer.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2018, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Google.Cloud.Firestore
+{
+    /// <summary>
+    /// Provides ordering comparisons for slash-separated resource paths.
+    /// </summary>
+    internal sealed class PathComparer : IComparer<string>
+    {
+        internal static PathComparer Instance { get; } = new PathComparer();
+
+        private PathComparer()
+        {
+        }
+
+        // Note: we don't handle null input, but this is never exposed, so we should never need to.
+        public int Compare(string left, string right)
+        {
+            // We can't just do a string comparison, because of cases such as:
+            // foo/bar/baz
+            // foo/bar-/baz
+            // Here "bar-" should come after "bar" because it's longer, but '-' is earlier than '/'.
+            int length = Math.Min(left.Length, right.Length);
+            for (int i = 0; i < length; i++)
+            {
+                char leftChar = left[i];
+                char rightChar = right[i];
+                if (leftChar != rightChar)
+                {
+                    return leftChar == '/' ? -1 // Left segment finishes earlier
+                        : rightChar == '/' ? 1  // Right segment finishes earlier
+                        : leftChar - rightChar; // Not a segment end, so just compare ordinals
+                }
+            }
+            // Shorter comes before longer
+            return left.Length.CompareTo(right.Length);
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueComparer.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueComparer.cs
@@ -133,30 +133,8 @@ namespace Google.Cloud.Firestore
             return result != 0 ? result : leftPoint.Longitude.CompareTo(rightPoint.Longitude);
         }
 
-        private int CompareResourcePaths(Value left, Value right)
-        {
-            // Note: this does no validation, but it's simple...
-            // We can't just do a string comparison, because of cases such as:
-            // foo/bar/baz
-            // foo/bar-/baz
-            // Here "bar-" should come after "bar" because it's longer, but '-' is earlier than '/'.
-            string leftReference = left.ReferenceValue;
-            string rightReference = right.ReferenceValue;
-            int length = Math.Min(leftReference.Length, rightReference.Length);
-            for (int i = 0; i < length; i++)
-            {
-                char leftChar = leftReference[i];
-                char rightChar = rightReference[i];
-                if (leftChar != rightChar)
-                {
-                    return leftChar == '/' ? -1 // Left segment finishes earlier
-                        : rightChar == '/' ? 1  // Right segment finishes earlier
-                        : leftChar - rightChar; // Not a segment end, so just compare ordinals
-                }
-            }
-            // Shorter comes before longer
-            return leftReference.Length.CompareTo(rightReference.Length);
-        }
+        private int CompareResourcePaths(Value left, Value right) =>
+            PathComparer.Instance.Compare(left.ReferenceValue, right.ReferenceValue);
 
         private int CompareArrays(Value left, Value right)
         {


### PR DESCRIPTION
Note that we don't *really* need `PathComparer` to implement `IComparer<string>` - we could just have a static method. This feels a little tidier though.