### PR TITLE
Add Google.Cloud.Spanner.Common.V1

### DIFF
--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/coverage.xml
@@ -7,6 +7,9 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Spanner.Admin.Database.V1</ModuleMask>
       </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Spanner.Common.V1</ModuleMask>
+      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Tests/coverage.xml
@@ -7,6 +7,9 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Spanner.Admin.Database.V1</ModuleMask>
       </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Spanner.Common.V1</ModuleMask>
+      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.sln
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Spanner.Admin.Database.V1.Tests", "Google.Cloud.Spanner.Admin.Database.V1.Tests\Google.Cloud.Spanner.Admin.Database.V1.Tests.csproj", "{3DBEE305-03E5-4DDB-A523-AF1621B999BC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Spanner.Common.V1", "..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj", "{776FAF0E-199C-4F71-9CA6-26F5DA5EC231}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +67,18 @@ Global
 		{3DBEE305-03E5-4DDB-A523-AF1621B999BC}.Release|x64.Build.0 = Release|x64
 		{3DBEE305-03E5-4DDB-A523-AF1621B999BC}.Release|x86.ActiveCfg = Release|x86
 		{3DBEE305-03E5-4DDB-A523-AF1621B999BC}.Release|x86.Build.0 = Release|x86
+		{776FAF0E-199C-4F71-9CA6-26F5DA5EC231}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{776FAF0E-199C-4F71-9CA6-26F5DA5EC231}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{776FAF0E-199C-4F71-9CA6-26F5DA5EC231}.Debug|x64.ActiveCfg = Debug|x64
+		{776FAF0E-199C-4F71-9CA6-26F5DA5EC231}.Debug|x64.Build.0 = Debug|x64
+		{776FAF0E-199C-4F71-9CA6-26F5DA5EC231}.Debug|x86.ActiveCfg = Debug|x86
+		{776FAF0E-199C-4F71-9CA6-26F5DA5EC231}.Debug|x86.Build.0 = Debug|x86
+		{776FAF0E-199C-4F71-9CA6-26F5DA5EC231}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{776FAF0E-199C-4F71-9CA6-26F5DA5EC231}.Release|Any CPU.Build.0 = Release|Any CPU
+		{776FAF0E-199C-4F71-9CA6-26F5DA5EC231}.Release|x64.ActiveCfg = Release|x64
+		{776FAF0E-199C-4F71-9CA6-26F5DA5EC231}.Release|x64.Build.0 = Release|x64
+		{776FAF0E-199C-4F71-9CA6-26F5DA5EC231}.Release|x86.ActiveCfg = Release|x86
+		{776FAF0E-199C-4F71-9CA6-26F5DA5EC231}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta02</Version>
+    <Version>2.0.0-beta00</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -26,6 +26,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.3.0" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="1.0.0" />
+    <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
     <PackageReference Include="Google.LongRunning" Version="1.0.0" />
     <PackageReference Include="Grpc.Core" Version="1.10.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/coverage.xml
@@ -7,6 +7,9 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Spanner.Admin.Instance.V1</ModuleMask>
       </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Spanner.Common.V1</ModuleMask>
+      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Tests/coverage.xml
@@ -7,6 +7,9 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Spanner.Admin.Instance.V1</ModuleMask>
       </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Spanner.Common.V1</ModuleMask>
+      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.sln
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Spanner.Admin.Instance.V1.Tests", "Google.Cloud.Spanner.Admin.Instance.V1.Tests\Google.Cloud.Spanner.Admin.Instance.V1.Tests.csproj", "{AF028A45-D1EA-4EC8-90EA-B583C4FBF095}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Spanner.Common.V1", "..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj", "{A2EB97F3-DC83-4C93-A359-111E32D52427}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +67,18 @@ Global
 		{AF028A45-D1EA-4EC8-90EA-B583C4FBF095}.Release|x64.Build.0 = Release|x64
 		{AF028A45-D1EA-4EC8-90EA-B583C4FBF095}.Release|x86.ActiveCfg = Release|x86
 		{AF028A45-D1EA-4EC8-90EA-B583C4FBF095}.Release|x86.Build.0 = Release|x86
+		{A2EB97F3-DC83-4C93-A359-111E32D52427}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2EB97F3-DC83-4C93-A359-111E32D52427}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2EB97F3-DC83-4C93-A359-111E32D52427}.Debug|x64.ActiveCfg = Debug|x64
+		{A2EB97F3-DC83-4C93-A359-111E32D52427}.Debug|x64.Build.0 = Debug|x64
+		{A2EB97F3-DC83-4C93-A359-111E32D52427}.Debug|x86.ActiveCfg = Debug|x86
+		{A2EB97F3-DC83-4C93-A359-111E32D52427}.Debug|x86.Build.0 = Debug|x86
+		{A2EB97F3-DC83-4C93-A359-111E32D52427}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2EB97F3-DC83-4C93-A359-111E32D52427}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2EB97F3-DC83-4C93-A359-111E32D52427}.Release|x64.ActiveCfg = Release|x64
+		{A2EB97F3-DC83-4C93-A359-111E32D52427}.Release|x64.Build.0 = Release|x64
+		{A2EB97F3-DC83-4C93-A359-111E32D52427}.Release|x86.ActiveCfg = Release|x86
+		{A2EB97F3-DC83-4C93-A359-111E32D52427}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta02</Version>
+    <Version>2.0.0-beta00</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -26,6 +26,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.3.0" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="1.0.0" />
+    <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
     <PackageReference Include="Google.LongRunning" Version="1.0.0" />
     <PackageReference Include="Grpc.Core" Version="1.10.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.sln
+++ b/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.sln
@@ -1,0 +1,36 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Spanner.Common.V1", "Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj", "{C42595D9-AF7A-49C1-A380-3A87A66D2528}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C42595D9-AF7A-49C1-A380-3A87A66D2528}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C42595D9-AF7A-49C1-A380-3A87A66D2528}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C42595D9-AF7A-49C1-A380-3A87A66D2528}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C42595D9-AF7A-49C1-A380-3A87A66D2528}.Debug|x64.Build.0 = Debug|Any CPU
+		{C42595D9-AF7A-49C1-A380-3A87A66D2528}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C42595D9-AF7A-49C1-A380-3A87A66D2528}.Debug|x86.Build.0 = Debug|Any CPU
+		{C42595D9-AF7A-49C1-A380-3A87A66D2528}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C42595D9-AF7A-49C1-A380-3A87A66D2528}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C42595D9-AF7A-49C1-A380-3A87A66D2528}.Release|x64.ActiveCfg = Release|Any CPU
+		{C42595D9-AF7A-49C1-A380-3A87A66D2528}.Release|x64.Build.0 = Release|Any CPU
+		{C42595D9-AF7A-49C1-A380-3A87A66D2528}.Release|x86.ActiveCfg = Release|Any CPU
+		{C42595D9-AF7A-49C1-A380-3A87A66D2528}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FD242F90-F0B0-47F8-9FA5-80D25775A561}
+	EndGlobalSection
+EndGlobal

--- a/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/DatabaseName.cs
+++ b/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/DatabaseName.cs
@@ -1,0 +1,120 @@
+﻿// Copyright 2018, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This code was originally auto-generated.
+
+using gax = Google.Api.Gax;
+using sys = System;
+
+namespace Google.Cloud.Spanner.Common.V1
+{
+    /// <summary>
+    /// Resource name for the 'database' resource.
+    /// </summary>
+    public sealed partial class DatabaseName : gax::IResourceName, sys::IEquatable<DatabaseName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}/databases/{database}");
+
+        /// <summary>
+        /// Parses the given database resource name in string form into a new
+        /// <see cref="DatabaseName"/> instance.
+        /// </summary>
+        /// <param name="databaseName">The database resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="DatabaseName"/> if successful.</returns>
+        public static DatabaseName Parse(string databaseName)
+        {
+            gax::GaxPreconditions.CheckNotNull(databaseName, nameof(databaseName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(databaseName);
+            return new DatabaseName(resourceName[0], resourceName[1], resourceName[2]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given database resource name in string form into a new
+        /// <see cref="DatabaseName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="databaseName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="databaseName">The database resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="DatabaseName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string databaseName, out DatabaseName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(databaseName, nameof(databaseName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(databaseName, out resourceName))
+            {
+                result = new DatabaseName(resourceName[0], resourceName[1], resourceName[2]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="DatabaseName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="instanceId">The instance ID. Must not be <c>null</c>.</param>
+        /// <param name="databaseId">The database ID. Must not be <c>null</c>.</param>
+        public DatabaseName(string projectId, string instanceId, string databaseId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            InstanceId = gax::GaxPreconditions.CheckNotNull(instanceId, nameof(instanceId));
+            DatabaseId = gax::GaxPreconditions.CheckNotNull(databaseId, nameof(databaseId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The instance ID. Never <c>null</c>.
+        /// </summary>
+        public string InstanceId { get; }
+
+        /// <summary>
+        /// The database ID. Never <c>null</c>.
+        /// </summary>
+        public string DatabaseId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, InstanceId, DatabaseId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as DatabaseName);
+
+        /// <inheritdoc />
+        public bool Equals(DatabaseName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(DatabaseName a, DatabaseName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(DatabaseName a, DatabaseName b) => !(a == b);
+    }
+}

--- a/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>2.0.0-beta00</Version>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Features>IOperation</Features>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -11,7 +11,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>Low-level Google client library to access the Google Cloud Spanner API. The ADO.NET provider (Google.Cloud.Spanner.Data) which depends on this package is generally preferred for Spanner access.</Description>
+    <Description>Common resource names used by all Spanner V1 APIs</Description>
     <PackageTags>Spanner;Google;Cloud</PackageTags>
     <Copyright>Copyright 2018 Google LLC</Copyright>
     <Authors>Google Inc.</Authors>
@@ -20,13 +20,10 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
-    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.3.0" />
-    <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="1.10.0" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax" Version="2.3.0" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/InstanceName.cs
+++ b/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/InstanceName.cs
@@ -1,0 +1,113 @@
+﻿// Copyright 2018, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This code was originally auto-generated.
+
+using gax = Google.Api.Gax;
+using sys = System;
+
+namespace Google.Cloud.Spanner.Common.V1
+{
+    /// <summary>
+    /// Resource name for the 'instance' resource.
+    /// </summary>
+    public sealed partial class InstanceName : gax::IResourceName, sys::IEquatable<InstanceName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}");
+
+        /// <summary>
+        /// Parses the given instance resource name in string form into a new
+        /// <see cref="InstanceName"/> instance.
+        /// </summary>
+        /// <param name="instanceName">The instance resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="InstanceName"/> if successful.</returns>
+        public static InstanceName Parse(string instanceName)
+        {
+            gax::GaxPreconditions.CheckNotNull(instanceName, nameof(instanceName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(instanceName);
+            return new InstanceName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given instance resource name in string form into a new
+        /// <see cref="InstanceName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="instanceName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="instanceName">The instance resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="InstanceName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string instanceName, out InstanceName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(instanceName, nameof(instanceName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(instanceName, out resourceName))
+            {
+                result = new InstanceName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="InstanceName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="instanceId">The instance ID. Must not be <c>null</c>.</param>
+        public InstanceName(string projectId, string instanceId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            InstanceId = gax::GaxPreconditions.CheckNotNull(instanceId, nameof(instanceId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The instance ID. Never <c>null</c>.
+        /// </summary>
+        public string InstanceId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, InstanceId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as InstanceName);
+
+        /// <inheritdoc />
+        public bool Equals(InstanceName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(InstanceName a, InstanceName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(InstanceName a, InstanceName b) => !(a == b);
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.sln
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.sln
@@ -24,6 +24,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Spanner.Data.Ycsb", "Google.Cloud.Spanner.Data.Ycsb\Google.Cloud.Spanner.Data.Ycsb.csproj", "{A08619C9-8766-4F71-88BE-BF0068EBCEF8}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Spanner.Common.V1", "..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj", "{186AE268-CC6E-4965-B337-7186E54AFE65}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -166,6 +168,18 @@ Global
 		{A08619C9-8766-4F71-88BE-BF0068EBCEF8}.Release|x64.Build.0 = Release|Any CPU
 		{A08619C9-8766-4F71-88BE-BF0068EBCEF8}.Release|x86.ActiveCfg = Release|Any CPU
 		{A08619C9-8766-4F71-88BE-BF0068EBCEF8}.Release|x86.Build.0 = Release|Any CPU
+		{186AE268-CC6E-4965-B337-7186E54AFE65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{186AE268-CC6E-4965-B337-7186E54AFE65}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{186AE268-CC6E-4965-B337-7186E54AFE65}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{186AE268-CC6E-4965-B337-7186E54AFE65}.Debug|x64.Build.0 = Debug|Any CPU
+		{186AE268-CC6E-4965-B337-7186E54AFE65}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{186AE268-CC6E-4965-B337-7186E54AFE65}.Debug|x86.Build.0 = Debug|Any CPU
+		{186AE268-CC6E-4965-B337-7186E54AFE65}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{186AE268-CC6E-4965-B337-7186E54AFE65}.Release|Any CPU.Build.0 = Release|Any CPU
+		{186AE268-CC6E-4965-B337-7186E54AFE65}.Release|x64.ActiveCfg = Release|Any CPU
+		{186AE268-CC6E-4965-B337-7186E54AFE65}.Release|x64.Build.0 = Release|Any CPU
+		{186AE268-CC6E-4965-B337-7186E54AFE65}.Release|x86.ActiveCfg = Release|Any CPU
+		{186AE268-CC6E-4965-B337-7186E54AFE65}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/coverage.xml
@@ -7,6 +7,9 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Spanner.V1</ModuleMask>
       </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Spanner.Common.V1</ModuleMask>
+      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Tests/coverage.xml
@@ -7,6 +7,9 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Spanner.V1</ModuleMask>
       </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Spanner.Common.V1</ModuleMask>
+      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.sln
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Spanner.V1.Tes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{65CDA7BA-D484-4B0F-B1F6-8FD8EFF5168F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Spanner.Common.V1", "..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj", "{F939879A-C2EF-4CE2-97D7-1424F6D643D2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,18 @@ Global
 		{65CDA7BA-D484-4B0F-B1F6-8FD8EFF5168F}.Release|x64.Build.0 = Release|Any CPU
 		{65CDA7BA-D484-4B0F-B1F6-8FD8EFF5168F}.Release|x86.ActiveCfg = Release|Any CPU
 		{65CDA7BA-D484-4B0F-B1F6-8FD8EFF5168F}.Release|x86.Build.0 = Release|Any CPU
+		{F939879A-C2EF-4CE2-97D7-1424F6D643D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F939879A-C2EF-4CE2-97D7-1424F6D643D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F939879A-C2EF-4CE2-97D7-1424F6D643D2}.Debug|x64.ActiveCfg = Debug|x64
+		{F939879A-C2EF-4CE2-97D7-1424F6D643D2}.Debug|x64.Build.0 = Debug|x64
+		{F939879A-C2EF-4CE2-97D7-1424F6D643D2}.Debug|x86.ActiveCfg = Debug|x86
+		{F939879A-C2EF-4CE2-97D7-1424F6D643D2}.Debug|x86.Build.0 = Debug|x86
+		{F939879A-C2EF-4CE2-97D7-1424F6D643D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F939879A-C2EF-4CE2-97D7-1424F6D643D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F939879A-C2EF-4CE2-97D7-1424F6D643D2}.Release|x64.ActiveCfg = Release|x64
+		{F939879A-C2EF-4CE2-97D7-1424F6D643D2}.Release|x64.Build.0 = Release|x64
+		{F939879A-C2EF-4CE2-97D7-1424F6D643D2}.Release|x86.ActiveCfg = Release|x86
+		{F939879A-C2EF-4CE2-97D7-1424F6D643D2}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -436,7 +436,7 @@
     "id": "Google.Cloud.Spanner.Admin.Database.V1",
     "productName": "Google Cloud Spanner Database Administration",
     "productUrl": "https://cloud.google.com/spanner/",
-    "version": "1.1.0-beta02",
+    "version": "2.0.0-beta00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Spanner Database Admin API.",
     "tags": [ "Spanner" ],
@@ -444,7 +444,8 @@
       "Google.LongRunning": "1.0.0",
       "Google.Api.Gax.Grpc": "2.3.0",
       "Grpc.Core": "1.10.0",
-      "Google.Cloud.Iam.V1": "1.0.0"
+      "Google.Cloud.Iam.V1": "1.0.0",
+      "Google.Cloud.Spanner.Common.V1": "project"
     }
   },
 
@@ -452,7 +453,7 @@
     "id": "Google.Cloud.Spanner.Admin.Instance.V1",
     "productName": "Google Cloud Spanner Instance Administration",
     "productUrl": "https://cloud.google.com/spanner/",
-    "version": "1.1.0-beta02",
+    "version": "2.0.0-beta00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Spanner Instance Admin API.",
     "tags": [ "Spanner" ],
@@ -460,7 +461,8 @@
       "Google.LongRunning": "1.0.0",
       "Google.Api.Gax.Grpc": "2.3.0",
       "Grpc.Core": "1.10.0",
-      "Google.Cloud.Iam.V1": "1.0.0"
+      "Google.Cloud.Iam.V1": "1.0.0",
+      "Google.Cloud.Spanner.Common.V1": "project"
     }
   },
 
@@ -510,10 +512,22 @@
   },
 
   {
+    "id": "Google.Cloud.Spanner.Common.V1",
+    "type": "other",
+    "targetFrameworks": "netstandard1.5;net45",
+    "version": "2.0.0-beta00",
+    "description": "Common resource names used by all Spanner V1 APIs",
+    "tags": [ "Spanner" ],
+    "dependencies": {
+      "Google.Api.Gax": "2.3.0"
+    }
+  },
+  
+  {
     "id": "Google.Cloud.Spanner.V1",
     "productName": "Google Cloud Spanner",
     "productUrl": "https://cloud.google.com/spanner/",
-    "version": "1.1.0-beta02",
+    "version": "2.0.0-beta00",
     "type": "grpc",
     "targetFrameworks": "netstandard1.5;netstandard2.0;net45",
     "testTargetFrameworks": "netcoreapp1.0;netcoreapp2.0;net452",
@@ -521,7 +535,8 @@
     "tags": [ "Spanner" ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "2.3.0",
-      "Grpc.Core": "1.10.0"
+      "Grpc.Core": "1.10.0",
+      "Google.Cloud.Spanner.Common.V1": "project"
     }
   },
 


### PR DESCRIPTION
This is a library containing common resource names used by multiple
Spanner V1 APIs. It does not contain ProjectName, as we expect that
to be supplied by Google.Api.Gax.

(With this change committed, we can tweak the codegen configuration
to use them.)

@evildour: I'm happy to do something similar for Bigtable, as we discussed before. Is now a good time to do that?