### PR TITLE
Add a Bigtable common code project

### DIFF
--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/coverage.xml
@@ -7,6 +7,9 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Bigtable.Admin.V2</ModuleMask>
       </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Bigtable.Common.V2</ModuleMask>
+      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Tests/coverage.xml
@@ -7,6 +7,9 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Bigtable.Admin.V2</ModuleMask>
       </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Bigtable.Common.V2</ModuleMask>
+      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.sln
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.sln
@@ -14,6 +14,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.LongRunning", "..\Go
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Bigtable.Admin.V2.Tests", "Google.Cloud.Bigtable.Admin.V2.Tests\Google.Cloud.Bigtable.Admin.V2.Tests.csproj", "{E5801C8E-D5E8-46C7-8F7F-38732726DE66}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Bigtable.Common.V2", "..\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2.csproj", "{2A508B20-A5E0-4429-B56E-808EEFFA6D28}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -96,6 +98,18 @@ Global
 		{E5801C8E-D5E8-46C7-8F7F-38732726DE66}.Release|x64.Build.0 = Release|Any CPU
 		{E5801C8E-D5E8-46C7-8F7F-38732726DE66}.Release|x86.ActiveCfg = Release|Any CPU
 		{E5801C8E-D5E8-46C7-8F7F-38732726DE66}.Release|x86.Build.0 = Release|Any CPU
+		{2A508B20-A5E0-4429-B56E-808EEFFA6D28}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A508B20-A5E0-4429-B56E-808EEFFA6D28}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A508B20-A5E0-4429-B56E-808EEFFA6D28}.Debug|x64.ActiveCfg = Debug|x64
+		{2A508B20-A5E0-4429-B56E-808EEFFA6D28}.Debug|x64.Build.0 = Debug|x64
+		{2A508B20-A5E0-4429-B56E-808EEFFA6D28}.Debug|x86.ActiveCfg = Debug|x86
+		{2A508B20-A5E0-4429-B56E-808EEFFA6D28}.Debug|x86.Build.0 = Debug|x86
+		{2A508B20-A5E0-4429-B56E-808EEFFA6D28}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A508B20-A5E0-4429-B56E-808EEFFA6D28}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A508B20-A5E0-4429-B56E-808EEFFA6D28}.Release|x64.ActiveCfg = Release|x64
+		{2A508B20-A5E0-4429-B56E-808EEFFA6D28}.Release|x64.Build.0 = Release|x64
+		{2A508B20-A5E0-4429-B56E-808EEFFA6D28}.Release|x86.ActiveCfg = Release|x86
+		{2A508B20-A5E0-4429-B56E-808EEFFA6D28}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.sln
+++ b/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.sln
@@ -1,0 +1,34 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Bigtable.Common.V2", "Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2.csproj", "{737EB9E9-2829-4A49-95FA-03CA42BA6911}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{737EB9E9-2829-4A49-95FA-03CA42BA6911}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{737EB9E9-2829-4A49-95FA-03CA42BA6911}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{737EB9E9-2829-4A49-95FA-03CA42BA6911}.Debug|x64.ActiveCfg = Debug|x64
+		{737EB9E9-2829-4A49-95FA-03CA42BA6911}.Debug|x64.Build.0 = Debug|x64
+		{737EB9E9-2829-4A49-95FA-03CA42BA6911}.Debug|x86.ActiveCfg = Debug|x86
+		{737EB9E9-2829-4A49-95FA-03CA42BA6911}.Debug|x86.Build.0 = Debug|x86
+		{737EB9E9-2829-4A49-95FA-03CA42BA6911}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{737EB9E9-2829-4A49-95FA-03CA42BA6911}.Release|Any CPU.Build.0 = Release|Any CPU
+		{737EB9E9-2829-4A49-95FA-03CA42BA6911}.Release|x64.ActiveCfg = Release|x64
+		{737EB9E9-2829-4A49-95FA-03CA42BA6911}.Release|x64.Build.0 = Release|x64
+		{737EB9E9-2829-4A49-95FA-03CA42BA6911}.Release|x86.ActiveCfg = Release|x86
+		{737EB9E9-2829-4A49-95FA-03CA42BA6911}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+EndGlobal

--- a/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha04</Version>
+    <Version>1.0.0-beta00</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -11,7 +11,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.</Description>
+    <Description>Common code used by Bigtable V2 APIs</Description>
     <PackageTags>Bigtable;Google;Cloud</PackageTags>
     <Copyright>Copyright 2018 Google LLC</Copyright>
     <Authors>Google Inc.</Authors>
@@ -20,15 +20,10 @@
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet</RepositoryUrl>
-    <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.3.0" />
-    <ProjectReference Include="..\..\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2.csproj" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="1.0.0" />
-    <PackageReference Include="Google.LongRunning" Version="1.0.0" />
-    <PackageReference Include="Grpc.Core" Version="1.10.0" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax" Version="2.3.0" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/TableName.cs
+++ b/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/TableName.cs
@@ -1,0 +1,120 @@
+﻿// Copyright 2018, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This code was originally auto-generated.
+
+using gax = Google.Api.Gax;
+using sys = System;
+
+namespace Google.Cloud.Bigtable.Common.V2
+{
+    /// <summary>
+    /// Resource name for the 'table' resource.
+    /// </summary>
+    public sealed partial class TableName : gax::IResourceName, sys::IEquatable<TableName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}/tables/{table}");
+
+        /// <summary>
+        /// Parses the given table resource name in string form into a new
+        /// <see cref="TableName"/> instance.
+        /// </summary>
+        /// <param name="tableName">The table resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="TableName"/> if successful.</returns>
+        public static TableName Parse(string tableName)
+        {
+            gax::GaxPreconditions.CheckNotNull(tableName, nameof(tableName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(tableName);
+            return new TableName(resourceName[0], resourceName[1], resourceName[2]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given table resource name in string form into a new
+        /// <see cref="TableName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="tableName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="tableName">The table resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="TableName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string tableName, out TableName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(tableName, nameof(tableName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(tableName, out resourceName))
+            {
+                result = new TableName(resourceName[0], resourceName[1], resourceName[2]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="TableName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="instanceId">The instance ID. Must not be <c>null</c>.</param>
+        /// <param name="tableId">The table ID. Must not be <c>null</c>.</param>
+        public TableName(string projectId, string instanceId, string tableId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            InstanceId = gax::GaxPreconditions.CheckNotNull(instanceId, nameof(instanceId));
+            TableId = gax::GaxPreconditions.CheckNotNull(tableId, nameof(tableId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The instance ID. Never <c>null</c>.
+        /// </summary>
+        public string InstanceId { get; }
+
+        /// <summary>
+        /// The table ID. Never <c>null</c>.
+        /// </summary>
+        public string TableId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, InstanceId, TableId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as TableName);
+
+        /// <inheritdoc />
+        public bool Equals(TableName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(TableName a, TableName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(TableName a, TableName b) => !(a == b);
+    }
+}

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/coverage.xml
@@ -7,6 +7,9 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Bigtable.V2</ModuleMask>
       </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Bigtable.Common.V2</ModuleMask>
+      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/coverage.xml
@@ -7,6 +7,9 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Bigtable.V2</ModuleMask>
       </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Bigtable.Common.V2</ModuleMask>
+      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/coverage.xml
@@ -7,6 +7,9 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Bigtable.V2</ModuleMask>
       </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Bigtable.Common.V2</ModuleMask>
+      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.sln
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.sln
@@ -16,6 +16,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Bigtable.Admin
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Bigtable.V2.GenerateClient", "Google.Cloud.Bigtable.V2.GenerateClient\Google.Cloud.Bigtable.V2.GenerateClient.csproj", "{97EC9E30-ADD3-4D80-A2D5-8D611557813E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Bigtable.Common.V2", "..\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2.csproj", "{FD3A1128-0981-460C-86F2-621CA0A4799D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -109,6 +111,18 @@ Global
 		{97EC9E30-ADD3-4D80-A2D5-8D611557813E}.Release|x64.Build.0 = Release|Any CPU
 		{97EC9E30-ADD3-4D80-A2D5-8D611557813E}.Release|x86.ActiveCfg = Release|Any CPU
 		{97EC9E30-ADD3-4D80-A2D5-8D611557813E}.Release|x86.Build.0 = Release|Any CPU
+		{FD3A1128-0981-460C-86F2-621CA0A4799D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD3A1128-0981-460C-86F2-621CA0A4799D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD3A1128-0981-460C-86F2-621CA0A4799D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FD3A1128-0981-460C-86F2-621CA0A4799D}.Debug|x64.Build.0 = Debug|Any CPU
+		{FD3A1128-0981-460C-86F2-621CA0A4799D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FD3A1128-0981-460C-86F2-621CA0A4799D}.Debug|x86.Build.0 = Debug|Any CPU
+		{FD3A1128-0981-460C-86F2-621CA0A4799D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD3A1128-0981-460C-86F2-621CA0A4799D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD3A1128-0981-460C-86F2-621CA0A4799D}.Release|x64.ActiveCfg = Release|Any CPU
+		{FD3A1128-0981-460C-86F2-621CA0A4799D}.Release|x64.Build.0 = Release|Any CPU
+		{FD3A1128-0981-460C-86F2-621CA0A4799D}.Release|x86.ActiveCfg = Release|Any CPU
+		{FD3A1128-0981-460C-86F2-621CA0A4799D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.3.0" />
+    <ProjectReference Include="..\..\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2.csproj" />
     <PackageReference Include="Grpc.Core" Version="1.10.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -58,13 +58,26 @@
     "tags": [ "Bigtable" ],
     "dependencies": {
       "Google.LongRunning": "1.0.0",
-      "Google.Cloud.Iam.V1": "1.0.0"
+      "Google.Cloud.Iam.V1": "1.0.0",
+      "Google.Cloud.Bigtable.Common.V2": "project"
     },
     "testDependencies": {
       "Google.Api.Gax.Grpc.Testing": "default"
     }
   },
 
+  {
+    "id": "Google.Cloud.Bigtable.Common.V2",
+    "type": "other",
+    "targetFrameworks": "netstandard1.5;net45",
+    "version": "1.0.0-beta00",
+    "description": "Common code used by Bigtable V2 APIs",
+    "tags": [ "Bigtable" ],
+    "dependencies": {
+      "Google.Api.Gax": "2.3.0"
+    }
+  },
+  
   {
     "id": "Google.Cloud.Bigtable.V2",
     "productName": "Google Bigtable",
@@ -73,6 +86,9 @@
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Bigtable API.",
     "tags": [ "Bigtable" ],
+    "dependencies": {
+      "Google.Cloud.Bigtable.Common.V2": "project"
+    },
     "testDependencies": {
       "Google.Api.Gax.Grpc.Testing": "default",
       "Google.Cloud.Bigtable.Admin.V2": "project"


### PR DESCRIPTION
Currently this only contains TableName; we might want to think about
anything else that's likely to become common. (Moving things into
the common project now is okay; we can't do it post-GA.)

Next step will be to update the configuration to avoid generating
TableName or ProjectName, but to refer to TableName in this project
and ProjectName in GAX.