### PR TITLE
Fix our code fix providers, which were no longer working.

### DIFF
--- a/tools/Google.Cloud.Tools.Analyzers.Tests/DefaultLiteralTest.cs
+++ b/tools/Google.Cloud.Tools.Analyzers.Tests/DefaultLiteralTest.cs
@@ -80,15 +80,7 @@ public class A
 {
     public void B(bool? x = default) { }
 }";
-            var expected = CreateDiagnostic("bool?", 4, 29);
-            VerifyCSharpDiagnostic(test, expected);
-
-            var newSource = @"
-public class A
-{
-    public void B(bool? x = default(bool?)) { }
-}";
-            VerifyCSharpFix(test, newSource);
+            VerifyCSharpDiagnostic(test);
         }
 
         [Fact]
@@ -124,15 +116,7 @@ public class A
 {
     public void B(System.DateTimeKind? x = default) { }
 }";
-            var expected = CreateDiagnostic("System.DateTimeKind?", 4, 44);
-            VerifyCSharpDiagnostic(test, expected);
-
-            var newSource = @"
-public class A
-{
-    public void B(System.DateTimeKind? x = default(System.DateTimeKind?)) { }
-}";
-            VerifyCSharpFix(test, newSource);
+            VerifyCSharpDiagnostic(test);
         }
 
         [Fact]
@@ -143,15 +127,7 @@ public class A
 {
     public void B(int? x = default) { }
 }";
-            var expected = CreateDiagnostic("int?", 4, 28);
-            VerifyCSharpDiagnostic(test, expected);
-
-            var newSource = @"
-public class A
-{
-    public void B(int? x = default(int?)) { }
-}";
-            VerifyCSharpFix(test, newSource);
+            VerifyCSharpDiagnostic(test);
         }
 
         [Fact]

--- a/tools/Google.Cloud.Tools.Analyzers/DefaultLiteralAnalyzer.cs
+++ b/tools/Google.Cloud.Tools.Analyzers/DefaultLiteralAnalyzer.cs
@@ -16,7 +16,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Semantics;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -24,6 +23,8 @@ using System.Linq;
 
 namespace Google.Cloud.Tools.Analyzers
 {
+    // TODO: https://github.com/dotnet/roslyn/issues/22578 is now fixed in Roslyn 2.7.0, so this can probably be removed,
+    //       but leave around for now just to catch issues if an older compiler is used.
     /// <summary>
     /// Warns about default literal expressions triggering https://github.com/dotnet/roslyn/issues/22578.
     /// </summary>

--- a/tools/Google.Cloud.Tools.Analyzers/DefaultLiteralCodeFixProvider.cs
+++ b/tools/Google.Cloud.Tools.Analyzers/DefaultLiteralCodeFixProvider.cs
@@ -17,8 +17,6 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Semantics;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/tools/Google.Cloud.Tools.Analyzers/Google.Cloud.Tools.Analyzers.csproj
+++ b/tools/Google.Cloud.Tools.Analyzers/Google.Cloud.Tools.Analyzers.csproj
@@ -8,8 +8,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.7.0" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
   </ItemGroup>
 </Project>

--- a/tools/Google.Cloud.Tools.Analyzers/PublicDependencyForbiddenAnalyzer.cs
+++ b/tools/Google.Cloud.Tools.Analyzers/PublicDependencyForbiddenAnalyzer.cs
@@ -16,7 +16,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Semantics;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;


### PR DESCRIPTION
It looks like newer versions of VS are not loading code fix providers compiled against older Roslyn versions even though the associated analyzers are loaded and used.