### PR TITLE
Default log entry label providers

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -268,13 +268,16 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 await client.GetAsync($"/Main/Warning/{testId}");
                 var results = _polling.GetEntries(startTime, testId, 1, LogSeverity.Warning);
                 var entry = results.Single();
-                Assert.Equal(2, entry.Labels.Count);
+                Assert.Equal(3, entry.Labels.Count);
                 var defaultLabel = entry.Labels.First();
                 Assert.Equal("some-key", defaultLabel.Key);
                 Assert.Equal("some-value", defaultLabel.Value);
-                var fooLabel = entry.Labels.Skip(1).Single();
+                var fooLabel = entry.Labels.Skip(1).First();
                 Assert.Equal("Foo", fooLabel.Key);
                 Assert.Equal("Hello, World!", fooLabel.Value);
+                var traceIdLabel = entry.Labels.Skip(2).Single();
+                Assert.Equal("trace_identifier", traceIdLabel.Key);
+                Assert.NotEmpty(traceIdLabel.Value);
             }
         }
     }
@@ -396,7 +399,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         public override void ConfigureServices(IServiceCollection services)
         {
             base.ConfigureServices(services);
-            services.AddSingleton<ILogEntryLabelProvider, FooLogEntryLabelProvider>();
+            services.AddLogEntryLabelProvider<FooLogEntryLabelProvider>();
+            services.AddLogEntryLabelProvider<TraceIdLogEntryLabelProvider>();
         }
 
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/ClientIpLogEntryLabelProviderTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/ClientIpLogEntryLabelProviderTest.cs
@@ -1,0 +1,78 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace Google.Cloud.Diagnostics.AspNetCore.Tests
+{
+    public class ClientIpLogEntryLabelProviderTest
+    {
+        [Fact]
+        public void ThrowsWithoutHttpContextAccessor()
+        {
+            Assert.Throws<ArgumentNullException>(
+                "httpContextAccessor",
+                () => new ClientIpLogEntryLabelProvider(httpContextAccessor: null));
+        }
+
+        [Fact]
+        public void AddClientIpLabel()
+        {
+            // Arrange
+            var mockHttpContext = new Mock<HttpContext>();
+            mockHttpContext.Setup(x => x.Connection.RemoteIpAddress).Returns(IPAddress.Loopback);
+
+            var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(mockHttpContext.Object);
+
+            var instance = new ClientIpLogEntryLabelProvider(mockHttpContextAccessor.Object);
+            var labels = new Dictionary<string, string>();
+
+            // Act
+            instance.Invoke(labels);
+
+            // Assert
+            Assert.Single(labels);
+            var label = labels.Single();
+            Assert.Equal("client_ip", label.Key);
+            Assert.Equal(IPAddress.Loopback.ToString(), label.Value);
+        }
+
+        [Fact]
+        public void DoesNotAddWhenNoRemoteIp()
+        {
+            // Arrange
+            var mockHttpContext = new Mock<HttpContext>();
+            mockHttpContext.Setup(x => x.Connection.RemoteIpAddress).Returns((IPAddress)null);
+
+            var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(mockHttpContext.Object);
+
+            var instance = new ClientIpLogEntryLabelProvider(mockHttpContextAccessor.Object);
+            var labels = new Dictionary<string, string>();
+
+            // Act
+            instance.Invoke(labels);
+
+            // Assert
+            Assert.Empty(labels);
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/EnvironmentNameLogEntryLabelProviderTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/EnvironmentNameLogEntryLabelProviderTest.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting;
+using Moq;
+using Xunit;
+
+namespace Google.Cloud.Diagnostics.AspNetCore.Tests
+{
+    public class EnvironmentNameLogEntryLabelProviderTest
+    {
+        [Fact]
+        public void ThrowsWithoutHostingEnvironment()
+        {
+            Assert.Throws<ArgumentNullException>(
+                "hostingEnvironment",
+                () => new EnvironmentNameLogEntryLabelProvider(hostingEnvironment: null));
+        }
+
+        [Fact]
+        public void AddsEnvironmentNameLabel()
+        {
+            // Arrange
+            var hostingEnvironmentMock = new Mock<IHostingEnvironment>();
+            hostingEnvironmentMock.Setup(x => x.EnvironmentName).Returns(EnvironmentName.Production);
+
+            var instance = new EnvironmentNameLogEntryLabelProvider(hostingEnvironmentMock.Object);
+            var labels = new Dictionary<string, string>();
+
+            // Act
+            instance.Invoke(labels);
+
+            // Assert
+            Assert.Single(labels);
+            var label = labels.Single();
+            Assert.Equal("aspnetcore_environment", label.Key);
+            Assert.Equal(EnvironmentName.Production, label.Value);
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/HttpLogEntryLabelProviderTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/HttpLogEntryLabelProviderTest.cs
@@ -1,0 +1,88 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace Google.Cloud.Diagnostics.AspNetCore.Tests
+{
+    public class HttpLogEntryLabelProviderTest
+    {
+        [Fact]
+        public void ThrowsWithoutHttpContextAccessor()
+        {
+            Assert.Throws<ArgumentNullException>(
+                "hostingEnvironment",
+                () => new EnvironmentNameLogEntryLabelProvider(hostingEnvironment: null));
+        }
+
+        [Fact]
+        public void DoesNotCallInvokeCoreWhenNoHttpContext()
+        {
+            // Arrange
+            var instance = new ThrowingHttpLogEntryLabelProvider(Mock.Of<IHttpContextAccessor>());
+            var labels = new Dictionary<string, string>();
+
+            // Act
+            // Should not throw because InvokeCore is never called and add any labels
+            instance.Invoke(labels);
+
+            // Assert
+            Assert.Empty(labels);
+        }
+
+        [Fact]
+        public void CallsInvokeCore()
+        {
+            // Arrange
+            var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(Mock.Of<HttpContext>());
+            var instance = new DummyHttpLogEntryLabelProvider(mockHttpContextAccessor.Object);
+            var labels = new Dictionary<string, string>();
+
+            // Act
+            instance.Invoke(labels);
+
+            // Assert
+            Assert.Single(labels);
+            Assert.Equal("foo", labels.First().Key);
+            Assert.Equal("bar", labels.First().Value);
+        }
+
+        private class DummyHttpLogEntryLabelProvider : HttpLogEntryLabelProvider
+        {
+            public DummyHttpLogEntryLabelProvider(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
+            {
+            }
+
+            protected override void InvokeCore(Dictionary<string, string> labels, HttpContext httpContext)
+            {
+                labels["foo"] = "bar";
+            }
+        }
+
+        private class ThrowingHttpLogEntryLabelProvider : HttpLogEntryLabelProvider
+        {
+            public ThrowingHttpLogEntryLabelProvider(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
+            {
+            }
+
+            protected override void InvokeCore(Dictionary<string, string> labels, HttpContext httpContext) => throw new NotImplementedException();
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/HttpLogEntryLabelProviderTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/HttpLogEntryLabelProviderTest.cs
@@ -27,8 +27,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
         public void ThrowsWithoutHttpContextAccessor()
         {
             Assert.Throws<ArgumentNullException>(
-                "hostingEnvironment",
-                () => new EnvironmentNameLogEntryLabelProvider(hostingEnvironment: null));
+                "httpContextAccessor",
+                () => new DummyHttpLogEntryLabelProvider(httpContextAccessor: null));
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/LabelProviderExtensionsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/LabelProviderExtensionsTest.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Google.Cloud.Diagnostics.AspNetCore.Tests
+{
+    public class LoggingExtensionsTest
+    {
+        [Fact]
+        public void AddsServiceFromType()
+        {
+            // Act
+            var services = new ServiceCollection()
+                .AddLogEntryLabelProvider<TraceIdLogEntryLabelProvider>();
+
+            // Assert
+            Assert.IsAssignableFrom<IServiceCollection>(services);
+            Assert.Single(services);
+            var descriptor = services.Single();
+
+            Assert.Equal(typeof(ILogEntryLabelProvider), descriptor.ServiceType);
+            Assert.Equal(typeof(TraceIdLogEntryLabelProvider), descriptor.ImplementationType);
+            Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+        }
+
+        [Fact]
+        public void AddsServiceFromFactory()
+        {
+            // Act
+            var services = new ServiceCollection()
+                .AddLogEntryLabelProvider(sp => new TraceIdLogEntryLabelProvider(sp.GetRequiredService<IHttpContextAccessor>()));
+
+            // Assert
+            Assert.IsAssignableFrom<IServiceCollection>(services);
+            Assert.Single(services);
+            var descriptor = services.Single();
+
+            Assert.Equal(typeof(ILogEntryLabelProvider), descriptor.ServiceType);
+            Assert.NotNull(descriptor.ImplementationFactory);
+            Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+        }
+
+        [Fact]
+        public void AddsServiceFromInstance()
+        {
+            // Act
+            var services = new ServiceCollection()
+                .AddLogEntryLabelProvider(new TraceIdLogEntryLabelProvider(Mock.Of<IHttpContextAccessor>()));
+
+            // Assert
+            Assert.IsAssignableFrom<IServiceCollection>(services);
+            Assert.Single(services);
+            var descriptor = services.Single();
+
+            Assert.Equal(typeof(ILogEntryLabelProvider), descriptor.ServiceType);
+            Assert.IsType<TraceIdLogEntryLabelProvider>(descriptor.ImplementationInstance);
+            Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/TraceIdLogEntryLabelProviderTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/TraceIdLogEntryLabelProviderTest.cs
@@ -1,0 +1,81 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace Google.Cloud.Diagnostics.AspNetCore.Tests
+{
+    public class TraceIdLogEntryLabelProviderTest
+    {
+        [Fact]
+        public void ThrowsWithoutHttpContextAccessor()
+        {
+            Assert.Throws<ArgumentNullException>(
+                "httpContextAccessor",
+                () => new TraceIdLogEntryLabelProvider(httpContextAccessor: null));
+        }
+
+        [Fact]
+        public void AddsTraceIdLabel()
+        {
+            // Arrange
+            var traceId = Guid.NewGuid().ToString();
+
+            var mockHttpContext = new Mock<HttpContext>();
+            mockHttpContext.Setup(x => x.TraceIdentifier).Returns(traceId);
+
+            var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(mockHttpContext.Object);
+
+            var instance = new TraceIdLogEntryLabelProvider(mockHttpContextAccessor.Object);
+            var labels = new Dictionary<string, string>();
+
+            // Act
+            instance.Invoke(labels);
+
+            // Assert
+            Assert.Single(labels);
+            var label = labels.Single();
+            Assert.Equal("trace_identifier", label.Key);
+            Assert.Equal(traceId, label.Value);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void DoesNotAddWhenNoTraceId(string traceId)
+        {
+            // Arrange
+            var mockHttpContext = new Mock<HttpContext>();
+            mockHttpContext.Setup(x => x.TraceIdentifier).Returns(traceId);
+
+            var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(mockHttpContext.Object);
+
+            var instance = new TraceIdLogEntryLabelProvider(mockHttpContextAccessor.Object);
+            var labels = new Dictionary<string, string>();
+
+            // Act
+            instance.Invoke(labels);
+
+            // Assert
+            Assert.Empty(labels);
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/UserLogEntryLabelProviderTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/UserLogEntryLabelProviderTest.cs
@@ -1,0 +1,178 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Security.Principal;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace Google.Cloud.Diagnostics.AspNetCore.Tests
+{
+    public class UserLogEntryLabelProviderTest
+    {
+        [Fact]
+        public void ThrowsWithoutHttpContextAccessor()
+        {
+            Assert.Throws<ArgumentNullException>(
+                "httpContextAccessor",
+                () => new UserLogEntryLabelProvider(httpContextAccessor: null));
+        }
+
+        [Fact]
+        public void AddsUserAuthenticatedLabel()
+        {
+            // Arrange
+            var mockHttpContext = new Mock<HttpContext>();
+            mockHttpContext.Setup(x => x.User.Identity.IsAuthenticated).Returns(false);
+
+            var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(mockHttpContext.Object);
+
+            var instance = new UserLogEntryLabelProvider(mockHttpContextAccessor.Object);
+            var labels = new Dictionary<string, string>();
+
+            // Act
+            instance.Invoke(labels);
+
+            // Assert
+            Assert.Single(labels);
+            var label = labels.Single();
+            Assert.Equal("user_authenticated", label.Key);
+            Assert.Equal(false.ToString(), label.Value);
+        }
+
+        [Fact]
+        public void AddsUserNameLabelWithEmptyUserName()
+        {
+            // Arrange
+            var mockHttpContext = new Mock<HttpContext>();
+            mockHttpContext.Setup(x => x.User.Identity.IsAuthenticated).Returns(true);
+
+            var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(mockHttpContext.Object);
+
+            var instance = new UserLogEntryLabelProvider(mockHttpContextAccessor.Object);
+            var labels = new Dictionary<string, string>();
+
+            // Act
+            instance.Invoke(labels);
+
+            // Assert
+            Assert.Equal(2, labels.Count);
+
+            var userAuthenticated = labels.First();
+            Assert.Equal("user_authenticated", userAuthenticated.Key);
+            Assert.Equal(true.ToString(), userAuthenticated.Value);
+
+            var userName = labels.Skip(1).Single();
+            Assert.Equal("user_name", userName.Key);
+            Assert.Null(userName.Value);
+        }
+
+        [Fact]
+        public void AddsUserNameLabelWithUserName()
+        {
+            // Arrange
+            var mockHttpContext = new Mock<HttpContext>();
+            mockHttpContext.Setup(x => x.User.Identity.IsAuthenticated).Returns(true);
+            mockHttpContext.Setup(x => x.User.Identity.Name).Returns("Foo");
+
+            var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(mockHttpContext.Object);
+
+            var instance = new UserLogEntryLabelProvider(mockHttpContextAccessor.Object);
+            var labels = new Dictionary<string, string>();
+
+            // Act
+            instance.Invoke(labels);
+
+            // Assert
+            Assert.Equal(2, labels.Count);
+
+            var userAuthenticated = labels.First();
+            Assert.Equal("user_authenticated", userAuthenticated.Key);
+            Assert.Equal(true.ToString(), userAuthenticated.Value);
+
+            var userName = labels.Skip(1).Single();
+            Assert.Equal("user_name", userName.Key);
+            Assert.Equal("Foo", userName.Value);
+        }
+
+        [Theory]
+        [InlineData("sub")]
+        [InlineData(ClaimTypes.Name)]
+        [InlineData(ClaimTypes.NameIdentifier)]
+        public void AddsUserNameLabelWithUserNameFromClaim(string claimType)
+        {
+            // Arrange
+            var mockHttpContext = new Mock<HttpContext>();
+            mockHttpContext.Setup(x => x.User.Identity).Returns(new ClaimsIdentity(new[] { new Claim(claimType, "Foo") }, "Cookies"));
+
+            var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(mockHttpContext.Object);
+
+            var instance = new UserLogEntryLabelProvider(mockHttpContextAccessor.Object);
+            var labels = new Dictionary<string, string>();
+
+            // Act
+            instance.Invoke(labels);
+
+            // Assert
+            Assert.Equal(2, labels.Count);
+
+            var userAuthenticated = labels.First();
+            Assert.Equal("user_authenticated", userAuthenticated.Key);
+            Assert.Equal(true.ToString(), userAuthenticated.Value);
+
+            var userName = labels.Skip(1).Single();
+            Assert.Equal("user_name", userName.Key);
+            Assert.Equal("Foo", userName.Value);
+        }
+
+        [Fact]
+        public void DoesNotAddWhenNoUser()
+        {
+            var mockHttpContext = new Mock<HttpContext>();
+            mockHttpContext.Setup(x => x.User).Returns((ClaimsPrincipal)null);
+            AssertLabelsEmpty(mockHttpContext);
+        }
+
+        [Fact]
+        public void DoesNotAddWhenNoUserIdentity()
+        {
+            var mockHttpContext = new Mock<HttpContext>();
+            mockHttpContext.Setup(x => x.User.Identity).Returns((IIdentity)null);
+            AssertLabelsEmpty(mockHttpContext);
+        }
+
+        private static void AssertLabelsEmpty(Mock<HttpContext> mockHttpContext)
+        {
+            // Arrange
+            var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(mockHttpContext.Object);
+
+            // Act
+            var instance = new UserLogEntryLabelProvider(mockHttpContextAccessor.Object);
+            var labels = new Dictionary<string, string>();
+            instance.Invoke(labels);
+
+            // Assert
+            Assert.Empty(labels);
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/GoogleDiagnosticsWebHostBuilderExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/GoogleDiagnosticsWebHostBuilderExtensions.cs
@@ -52,6 +52,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             {
                 projectId = Project.GetAndCheckProjectId(projectId, monitoredResource);
 
+                services.AddLogEntryLabelProvider<TraceIdLogEntryLabelProvider>();
                 services.AddSingleton<IStartupFilter>(new GoogleDiagnosticsStartupFilter(projectId, monitoredResource));
                 services.AddGoogleTrace(options => options.ProjectId = projectId);
                 services.AddGoogleExceptionLogging(options =>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/ClientIpLogEntryLabelProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/ClientIpLogEntryLabelProvider.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+
+namespace Google.Cloud.Diagnostics.AspNetCore
+{
+    /// <summary>
+    /// A <see cref="ILogEntryLabelProvider"/> implementation which adds the client's IP-address to the log entry labels.
+    /// </summary>
+    public class ClientIpLogEntryLabelProvider : HttpLogEntryLabelProvider
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientIpLogEntryLabelProvider"/> class.
+        /// </summary>
+        /// <param name="httpContextAccessor">The <see cref="IHttpContextAccessor"/> instance with the <see cref="HttpContext"/>.</param>
+        public ClientIpLogEntryLabelProvider(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override void InvokeCore(Dictionary<string, string> labels, HttpContext httpContext)
+        {
+            if (!string.IsNullOrEmpty(httpContext.Connection.RemoteIpAddress?.ToString()))
+            {
+                labels["client_ip"] = httpContext.Connection.RemoteIpAddress.ToString();
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/EnvironmentNameLogEntryLabelProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/EnvironmentNameLogEntryLabelProvider.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using Google.Api.Gax;
 using Microsoft.AspNetCore.Hosting;
 
 namespace Google.Cloud.Diagnostics.AspNetCore
@@ -31,7 +32,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <param name="hostingEnvironment">The <see cref="IHostingEnvironment"/> instance to retrieve the environment name from.</param>
         public EnvironmentNameLogEntryLabelProvider(IHostingEnvironment hostingEnvironment)
         {
-            _hostingEnvironment = hostingEnvironment ?? throw new ArgumentNullException(nameof(hostingEnvironment));
+            _hostingEnvironment = GaxPreconditions.CheckNotNull(hostingEnvironment, nameof(hostingEnvironment));
         }
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/EnvironmentNameLogEntryLabelProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/EnvironmentNameLogEntryLabelProvider.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Google.Cloud.Diagnostics.AspNetCore
+{
+    /// <summary>
+    /// A <see cref="ILogEntryLabelProvider"/> implementation which adds the <see cref="IHostingEnvironment.EnvironmentName"/> to the log entry labels.
+    /// </summary>
+    public class EnvironmentNameLogEntryLabelProvider : ILogEntryLabelProvider
+    {
+        private readonly IHostingEnvironment _hostingEnvironment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnvironmentNameLogEntryLabelProvider"/> class.
+        /// </summary>
+        /// <param name="hostingEnvironment">The <see cref="IHostingEnvironment"/> instance to retrieve the environment name from.</param>
+        public EnvironmentNameLogEntryLabelProvider(IHostingEnvironment hostingEnvironment)
+        {
+            _hostingEnvironment = hostingEnvironment ?? throw new ArgumentNullException(nameof(hostingEnvironment));
+        }
+
+        /// <inheritdoc/>
+        public void Invoke(Dictionary<string, string> labels)
+        {
+            labels["aspnetcore_environment"] = _hostingEnvironment.EnvironmentName;
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/HttpLogEntryLabelProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/HttpLogEntryLabelProvider.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using Google.Api.Gax;
 using Microsoft.AspNetCore.Http;
 
 namespace Google.Cloud.Diagnostics.AspNetCore
@@ -31,7 +32,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <param name="httpContextAccessor">The <see cref="IHttpContextAccessor"/> instance with the <see cref="HttpContext"/>.</param>
         protected HttpLogEntryLabelProvider(IHttpContextAccessor httpContextAccessor)
         {
-            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+            _httpContextAccessor = GaxPreconditions.CheckNotNull(httpContextAccessor, nameof(httpContextAccessor));
         }
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/HttpLogEntryLabelProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/HttpLogEntryLabelProvider.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+
+namespace Google.Cloud.Diagnostics.AspNetCore
+{
+    /// <summary>
+    /// Base class for <see cref="ILogEntryLabelProvider"/> implementations which needs an <see cref="HttpContext"/> instance.
+    /// </summary>
+    public abstract class HttpLogEntryLabelProvider : ILogEntryLabelProvider
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        /// <summary>
+        /// Initializes the <see cref="HttpLogEntryLabelProvider"/> base class.
+        /// </summary>
+        /// <param name="httpContextAccessor">The <see cref="IHttpContextAccessor"/> instance with the <see cref="HttpContext"/>.</param>
+        protected HttpLogEntryLabelProvider(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+        }
+
+        /// <inheritdoc/>
+        public void Invoke(Dictionary<string, string> labels)
+        {
+            if (_httpContextAccessor.HttpContext != null)
+            {
+                InvokeCore(labels, _httpContextAccessor.HttpContext);
+            }
+        }
+
+        /// <summary>
+        /// In a derived class, invokes the core logic of the <see cref="ILogEntryLabelProvider"/> using the <see cref="HttpContext"/> instance.
+        /// </summary>
+        /// <param name="labels">The log entry labels to augment.</param>
+        /// <param name="httpContext">The <see cref="HttpContext"/> instance.</param>
+        protected abstract void InvokeCore(Dictionary<string, string> labels, HttpContext httpContext);
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/LabelProviderExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/LabelProviderExtensions.cs
@@ -30,9 +30,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <returns>The <see cref="IServiceCollection"/> instance.</returns>
         public static IServiceCollection AddLogEntryLabelProvider<T>(this IServiceCollection serivces)
             where T : class, ILogEntryLabelProvider
-        {
-            return serivces.AddSingleton<ILogEntryLabelProvider, T>();
-        }
+            => serivces.AddSingleton<ILogEntryLabelProvider, T>();
 
         /// <summary>
         /// Adds a <see cref="ILogEntryLabelProvider"/> of type <typeparamref name="T"/> to the service collection instance.
@@ -43,9 +41,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <returns>The <see cref="IServiceCollection"/> instance.</returns>
         public static IServiceCollection AddLogEntryLabelProvider<T>(this IServiceCollection serivces, Func<IServiceProvider, T> implementationFactory)
             where T : class, ILogEntryLabelProvider
-        {
-            return serivces.AddSingleton<ILogEntryLabelProvider, T>(implementationFactory);
-        }
+             => serivces.AddSingleton<ILogEntryLabelProvider, T>(implementationFactory);
 
         /// <summary>
         /// Adds a <see cref="ILogEntryLabelProvider"/> of type <typeparamref name="T"/> to the service collection instance.
@@ -56,8 +52,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <returns>The <see cref="IServiceCollection"/> instance.</returns>
         public static IServiceCollection AddLogEntryLabelProvider<T>(this IServiceCollection serivces, T instance)
             where T : class, ILogEntryLabelProvider
-        {
-            return serivces.AddSingleton<ILogEntryLabelProvider>(instance);
-        }
+            => serivces.AddSingleton<ILogEntryLabelProvider>(instance);
     }
 }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/LabelProviderExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/LabelProviderExtensions.cs
@@ -1,0 +1,63 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Google.Cloud.Diagnostics.AspNetCore
+{
+    /// <summary>
+    /// Provides extension methods to register <see cref="ILogEntryLabelProvider"/> implementations.
+    /// </summary>
+    public static class LabelProviderExtensions
+    {
+        /// <summary>
+        /// Adds a <see cref="ILogEntryLabelProvider"/> of type <typeparamref name="T"/> to the service collection instance.
+        /// </summary>
+        /// <typeparam name="T">The type of the <see cref="ILogEntryLabelProvider"/> implementation.</typeparam>
+        /// <param name="serivces">The <see cref="IServiceCollection"/> instance.</param>
+        /// <returns>The <see cref="IServiceCollection"/> instance.</returns>
+        public static IServiceCollection AddLogEntryLabelProvider<T>(this IServiceCollection serivces)
+            where T : class, ILogEntryLabelProvider
+        {
+            return serivces.AddSingleton<ILogEntryLabelProvider, T>();
+        }
+
+        /// <summary>
+        /// Adds a <see cref="ILogEntryLabelProvider"/> of type <typeparamref name="T"/> to the service collection instance.
+        /// </summary>
+        /// <typeparam name="T">The type of the <see cref="ILogEntryLabelProvider"/> implementation.</typeparam>
+        /// <param name="serivces">The <see cref="IServiceCollection"/> instance.</param>
+        /// <param name="implementationFactory">The factory that creates the service.</param>
+        /// <returns>The <see cref="IServiceCollection"/> instance.</returns>
+        public static IServiceCollection AddLogEntryLabelProvider<T>(this IServiceCollection serivces, Func<IServiceProvider, T> implementationFactory)
+            where T : class, ILogEntryLabelProvider
+        {
+            return serivces.AddSingleton<ILogEntryLabelProvider, T>(implementationFactory);
+        }
+
+        /// <summary>
+        /// Adds a <see cref="ILogEntryLabelProvider"/> of type <typeparamref name="T"/> to the service collection instance.
+        /// </summary>
+        /// <typeparam name="T">The type of the <see cref="ILogEntryLabelProvider"/> implementation.</typeparam>
+        /// <param name="serivces">The <see cref="IServiceCollection"/> instance.</param>
+        /// <param name="instance">The instance of <typeparamref name="T"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/> instance.</returns>
+        public static IServiceCollection AddLogEntryLabelProvider<T>(this IServiceCollection serivces, T instance)
+            where T : class, ILogEntryLabelProvider
+        {
+            return serivces.AddSingleton<ILogEntryLabelProvider>(instance);
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/TraceIdLogEntryLabelProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/TraceIdLogEntryLabelProvider.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+
+namespace Google.Cloud.Diagnostics.AspNetCore
+{
+    /// <summary>
+    /// A <see cref="ILogEntryLabelProvider"/> implementation which adds the <see cref="HttpContext.TraceIdentifier"/> to the log entry labels.
+    /// </summary>
+    public class TraceIdLogEntryLabelProvider : HttpLogEntryLabelProvider
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TraceIdLogEntryLabelProvider"/> class.
+        /// </summary>
+        /// <param name="httpContextAccessor">The <see cref="IHttpContextAccessor"/> instance with the <see cref="HttpContext"/>.</param>
+        public TraceIdLogEntryLabelProvider(IHttpContextAccessor httpContextAccessor)
+            : base(httpContextAccessor)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void InvokeCore(Dictionary<string, string> labels, HttpContext httpContext)
+        {
+            if (!string.IsNullOrEmpty(httpContext.TraceIdentifier))
+            {
+                labels["trace_identifier"] = httpContext.TraceIdentifier;
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/UserLogEntryLabelProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/UserLogEntryLabelProvider.cs
@@ -1,0 +1,68 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Security.Principal;
+using Microsoft.AspNetCore.Http;
+
+namespace Google.Cloud.Diagnostics.AspNetCore
+{
+    /// <summary>
+    /// A <see cref="ILogEntryLabelProvider"/> which adds the information of the authenitacted user to the log entry labels.
+    /// </summary>
+    public class UserLogEntryLabelProvider : HttpLogEntryLabelProvider
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserLogEntryLabelProvider"/> class.
+        /// </summary>
+        /// <param name="httpContextAccessor">The <see cref="IHttpContextAccessor"/> instance with the <see cref="HttpContext"/>.</param>
+        public UserLogEntryLabelProvider(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override void InvokeCore(Dictionary<string, string> labels, HttpContext httpContext)
+        {
+            if (httpContext.User?.Identity != null)
+            {
+                labels["user_authenticated"] = httpContext.User.Identity.IsAuthenticated.ToString();
+                if (httpContext.User.Identity.IsAuthenticated)
+                {
+                    labels["user_name"] = GetUserName(httpContext.User.Identity);
+                }
+            }
+        }
+
+        private string GetUserName(IIdentity identity)
+        {
+            var name = identity.Name;
+            if (name != null)
+            {
+                return name;
+            }
+
+            if (identity is ClaimsIdentity claimsIdentity)
+            {
+                return GetClaimValue(claimsIdentity, "sub")
+                    ?? GetClaimValue(claimsIdentity, ClaimTypes.Name)
+                    ?? GetClaimValue(claimsIdentity, ClaimTypes.NameIdentifier);
+            }
+
+            return null;
+        }
+
+        private string GetClaimValue(ClaimsIdentity identity, string claimsType) => identity.FindFirst(claimsType)?.Value;
+    }
+}


### PR DESCRIPTION
Adds default log entry label providers which a user can add. The `TraceIdLogEntryLabelProvider` configured by default. The others are opt-in.

Resolves #2120 