### PR TITLE
Update the Firestore gRPC package as well

### DIFF
--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.csproj
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -304,7 +304,7 @@
     "id": "Google.Cloud.Firestore.V1Beta1",
     "productName": "Firestore",
     "productUrl": "https://firebase.google.com",
-    "version": "1.0.0-beta02",
+    "version": "1.0.0-beta03",
     "type": "grpc",
     "description": "Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore.Data package instead.",
     "tags": [ "firestore", "firebase" ],


### PR DESCRIPTION
(We have a project reference from Google.Cloud.Firestore to Google.Cloud.Firestore.V1Beta1, so we need to release them together. We'll split them when we're closer to GA.)