### PR TITLE
Rename TransactionOptions.Create to ForMaxAttempts

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/RunInTransactionTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/RunInTransactionTest.cs
@@ -102,8 +102,8 @@ namespace Google.Cloud.Firestore.IntegrationTests
             var doc = await _fixture.NonQueryCollection.AddAsync(new { Count = 0 });
             var latch = new CountdownEvent(2);
 
-            var t1 = db.RunTransactionAsync(IncrementCounter, TransactionOptions.Create(1));
-            var t2 = db.RunTransactionAsync(IncrementCounter, TransactionOptions.Create(1));
+            var t1 = db.RunTransactionAsync(IncrementCounter, TransactionOptions.ForMaxAttempts(1));
+            var t2 = db.RunTransactionAsync(IncrementCounter, TransactionOptions.ForMaxAttempts(1));
             await Assert.ThrowsAsync<RpcException>(() => Task.WhenAll(t1, t2));
 
             // Exactly one of the transactions should be faulted.

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FirestoreDbTest.RunTransactionAsync.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FirestoreDbTest.RunTransactionAsync.cs
@@ -127,7 +127,7 @@ namespace Google.Cloud.Firestore.Tests
         public async Task RunTransactionAsync_TooManyRetries(int? userSpecifiedAttempts)
         {
             int actualAttempts = userSpecifiedAttempts ?? TransactionOptions.Default.MaxAttempts;
-            var options = userSpecifiedAttempts == null ? null : TransactionOptions.Create(userSpecifiedAttempts.Value);
+            var options = userSpecifiedAttempts == null ? null : TransactionOptions.ForMaxAttempts(userSpecifiedAttempts.Value);
 
             var client = new TransactionTestingClient(actualAttempts, CreateRpcException(StatusCode.Aborted));
             var db = FirestoreDb.Create("proj", "db", client);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/TransactionOptionsTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/TransactionOptionsTest.cs
@@ -23,18 +23,18 @@ namespace Google.Cloud.Firestore.Tests
         [InlineData(0)]
         [InlineData(-1)]
         [InlineData(-10)]
-        public void Create_Invalid(int attempts)
+        public void ForMaxAttempts_Invalid(int attempts)
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => TransactionOptions.Create(attempts));
+            Assert.Throws<ArgumentOutOfRangeException>(() => TransactionOptions.ForMaxAttempts(attempts));
         }
 
         [Theory]
         [InlineData(1)]
         [InlineData(5)]
         [InlineData(int.MaxValue)]
-        public void Create_Valid(int attempts)
+        public void ForMaxAttempts_Valid(int attempts)
         {
-            var options = TransactionOptions.Create(attempts);
+            var options = TransactionOptions.ForMaxAttempts(attempts);
             Assert.Equal(attempts, options.MaxAttempts);
         }
     }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/TransactionOptions.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/TransactionOptions.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Google.Api.Gax;
-using System;
 
 namespace Google.Cloud.Firestore
 {
@@ -42,7 +41,7 @@ namespace Google.Cloud.Firestore
         /// </summary>
         /// <param name="maxAttempts">The number of times a transaction will be attempted before failing. Must be positive.</param>
         /// <returns>A new options object.</returns>
-        public static TransactionOptions Create(int maxAttempts)
+        public static TransactionOptions ForMaxAttempts(int maxAttempts)
         {
             GaxPreconditions.CheckArgumentRange(maxAttempts, nameof(maxAttempts), 1, int.MaxValue);
             return new TransactionOptions(maxAttempts);


### PR DESCRIPTION
In the future we may have more options, at which point Create would
be ambiguous. (At that point we'll add fluent methods to create a
clone with different options etc, but this method will be fine.)