### PR TITLE
Add back the HttpContextAccessor to CloudTrace

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
@@ -18,6 +18,7 @@ using Google.Cloud.Trace.V1;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 
 namespace Google.Cloud.Diagnostics.AspNetCore
@@ -115,6 +116,9 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             services.AddScoped(CreateTraceHeaderContext);
 
             services.AddSingleton(tracerFactory);
+
+            // Only add the HttpContextAccessor if it's not already added.
+            services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
             services.AddSingleton(ManagedTracer.CreateDelegatingTracer(() => ContextTracerManager.GetCurrentTracer()));
             services.AddSingleton(new TraceHeaderPropagatingHandler(() => ContextTracerManager.GetCurrentTracer()));

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
@@ -118,6 +118,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             services.AddSingleton(tracerFactory);
 
             // Only add the HttpContextAccessor if it's not already added.
+            // This is needed to get the `TraceHeaderContext`. See `CreateTraceHeaderContext`.
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
             services.AddSingleton(ManagedTracer.CreateDelegatingTracer(() => ContextTracerManager.GetCurrentTracer()));


### PR DESCRIPTION
This was removed in PR #2096 as it was no longer used in most of the code but is still used to get trace headers.