### PR TITLE
Finish Firestore Watch implementation

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
@@ -11,8 +11,10 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Google.Api.Gax.Testing" Version="2.4.0-beta02" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
+    <PackageReference Include="Grpc.Core.Testing" Version="1.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
@@ -11,8 +11,10 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Google.Api.Gax.Testing" Version="2.4.0-beta02" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
+    <PackageReference Include="Grpc.Core.Testing" Version="1.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/UserGuideSnippets.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/UserGuideSnippets.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
 using Xunit;
+using static Google.Cloud.Firestore.Snippets.DataModelSnippets;
 
 namespace Google.Cloud.Firestore.Snippets
 {
@@ -339,6 +340,55 @@ namespace Google.Cloud.Firestore.Snippets
                 City city = document.ConvertTo<City>();
                 Console.WriteLine($"{city.Name}: {city.Population}");
             }
+            // End sample
+        }
+
+        [Fact]
+        public async Task ListenQuery()
+        {
+            string projectId = _fixture.ProjectId;
+            string collectionId = _fixture.CreateUniqueCollection().Id;
+            // Sample: ListenQuery
+            FirestoreDb db = FirestoreDb.Create(projectId);
+            CollectionReference collection = db.Collection(collectionId);
+            Query query = collection.WhereGreaterThan("Score", 5).OrderByDescending("Score");
+
+            SnapshotListener listener = query.Listen(snapshot =>
+            {
+                Console.WriteLine($"Callback received snapshot");
+                Console.WriteLine($"Count: {snapshot.Count}");
+                Console.WriteLine("Changes:");
+                foreach (DocumentChange change in snapshot.Changes)
+                {
+                    Console.WriteLine($"{change.Document.Reference.Id}: ChangeType={change.ChangeType}; OldIndex={change.OldIndex}; NewIndex={change.NewIndex})");
+                }
+                Console.WriteLine();
+            });
+
+            Console.WriteLine("Creating document for Sophie (Score = 7)");
+            var doc1Ref = await collection.AddAsync(new { Name = "Sophie", Score = 7 });
+            Console.WriteLine($"Sophie document ID: {doc1Ref.Id}");
+            await Task.Delay(1000);
+
+            Console.WriteLine("Creating document for James (Score = 10)");
+            var doc2Ref = await collection.AddAsync(new { Name = "James", Score = 10 });
+            Console.WriteLine($"James document ID: {doc2Ref.Id}");
+            await Task.Delay(1000);
+
+            Console.WriteLine("Modifying document for Sophie (set Score = 11, higher than score for James)");
+            await doc1Ref.UpdateAsync("Score", 11);
+            await Task.Delay(1000);
+
+            Console.WriteLine("Modifying document for James (set Score = 4, below threshold for query)");
+            await doc2Ref.UpdateAsync("Score", 4);
+            await Task.Delay(1000);
+
+            Console.WriteLine("Deleting document for Sophie");
+            await doc1Ref.DeleteAsync();
+            await Task.Delay(1000);
+
+            Console.WriteLine("Stopping listener");
+            await listener.StopAsync();
             // End sample
         }
     }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
@@ -11,8 +11,10 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Google.Api.Gax.Testing" Version="2.4.0-beta02" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
+    <PackageReference Include="Grpc.Core.Testing" Version="1.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Proto/ProtoTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Proto/ProtoTest.cs
@@ -286,7 +286,7 @@ namespace Google.Cloud.Firestore.Tests.Proto
             {
                 // TODO: Should we actually check that it's only the last response that causes the exception?
                 var exception = await Assert.ThrowsAnyAsync<Exception>(action);
-                Assert.True(exception is ArgumentException || exception is InvalidOperationException || exception is RpcException,
+                Assert.True(exception is ArgumentException || exception is InvalidOperationException,
                     $"Exception type: {exception.GetType()}");
             }
             else

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WatchStreamTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WatchStreamTest.cs
@@ -1,0 +1,574 @@
+﻿// Copyright 2018, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Grpc;
+using Google.Api.Gax.Testing;
+using Google.Cloud.Firestore.V1Beta1;
+using Google.Protobuf;
+using Grpc.Core;
+using Grpc.Core.Testing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Cloud.Firestore.V1Beta1.FirestoreClient;
+using static Google.Cloud.Firestore.V1Beta1.StructuredQuery.Types;
+using static Google.Cloud.Firestore.V1Beta1.Target.Types;
+
+namespace Google.Cloud.Firestore.Tests
+{
+    public class WatchStreamTest
+    {
+        /// <summary>
+        /// A timeout for waiting for asynchronous operations. The code is designed
+        /// so that if this *does* time out, it always represents a failure. We should never
+        /// actually need this much time; it just prevents tests from hanging entirely.
+        /// </summary>
+        private static readonly TimeSpan s_timeout = TimeSpan.FromSeconds(10);
+
+        [Fact]
+        public void Stop()
+        {
+            var sequence = new TestSequence();
+            sequence.ExpectConnect(null, StreamInitializationCause.WatchStarting);
+            sequence.ProvideResponse(WatchResponseResult.Continue);
+            sequence.WaitForCancellation();
+
+            Task task = sequence.RunToStability();
+            sequence.WatchStream.Stop(CancellationToken.None);
+            task.Wait();
+            sequence.Verify();
+        }
+
+        [Fact]
+        public void StreamReset()
+        {
+            ByteString token = ByteString.CopyFromUtf8("token");
+            var sequence = new TestSequence();
+            sequence.ExpectConnect(null, StreamInitializationCause.WatchStarting);
+            sequence.ProvideResponse(WatchResponseResult.Continue);
+            sequence.ProvideResponse(WatchResponseResult.ResetStream);
+            // First reset doesn't get a token
+            sequence.ExpectConnect(null, StreamInitializationCause.ResetRequested);
+            sequence.ProvideResponse(WatchResponseResult.StreamHealthy, token);
+            sequence.ProvideResponse(WatchResponseResult.ResetStream);
+            // Second reset does
+            sequence.ExpectConnect(token, StreamInitializationCause.ResetRequested);
+            sequence.WaitForCancellation();
+
+            Task task = sequence.RunToStability();
+            sequence.WatchStream.Stop(CancellationToken.None);
+            task.Wait();
+            sequence.Verify();
+        }
+
+        [Fact]
+        public void StreamComplete()
+        {
+            ByteString token1 = ByteString.CopyFromUtf8("token1");
+            ByteString token2 = ByteString.CopyFromUtf8("token2");
+            var sequence = new TestSequence();
+            sequence.ExpectConnect(null, StreamInitializationCause.WatchStarting);
+            sequence.ProvideResponse(WatchResponseResult.Continue);
+            sequence.ProvideResponse(WatchResponseResult.StreamHealthy, token1);
+            sequence.ProvideResponse(WatchResponseResult.StreamHealthy, token2);
+            sequence.ProvideResponse(WatchResponseResult.Continue);
+            // The stream ended. Restart with the last token.
+            sequence.ExpectConnect(token2, StreamInitializationCause.StreamCompleted);
+            sequence.ProvideResponse(WatchResponseResult.Continue);
+            sequence.WaitForCancellation();
+
+            Task task = sequence.RunToStability();
+            sequence.WatchStream.Stop(CancellationToken.None);
+            task.Wait();
+            sequence.Verify();
+        }
+
+        [Fact]
+        public void RetriableRpcException()
+        {
+            ByteString token1 = ByteString.CopyFromUtf8("token1");
+            ByteString token2 = ByteString.CopyFromUtf8("token2");
+            var sequence = new TestSequence();
+            sequence.ExpectConnect(null, StreamInitializationCause.WatchStarting);
+            sequence.ProvideResponse(WatchResponseResult.Continue);
+            sequence.ProvideResponse(WatchResponseResult.StreamHealthy, token1);
+            sequence.ProvideResponse(WatchResponseResult.StreamHealthy, token2);
+            sequence.RpcException(new RpcException(new Status(StatusCode.DeadlineExceeded, "This exception is transient")));
+            // The server throw a retriable exception. Reinitialize.
+            sequence.ExpectConnect(token2, StreamInitializationCause.RpcError);
+            sequence.ProvideResponse(WatchResponseResult.Continue);
+            sequence.WaitForCancellation();
+
+            Task task = sequence.RunToStability();
+            sequence.WatchStream.Stop(CancellationToken.None);
+            task.Wait();
+            sequence.Verify();
+        }
+
+        [Fact]
+        public void ResourceExhaustedRpcException()
+        {
+            ByteString token1 = ByteString.CopyFromUtf8("token1");
+            ByteString token2 = ByteString.CopyFromUtf8("token2");
+            var sequence = new TestSequence();
+            sequence.ExpectConnect(null, StreamInitializationCause.WatchStarting);
+            sequence.ProvideResponse(WatchResponseResult.Continue);
+            sequence.ProvideResponse(WatchResponseResult.StreamHealthy, token1);
+            sequence.ProvideResponse(WatchResponseResult.StreamHealthy, token2);
+            // This exception will cause us to double our backoff.
+            // TODO: Timing tests in general.
+            sequence.RpcException(new RpcException(new Status(StatusCode.ResourceExhausted, "This exception is transient")));
+            // The server throw a retriable exception. Reinitialize.
+            sequence.ExpectConnect(token2, StreamInitializationCause.RpcError);
+            sequence.ProvideResponse(WatchResponseResult.Continue);
+            sequence.WaitForCancellation();
+
+            Task task = sequence.RunToStability();
+            sequence.WatchStream.Stop(CancellationToken.None);
+            task.Wait();
+            sequence.Verify();
+        }
+
+        [Fact]
+        public void NonRetriableRpcException()
+        {
+            ByteString token1 = ByteString.CopyFromUtf8("token1");
+            ByteString token2 = ByteString.CopyFromUtf8("token2");
+            var sequence = new TestSequence();
+            sequence.ExpectConnect(null, StreamInitializationCause.WatchStarting);
+            sequence.ProvideResponse(WatchResponseResult.Continue);
+            sequence.ProvideResponse(WatchResponseResult.StreamHealthy, token1);
+            sequence.ProvideResponse(WatchResponseResult.StreamHealthy, token2);
+            // This exception is not retriable.
+            var exception = new RpcException(new Status(StatusCode.InvalidArgument, "This exception is permanent"));
+            sequence.RpcException(exception);
+
+            Task task = sequence.RunToStability();
+            Assert.Equal(TaskStatus.Faulted, task.Status);
+            Assert.Equal(exception, task.Exception.InnerException);
+            sequence.Verify();
+        }
+
+        [Fact]
+        public void InitialTokenCancellation_WhileRunning()
+        {
+            var tokenSource = new CancellationTokenSource();
+            var sequence = new TestSequence(tokenSource.Token);
+            sequence.ExpectConnect(null, StreamInitializationCause.WatchStarting);
+            sequence.ProvideResponse(WatchResponseResult.Continue);
+            sequence.WaitForCancellation();
+
+            Task task = sequence.RunToStability();
+            tokenSource.Cancel();
+            // If it doesn't finish quickly, Task.Wait will time out and the assertion will fail.
+            Assert.Throws<AggregateException>(() => task.Wait(s_timeout));
+            Assert.Equal(TaskStatus.Canceled, task.Status);
+        }
+
+        [Fact]
+        public void InitialTokenCancellation_WhileServerHanging()
+        {
+            var tokenSource = new CancellationTokenSource();
+            var sequence = new TestSequence(tokenSource.Token);
+            sequence.ExpectConnect(null, StreamInitializationCause.WatchStarting);
+            sequence.ProvideResponse(WatchResponseResult.Continue);
+            sequence.WaitForCancellation();
+
+            Task task = sequence.RunToStability();
+            tokenSource.Cancel();
+            AssertTaskIsCancelledSoon(task);
+            sequence.Verify();
+        }
+
+        [Fact]
+        public void InitialTokenCancellation_WhileStateMachineHanging()
+        {
+            var tokenSource = new CancellationTokenSource();
+            var sequence = new TestSequence(tokenSource.Token);
+            sequence.ExpectConnect(null, StreamInitializationCause.WatchStarting);
+            sequence.ProvideResponse(WatchResponseResult.Continue);
+            sequence.ProvideResponseHangingInStateMachine();
+
+            Task task = sequence.RunToStability();
+            tokenSource.Cancel();
+            AssertTaskIsCancelledSoon(task);
+            sequence.Verify();
+        }
+
+        [Fact]
+        public void StopTokenCancellation()
+        {
+            var sequence = new TestSequence();
+            sequence.ExpectConnect(null, StreamInitializationCause.WatchStarting);
+            sequence.ProvideResponse(WatchResponseResult.Continue);
+            sequence.ProvideResponseHangingInStateMachine();
+
+            Task task = sequence.RunToStability();
+            var tokenSource = new CancellationTokenSource();
+            sequence.WatchStream.Stop(tokenSource.Token);
+            tokenSource.Cancel();
+            AssertTaskIsCancelledSoon(task);
+            sequence.Verify();
+        }
+
+        [Fact]
+        public void CreateTarget_Query()
+        {
+            var client = new FakeFirestoreClient();
+            var db = FirestoreDb.Create("project", "db", client);
+            var query = db.Collection("col").Limit(10);
+            var expected = new Target
+            {
+                TargetId = WatchStream.WatchTargetId,
+                Query = new QueryTarget
+                {
+                    Parent = db.DocumentsPath,
+                    StructuredQuery = new StructuredQuery
+                    {
+                        From = { new CollectionSelector { CollectionId = "col" } },
+                        Limit = 10
+                    }
+                }
+            };
+            var actual = WatchStream.CreateTarget(query);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CreateTarget_Document()
+        {
+            var client = new FakeFirestoreClient();
+            var db = FirestoreDb.Create("project", "db", client);
+            var doc = db.Document("col/doc");
+            var expected = new Target
+            {
+                TargetId = WatchStream.WatchTargetId,
+                Documents = new DocumentsTarget { Documents = { doc.Path } }
+            };
+            var actual = WatchStream.CreateTarget(doc);
+            Assert.Equal(expected, actual);
+        }
+
+        private void AssertTaskIsCancelledSoon(Task task)
+        {
+            // If it doesn't finish quickly, Task.Wait will time out and the assertion will fail.
+            Assert.Throws<AggregateException>(() => task.Wait(s_timeout));
+            Assert.Equal(TaskStatus.Canceled, task.Status);
+        }
+
+        /// <summary>
+        /// A test sequence, used to set up expectations of how the gRPC stream and the state machine interact.
+        /// </summary>
+        private class TestSequence
+        {
+            private readonly List<FakeWatchStream> _streams;
+            private readonly FakeFirestoreListenClient _client;
+            /// <summary>
+            /// This task will complete when either the server or the state machine is deliberately hanging, waiting
+            /// for cancellation.
+            /// </summary>
+            private readonly TaskCompletionSource<int> _completionTaskSource = new TaskCompletionSource<int>();
+            private readonly FakeScheduler _scheduler;
+
+            private FakeWatchStream _currentStream;
+            private List<Func<ListenResponse>> _currentResponseList;
+            private FakeWatchState _watchState;
+            private int _responseIndex;
+
+            internal WatchStream WatchStream { get; }
+
+            internal TestSequence(CancellationToken initialCancellationToken = default)
+            {
+                _streams = new List<FakeWatchStream>();
+                _client = new FakeFirestoreListenClient(_streams);
+                _watchState = new FakeWatchState(TriggerCompletion);
+                var db = FirestoreDb.Create("project", "db", _client);
+                var target = WatchStream.CreateTarget(db.Document("col/doc"));
+                _scheduler = new FakeScheduler();
+                WatchStream = new WatchStream(_scheduler, _watchState, target, db, initialCancellationToken);
+            }
+
+            /// <summary>
+            /// Expect the WatchStream to call the Listen RPC, and then cll OnStreamInitialization with the given cause.
+            /// </summary>
+            internal void ExpectConnect(ByteString expectedResumeToken, StreamInitializationCause expectedCause)
+            {
+                _currentResponseList = new List<Func<ListenResponse>>();
+                var expectedRequest = WatchStream.CreateRequest(expectedResumeToken);
+                _currentStream = new FakeWatchStream(expectedRequest, new FakeResponseList(_currentResponseList, TriggerCompletion));
+                _streams.Add(_currentStream);
+                _watchState.ExpectInitialization(expectedCause);
+            }
+
+            /// <summary>
+            /// Causes the fake server to provide a response, which we expect to be passed to the
+            /// state machine. The resume token for the state machine is set to <paramref name="resumeToken"/> for
+            /// requests which occur after this point.
+            /// </summary>
+            internal void ProvideResponse(WatchResponseResult result, ByteString resumeToken)
+            {
+                _watchState.AddResumeToken(_responseIndex, resumeToken);
+                ProvideResponse(result);
+            }
+
+            /// <summary>
+            /// Causes the fake server to provide a response, which we expect to be passed to the
+            /// state machine.
+            /// </summary>
+            internal void ProvideResponse(WatchResponseResult result)
+            {
+                // The response is opaque to WatchStream, but we want to make sure the state machine gets the 
+                var response = new ListenResponse { TargetChange = new TargetChange { TargetIds = { _responseIndex++ } } };
+                _currentResponseList.Add(() => response);
+                _watchState.ExpectResponse(response, result);
+            }
+
+            /// <summary>
+            /// Causes the fake server to provide a response which is passed to the state machine - which then
+            /// hangs (expecting its cancellation token to be cancelled).
+            /// </summary>
+            internal void ProvideResponseHangingInStateMachine()
+            {
+                var response = new ListenResponse { TargetChange = new TargetChange { TargetIds = { _responseIndex++ } } };
+                _currentResponseList.Add(() => response);
+                _watchState.ExpectResponseAndWaitForUserCancellation(response);
+            }
+
+            /// <summary>
+            /// Causes the fake server to throw the given exception from the gRPC stream.
+            /// </summary>
+            internal void RpcException(RpcException exception)
+            {
+                _currentResponseList.Add(() => throw exception);
+            }
+
+            /// <summary>
+            /// Causes the fake server to effectively wait: the gRPC stream of responses doesn't return another item.
+            /// </summary>
+            internal void WaitForCancellation()
+            {
+                _currentResponseList.Add(null);
+            }
+
+            private void TriggerCompletion() => _completionTaskSource.SetResult(0);
+
+            /// <summary>
+            /// Verifies that all the RPC stream responses and state machine calls have been consumed appropriately.
+            /// </summary>
+            internal void Verify()
+            {
+                // Check the state machine had all the expected calls
+                _watchState.Verify();
+                // Check that all the streams were closed and disposed, with
+                _client.Verify();
+            }
+
+            /// <summary>
+            /// Runs the test sequence until either the fake server is paused, or all its responses have been consumed.
+            /// </summary>
+            /// <returns>The task from the WatchStream.StartAsync method</returns>
+            internal Task RunToStability()
+            {
+                Task task = null;
+                _scheduler.Run(() =>
+                {
+                    task = WatchStream.StartAsync();
+                    // Wait for:
+                    // - The server to go into "hanging" mode
+                    // - The listening task to complete (e.g. due to an error)
+                    // - A timeout (because something is broken)
+                    Task.WaitAny(new[] { task, _completionTaskSource.Task }, s_timeout);
+                });
+                return task;
+            }
+        }
+
+        private class FakeWatchState : IWatchState
+        {
+            private List<(int index, ByteString token)> _resumeTokens = new List<(int, ByteString)> { (-1, null) };
+            private int _lastSeenIndex = -1;
+            // Very primitive mocking; we can't use Moq due to the types being internal.
+            private Queue<Delegate> _expectedCalls = new Queue<Delegate>();
+            private readonly Action _hangingCallback;
+
+            public ByteString ResumeToken => _resumeTokens.Last(tuple => tuple.index <= _lastSeenIndex).token;
+
+            internal FakeWatchState(Action hangingCallback) => _hangingCallback = hangingCallback;
+
+            public Task<WatchResponseResult> HandleResponseAsync(ListenResponse response, CancellationToken cancellationToken)
+            {
+                _lastSeenIndex = response.TargetChange.TargetIds[0];
+                var call = (Func<ListenResponse, CancellationToken, Task<WatchResponseResult>>) _expectedCalls.Dequeue();
+                return call(response, cancellationToken);
+            }
+
+            public void OnStreamInitialization(StreamInitializationCause cause)
+            {
+                var call = (Action<StreamInitializationCause>) _expectedCalls.Dequeue();
+                call(cause);
+            }
+
+            internal void AddResumeToken(int index, ByteString token) => _resumeTokens.Add((index, token));
+
+            internal void ExpectResponse(ListenResponse expectedResponse, WatchResponseResult result)
+            {
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+                Func<ListenResponse, CancellationToken, Task<WatchResponseResult>> call = async (response, _) =>
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+                {
+                    Assert.Equal(expectedResponse, response);
+                    return result;
+                };
+                _expectedCalls.Enqueue(call);
+            }
+
+            internal void ExpectResponseAndWaitForUserCancellation(ListenResponse expectedResponse)
+            {
+                Func<ListenResponse, CancellationToken, Task<WatchResponseResult>> call = async (response, cancellationToken) =>
+                {
+                    Assert.Equal(expectedResponse, response);
+                    _hangingCallback();
+                    await Task.Delay(s_timeout, cancellationToken).ConfigureAwait(false);
+                    throw new InvalidOperationException("Shouldn't get here");
+                };
+                _expectedCalls.Enqueue(call);
+            }
+
+            internal void ExpectInitialization(StreamInitializationCause expectedCause)
+            {
+                Action<StreamInitializationCause> call = cause => Assert.Equal(expectedCause, cause);
+                _expectedCalls.Enqueue(call);
+            }
+
+            internal void Verify() => Assert.Empty(_expectedCalls);
+        }
+
+        private class FakeFirestoreListenClient : FakeFirestoreClient
+        {
+            private readonly List<FakeWatchStream> _streams;
+            private int _index;
+
+            internal FakeFirestoreListenClient(List<FakeWatchStream> streams) =>
+                _streams = streams;
+
+            public override ListenStream Listen(
+                CallSettings callSettings = null,
+                BidirectionalStreamingSettings streamingSettings = null) =>
+                _streams[_index++];
+
+            internal void Verify()
+            {
+                // All streams should have been used.
+                Assert.Equal(_streams.Count, _index);
+
+                // Each stream should be exhausted.
+                for (int i = 0; i < _streams.Count; i++)
+                {
+                    _streams[i].Verify(i);
+                }
+            }
+        }
+
+        private class FakeResponseList : IAsyncEnumerator<ListenResponse>
+        {
+            private readonly List<Func<ListenResponse>> _responses;
+            private int _index = -1;
+            private readonly Action _hangingCallback;
+
+            public ListenResponse Current => _responses[_index].Invoke();
+
+            internal FakeResponseList(List<Func<ListenResponse>> responses, Action hangingCallback)
+            {
+                _responses = responses;
+                _hangingCallback = hangingCallback;
+            }
+
+            public void Dispose() { }
+
+            public async Task<bool> MoveNext(CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (_index < _responses.Count)
+                {
+                    _index++;
+                }
+                // We use a null response provider to mean "Wait, we're expecting to be cancelled".
+                if (_index < _responses.Count && _responses[_index] == null)
+                {
+                    _hangingCallback();
+                    await Task.Delay(s_timeout, cancellationToken);
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+                return _index < _responses.Count;
+            }
+
+            internal void Verify(int streamIndex)
+            {
+                // We should either have exhausted the stream or be looking at the last element.
+                Assert.True(_index >= _responses.Count - 1, $"streamIndex={streamIndex}; _index = {_index}; Count={_responses.Count}");
+            }
+        }
+
+        private class FakeWatchStream : ListenStream
+        {
+            private readonly FakeResponseList _responses;
+            private readonly ListenRequest _expectedRequest;
+            internal bool Completed { get; private set; }
+            internal bool Disposed { get; private set; }
+            private bool _requestWritten = false;
+            private AsyncDuplexStreamingCall<ListenRequest, ListenResponse> _grpcCall;
+
+            internal FakeWatchStream(ListenRequest expectedRequest, FakeResponseList responses)
+            {
+                _expectedRequest = expectedRequest;
+                _responses = responses;
+                // We only use the gRPC call for disposal. This is a bit unpleasant (rather than providing a reader/writer etc) but
+                // it's simple and enough for what we need.
+                _grpcCall = TestCalls.AsyncDuplexStreamingCall<ListenResponse, ListenRequest>(null, null, null, null, null, () => Disposed = true);
+            }
+
+            public override AsyncDuplexStreamingCall<ListenRequest, ListenResponse> GrpcCall => _grpcCall;
+
+            public override IAsyncEnumerator<ListenResponse> ResponseStream => _responses;
+
+            public override Task TryWriteAsync(ListenRequest message, WriteOptions options) =>
+                TryWriteAsync(message);
+
+            public override async Task TryWriteAsync(ListenRequest message)
+            {
+                Assert.False(_requestWritten);
+                _requestWritten = true;
+                Assert.Equal(_expectedRequest, message);
+                await Task.Yield();
+            }
+
+            public override async Task TryWriteCompleteAsync()
+            {
+                Completed = true;
+                await Task.Yield();
+            }
+
+            public void Verify(int streamIndex)
+            {
+                Assert.True(_requestWritten);
+                Assert.True(Completed);
+                Assert.True(Disposed);
+                _responses.Verify(streamIndex);
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentReference.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentReference.cs
@@ -236,5 +236,18 @@ namespace Google.Cloud.Firestore
             var stream = new WatchStream(new WatchState(Parent, queryCallback), target, Database, cancellationToken);
             return SnapshotListener.Start(stream);
         }
+
+        /// <summary>
+        /// Watch this document for changes. This method is a convenience method over <see cref="Listen(Func{DocumentSnapshot, CancellationToken, Task}, CancellationToken)"/>,
+        /// wrapping a synchronous callback to create an asynchronous one.
+        /// </summary>
+        /// <param name="callback">The callback to invoke each time the query results change. Must not be null.</param>
+        /// <param name="cancellationToken">Optional cancellation token which may be used to cancel the listening operation.</param>
+        /// <returns>A <see cref="SnapshotListener"/> which may be used to monitor the listening operation and stop it gracefully.</returns>
+        public SnapshotListener Listen(Action<DocumentSnapshot> callback, CancellationToken cancellationToken = default)
+        {
+            GaxPreconditions.CheckNotNull(callback, nameof(callback));
+            return Listen((snapshot, _) => { callback(snapshot); return Task.FromResult(0); }, cancellationToken);
+        }
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Query.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Query.cs
@@ -754,6 +754,19 @@ namespace Google.Cloud.Firestore
             return SnapshotListener.Start(stream);
         }
 
+        /// <summary>
+        /// Listen to this query for changes. This method is a convenience method over <see cref="Listen(Func{QuerySnapshot, CancellationToken, Task}, CancellationToken)"/>,
+        /// wrapping a synchronous callback to create an asynchronous one.
+        /// </summary>
+        /// <param name="callback">The callback to invoke each time the query results change. Must not be null.</param>
+        /// <param name="cancellationToken">Optional cancellation token which may be used to cancel the listening operation.</param>
+        /// <returns>A <see cref="SnapshotListener"/> which may be used to monitor the listening operation and stop it gracefully.</returns>
+        public SnapshotListener Listen(Action<QuerySnapshot> callback, CancellationToken cancellationToken = default)
+        {
+            GaxPreconditions.CheckNotNull(callback, nameof(callback));
+            return Listen((snapshot, _) => { callback(snapshot); return Task.FromResult(0); }, cancellationToken);
+        }
+
         // Structs representing orderings and filters but using FieldPath instead of FieldReference.
         // This allows us to use fields specified in the ordering/filter in this more convenient form.
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Query.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Query.cs
@@ -738,7 +738,22 @@ namespace Google.Cloud.Firestore
             EqualityHelpers.GetListHashCode(_projections),
             _startAt?.GetHashCode() ?? -1,
             _endAt?.GetHashCode() ?? -1);
-        
+
+        // TODO: Should this be ListenAsync?
+        /// <summary>
+        /// Listen to this query for changes.
+        /// </summary>
+        /// <param name="callback">The callback to invoke each time the query results change. Must not be null.</param>
+        /// <param name="cancellationToken">Optional cancellation token which may be used to cancel the listening operation.</param>
+        /// <returns>A <see cref="SnapshotListener"/> which may be used to monitor the listening operation and stop it gracefully.</returns>
+        public SnapshotListener Listen(Func<QuerySnapshot, CancellationToken, Task> callback, CancellationToken cancellationToken = default)
+        {
+            GaxPreconditions.CheckNotNull(callback, nameof(callback));
+            var target = WatchStream.CreateTarget(this);
+            var stream = new WatchStream(new WatchState(this, callback), target, Database, cancellationToken);
+            return SnapshotListener.Start(stream);
+        }
+
         // Structs representing orderings and filters but using FieldPath instead of FieldReference.
         // This allows us to use fields specified in the ordering/filter in this more convenient form.
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/SnapshotListener.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/SnapshotListener.cs
@@ -1,0 +1,67 @@
+﻿// Copyright 2018, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Firestore
+{
+    /// <summary>
+    /// An ongoing "listen" or "watch" operation on either document or query snapshots.
+    /// This is returned from <c>Listen</c> methods.
+    /// </summary>
+    public sealed class SnapshotListener
+    {
+        private readonly WatchStream _stream;
+        private int _stopped;
+
+        // TODO: Rename! (Don't know what to though...)
+        /// <summary>
+        /// A task that will complete when the listen operation finishes.
+        /// TODO: More documentation
+        /// </summary>
+        public Task Task { get; }
+
+        internal SnapshotListener(WatchStream stream, Task task)
+        {
+            _stream = stream;
+            Task = task;
+        }
+
+        internal static SnapshotListener Start(WatchStream stream)
+        {
+            var task = stream.StartAsync();
+            return new SnapshotListener(stream, task);
+        }
+
+        /// <summary>
+        /// Requests that the client stops listening for changes. If a callback is in progress,
+        /// that will be allowed to complete, but cancelling <paramref name="cancellationToken"/> will
+        /// cancel the token passed to the callback, allowing for prompt cancellation if required.
+        /// </summary>
+        /// <remarks>This method must only be called once per listener.</remarks>
+        /// <param name="cancellationToken">A cancellation token to cancel a callback if one is in progress.</param>
+        /// <returns>The task to indicate listener completion. This returns the same as <see cref="Task"/>.</returns>
+        public Task StopAsync(CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Exchange(ref _stopped, 1) != 0)
+            {
+                throw new InvalidOperationException($"{nameof(StopAsync)} can only be called once");
+            }
+            _stream.Stop(cancellationToken);
+            return Task;
+        }        
+    }
+}

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WatchStream.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WatchStream.cs
@@ -15,6 +15,7 @@
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Cloud.Firestore.V1Beta1;
+using Google.Protobuf;
 using Grpc.Core;
 using System;
 using System.Collections.Generic;
@@ -136,12 +137,12 @@ namespace Google.Cloud.Firestore
             }
             finally
             {
-                _networkCancellationTokenSource.Dispose();
-                _callbackCancellationTokenSource.Dispose();
                 lock (_stateLock)
                 {
-                    _finished = true;
+                    _networkCancellationTokenSource.Dispose();
+                    _callbackCancellationTokenSource.Dispose();
                     _stopCancellationTokenRegistration.Dispose();
+                    _finished = true;
                 }
                 // Make sure we clean up even if we get an exception we don't handle explicitly.
                 await CloseStreamAsync().ConfigureAwait(false);
@@ -162,7 +163,7 @@ namespace Google.Cloud.Firestore
                             await _scheduler.Delay(_backoffJitter.GetDelay(nextBackoff), _networkCancellationTokenSource.Token).ConfigureAwait(false);
                             nextBackoff = _backoffSettings.NextDelay(nextBackoff);
                             underlyingStream = _db.Client.Listen();
-                            await underlyingStream.TryWriteAsync(CreateRequest()).ConfigureAwait(false);
+                            await underlyingStream.TryWriteAsync(CreateRequest(_state.ResumeToken)).ConfigureAwait(false);
                             _state.OnStreamInitialization(cause);
                         }
                         // Wait for a response or end-of-stream
@@ -209,17 +210,17 @@ namespace Google.Cloud.Firestore
 
         internal void Stop(CancellationToken userCancellationToken)
         {
-            if (userCancellationToken.CanBeCanceled)
+            lock (_stateLock)
             {
-                lock (_stateLock)
+                if (!_finished)
                 {
-                    if (!_finished)
+                    if (userCancellationToken.CanBeCanceled)
                     {
                         _stopCancellationTokenRegistration = userCancellationToken.Register(() => _callbackCancellationTokenSource.Cancel());
                     }
+                    _networkCancellationTokenSource.Cancel();
                 }
             }
-            _networkCancellationTokenSource.Cancel();
         }
 
         internal static Target CreateTarget(DocumentReference doc) =>
@@ -236,16 +237,17 @@ namespace Google.Cloud.Firestore
                 TargetId = WatchTargetId
             };
 
-        private ListenRequest CreateRequest()
+        // Visible for testing
+        internal ListenRequest CreateRequest(ByteString resumeToken)
         {
             var request = new ListenRequest
             {
                 AddTarget = _target.Clone(),
                 Database = _db.RootPath
             };
-            if (_state.ResumeToken != null)
+            if (resumeToken != null)
             {
-                request.AddTarget.ResumeToken = _state.ResumeToken;
+                request.AddTarget.ResumeToken = resumeToken;
             }
             return request;
         }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WatchStream.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WatchStream.cs
@@ -12,11 +12,242 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Firestore.V1Beta1;
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Google.Cloud.Firestore
 {
-    // Note: this class will eventually contain the gRPC-focused parts of Watch.
+    // TODO: Put this into GAX; there's already an internal method, but it doesn't
+    // handle an initial value less than settings.Delay.
+    internal static class BackoffSettingsExtensions
+    {
+        internal static TimeSpan NextDelay(this BackoffSettings settings, TimeSpan currentDelay)
+        {
+            checked
+            {
+                if (currentDelay < settings.Delay)
+                {
+                    return settings.Delay;
+                }
+                TimeSpan next = new TimeSpan((long)(currentDelay.Ticks * settings.DelayMultiplier));
+                return next < settings.MaxDelay ? next : settings.MaxDelay;
+            }
+        }
+    }
+
     internal sealed class WatchStream
     {
+        private static readonly HashSet<StatusCode> s_transientErrorStatusCodes = new HashSet<StatusCode>
+        {
+            StatusCode.Cancelled,
+            StatusCode.Unknown,
+            StatusCode.DeadlineExceeded,
+            StatusCode.ResourceExhausted,
+            StatusCode.Internal,
+            StatusCode.Unavailable,
+            StatusCode.Unauthenticated
+        };
+
         internal const int WatchTargetId = 0x4323; // "C#"
+        private readonly IScheduler _scheduler;
+        private readonly FirestoreDb _db;
+        // The token source for all network operations. This is cancelled when a stop is requested,
+        // even if the user never cancels a token.
+        private readonly CancellationTokenSource _networkCancellationTokenSource;
+        // The token source for the callback. This is cancelled if the user cancels either the initial
+        // cancellation token provided to Listen, or the cancellation token provided to StopAsync.
+        private readonly CancellationTokenSource _callbackCancellationTokenSource;
+        private readonly IWatchState _state;
+        private readonly RetrySettings.IJitter _backoffJitter;
+        private readonly BackoffSettings _backoffSettings;
+        private readonly Target _target;
+
+        private readonly object _stateLock = new object();
+
+        // Only mutable variables within the class: if the user calls Stop and passes in a cancellation token,
+        // we link it with _callbackCancellationTokenSource, and need to be able to dispose of that registration
+        // on exit. These variables are protected by _stateLock.
+        private CancellationTokenRegistration _stopCancellationTokenRegistration;
+        private bool _finished;
+
+        internal WatchStream(IWatchState state, Target target, FirestoreDb db, CancellationToken cancellationToken)
+            : this(SystemScheduler.Instance, state, target, db, cancellationToken)
+        {
+        }
+
+        internal WatchStream(IScheduler scheduler, IWatchState state, Target target, FirestoreDb db, CancellationToken cancellationToken)
+        {
+            _scheduler = scheduler;
+            _state = state;
+            _target = target;
+            _db = db;
+            _callbackCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _networkCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_callbackCancellationTokenSource.Token);
+
+            // TODO: Make these configurable?
+            _backoffSettings = new BackoffSettings(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30), 2.0);
+            _backoffJitter = RetrySettings.RandomJitter;
+        }
+
+        internal async Task StartAsync()
+        {
+            // State used within the method. This is modified by local methods too.
+            StreamInitializationCause cause = StreamInitializationCause.WatchStarting;
+            FirestoreClient.ListenStream underlyingStream = null;
+            TimeSpan nextBackoff = TimeSpan.Zero;
+
+            try
+            {
+                // This won't actually run forever. Calling Stop will cancel the cancellation token, and we'll end up with
+                // an exception which may or may not be caught.
+                while (true)
+                {
+                    var serverResponse = await GetNextResponse().ConfigureAwait(false);
+                    _callbackCancellationTokenSource.Token.ThrowIfCancellationRequested();
+                    var result = await _state.HandleResponseAsync(serverResponse, _callbackCancellationTokenSource.Token).ConfigureAwait(false);
+                    switch (result)
+                    {
+                        case WatchResponseResult.Continue:
+                            break;
+                        case WatchResponseResult.ResetStream:
+                            await CloseStreamAsync().ConfigureAwait(false);
+                            cause = StreamInitializationCause.ResetRequested;
+                            break;
+                        case WatchResponseResult.StreamHealthy:
+                            nextBackoff = TimeSpan.Zero;
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Unknown result type: {result}");
+                    }
+                    // What about other exception types?
+                }
+            }
+            // Swallow cancellation exceptions unless one of the user-provided cancellation tokens has been
+            // cancelled, in which case it's fine to let it through.
+            catch (OperationCanceledException) when (!_callbackCancellationTokenSource.Token.IsCancellationRequested)
+            {
+                // We really do just swallow the exception. No need for logging.
+            }
+            finally
+            {
+                _networkCancellationTokenSource.Dispose();
+                _callbackCancellationTokenSource.Dispose();
+                lock (_stateLock)
+                {
+                    _finished = true;
+                    _stopCancellationTokenRegistration.Dispose();
+                }
+                // Make sure we clean up even if we get an exception we don't handle explicitly.
+                await CloseStreamAsync().ConfigureAwait(false);
+            }
+
+
+            // Local method responsible for fetching the next response from the server stream, including
+            // stream initialization and error handling.
+            async Task<ListenResponse> GetNextResponse()
+            {
+                while (true)
+                {
+                    try
+                    {
+                        // If we're just starting, or we've closed the stream or it broke, restart.
+                        if (underlyingStream == null)
+                        {
+                            await _scheduler.Delay(_backoffJitter.GetDelay(nextBackoff), _networkCancellationTokenSource.Token).ConfigureAwait(false);
+                            nextBackoff = _backoffSettings.NextDelay(nextBackoff);
+                            underlyingStream = _db.Client.Listen();
+                            await underlyingStream.TryWriteAsync(CreateRequest()).ConfigureAwait(false);
+                            _state.OnStreamInitialization(cause);
+                        }
+                        // Wait for a response or end-of-stream
+                        var next = await underlyingStream.ResponseStream.MoveNext(_networkCancellationTokenSource.Token).ConfigureAwait(false);
+
+                        // If the server provided a response, return it
+                        if (next)
+                        {
+                            return underlyingStream.ResponseStream.Current;
+                        }
+                        // Otherwise, close the current stream and restart.
+                        await CloseStreamAsync().ConfigureAwait(false);
+                        cause = StreamInitializationCause.StreamCompleted;
+                    }
+                    catch (RpcException e) when (s_transientErrorStatusCodes.Contains(e.Status.StatusCode))
+                    {
+                        // Close the current stream, ready to create a new one.
+                        await CloseStreamAsync().ConfigureAwait(false);
+                        // Extend the back-off if necessary.
+                        if (e.Status.StatusCode == StatusCode.ResourceExhausted)
+                        {
+                            nextBackoff = _backoffSettings.NextDelay(nextBackoff);
+                        }
+                        cause = StreamInitializationCause.RpcError;
+                    }
+                }
+            }
+
+            async Task CloseStreamAsync()
+            {
+                if (underlyingStream != null)
+                {
+                    var completeTask = underlyingStream.TryWriteCompleteAsync();
+                    // TODO: Handle exceptions from this?
+                    if (completeTask != null)
+                    {
+                        await completeTask.ConfigureAwait(false);
+                    }
+                    underlyingStream.GrpcCall.Dispose();
+                }
+                underlyingStream = null;
+            }
+        }
+
+        internal void Stop(CancellationToken userCancellationToken)
+        {
+            if (userCancellationToken.CanBeCanceled)
+            {
+                lock (_stateLock)
+                {
+                    if (!_finished)
+                    {
+                        _stopCancellationTokenRegistration = userCancellationToken.Register(() => _callbackCancellationTokenSource.Cancel());
+                    }
+                }
+            }
+            _networkCancellationTokenSource.Cancel();
+        }
+
+        internal static Target CreateTarget(DocumentReference doc) =>
+            new Target
+            {
+                Documents = new Target.Types.DocumentsTarget { Documents = { doc.Path } },
+                TargetId = WatchTargetId
+            };
+
+        internal static Target CreateTarget(Query query) =>
+            new Target
+            {
+                Query = new Target.Types.QueryTarget { Parent = query.ParentPath, StructuredQuery = query.ToStructuredQuery() },
+                TargetId = WatchTargetId
+            };
+
+        private ListenRequest CreateRequest()
+        {
+            var request = new ListenRequest
+            {
+                AddTarget = _target.Clone(),
+                Database = _db.RootPath
+            };
+            if (_state.ResumeToken != null)
+            {
+                request.AddTarget.ResumeToken = _state.ResumeToken;
+            }
+            return request;
+        }
     }
 }

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -296,6 +296,8 @@
       "Grpc.Core": "default"
     },
     "testDependencies": {
+      "Google.Api.Gax.Testing": "default",
+      "Grpc.Core.Testing": "default",
       "System.ValueTuple": "4.4.0"
     }
   },

--- a/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
+++ b/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
@@ -59,6 +59,7 @@ namespace Google.Cloud.Tools.ProjectGenerator
             { "Google.Api.Gax.Testing", DefaultGaxVersion },
             { "Google.Api.Gax.Grpc.Testing", DefaultGaxVersion },
             { GrpcPackage, GrpcVersion },
+            { "Grpc.Core.Testing", GrpcVersion }
         };
 
         // Hard-coded versions for all analyzer projects.


### PR DESCRIPTION
It's probably worth reviewing the first commit, and we could potentially merge that while we discuss everything else - or keep it in this PR.

Initially I'm looking for feedback on the structure:

- Does the public API look correct?
- Does the separation of SnapshotListener from WatchStream make sense, or should I combine them?
- Does the shape of WatchStream.Start make sense, even if some async aspects may be wrong?

(Any implementation aspects which are clearly broken would be good to know too...)