### PR TITLE
Don't assume ordering of maps in test results.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -269,14 +269,11 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 var results = _polling.GetEntries(startTime, testId, 1, LogSeverity.Warning);
                 var entry = results.Single();
                 Assert.Equal(3, entry.Labels.Count);
-                var defaultLabel = entry.Labels.First();
-                Assert.Equal("some-key", defaultLabel.Key);
+                var defaultLabel = entry.Labels.Single(l => l.Key.Equals("some-key"));
                 Assert.Equal("some-value", defaultLabel.Value);
-                var fooLabel = entry.Labels.Skip(1).First();
-                Assert.Equal("Foo", fooLabel.Key);
+                var fooLabel = entry.Labels.Single(l => l.Key.Equals("Foo"));
                 Assert.Equal("Hello, World!", fooLabel.Value);
-                var traceIdLabel = entry.Labels.Skip(2).Single();
-                Assert.Equal("trace_identifier", traceIdLabel.Key);
+                var traceIdLabel = entry.Labels.Single(l => l.Key.Equals("trace_identifier"));
                 Assert.NotEmpty(traceIdLabel.Value);
             }
         }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -269,12 +269,9 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 var results = _polling.GetEntries(startTime, testId, 1, LogSeverity.Warning);
                 var entry = results.Single();
                 Assert.Equal(3, entry.Labels.Count);
-                var defaultLabel = entry.Labels.Single(l => l.Key.Equals("some-key"));
-                Assert.Equal("some-value", defaultLabel.Value);
-                var fooLabel = entry.Labels.Single(l => l.Key.Equals("Foo"));
-                Assert.Equal("Hello, World!", fooLabel.Value);
-                var traceIdLabel = entry.Labels.Single(l => l.Key.Equals("trace_identifier"));
-                Assert.NotEmpty(traceIdLabel.Value);
+                Assert.Equal("some-value", entry.Labels["some-key"]);
+                Assert.Equal("Hello, World!", entry.Labels["Foo"]);
+                Assert.NotEmpty(entry.Labels["trace_identifier"]);
             }
         }
     }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/UserLogEntryLabelProviderTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/UserLogEntryLabelProviderTest.cs
@@ -73,13 +73,12 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             instance.Invoke(labels);
 
             // Assert
-            Assert.Equal(2, labels.Count);
-
-            var userAuthenticated = labels.Single(l => l.Key.Equals("user_authenticated"));
-            Assert.Equal(true.ToString(), userAuthenticated.Value);
-
-            var userName = labels.Single(l => l.Key.Equals("user_name"));
-            Assert.Null(userName.Value);
+            var expected = new Dictionary<string, string>
+            {
+                { "user_authenticated", true.ToString() },
+                { "user_name", null }
+            };
+            Assert.Equal(expected, labels);
         }
 
         [Fact]
@@ -100,13 +99,12 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             instance.Invoke(labels);
 
             // Assert
-            Assert.Equal(2, labels.Count);
-
-            var userAuthenticated = labels.Single(l => l.Key.Equals("user_authenticated"));
-            Assert.Equal(true.ToString(), userAuthenticated.Value);
-
-            var userName = labels.Single(l => l.Key.Equals("user_name"));
-            Assert.Equal("Foo", userName.Value);
+           var expected = new Dictionary<string, string>
+            {
+                { "user_authenticated", true.ToString() },
+                { "user_name", "Foo" }
+            };
+            Assert.Equal(expected, labels);
         }
 
         [Theory]
@@ -129,13 +127,12 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             instance.Invoke(labels);
 
             // Assert
-            Assert.Equal(2, labels.Count);
-
-            var userAuthenticated = labels.Single(l => l.Key.Equals("user_authenticated"));
-            Assert.Equal(true.ToString(), userAuthenticated.Value);
-
-            var userName = labels.Single(l => l.Key.Equals("user_name"));
-            Assert.Equal("Foo", userName.Value);
+            var expected = new Dictionary<string, string>
+            {
+                { "user_authenticated", true.ToString() },
+                { "user_name", "Foo" }
+            };
+            Assert.Equal(expected, labels);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/UserLogEntryLabelProviderTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/UserLogEntryLabelProviderTest.cs
@@ -75,12 +75,10 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             // Assert
             Assert.Equal(2, labels.Count);
 
-            var userAuthenticated = labels.First();
-            Assert.Equal("user_authenticated", userAuthenticated.Key);
+            var userAuthenticated = labels.Single(l => l.Key.Equals("user_authenticated"));
             Assert.Equal(true.ToString(), userAuthenticated.Value);
 
-            var userName = labels.Skip(1).Single();
-            Assert.Equal("user_name", userName.Key);
+            var userName = labels.Single(l => l.Key.Equals("user_name"));
             Assert.Null(userName.Value);
         }
 
@@ -104,12 +102,10 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             // Assert
             Assert.Equal(2, labels.Count);
 
-            var userAuthenticated = labels.First();
-            Assert.Equal("user_authenticated", userAuthenticated.Key);
+            var userAuthenticated = labels.Single(l => l.Key.Equals("user_authenticated"));
             Assert.Equal(true.ToString(), userAuthenticated.Value);
 
-            var userName = labels.Skip(1).Single();
-            Assert.Equal("user_name", userName.Key);
+            var userName = labels.Single(l => l.Key.Equals("user_name"));
             Assert.Equal("Foo", userName.Value);
         }
 
@@ -135,12 +131,10 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             // Assert
             Assert.Equal(2, labels.Count);
 
-            var userAuthenticated = labels.First();
-            Assert.Equal("user_authenticated", userAuthenticated.Key);
+            var userAuthenticated = labels.Single(l => l.Key.Equals("user_authenticated"));
             Assert.Equal(true.ToString(), userAuthenticated.Value);
 
-            var userName = labels.Skip(1).Single();
-            Assert.Equal("user_name", userName.Key);
+            var userName = labels.Single(l => l.Key.Equals("user_name"));
             Assert.Equal("Foo", userName.Value);
         }
 


### PR DESCRIPTION
This is causing flaky tests.