### PR TITLE
Release of Google.Cloud.Diagnostics.* 2.0.1

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <TargetFrameworks>net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net45</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <TargetFrameworks>netstandard1.5;net46</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/TimedBufferingConsumerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/TimedBufferingConsumerTest.cs
@@ -125,35 +125,15 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         }
 
         [Fact]
-        public void Timer_SwallowRpcException()
+        public void Timer_SwallowException()
         {
             var mockConsumer = new Mock<IConsumer<int>>();
             var fakeTimer = new FakeThreadingTimer();
             var consumer = new TimedBufferingConsumer<int>(mockConsumer.Object, _waitTime, fakeTimer);
 
-            mockConsumer.Setup(c => c.Receive(It.IsAny<IEnumerable<int>>())).Throws(new RpcException(Status.DefaultCancelled));
+            mockConsumer.Setup(c => c.Receive(It.IsAny<IEnumerable<int>>())).Throws(new Exception());
             consumer.Receive(new[] { 1, 2, 3, 4, 5 });
             fakeTimer.FullTick();
-            mockConsumer.Verify(c => c.Receive(It.IsAny<IEnumerable<int>>()), Times.Once());
-        }
-
-        [Fact]
-        public void Timer_Exception()
-        {
-            var mockConsumer = new Mock<IConsumer<int>>();
-            var fakeTimer = new FakeThreadingTimer();
-            var consumer = new TimedBufferingConsumer<int>(mockConsumer.Object, _waitTime, fakeTimer);
-
-            mockConsumer.Setup(c => c.Receive(It.IsAny<IEnumerable<int>>())).Throws(new DivideByZeroException());
-            consumer.Receive(new[] { 1, 2, 3, 4, 5 });
-            try
-            {
-                fakeTimer.FullTick();
-                Assert.True(false);
-            }
-            catch (Exception e) when (!(e is Xunit.Sdk.XunitException))
-            {
-            }
             mockConsumer.Verify(c => c.Receive(It.IsAny<IEnumerable<int>>()), Times.Once());
         }
     }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/TimedBufferingConsumer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/TimedBufferingConsumer.cs
@@ -48,12 +48,10 @@ namespace Google.Cloud.Diagnostics.Common
                 {
                     Flush();
                 }
-                catch (RpcException)
+                catch (Exception)
                 {
                     // TODO(talarico): This is a short term solution to ensure 
                     // we do not kill a process. See issue #842 to track the long term solution.
-                    // This solution is dependent on implementation details specifically the fact
-                    // that all consumers that make requests are gRPC based.
                 }
             }, waitTime);
         }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/TimedBufferingConsumer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/TimedBufferingConsumer.cs
@@ -51,7 +51,7 @@ namespace Google.Cloud.Diagnostics.Common
                 catch (Exception)
                 {
                     // TODO(talarico): This is a short term solution to ensure 
-                    // we do not kill a process. See issue #842 to track the long term solution.
+                    // we do not kill a process. See issue #2182 to track the long term solution.
                 }
             }, waitTime);
         }

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -139,7 +139,7 @@
 
   {
     "id": "Google.Cloud.Diagnostics.AspNet",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "type": "other",
     "targetFrameworks": "net45",
     "testTargetFrameworks": "net452",
@@ -161,7 +161,7 @@
 
   {
     "id": "Google.Cloud.Diagnostics.AspNetCore",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "type": "other",
     "targetFrameworks": "netstandard1.5;net46",
     "testTargetFrameworks": "netcoreapp1.0;netcoreapp2.0;net46",
@@ -186,7 +186,7 @@
 
   {
     "id": "Google.Cloud.Diagnostics.Common",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "type": "other",
     "targetFrameworks": "netstandard1.5;net45",
     "testTargetFrameworks": "netcoreapp1.0;net452",


### PR DESCRIPTION
Catch all Exceptions in the TimedBuffer timer to avoid ever bringing down an application.

I ran all the integration and unit tests and all is good. I'm going to have to release manually as I don't think the current deployment can handle the older scripts.