### PR TITLE
Add public constructors for types returned by BigQueryClient

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryPageTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryPageTest.cs
@@ -42,7 +42,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
         {
             var nextPageToken = "token";
             var schema = new TableSchema();
-            var row = new BigQueryRow(new TableRow(), schema, schema.IndexFieldNames());
+            var row = new BigQueryRow(new TableRow(), schema);
             var rawPage = new Page<BigQueryRow>(new List<BigQueryRow> { row }, nextPageToken);
             var jobReference = new JobReference { ProjectId = "project", JobId = "job" };
             var tableReference = new TableReference { ProjectId = "project", DatasetId = "dataset", TableId = "table" };

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
@@ -55,7 +55,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     new TableCell { V = new JObject { ["f"] = new JArray {new JObject { ["v"] = "100" }, new JObject { ["v"] = "xyz" } } } }
                 }
             };
-            var row = CreateRow(rawRow, schema);
+            var row = new BigQueryRow(rawRow, schema);
             Assert.Equal(10, (long)row["integer"]);
             Assert.Equal(true, (bool)row["bool"]);
             Assert.Equal(new byte[] { 1, 2 }, (byte[])row["bytes"]);
@@ -103,7 +103,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     } }
                 }
             };
-            var row = CreateRow(rawRow, schema);
+            var row = new BigQueryRow(rawRow, schema);
             Assert.Equal(new[] { 10L, 20L }, (long[])row["integer"]);
             Assert.Equal(new[] { true, false }, (bool[])row["bool"]);
             Assert.Equal(new[] { new byte[] { 1, 2 }, new byte[] { 1, 3 } }, (byte[][])row["bytes"]);
@@ -138,7 +138,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     new TableCell { V = null }
                 }
             };
-            var row = CreateRow(rawRow, schema);
+            var row = new BigQueryRow(rawRow, schema);
             Assert.Null(row["text"]);
         }
 
@@ -157,14 +157,12 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     new TableCell { V = new JObject { ["f"] = new JArray {new JObject { ["v"] = "100" } } } }
                 }
             };
-            var row = CreateRow(rawRow, schema);
+            var row = new BigQueryRow(rawRow, schema);
             Assert.Throws<InvalidOperationException>(() => row["struct"]);
         }
 
         private JArray CreateArray(params string[] values) => new JArray(values.Select(CreateObject));
 
         private JObject CreateObject(string value) => new JObject { ["v"] = value };
-
-        private BigQueryRow CreateRow(TableRow rawRow, TableSchema schema) => new BigQueryRow(rawRow, schema, schema.IndexFieldNames());
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDataset.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDataset.cs
@@ -64,10 +64,19 @@ namespace Google.Cloud.BigQuery.V2
         {
         }
 
-        internal BigQueryDataset(BigQueryClient client, Dataset resource)
+        /// <summary>
+        /// Constructs a new dataset.
+        /// </summary>
+        /// <remarks>
+        /// This is public to allow tests to construct instances for production code to consume;
+        /// production code should not normally construct instances itself.
+        /// </remarks>
+        /// <param name="client">The client to use for operations on the dataset. Must not be null.</param>
+        /// <param name="resource">The REST-ful resource representing the dataset. Must not be null.</param>
+        public BigQueryDataset(BigQueryClient client, Dataset resource)
         {
-            _client = client;
-            Resource = resource;
+            _client = GaxPreconditions.CheckNotNull(client, nameof(client));
+            Resource = GaxPreconditions.CheckNotNull(resource, nameof(resource));
         }
 
         /// <summary>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryJob.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryJob.cs
@@ -65,10 +65,19 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         public JobStatus Status => Resource.Status;
 
-        internal BigQueryJob(BigQueryClient client, Job resource)
+        /// <summary>
+        /// Constructs a new job.
+        /// </summary>
+        /// <remarks>
+        /// This is public to allow tests to construct instances for production code to consume;
+        /// production code should not normally construct instances itself.
+        /// </remarks>
+        /// <param name="client">The client to use for operations on the job. Must not be null.</param>
+        /// <param name="resource">The REST-ful resource representing the job. Must not be null.</param>
+        public BigQueryJob(BigQueryClient client, Job resource)
         {
-            _client = client;
-            Resource = resource;
+            _client = GaxPreconditions.CheckNotNull(client, nameof(client));
+            Resource = GaxPreconditions.CheckNotNull(resource, nameof(resource));
         }
 
         internal BigQueryJob(BigQueryClient client, JobList.JobsData resource)

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryResults.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryResults.cs
@@ -75,7 +75,18 @@ namespace Google.Cloud.BigQuery.V2
         /// <returns>An iterator over the query results.</returns>
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        internal BigQueryResults(BigQueryClient client, GetQueryResultsResponse response, TableReference tableReference, ListRowsOptions options)
+        /// <summary>
+        /// Constructs a new set of results.
+        /// </summary>
+        /// <remarks>
+        /// This is public to allow tests to construct instances for production code to consume;
+        /// production code should not normally construct instances itself.
+        /// </remarks>
+        /// <param name="client">The client to use for further operations. Must not be null.</param>
+        /// <param name="response">The response to a GetQueryResults API call. Must not be null.</param>
+        /// <param name="tableReference">A reference to the table containing the results.</param>
+        /// <param name="options">Options to use when listing rows. May be null.</param>
+        public BigQueryResults(BigQueryClient client, GetQueryResultsResponse response, TableReference tableReference, ListRowsOptions options)
         {
             _client = GaxPreconditions.CheckNotNull(client, nameof(client));
             _response = GaxPreconditions.CheckNotNull(response, nameof(response));

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax;
 using Google.Apis.Bigquery.v2.Data;
 using Newtonsoft.Json.Linq;
 using System;
@@ -37,10 +38,23 @@ namespace Google.Cloud.BigQuery.V2
 
         private readonly IDictionary<string, int> _fieldNameIndexMap;
 
+        /// <summary>
+        /// Constructs a row from the underlying REST-ful resource and schema.
+        /// </summary>
+        /// <remarks>
+        /// This is public to allow tests to construct instances for production code to consume;
+        /// production code should not normally construct instances itself.
+        /// </remarks>
+        /// <param name="rawRow">The underlying REST-ful row resource. Must not be null.</param>
+        /// <param name="schema">The table schema. Must not be null.</param>
+        public BigQueryRow(TableRow rawRow, TableSchema schema) : this(rawRow, schema, schema?.IndexFieldNames())
+        {
+        }
+
         internal BigQueryRow(TableRow rawRow, TableSchema schema, IDictionary<string, int> fieldNameIndexMap)
         {
-            Schema = schema;
-            RawRow = rawRow;
+            RawRow = GaxPreconditions.CheckNotNull(rawRow, nameof(rawRow));
+            Schema = GaxPreconditions.CheckNotNull(schema, nameof(schema));
             _fieldNameIndexMap = fieldNameIndexMap;
         }
 

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryTable.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryTable.cs
@@ -64,10 +64,19 @@ namespace Google.Cloud.BigQuery.V2
         /// </remarks>
         public TableReference Reference => Resource.TableReference;
 
-        internal BigQueryTable(BigQueryClient client, Table resource)
+        /// <summary>
+        /// Constructs a new table.
+        /// </summary>
+        /// <remarks>
+        /// This is public to allow tests to construct instances for production code to consume;
+        /// production code should not normally construct instances itself.
+        /// </remarks>
+        /// <param name="client">The client to use for operations on the table. Must not be null.</param>
+        /// <param name="resource">The REST-ful resource representing the table. Must not be null.</param>
+        public BigQueryTable(BigQueryClient client, Table resource)
         {
-            _client = client;
-            Resource = resource;
+            _client = GaxPreconditions.CheckNotNull(client, nameof(client));
+            Resource = GaxPreconditions.CheckNotNull(resource, nameof(resource));
         }
 
         /// <summary>


### PR DESCRIPTION
This allows tests to provide fake data. Only BigQueryClient itself
would be faked out in such a context: everything else delegates to
BigQueryClient for API calls, but fake data can be provided with the
production classes.

Fixes #2170.