### PR TITLE
Regenerate all APIs

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/ResourceNames.cs
@@ -51,7 +51,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="LocationName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string locationName, out LocationName result)
         {
             gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
@@ -143,7 +143,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <param name="projectDataSourceName">The project_data_source resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="ProjectDataSourceName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string projectDataSourceName, out ProjectDataSourceName result)
         {
             gax::GaxPreconditions.CheckNotNull(projectDataSourceName, nameof(projectDataSourceName));
@@ -235,7 +235,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <param name="locationDataSourceName">The location_data_source resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="LocationDataSourceName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string locationDataSourceName, out LocationDataSourceName result)
         {
             gax::GaxPreconditions.CheckNotNull(locationDataSourceName, nameof(locationDataSourceName));
@@ -334,7 +334,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <param name="projectTransferConfigName">The project_transfer_config resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="ProjectTransferConfigName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string projectTransferConfigName, out ProjectTransferConfigName result)
         {
             gax::GaxPreconditions.CheckNotNull(projectTransferConfigName, nameof(projectTransferConfigName));
@@ -426,7 +426,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <param name="locationTransferConfigName">The location_transfer_config resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="LocationTransferConfigName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string locationTransferConfigName, out LocationTransferConfigName result)
         {
             gax::GaxPreconditions.CheckNotNull(locationTransferConfigName, nameof(locationTransferConfigName));
@@ -525,7 +525,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <param name="projectRunName">The project_run resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="ProjectRunName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string projectRunName, out ProjectRunName result)
         {
             gax::GaxPreconditions.CheckNotNull(projectRunName, nameof(projectRunName));
@@ -624,7 +624,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <param name="locationRunName">The location_run resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="LocationRunName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string locationRunName, out LocationRunName result)
         {
             gax::GaxPreconditions.CheckNotNull(locationRunName, nameof(locationRunName));

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/ResourceNames.cs
@@ -53,7 +53,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <param name="instanceName">The instance resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="InstanceName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string instanceName, out InstanceName result)
         {
             gax::GaxPreconditions.CheckNotNull(instanceName, nameof(instanceName));
@@ -145,7 +145,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <param name="appProfileName">The app_profile resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="AppProfileName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string appProfileName, out AppProfileName result)
         {
             gax::GaxPreconditions.CheckNotNull(appProfileName, nameof(appProfileName));
@@ -244,7 +244,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <param name="clusterName">The cluster resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="ClusterName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string clusterName, out ClusterName result)
         {
             gax::GaxPreconditions.CheckNotNull(clusterName, nameof(clusterName));
@@ -343,7 +343,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="LocationName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string locationName, out LocationName result)
         {
             gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
@@ -435,7 +435,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <param name="snapshotName">The snapshot resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="SnapshotName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string snapshotName, out SnapshotName result)
         {
             gax::GaxPreconditions.CheckNotNull(snapshotName, nameof(snapshotName));

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/AgentsClientSnippets.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/AgentsClientSnippets.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using Google.Api.Gax.ResourceNames;
 using Google.Cloud.ClientTesting;
 using System;
 using System.Collections.Generic;

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/AgentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/AgentsClientSnippets.g.cs
@@ -18,6 +18,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
 {
     using Google.Api.Gax;
     using Google.Api.Gax.Grpc;
+    using Google.Api.Gax.ResourceNames;
     using apis = Google.Cloud.Dialogflow.V2;
     using Google.LongRunning;
     using Google.Protobuf;

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Tests/AgentsClientTest.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Tests/AgentsClientTest.g.cs
@@ -18,6 +18,7 @@ namespace Google.Cloud.Dialogflow.V2.Tests
 {
     using Google.Api.Gax;
     using Google.Api.Gax.Grpc;
+    using Google.Api.Gax.ResourceNames;
     using apis = Google.Cloud.Dialogflow.V2;
     using Google.LongRunning;
     using Google.Protobuf.WellKnownTypes;

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.sln
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.sln
@@ -1,15 +1,14 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Dialogflow.V2", "Google.Cloud.Dialogflow.V2\Google.Cloud.Dialogflow.V2.csproj", "{FAFF3EAB-F87E-4869-9512-174B54B1F466}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Dialogflow.V2", "Google.Cloud.Dialogflow.V2\Google.Cloud.Dialogflow.V2.csproj", "{FAFF3EAB-F87E-4869-9512-174B54B1F466}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Dialogflow.V2.Snippets", "Google.Cloud.Dialogflow.V2.Snippets\Google.Cloud.Dialogflow.V2.Snippets.csproj", "{D073F4EC-580A-49FC-8C0F-6221C13A4F44}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Dialogflow.V2.Snippets", "Google.Cloud.Dialogflow.V2.Snippets\Google.Cloud.Dialogflow.V2.Snippets.csproj", "{D073F4EC-580A-49FC-8C0F-6221C13A4F44}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{65412C45-9D3D-4C1B-8F12-34A7F349FA78}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{65412C45-9D3D-4C1B-8F12-34A7F349FA78}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Dialogflow.V2.Tests", "Google.Cloud.Dialogflow.V2.Tests\Google.Cloud.Dialogflow.V2.Tests.csproj", "{B846A44D-F0DD-4CC9-9759-28C591FB557F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Dialogflow.V2.Tests", "Google.Cloud.Dialogflow.V2.Tests\Google.Cloud.Dialogflow.V2.Tests.csproj", "{B846A44D-F0DD-4CC9-9759-28C591FB557F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,57 +19,60 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Debug|x64.ActiveCfg = Debug|x64
-		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Debug|x64.Build.0 = Debug|x64
-		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Debug|x86.ActiveCfg = Debug|x86
-		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Debug|x86.Build.0 = Debug|x86
+		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Debug|x64.Build.0 = Debug|Any CPU
+		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Debug|x86.Build.0 = Debug|Any CPU
 		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Release|x64.ActiveCfg = Release|x64
-		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Release|x64.Build.0 = Release|x64
-		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Release|x86.ActiveCfg = Release|x86
-		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Release|x86.Build.0 = Release|x86
+		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Release|x64.ActiveCfg = Release|Any CPU
+		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Release|x64.Build.0 = Release|Any CPU
+		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Release|x86.ActiveCfg = Release|Any CPU
+		{FAFF3EAB-F87E-4869-9512-174B54B1F466}.Release|x86.Build.0 = Release|Any CPU
 		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Debug|x64.ActiveCfg = Debug|x64
-		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Debug|x64.Build.0 = Debug|x64
-		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Debug|x86.ActiveCfg = Debug|x86
-		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Debug|x86.Build.0 = Debug|x86
+		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Debug|x64.Build.0 = Debug|Any CPU
+		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Debug|x86.Build.0 = Debug|Any CPU
 		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Release|x64.ActiveCfg = Release|x64
-		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Release|x64.Build.0 = Release|x64
-		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Release|x86.ActiveCfg = Release|x86
-		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Release|x86.Build.0 = Release|x86
+		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Release|x64.ActiveCfg = Release|Any CPU
+		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Release|x64.Build.0 = Release|Any CPU
+		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Release|x86.ActiveCfg = Release|Any CPU
+		{D073F4EC-580A-49FC-8C0F-6221C13A4F44}.Release|x86.Build.0 = Release|Any CPU
 		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Debug|x64.ActiveCfg = Debug|x64
-		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Debug|x64.Build.0 = Debug|x64
-		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Debug|x86.ActiveCfg = Debug|x86
-		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Debug|x86.Build.0 = Debug|x86
+		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Debug|x64.Build.0 = Debug|Any CPU
+		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Debug|x86.Build.0 = Debug|Any CPU
 		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Release|Any CPU.Build.0 = Release|Any CPU
-		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Release|x64.ActiveCfg = Release|x64
-		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Release|x64.Build.0 = Release|x64
-		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Release|x86.ActiveCfg = Release|x86
-		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Release|x86.Build.0 = Release|x86
+		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Release|x64.ActiveCfg = Release|Any CPU
+		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Release|x64.Build.0 = Release|Any CPU
+		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Release|x86.ActiveCfg = Release|Any CPU
+		{65412C45-9D3D-4C1B-8F12-34A7F349FA78}.Release|x86.Build.0 = Release|Any CPU
 		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Debug|x64.ActiveCfg = Debug|x64
-		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Debug|x64.Build.0 = Debug|x64
-		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Debug|x86.ActiveCfg = Debug|x86
-		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Debug|x86.Build.0 = Debug|x86
+		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Debug|x64.Build.0 = Debug|Any CPU
+		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Debug|x86.Build.0 = Debug|Any CPU
 		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Release|x64.ActiveCfg = Release|x64
-		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Release|x64.Build.0 = Release|x64
-		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Release|x86.ActiveCfg = Release|x86
-		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Release|x86.Build.0 = Release|x86
+		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Release|x64.ActiveCfg = Release|Any CPU
+		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Release|x64.Build.0 = Release|Any CPU
+		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Release|x86.ActiveCfg = Release|Any CPU
+		{B846A44D-F0DD-4CC9-9759-28C591FB557F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4B9455F4-BB37-45E4-ADE6-F083326913BA}
 	EndGlobalSection
 EndGlobal

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentsClient.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentsClient.cs
@@ -16,6 +16,7 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
+using gaxres = Google.Api.Gax.ResourceNames;
 using lro = Google.LongRunning;
 using pb = Google.Protobuf;
 using pbwkt = Google.Protobuf.WellKnownTypes;
@@ -550,7 +551,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual stt::Task<Agent> GetAgentAsync(
-            ProjectName parent,
+            gaxres::ProjectName parent,
             gaxgrpc::CallSettings callSettings = null) => GetAgentAsync(
                 new GetAgentRequest
                 {
@@ -572,7 +573,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual stt::Task<Agent> GetAgentAsync(
-            ProjectName parent,
+            gaxres::ProjectName parent,
             st::CancellationToken cancellationToken) => GetAgentAsync(
                 parent,
                 gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
@@ -591,7 +592,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// The RPC response.
         /// </returns>
         public virtual Agent GetAgent(
-            ProjectName parent,
+            gaxres::ProjectName parent,
             gaxgrpc::CallSettings callSettings = null) => GetAgent(
                 new GetAgentRequest
                 {
@@ -683,7 +684,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// A pageable asynchronous sequence of <see cref="Agent"/> resources.
         /// </returns>
         public virtual gax::PagedAsyncEnumerable<SearchAgentsResponse, Agent> SearchAgentsAsync(
-            ProjectName parent,
+            gaxres::ProjectName parent,
             string pageToken = null,
             int? pageSize = null,
             gaxgrpc::CallSettings callSettings = null) => SearchAgentsAsync(
@@ -723,7 +724,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// A pageable sequence of <see cref="Agent"/> resources.
         /// </returns>
         public virtual gax::PagedEnumerable<SearchAgentsResponse, Agent> SearchAgents(
-            ProjectName parent,
+            gaxres::ProjectName parent,
             string pageToken = null,
             int? pageSize = null,
             gaxgrpc::CallSettings callSettings = null) => SearchAgents(
@@ -802,7 +803,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual stt::Task<lro::Operation<pbwkt::Empty, pbwkt::Struct>> TrainAgentAsync(
-            ProjectName parent,
+            gaxres::ProjectName parent,
             gaxgrpc::CallSettings callSettings = null) => TrainAgentAsync(
                 new TrainAgentRequest
                 {
@@ -827,7 +828,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual stt::Task<lro::Operation<pbwkt::Empty, pbwkt::Struct>> TrainAgentAsync(
-            ProjectName parent,
+            gaxres::ProjectName parent,
             st::CancellationToken cancellationToken) => TrainAgentAsync(
                 parent,
                 gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
@@ -849,7 +850,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// The RPC response.
         /// </returns>
         public virtual lro::Operation<pbwkt::Empty, pbwkt::Struct> TrainAgent(
-            ProjectName parent,
+            gaxres::ProjectName parent,
             gaxgrpc::CallSettings callSettings = null) => TrainAgent(
                 new TrainAgentRequest
                 {
@@ -952,7 +953,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual stt::Task<lro::Operation<ExportAgentResponse, pbwkt::Struct>> ExportAgentAsync(
-            ProjectName parent,
+            gaxres::ProjectName parent,
             gaxgrpc::CallSettings callSettings = null) => ExportAgentAsync(
                 new ExportAgentRequest
                 {
@@ -977,7 +978,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// A Task containing the RPC response.
         /// </returns>
         public virtual stt::Task<lro::Operation<ExportAgentResponse, pbwkt::Struct>> ExportAgentAsync(
-            ProjectName parent,
+            gaxres::ProjectName parent,
             st::CancellationToken cancellationToken) => ExportAgentAsync(
                 parent,
                 gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
@@ -999,7 +1000,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// The RPC response.
         /// </returns>
         public virtual lro::Operation<ExportAgentResponse, pbwkt::Struct> ExportAgent(
-            ProjectName parent,
+            gaxres::ProjectName parent,
             gaxgrpc::CallSettings callSettings = null) => ExportAgent(
                 new ExportAgentRequest
                 {

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ResourceNames.cs
@@ -15,96 +15,12 @@
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
+using gaxres = Google.Api.Gax.ResourceNames;
 using sys = System;
 using linq = System.Linq;
 
 namespace Google.Cloud.Dialogflow.V2
 {
-    /// <summary>
-    /// Resource name for the 'project' resource.
-    /// </summary>
-    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
-
-        /// <summary>
-        /// Parses the given project resource name in string form into a new
-        /// <see cref="ProjectName"/> instance.
-        /// </summary>
-        /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="ProjectName"/> if successful.</returns>
-        public static ProjectName Parse(string projectName)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(projectName);
-            return new ProjectName(resourceName[0]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given project resource name in string form into a new
-        /// <see cref="ProjectName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="ProjectName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string projectName, out ProjectName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(projectName, out resourceName))
-            {
-                result = new ProjectName(resourceName[0]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="ProjectName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        public ProjectName(string projectId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ProjectName);
-
-        /// <inheritdoc />
-        public bool Equals(ProjectName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(ProjectName a, ProjectName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(ProjectName a, ProjectName b) => !(a == b);
-    }
-
     /// <summary>
     /// Resource name for the 'session' resource.
     /// </summary>
@@ -136,7 +52,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// <param name="sessionName">The session resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="SessionName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string sessionName, out SessionName result)
         {
             gax::GaxPreconditions.CheckNotNull(sessionName, nameof(sessionName));
@@ -228,7 +144,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// <param name="contextName">The context resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="ContextName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string contextName, out ContextName result)
         {
             gax::GaxPreconditions.CheckNotNull(contextName, nameof(contextName));
@@ -327,7 +243,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// <param name="projectAgentName">The project_agent resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="ProjectAgentName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string projectAgentName, out ProjectAgentName result)
         {
             gax::GaxPreconditions.CheckNotNull(projectAgentName, nameof(projectAgentName));
@@ -412,7 +328,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// <param name="entityTypeName">The entity_type resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="EntityTypeName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string entityTypeName, out EntityTypeName result)
         {
             gax::GaxPreconditions.CheckNotNull(entityTypeName, nameof(entityTypeName));
@@ -504,7 +420,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// <param name="intentName">The intent resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="IntentName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string intentName, out IntentName result)
         {
             gax::GaxPreconditions.CheckNotNull(intentName, nameof(intentName));
@@ -596,7 +512,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// <param name="agentName">The agent resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="AgentName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string agentName, out AgentName result)
         {
             gax::GaxPreconditions.CheckNotNull(agentName, nameof(agentName));
@@ -688,7 +604,7 @@ namespace Google.Cloud.Dialogflow.V2
         /// <param name="sessionEntityTypeName">The session_entity_type resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="SessionEntityTypeName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string sessionEntityTypeName, out SessionEntityTypeName result)
         {
             gax::GaxPreconditions.CheckNotNull(sessionEntityTypeName, nameof(sessionEntityTypeName));
@@ -1007,11 +923,11 @@ namespace Google.Cloud.Dialogflow.V2
     public partial class ExportAgentRequest
     {
         /// <summary>
-        /// <see cref="Google.Cloud.Dialogflow.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="gaxres::ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public Google.Cloud.Dialogflow.V2.ProjectName ParentAsProjectName
+        public gaxres::ProjectName ParentAsProjectName
         {
-            get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dialogflow.V2.ProjectName.Parse(Parent); }
+            get { return string.IsNullOrEmpty(Parent) ? null : gaxres::ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
         }
 
@@ -1020,11 +936,11 @@ namespace Google.Cloud.Dialogflow.V2
     public partial class GetAgentRequest
     {
         /// <summary>
-        /// <see cref="Google.Cloud.Dialogflow.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="gaxres::ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public Google.Cloud.Dialogflow.V2.ProjectName ParentAsProjectName
+        public gaxres::ProjectName ParentAsProjectName
         {
-            get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dialogflow.V2.ProjectName.Parse(Parent); }
+            get { return string.IsNullOrEmpty(Parent) ? null : gaxres::ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
         }
 
@@ -1085,11 +1001,11 @@ namespace Google.Cloud.Dialogflow.V2
     public partial class ImportAgentRequest
     {
         /// <summary>
-        /// <see cref="Google.Cloud.Dialogflow.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="gaxres::ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public Google.Cloud.Dialogflow.V2.ProjectName ParentAsProjectName
+        public gaxres::ProjectName ParentAsProjectName
         {
-            get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dialogflow.V2.ProjectName.Parse(Parent); }
+            get { return string.IsNullOrEmpty(Parent) ? null : gaxres::ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
         }
 
@@ -1163,11 +1079,11 @@ namespace Google.Cloud.Dialogflow.V2
     public partial class RestoreAgentRequest
     {
         /// <summary>
-        /// <see cref="Google.Cloud.Dialogflow.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="gaxres::ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public Google.Cloud.Dialogflow.V2.ProjectName ParentAsProjectName
+        public gaxres::ProjectName ParentAsProjectName
         {
-            get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dialogflow.V2.ProjectName.Parse(Parent); }
+            get { return string.IsNullOrEmpty(Parent) ? null : gaxres::ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
         }
 
@@ -1176,11 +1092,11 @@ namespace Google.Cloud.Dialogflow.V2
     public partial class SearchAgentsRequest
     {
         /// <summary>
-        /// <see cref="Google.Cloud.Dialogflow.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="gaxres::ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public Google.Cloud.Dialogflow.V2.ProjectName ParentAsProjectName
+        public gaxres::ProjectName ParentAsProjectName
         {
-            get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dialogflow.V2.ProjectName.Parse(Parent); }
+            get { return string.IsNullOrEmpty(Parent) ? null : gaxres::ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
         }
 
@@ -1202,11 +1118,11 @@ namespace Google.Cloud.Dialogflow.V2
     public partial class TrainAgentRequest
     {
         /// <summary>
-        /// <see cref="Google.Cloud.Dialogflow.V2.ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// <see cref="gaxres::ProjectName"/>-typed view over the <see cref="Parent"/> resource name property.
         /// </summary>
-        public Google.Cloud.Dialogflow.V2.ProjectName ParentAsProjectName
+        public gaxres::ProjectName ParentAsProjectName
         {
-            get { return string.IsNullOrEmpty(Parent) ? null : Google.Cloud.Dialogflow.V2.ProjectName.Parse(Parent); }
+            get { return string.IsNullOrEmpty(Parent) ? null : gaxres::ProjectName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
         }
 

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/ResourceNames.cs
@@ -52,7 +52,7 @@ namespace Google.Cloud.Dlp.V2
         /// <param name="organizationDeidentifyTemplateName">The organization_deidentify_template resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="OrganizationDeidentifyTemplateName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string organizationDeidentifyTemplateName, out OrganizationDeidentifyTemplateName result)
         {
             gax::GaxPreconditions.CheckNotNull(organizationDeidentifyTemplateName, nameof(organizationDeidentifyTemplateName));
@@ -144,7 +144,7 @@ namespace Google.Cloud.Dlp.V2
         /// <param name="projectDeidentifyTemplateName">The project_deidentify_template resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="ProjectDeidentifyTemplateName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string projectDeidentifyTemplateName, out ProjectDeidentifyTemplateName result)
         {
             gax::GaxPreconditions.CheckNotNull(projectDeidentifyTemplateName, nameof(projectDeidentifyTemplateName));
@@ -236,7 +236,7 @@ namespace Google.Cloud.Dlp.V2
         /// <param name="organizationInspectTemplateName">The organization_inspect_template resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="OrganizationInspectTemplateName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string organizationInspectTemplateName, out OrganizationInspectTemplateName result)
         {
             gax::GaxPreconditions.CheckNotNull(organizationInspectTemplateName, nameof(organizationInspectTemplateName));
@@ -328,7 +328,7 @@ namespace Google.Cloud.Dlp.V2
         /// <param name="projectInspectTemplateName">The project_inspect_template resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="ProjectInspectTemplateName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string projectInspectTemplateName, out ProjectInspectTemplateName result)
         {
             gax::GaxPreconditions.CheckNotNull(projectInspectTemplateName, nameof(projectInspectTemplateName));
@@ -420,7 +420,7 @@ namespace Google.Cloud.Dlp.V2
         /// <param name="projectJobTriggerName">The project_job_trigger resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="ProjectJobTriggerName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string projectJobTriggerName, out ProjectJobTriggerName result)
         {
             gax::GaxPreconditions.CheckNotNull(projectJobTriggerName, nameof(projectJobTriggerName));
@@ -512,7 +512,7 @@ namespace Google.Cloud.Dlp.V2
         /// <param name="dlpJobName">The dlp_job resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="DlpJobName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string dlpJobName, out DlpJobName result)
         {
             gax::GaxPreconditions.CheckNotNull(dlpJobName, nameof(dlpJobName));

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ResourceNames.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ResourceNames.cs
@@ -52,7 +52,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <param name="groupName">The group resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="GroupName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string groupName, out GroupName result)
         {
             gax::GaxPreconditions.CheckNotNull(groupName, nameof(groupName));

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/ResourceNames.cs
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/ResourceNames.cs
@@ -51,7 +51,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// <param name="databaseRootName">The database_root resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="DatabaseRootName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string databaseRootName, out DatabaseRootName result)
         {
             gax::GaxPreconditions.CheckNotNull(databaseRootName, nameof(databaseRootName));
@@ -143,7 +143,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// <param name="documentRootName">The document_root resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="DocumentRootName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string documentRootName, out DocumentRootName result)
         {
             gax::GaxPreconditions.CheckNotNull(documentRootName, nameof(documentRootName));
@@ -235,7 +235,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// <param name="documentPathName">The document_path resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="DocumentPathName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string documentPathName, out DocumentPathName result)
         {
             gax::GaxPreconditions.CheckNotNull(documentPathName, nameof(documentPathName));
@@ -334,7 +334,7 @@ namespace Google.Cloud.Firestore.V1Beta1
         /// <param name="anyPathName">The any_path resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="AnyPathName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string anyPathName, out AnyPathName result)
         {
             gax::GaxPreconditions.CheckNotNull(anyPathName, nameof(anyPathName));

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ResourceNames.cs
@@ -51,7 +51,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="ProjectName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string projectName, out ProjectName result)
         {
             gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
@@ -136,7 +136,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="logName">The log resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="LogName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string logName, out LogName result)
         {
             gax::GaxPreconditions.CheckNotNull(logName, nameof(logName));
@@ -228,7 +228,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="sinkName">The sink resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="SinkName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string sinkName, out SinkName result)
         {
             gax::GaxPreconditions.CheckNotNull(sinkName, nameof(sinkName));
@@ -320,7 +320,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="metricName">The metric resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="MetricName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string metricName, out MetricName result)
         {
             gax::GaxPreconditions.CheckNotNull(metricName, nameof(metricName));
@@ -412,7 +412,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="exclusionName">The exclusion resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="ExclusionName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string exclusionName, out ExclusionName result)
         {
             gax::GaxPreconditions.CheckNotNull(exclusionName, nameof(exclusionName));
@@ -504,7 +504,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="organizationName">The organization resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="OrganizationName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string organizationName, out OrganizationName result)
         {
             gax::GaxPreconditions.CheckNotNull(organizationName, nameof(organizationName));
@@ -589,7 +589,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="organizationLogName">The organization_log resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="OrganizationLogName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string organizationLogName, out OrganizationLogName result)
         {
             gax::GaxPreconditions.CheckNotNull(organizationLogName, nameof(organizationLogName));
@@ -681,7 +681,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="organizationSinkName">The organization_sink resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="OrganizationSinkName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string organizationSinkName, out OrganizationSinkName result)
         {
             gax::GaxPreconditions.CheckNotNull(organizationSinkName, nameof(organizationSinkName));
@@ -773,7 +773,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="organizationExclusionName">The organization_exclusion resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="OrganizationExclusionName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string organizationExclusionName, out OrganizationExclusionName result)
         {
             gax::GaxPreconditions.CheckNotNull(organizationExclusionName, nameof(organizationExclusionName));
@@ -865,7 +865,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="folderName">The folder resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="FolderName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string folderName, out FolderName result)
         {
             gax::GaxPreconditions.CheckNotNull(folderName, nameof(folderName));
@@ -950,7 +950,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="folderLogName">The folder_log resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="FolderLogName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string folderLogName, out FolderLogName result)
         {
             gax::GaxPreconditions.CheckNotNull(folderLogName, nameof(folderLogName));
@@ -1042,7 +1042,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="folderSinkName">The folder_sink resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="FolderSinkName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string folderSinkName, out FolderSinkName result)
         {
             gax::GaxPreconditions.CheckNotNull(folderSinkName, nameof(folderSinkName));
@@ -1134,7 +1134,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="folderExclusionName">The folder_exclusion resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="FolderExclusionName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string folderExclusionName, out FolderExclusionName result)
         {
             gax::GaxPreconditions.CheckNotNull(folderExclusionName, nameof(folderExclusionName));
@@ -1226,7 +1226,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="billingName">The billing resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="BillingName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string billingName, out BillingName result)
         {
             gax::GaxPreconditions.CheckNotNull(billingName, nameof(billingName));
@@ -1311,7 +1311,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="billingLogName">The billing_log resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="BillingLogName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string billingLogName, out BillingLogName result)
         {
             gax::GaxPreconditions.CheckNotNull(billingLogName, nameof(billingLogName));
@@ -1403,7 +1403,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="billingSinkName">The billing_sink resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="BillingSinkName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string billingSinkName, out BillingSinkName result)
         {
             gax::GaxPreconditions.CheckNotNull(billingSinkName, nameof(billingSinkName));
@@ -1495,7 +1495,7 @@ namespace Google.Cloud.Logging.V2
         /// <param name="billingExclusionName">The billing_exclusion resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="BillingExclusionName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string billingExclusionName, out BillingExclusionName result)
         {
             gax::GaxPreconditions.CheckNotNull(billingExclusionName, nameof(billingExclusionName));

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ResourceNames.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ResourceNames.cs
@@ -51,7 +51,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="ProjectName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string projectName, out ProjectName result)
         {
             gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
@@ -136,7 +136,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <param name="alertPolicyName">The alert_policy resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="AlertPolicyName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string alertPolicyName, out AlertPolicyName result)
         {
             gax::GaxPreconditions.CheckNotNull(alertPolicyName, nameof(alertPolicyName));
@@ -228,7 +228,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <param name="alertPolicyConditionName">The alert_policy_condition resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="AlertPolicyConditionName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string alertPolicyConditionName, out AlertPolicyConditionName result)
         {
             gax::GaxPreconditions.CheckNotNull(alertPolicyConditionName, nameof(alertPolicyConditionName));
@@ -327,7 +327,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <param name="groupName">The group resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="GroupName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string groupName, out GroupName result)
         {
             gax::GaxPreconditions.CheckNotNull(groupName, nameof(groupName));
@@ -419,7 +419,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <param name="metricDescriptorName">The metric_descriptor resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="MetricDescriptorName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string metricDescriptorName, out MetricDescriptorName result)
         {
             gax::GaxPreconditions.CheckNotNull(metricDescriptorName, nameof(metricDescriptorName));
@@ -511,7 +511,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <param name="monitoredResourceDescriptorName">The monitored_resource_descriptor resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="MonitoredResourceDescriptorName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string monitoredResourceDescriptorName, out MonitoredResourceDescriptorName result)
         {
             gax::GaxPreconditions.CheckNotNull(monitoredResourceDescriptorName, nameof(monitoredResourceDescriptorName));
@@ -603,7 +603,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <param name="notificationChannelName">The notification_channel resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="NotificationChannelName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string notificationChannelName, out NotificationChannelName result)
         {
             gax::GaxPreconditions.CheckNotNull(notificationChannelName, nameof(notificationChannelName));
@@ -695,7 +695,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <param name="notificationChannelDescriptorName">The notification_channel_descriptor resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="NotificationChannelDescriptorName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string notificationChannelDescriptorName, out NotificationChannelDescriptorName result)
         {
             gax::GaxPreconditions.CheckNotNull(notificationChannelDescriptorName, nameof(notificationChannelDescriptorName));
@@ -787,7 +787,7 @@ namespace Google.Cloud.Monitoring.V3
         /// <param name="uptimeCheckConfigName">The uptime_check_config resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="UptimeCheckConfigName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string uptimeCheckConfigName, out UptimeCheckConfigName result)
         {
             gax::GaxPreconditions.CheckNotNull(uptimeCheckConfigName, nameof(uptimeCheckConfigName));

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/ResourceNames.cs
@@ -51,7 +51,7 @@ namespace Google.Cloud.OsLogin.V1
         /// <param name="userName">The user resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="UserName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string userName, out UserName result)
         {
             gax::GaxPreconditions.CheckNotNull(userName, nameof(userName));
@@ -136,7 +136,7 @@ namespace Google.Cloud.OsLogin.V1
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="ProjectName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string projectName, out ProjectName result)
         {
             gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
@@ -228,7 +228,7 @@ namespace Google.Cloud.OsLogin.V1
         /// <param name="fingerprintName">The fingerprint resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="FingerprintName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string fingerprintName, out FingerprintName result)
         {
             gax::GaxPreconditions.CheckNotNull(fingerprintName, nameof(fingerprintName));

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/ResourceNames.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/ResourceNames.cs
@@ -51,7 +51,7 @@ namespace Google.Cloud.OsLogin.V1Beta
         /// <param name="userName">The user resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="UserName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string userName, out UserName result)
         {
             gax::GaxPreconditions.CheckNotNull(userName, nameof(userName));
@@ -136,7 +136,7 @@ namespace Google.Cloud.OsLogin.V1Beta
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="ProjectName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string projectName, out ProjectName result)
         {
             gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
@@ -228,7 +228,7 @@ namespace Google.Cloud.OsLogin.V1Beta
         /// <param name="fingerprintName">The fingerprint resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="FingerprintName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string fingerprintName, out FingerprintName result)
         {
             gax::GaxPreconditions.CheckNotNull(fingerprintName, nameof(fingerprintName));

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/ResourceNames.cs
@@ -53,7 +53,7 @@ namespace Google.Cloud.PubSub.V1
         /// <param name="snapshotName">The snapshot resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="SnapshotName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string snapshotName, out SnapshotName result)
         {
             gax::GaxPreconditions.CheckNotNull(snapshotName, nameof(snapshotName));
@@ -145,7 +145,7 @@ namespace Google.Cloud.PubSub.V1
         /// <param name="subscriptionName">The subscription resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="SubscriptionName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string subscriptionName, out SubscriptionName result)
         {
             gax::GaxPreconditions.CheckNotNull(subscriptionName, nameof(subscriptionName));
@@ -237,7 +237,7 @@ namespace Google.Cloud.PubSub.V1
         /// <param name="topicName">The topic resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="TopicName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string topicName, out TopicName result)
         {
             gax::GaxPreconditions.CheckNotNull(topicName, nameof(topicName));

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/ResourceNames.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/ResourceNames.cs
@@ -51,7 +51,7 @@ namespace Google.Cloud.Redis.V1Beta1
         /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="LocationName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string locationName, out LocationName result)
         {
             gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
@@ -143,7 +143,7 @@ namespace Google.Cloud.Redis.V1Beta1
         /// <param name="instanceName">The instance resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="InstanceName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string instanceName, out InstanceName result)
         {
             gax::GaxPreconditions.CheckNotNull(instanceName, nameof(instanceName));

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/ResourceNames.cs
@@ -53,7 +53,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <param name="instanceConfigName">The instance_config resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="InstanceConfigName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string instanceConfigName, out InstanceConfigName result)
         {
             gax::GaxPreconditions.CheckNotNull(instanceConfigName, nameof(instanceConfigName));

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ResourceNames.cs
@@ -52,7 +52,7 @@ namespace Google.Cloud.Spanner.V1
         /// <param name="sessionName">The session resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="SessionName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string sessionName, out SessionName result)
         {
             gax::GaxPreconditions.CheckNotNull(sessionName, nameof(sessionName));

--- a/apis/Google.Cloud.Tasks.V2Beta2/Google.Cloud.Tasks.V2Beta2/ResourceNames.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta2/Google.Cloud.Tasks.V2Beta2/ResourceNames.cs
@@ -51,7 +51,7 @@ namespace Google.Cloud.Tasks.V2Beta2
         /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="LocationName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string locationName, out LocationName result)
         {
             gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
@@ -143,7 +143,7 @@ namespace Google.Cloud.Tasks.V2Beta2
         /// <param name="queueName">The queue resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="QueueName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string queueName, out QueueName result)
         {
             gax::GaxPreconditions.CheckNotNull(queueName, nameof(queueName));
@@ -242,7 +242,7 @@ namespace Google.Cloud.Tasks.V2Beta2
         /// <param name="taskName">The task resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="TaskName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string taskName, out TaskName result)
         {
             gax::GaxPreconditions.CheckNotNull(taskName, nameof(taskName));

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/CloudTts.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/CloudTts.cs
@@ -57,11 +57,12 @@ namespace Google.Cloud.TextToSpeech.V1 {
             "bnRoZXNpemVTcGVlY2gSNS5nb29nbGUuY2xvdWQudGV4dHRvc3BlZWNoLnYx",
             "LlN5bnRoZXNpemVTcGVlY2hSZXF1ZXN0GjYuZ29vZ2xlLmNsb3VkLnRleHR0",
             "b3NwZWVjaC52MS5TeW50aGVzaXplU3BlZWNoUmVzcG9uc2UiHoLT5JMCGCIT",
-            "L3YxL3RleHQ6c3ludGhlc2l6ZToBKkKjAQogY29tLmdvb2dsZS5jbG91ZC50",
+            "L3YxL3RleHQ6c3ludGhlc2l6ZToBKkLCAQogY29tLmdvb2dsZS5jbG91ZC50",
             "ZXh0dG9zcGVlY2gudjFCEVRleHRUb1NwZWVjaFByb3RvUAFaSGdvb2dsZS5n",
             "b2xhbmcub3JnL2dlbnByb3RvL2dvb2dsZWFwaXMvY2xvdWQvdGV4dHRvc3Bl",
             "ZWNoL3YxO3RleHR0b3NwZWVjaPgBAaoCHEdvb2dsZS5DbG91ZC5UZXh0VG9T",
-            "cGVlY2guVjFiBnByb3RvMw=="));
+            "cGVlY2guVjHKAhxHb29nbGVcQ2xvdWRcVGV4dFRvU3BlZWNoXFYxYgZwcm90",
+            "bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Api.AnnotationsReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Google.Cloud.TextToSpeech.V1.SsmlVoiceGender), typeof(global::Google.Cloud.TextToSpeech.V1.AudioEncoding), }, new pbr::GeneratedClrTypeInfo[] {

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/ResourceNames.cs
@@ -52,7 +52,7 @@ namespace Google.Cloud.Trace.V2
         /// <param name="spanName">The span resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="SpanName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string spanName, out SpanName result)
         {
             gax::GaxPreconditions.CheckNotNull(spanName, nameof(spanName));


### PR DESCRIPTION
Most changes are fixing a documentation typo. Additionally:

- Dialogflow now uses the common ProjectName resource
- Cloud TTS has an insignificant proto descriptor change

(Will merge on green)