### PR TITLE
Pubsub unary acks/extends

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/PubSubClientTest.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/PubSubClientTest.cs
@@ -45,7 +45,7 @@ namespace Google.Cloud.PubSub.V1.IntegrationTests
         private async Task RunBulkMessaging(
             int messageCount, int minMessageSize, int maxMessageSize, int maxMessagesInFlight, int initialNackCount,
             TimeSpan? timeouts = null, int? cancelAfterRecvCount = null, TimeSpan? interPublishDelay = null,
-            TimeSpan? debugOutputPeriod = null)
+            TimeSpan? debugOutputPeriod = null, int? clientCount = null)
         {
             // Force messages to be at least 4 bytes long, so an int ID can be used.
             minMessageSize = Math.Max(4, minMessageSize);
@@ -84,6 +84,7 @@ namespace Google.Cloud.PubSub.V1.IntegrationTests
                     }
                 )).ConfigureAwait(false);
             var simpleSubscriber = await SubscriberClient.CreateAsync(subscriptionName,
+                clientCreationSettings: new SubscriberClient.ClientCreationSettings(clientCount: clientCount),
                 settings: new SubscriberClient.Settings
                 {
                     StreamAckDeadline = timeouts,
@@ -232,10 +233,10 @@ namespace Google.Cloud.PubSub.V1.IntegrationTests
             Console.WriteLine("Test complete.");
         }
 
-        [Fact]
-        public async Task ManySmallMessages()
+        [Theory, CombinatorialData]
+        public async Task ManySmallMessages([CombinatorialValues(0, 1, 2)] int clientCount)
         {
-            await RunBulkMessaging(2_000_000, 1, 10, 10_000, 0);
+            await RunBulkMessaging(1_000_000, 1, 10, 10_000, 0, clientCount: clientCount > 0 ? clientCount : (int?)null);
         }
 
         [Theory(Skip = "Very long-running test; takes 6 hours")]

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/ReQueueTest.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/ReQueueTest.cs
@@ -1,7 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System.Linq;
-using System.Text;
 using Xunit;
 
 namespace Google.Cloud.PubSub.V1.Tests

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/ReQueueTest.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/ReQueueTest.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Google.Cloud.PubSub.V1.Tests
+{
+    public class ReQueueTest
+    {
+        [Theory, CombinatorialData]
+        public void EnqueueDequeue([CombinatorialValues(0, 1, 2, 3, 4, 5)] int dequeueCount)
+        {
+            var q = new SubscriberClientImpl.ReQueue<string>();
+            q.Enqueue("a");
+            q.Enqueue(new[] { "b", "c" });
+            var dequeued = q.Dequeue(dequeueCount, null);
+            var expected = new[] { "a", "b", "c" }.Take(dequeueCount);
+            Assert.Equal(expected, dequeued);
+        }
+
+        [Theory, CombinatorialData]
+        public void RequeueDequeue([CombinatorialValues(0, 1, 2, 3, 4, 5)] int dequeueCount)
+        {
+            var q = new SubscriberClientImpl.ReQueue<string>();
+            q.Requeue(new[] { "a" });
+            q.Requeue(new[] { "b", "c" });
+            var dequeued = q.Dequeue(dequeueCount, null);
+            var expected = new[] { "a", "b", "c" }.Take(dequeueCount);
+            Assert.Equal(expected, dequeued);
+        }
+
+        [Theory, CombinatorialData]
+        public void EnqueueRequeueDequeue([CombinatorialValues(0, 1, 2, 3, 4, 5, 6, 7)] int dequeueCount)
+        {
+            var q = new SubscriberClientImpl.ReQueue<string>();
+            q.Enqueue("d");
+            q.Requeue(new[] { "a", "b" });
+            q.Enqueue(new[] { "e", "f" });
+            q.Requeue(new[] { "c" });
+            var dequeued = q.Dequeue(dequeueCount, null);
+            var expected = new[] { "a", "b", "c", "d", "e", "f" }.Take(dequeueCount);
+            Assert.Equal(expected, dequeued);
+        }
+
+        [Fact]
+        public void Count()
+        {
+            var q = new SubscriberClientImpl.ReQueue<string>();
+            Assert.Equal(0, q.Count);
+            q.Enqueue("a");
+            Assert.Equal(1, q.Count);
+            q.Requeue(new[] { "b" });
+            Assert.Equal(2, q.Count);
+            q.Requeue(new[] { "c", "d" });
+            Assert.Equal(4, q.Count);
+            q.Dequeue(1, null);
+            Assert.Equal(3, q.Count);
+            q.Dequeue(2, null);
+            Assert.Equal(1, q.Count);
+            q.Enqueue("e");
+            q.Requeue(new[] { "f" });
+            Assert.Equal(3, q.Count);
+            q.Dequeue(10, null);
+            Assert.Equal(0, q.Count);
+        }
+    }
+}

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/RequeueableQueueTest.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/RequeueableQueueTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017, Google Inc. All rights reserved.
+﻿// Copyright 2018, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@ using Xunit;
 
 namespace Google.Cloud.PubSub.V1.Tests
 {
-    public class ReQueueTest
+    public class RequeueableQueueTest
     {
         [Theory, CombinatorialData]
         public void EnqueueDequeue([CombinatorialValues(0, 1, 2, 3, 4, 5)] int dequeueCount)
         {
-            var q = new SubscriberClientImpl.ReQueue<string>();
+            var q = new SubscriberClientImpl.RequeueableQueue<string>();
             q.Enqueue("a");
             q.Enqueue(new[] { "b", "c" });
             var dequeued = q.Dequeue(dequeueCount, null);
@@ -33,7 +33,7 @@ namespace Google.Cloud.PubSub.V1.Tests
         [Theory, CombinatorialData]
         public void RequeueDequeue([CombinatorialValues(0, 1, 2, 3, 4, 5)] int dequeueCount)
         {
-            var q = new SubscriberClientImpl.ReQueue<string>();
+            var q = new SubscriberClientImpl.RequeueableQueue<string>();
             q.Requeue(new[] { "a" });
             q.Requeue(new[] { "b", "c" });
             var dequeued = q.Dequeue(dequeueCount, null);
@@ -44,7 +44,7 @@ namespace Google.Cloud.PubSub.V1.Tests
         [Theory, CombinatorialData]
         public void EnqueueRequeueDequeue([CombinatorialValues(0, 1, 2, 3, 4, 5, 6, 7)] int dequeueCount)
         {
-            var q = new SubscriberClientImpl.ReQueue<string>();
+            var q = new SubscriberClientImpl.RequeueableQueue<string>();
             q.Enqueue("d");
             q.Requeue(new[] { "a", "b" });
             q.Enqueue(new[] { "e", "f" });
@@ -57,7 +57,7 @@ namespace Google.Cloud.PubSub.V1.Tests
         [Fact]
         public void Count()
         {
-            var q = new SubscriberClientImpl.ReQueue<string>();
+            var q = new SubscriberClientImpl.RequeueableQueue<string>();
             Assert.Equal(0, q.Count);
             q.Enqueue("a");
             Assert.Equal(1, q.Count);

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/SubscriberClientTest.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/SubscriberClientTest.cs
@@ -174,7 +174,7 @@ namespace Google.Cloud.PubSub.V1.Tests
                 {
                     if (message.ModifyDeadlineAckIds.Count != 0 || message.AckIds.Count != 0)
                     {
-                        throw new InvalidOperationException("WriteAsync must not modify deadlines.");
+                        throw new InvalidOperationException("WriteAsync must not modify deadlines or send acks/nacks.");
                     }
                     // TODO: Record write time
                     return Task.FromResult(0);
@@ -255,14 +255,8 @@ namespace Google.Cloud.PubSub.V1.Tests
                 }
                 lock (_lock)
                 {
-                    if (ackDeadlineSeconds == 0)
-                    {
-                        _nacks.AddRange(ackIds.Select(id => new TimedId(_clock.GetCurrentDateTimeUtc(), id)));
-                    }
-                    else
-                    {
-                        _extends.AddRange(ackIds.Select(id => new TimedId(_clock.GetCurrentDateTimeUtc(), id)));
-                    }
+                    var ids = ackDeadlineSeconds == 0 ? _nacks : _extends;
+                    ids.AddRange(ackIds.Select(id => new TimedId(_clock.GetCurrentDateTimeUtc(), id)));
                 }
             }
         }

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Tasks/TestAwaiter.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Tasks/TestAwaiter.cs
@@ -28,8 +28,8 @@ namespace Google.Cloud.PubSub.V1.Tests.Tasks
             _taskScheduler = taskScheduler;
         }
 
-        private Task _task;
-        private TaskScheduler _taskScheduler;
+        private readonly Task _task;
+        private readonly TaskScheduler _taskScheduler;
 
         public void OnCompleted(Action continuation) =>
             _task.ContinueWith(_ => continuation(), CancellationToken.None, TaskContinuationOptions.DenyChildAttach, _taskScheduler);
@@ -47,8 +47,8 @@ namespace Google.Cloud.PubSub.V1.Tests.Tasks
             _taskScheduler = taskScheduler;
         }
 
-        private Task<T> _task;
-        private TaskScheduler _taskScheduler;
+        private readonly Task<T> _task;
+        private readonly TaskScheduler _taskScheduler;
 
         public void OnCompleted(Action continuation) =>
             _task.ContinueWith(_ => continuation(), CancellationToken.None, TaskContinuationOptions.DenyChildAttach, _taskScheduler);

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Extensions.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Extensions.cs
@@ -15,6 +15,7 @@
 using Grpc.Core;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Google.Cloud.PubSub.V1
 {
@@ -64,6 +65,12 @@ namespace Google.Cloud.PubSub.V1
 
         internal static IEnumerable<Exception> AllExceptions(this Exception e) =>
             (IEnumerable<Exception>)(e as AggregateException)?.Flatten().InnerExceptions ?? new[] { e };
+
+        internal static Exception FlattenIfPossible(this Exception e)
+        {
+            var exs = e.AllExceptions().ToList();
+            return exs.Count == 1 ? exs[0] : new AggregateException(exs);
+        }
 
         internal static bool IsRecoverable(this RpcException e)
         {

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
@@ -16,7 +16,6 @@ using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Apis.Auth.OAuth2;
 using Google.Cloud.PubSub.V1.Tasks;
-using Google.Protobuf.Collections;
 using Grpc.Auth;
 using Grpc.Core;
 using System;

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Tasks/TaskHelper.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Tasks/TaskHelper.cs
@@ -30,6 +30,7 @@ namespace Google.Cloud.PubSub.V1.Tasks
         {
             public override TaskScheduler TaskScheduler => TaskScheduler.Default;
             public override Task<T> Run<T>(Func<Task<T>> function) => Task.Run(function);
+            public override Task Run(Func<Task> function) => Task.Run(function);
             public override void Wait(Task task) => task.Wait();
             public override TaskAwaitable ConfigureAwait(Task task) =>
                 new TaskAwaitable(new ForwardingAwaiter(task.ConfigureAwait(false).GetAwaiter()));


### PR DESCRIPTION
No longer using streaming push to ack/nack and extend messages.

Also a fairly major rewrite of the per-channel code.