### PR TITLE
Added LogBuilderExtension for ASP.NET Core Diagnostic project

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogBuilderExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogBuilderExtensions.cs
@@ -1,0 +1,62 @@
+﻿#if NETSTANDARD2_0
+using System;
+using Google.Api.Gax;
+using Google.Cloud.Diagnostics.Common;
+using Google.Cloud.Logging.V2;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Google.Cloud.Diagnostics.AspNetCore.Logging
+{
+	/// <summary>
+	/// Extensions to add <see cref="GoogleLoggerProvider"/>s to an <see cref="ILoggingBuilder"/>.
+	/// </summary>
+	/// 
+	/// <example>
+	/// <code>
+	/// .ConfigureLogging((hostingContext, logging) =>
+	/// {
+	///     string projectId = "[Google Cloud Platform project ID]";
+	///     var serviceProvider = logging.Services.BuildServiceProvider();
+	///     logging.AddGoogle(serviceProvider);
+	///     ...
+	/// }
+	/// </code>
+	/// </example>
+	/// 
+	/// <remarks>
+	/// Logs to Google Stackdriver Cloud Logging.
+	/// Docs: https://cloud.google.com/logging/docs/
+	/// </remarks>
+	/// <seealso cref="GoogleLogger"/>
+	public static class GoogleLogBuilderExtensions
+    {
+		/// <summary>
+		/// Adds a <see cref="GoogleLoggerProvider"/> for <see cref="GoogleLogger"/>s.
+		/// </summary>
+		/// <param name="builder">The logger builder. Cannot be null.</param>
+		/// <param name="serviceProvider">The service provider to resolve additional services from.</param>
+		/// <param name="projectId">Optional if running on Google App Engine or Google Compute Engine.
+		///     The Google Cloud Platform project ID. If unspecified and running on GAE or GCE the project ID will be
+		///     detected from the platform.</param>
+		/// <param name="options">Optional, options for the logger.</param>
+		/// <param name="client">Optional, logging client.</param>
+		public static void AddGoogle(this ILoggingBuilder builder, 
+								IServiceProvider serviceProvider, 
+								string projectId = null,
+								LoggerOptions options = null, 
+								LoggingServiceV2Client client = null)
+		{
+			GaxPreconditions.CheckNotNull(builder, nameof(builder));
+
+			options = options ?? LoggerOptions.Create();
+			projectId = Project.GetAndCheckProjectId(projectId, options.MonitoredResource);
+			LogTarget logTarget = LogTarget.ForProject(projectId);
+
+			var provider = GoogleLoggerProvider.Create(serviceProvider, projectId, options, client);
+
+			builder.Services.AddSingleton<ILoggerProvider>(provider);
+		}
+	}
+}
+#endif


### PR DESCRIPTION
ASP.NET Core 2.x allows you to configure the logging, but also DI, directly into the [WebHostBuilder](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.hosting.webhostbuilder?view=aspnetcore-2.1) besides that into the "classic" `Startup` class.

This is very helpful because you can have the logging system up & running before the application startup. Unfortunately you can't do that in the same way you do into the startup class (using `ILoggerFactory`) but you have to use the `ILoggingBuilder` interface ([here](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.iloggingbuilder?view=aspnetcore-2.1) more info) and register the `ILoggerProvider`.

I've added an extension method that makes this easier, below an example:

```csharp
new WebHostBuilder()
.UseKestrel()
.ConfigureServices(services =>
{
	services.AddGoogleExceptionLogging(options =>
	{
		options.ProjectId = "[Google Cloud Platform project ID]";
		options.ServiceName = "My Super ServiceName";
	});

	// Add trace service.
	services.AddGoogleTrace(options =>
	{
		options.ProjectId = "my-project-id";
		options.Options = TraceOptions.Create(bufferOptions: BufferOptions.NoBuffer());
	});
})
.ConfigureLogging((hostingContext, logging) =>
{
	string projectId = "[Google Cloud Platform project ID]";
	var serviceProvider = logging.Services.BuildServiceProvider();
	logging.AddGoogle(serviceProvider);
})
.UseIISIntegration()
.UseContentRoot(Directory.GetCurrentDirectory())
.UseStartup<Startup>()
.Build()
.Run();
```

Note:
Unfortunately the method `GoogleLoggerProvider.Create` requires an instance of `IServiceProvider` (the nuget packaged doesn't need it, probably the master is a different version) so the developer must call the extension method `BuildServiceProvider` before to use `logging.AddGoogle()`.

I see two possible ways to resolve this:

* Remove the mandatory `IServiceProvider` from `GoogleLoggerProvider.Create` 
* Add a dependency into the project (`Microsoft.Extensions.DependencyInjection`) and call `BuildServiceProvider` for the user (in case of null of course)

