### PR TITLE
Increase real-time test deadline

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Tasks/TestScheduler.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Tasks/TestScheduler.cs
@@ -501,7 +501,7 @@ namespace Google.Cloud.PubSub.V1.Tests.Tasks
         public T Run<T>(Func<Task<T>> taskProvider)
         {
             var simulatedTimeout = Clock.GetCurrentDateTimeUtc() + TimeSpan.FromHours(24);
-            var realCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var realCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
             var mainTask = TaskHelper.Run(taskProvider);
             while (true)
             {


### PR DESCRIPTION
When running on CI infrastructre, complex tests sometimes take a while to execute