### PR TITLE
Including the client lib version as part of the generated documentation.

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/index.md
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.BigQuery.V2/docs/index.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/index.md
@@ -3,6 +3,8 @@
 {{description}}
 It wraps the `Google.Apis.Bigquery.v2` generated library, providing a higher-level API to make it easier to use.
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Bigtable.Admin.V2/docs/index.md
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Bigtable.V2/docs/index.md
+++ b/apis/Google.Cloud.Bigtable.V2/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Container.V1/docs/index.md
+++ b/apis/Google.Cloud.Container.V1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Dataproc.V1/docs/index.md
+++ b/apis/Google.Cloud.Dataproc.V1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Datastore.V1/docs/index.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Debugger.V2/docs/index.md
+++ b/apis/Google.Cloud.Debugger.V2/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Diagnostics.AspNet/docs/index.md
+++ b/apis/Google.Cloud.Diagnostics.AspNet/docs/index.md
@@ -5,6 +5,8 @@ It allows for simple integration of Stackdriver into ASP.NET applications with m
 
 `Google.Cloud.Diagnostics.AspNet` currently supports Stackdriver Error Reporting and Stackdriver Trace.
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
@@ -6,6 +6,8 @@ It allows for simple integration of Stackdriver into ASP.NET applications with m
 `Google.Cloud.Diagnostics.AspNetCore` currently supports Stackdriver Error Reporting, Stackdriver Logging
 and Stackdriver Trace.
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Dialogflow.V2/docs/index.md
+++ b/apis/Google.Cloud.Dialogflow.V2/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Dlp.V2/docs/index.md
+++ b/apis/Google.Cloud.Dlp.V2/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/docs/index.md
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/docs/index.md
@@ -2,6 +2,8 @@
 
 `Google.Cloud.EntityFrameworkCore.Spanner` is the EF Core provider for Cloud Spanner.
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/docs/index.md
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 Support for automatic error reporting can be found in the
 [`Google.Cloud.Diagnostics.AspNet`](../Google.Cloud.Diagnostics.AspNet/index.html)
 NuGet package.

--- a/apis/Google.Cloud.Firestore/docs/index.md
+++ b/apis/Google.Cloud.Firestore/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Language.V1/docs/index.md
+++ b/apis/Google.Cloud.Language.V1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 If you're looking for the experimental features, you can find them
 in [this separate package](../Google.Cloud.Language.V1.Experimental/index.html).
 

--- a/apis/Google.Cloud.Logging.Log4Net/docs/index.md
+++ b/apis/Google.Cloud.Logging.Log4Net/docs/index.md
@@ -4,6 +4,8 @@
 Logging](https://cloud.google.com/logging/) with
 [log4net](https://logging.apache.org/log4net/).
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Logging.NLog/docs/index.md
+++ b/apis/Google.Cloud.Logging.NLog/docs/index.md
@@ -3,6 +3,8 @@
 `Google.Cloud.Logging.NLog` is a .NET client library to integrate [Google Stackdriver
 Logging](https://cloud.google.com/logging/) with [NLog](http://nlog-project.org/).
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Logging.V2/docs/index.md
+++ b/apis/Google.Cloud.Logging.V2/docs/index.md
@@ -1,6 +1,9 @@
 {{title}}
 
 {{description}}
+
+{{version}}
+
 Integration with [log4net](https://logging.apache.org/log4net/) is provided by
 the [Google.Cloud.Logging.Log4Net](../Google.Cloud.Logging.Log4Net/index.html) package.
 

--- a/apis/Google.Cloud.Metadata.V1/docs/index.md
+++ b/apis/Google.Cloud.Metadata.V1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 # Authentication

--- a/apis/Google.Cloud.Monitoring.V3/docs/index.md
+++ b/apis/Google.Cloud.Monitoring.V3/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.OsLogin.V1/docs/index.md
+++ b/apis/Google.Cloud.OsLogin.V1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.OsLogin.V1Beta/docs/index.md
+++ b/apis/Google.Cloud.OsLogin.V1Beta/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.PubSub.V1/docs/index.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 # Class renaming in [v1.0.0-beta16](https://www.nuget.org/packages/Google.Cloud.PubSub.V1/1.0.0-beta16)
 
 The following classes have been renamed when moving from version 1.0.0-beta15 to 1.0.0-beta16:

--- a/apis/Google.Cloud.Redis.V1Beta1/docs/index.md
+++ b/apis/Google.Cloud.Redis.V1Beta1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Spanner.Data/docs/index.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/index.md
@@ -3,6 +3,8 @@
 `Google.Cloud.Spanner.Data` is the ADO.NET provider for Cloud Spanner. It is the recommended
 package for regular Cloud Spanner database access from .NET.
 
+{{version}}
+
 The [Google.Cloud.Spanner.Admin.Instance.V1](../Google.Cloud.Spanner.Admin.Instance.V1/) package
 should be used for Cloud Spanner instance administration, such as creating or deleting instances.
 

--- a/apis/Google.Cloud.Speech.V1/docs/index.md
+++ b/apis/Google.Cloud.Speech.V1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Storage.V1/docs/index.md
+++ b/apis/Google.Cloud.Storage.V1/docs/index.md
@@ -3,6 +3,8 @@
 {{description}}
 It wraps the `Google.Apis.Storage.v1` generated library, providing a higher-level API to make it easier to use.
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Tasks.V2Beta2/docs/index.md
+++ b/apis/Google.Cloud.Tasks.V2Beta2/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.TextToSpeech.V1/docs/index.md
+++ b/apis/Google.Cloud.TextToSpeech.V1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Trace.V1/docs/index.md
+++ b/apis/Google.Cloud.Trace.V1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Trace.V2/docs/index.md
+++ b/apis/Google.Cloud.Trace.V2/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Translation.V2/docs/index.md
+++ b/apis/Google.Cloud.Translation.V2/docs/index.md
@@ -3,6 +3,8 @@
 {{description}}
 It wraps the `Google.Apis.Translate.v2` generated library, providing a higher-level API to make it easier to use.
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.VideoIntelligence.V1/docs/index.md
+++ b/apis/Google.Cloud.VideoIntelligence.V1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Vision.V1/docs/index.md
+++ b/apis/Google.Cloud.Vision.V1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Vision.V1P1Beta1/docs/index.md
+++ b/apis/Google.Cloud.Vision.V1P1Beta1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Vision.V1P2Beta1/docs/index.md
+++ b/apis/Google.Cloud.Vision.V1P2Beta1/docs/index.md
@@ -2,6 +2,8 @@
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}

--- a/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
+++ b/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
@@ -179,6 +179,10 @@ namespace Google.Cloud.Tools.GenerateDocfxSources
         {
             string title = $"# {api.Id}";
             string description = $"`{api.Id}` is a.NET client library for the [{api.ProductName} API]({api.ProductUrl}).";
+            string version =
+$@"Note:
+This documentation is for version `{ api.Version}` of the library.
+Some samples may not work with other versions.";
             string installation =
 $@"# Installation
 
@@ -187,10 +191,11 @@ your project in the normal way (for example by right-clicking on the
 project in Visual Studio and choosing ""Manage NuGet Packages..."").";
             if (!api.IsReleaseVersion)
             {
-                installation += @"
+                installation += $@"
 Please ensure you enable pre-release packages (for example, in the
 Visual Studio NuGet user interface, check the ""Include prerelease""
-box).";
+box). Some of the following samples might only work with the latest 
+pre-release version (`{api.Version}`) of `{api.Id}`.";
             }
 
             string auth =
@@ -212,6 +217,7 @@ specifying an end-point or channel and settings.";
             return text
                 .Replace("{{title}}", title)
                 .Replace("{{description}}", description)
+                .Replace("{{version}}", version)
                 .Replace("{{installation}}", installation)
                 .Replace("{{auth}}", auth)
                 .Replace("{{client-classes}}", clientClasses)

--- a/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
+++ b/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
@@ -245,6 +245,8 @@ namespace Google.Cloud.Tools.ProjectGenerator
 
 {{description}}
 
+{{version}}
+
 {{installation}}
 
 {{auth}}


### PR DESCRIPTION
Adding the client lib version on the generated docs.
It looks like this for `Diagnostics.AspNetCore`:
![image](https://user-images.githubusercontent.com/14878252/41044875-19c8de92-699f-11e8-9744-b5fdc0f993b0.png)
One thing, this is relaying on `apis/apis.json` for the version and I don't know if we always maintain that file up to date, it seems so.