### PR TITLE
Rename SnapshotListener to FirestoreChangeListener

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/UserGuideSnippets.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/UserGuideSnippets.cs
@@ -353,7 +353,7 @@ namespace Google.Cloud.Firestore.Snippets
             CollectionReference collection = db.Collection(collectionId);
             Query query = collection.WhereGreaterThan("Score", 5).OrderByDescending("Score");
 
-            SnapshotListener listener = query.Listen(snapshot =>
+            FirestoreChangeListener listener = query.Listen(snapshot =>
             {
                 Console.WriteLine($"Callback received snapshot");
                 Console.WriteLine($"Count: {snapshot.Count}");

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentReference.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentReference.cs
@@ -214,8 +214,8 @@ namespace Google.Cloud.Firestore
         /// </summary>
         /// <param name="callback">The callback to invoke each time the document changes. Must not be null.</param>
         /// <param name="cancellationToken">Optional cancellation token which may be used to cancel the listening operation.</param>
-        /// <returns>A <see cref="SnapshotListener"/> which may be used to monitor the listening operation and stop it gracefully.</returns>
-        public SnapshotListener Listen(Func<DocumentSnapshot, CancellationToken, Task> callback, CancellationToken cancellationToken = default)
+        /// <returns>A <see cref="FirestoreChangeListener"/> which may be used to monitor the listening operation and stop it gracefully.</returns>
+        public FirestoreChangeListener Listen(Func<DocumentSnapshot, CancellationToken, Task> callback, CancellationToken cancellationToken = default)
         {
             GaxPreconditions.CheckNotNull(callback, nameof(callback));
             var target = WatchStream.CreateTarget(this);
@@ -234,7 +234,7 @@ namespace Google.Cloud.Firestore
                 await callback(missingDoc, cancellationToken).ConfigureAwait(false);
             };
             var stream = new WatchStream(new WatchState(Parent, queryCallback), target, Database, cancellationToken);
-            return SnapshotListener.Start(stream);
+            return FirestoreChangeListener.Start(stream);
         }
 
         /// <summary>
@@ -243,8 +243,8 @@ namespace Google.Cloud.Firestore
         /// </summary>
         /// <param name="callback">The callback to invoke each time the query results change. Must not be null.</param>
         /// <param name="cancellationToken">Optional cancellation token which may be used to cancel the listening operation.</param>
-        /// <returns>A <see cref="SnapshotListener"/> which may be used to monitor the listening operation and stop it gracefully.</returns>
-        public SnapshotListener Listen(Action<DocumentSnapshot> callback, CancellationToken cancellationToken = default)
+        /// <returns>A <see cref="FirestoreChangeListener"/> which may be used to monitor the listening operation and stop it gracefully.</returns>
+        public FirestoreChangeListener Listen(Action<DocumentSnapshot> callback, CancellationToken cancellationToken = default)
         {
             GaxPreconditions.CheckNotNull(callback, nameof(callback));
             return Listen((snapshot, _) => { callback(snapshot); return Task.FromResult(0); }, cancellationToken);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreChangeListener.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreChangeListener.cs
@@ -22,7 +22,7 @@ namespace Google.Cloud.Firestore
     /// An ongoing "listen" or "watch" operation on either document or query snapshots.
     /// This is returned from <c>Listen</c> methods.
     /// </summary>
-    public sealed class SnapshotListener
+    public sealed class FirestoreChangeListener
     {
         private readonly WatchStream _stream;
         private int _stopped;
@@ -39,16 +39,16 @@ namespace Google.Cloud.Firestore
         /// </remarks>
         public Task ListenerTask { get; }
 
-        internal SnapshotListener(WatchStream stream, Task task)
+        internal FirestoreChangeListener(WatchStream stream, Task task)
         {
             _stream = stream;
             ListenerTask = task;
         }
 
-        internal static SnapshotListener Start(WatchStream stream)
+        internal static FirestoreChangeListener Start(WatchStream stream)
         {
             var task = stream.StartAsync();
-            return new SnapshotListener(stream, task);
+            return new FirestoreChangeListener(stream, task);
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Query.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Query.cs
@@ -739,19 +739,18 @@ namespace Google.Cloud.Firestore
             _startAt?.GetHashCode() ?? -1,
             _endAt?.GetHashCode() ?? -1);
 
-        // TODO: Should this be ListenAsync?
         /// <summary>
         /// Listen to this query for changes.
         /// </summary>
         /// <param name="callback">The callback to invoke each time the query results change. Must not be null.</param>
         /// <param name="cancellationToken">Optional cancellation token which may be used to cancel the listening operation.</param>
-        /// <returns>A <see cref="SnapshotListener"/> which may be used to monitor the listening operation and stop it gracefully.</returns>
-        public SnapshotListener Listen(Func<QuerySnapshot, CancellationToken, Task> callback, CancellationToken cancellationToken = default)
+        /// <returns>A <see cref="FirestoreChangeListener"/> which may be used to monitor the listening operation and stop it gracefully.</returns>
+        public FirestoreChangeListener Listen(Func<QuerySnapshot, CancellationToken, Task> callback, CancellationToken cancellationToken = default)
         {
             GaxPreconditions.CheckNotNull(callback, nameof(callback));
             var target = WatchStream.CreateTarget(this);
             var stream = new WatchStream(new WatchState(this, callback), target, Database, cancellationToken);
-            return SnapshotListener.Start(stream);
+            return FirestoreChangeListener.Start(stream);
         }
 
         /// <summary>
@@ -760,8 +759,8 @@ namespace Google.Cloud.Firestore
         /// </summary>
         /// <param name="callback">The callback to invoke each time the query results change. Must not be null.</param>
         /// <param name="cancellationToken">Optional cancellation token which may be used to cancel the listening operation.</param>
-        /// <returns>A <see cref="SnapshotListener"/> which may be used to monitor the listening operation and stop it gracefully.</returns>
-        public SnapshotListener Listen(Action<QuerySnapshot> callback, CancellationToken cancellationToken = default)
+        /// <returns>A <see cref="FirestoreChangeListener"/> which may be used to monitor the listening operation and stop it gracefully.</returns>
+        public FirestoreChangeListener Listen(Action<QuerySnapshot> callback, CancellationToken cancellationToken = default)
         {
             GaxPreconditions.CheckNotNull(callback, nameof(callback));
             return Listen((snapshot, _) => { callback(snapshot); return Task.FromResult(0); }, cancellationToken);


### PR DESCRIPTION
This is the final change needed before we create a new Firestore beta release