### PR TITLE
Fix Spanner integration tests

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
@@ -74,6 +74,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 cmd.Parameters.Add("K", SpannerDbType.String, _lastKey);
                 using (var reader = await cmd.ExecuteReaderAsync())
                 {
+                    Assert.True(await reader.ReadAsync());
                     readerAction(reader);
                 }
             }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReader.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReader.cs
@@ -143,6 +143,8 @@ namespace Google.Cloud.Spanner.Data
             return SpannerDbType.FromProtobufType(fieldMetadata.Type).DefaultClrType;
         }
 
+        // TODO: Remove duplication by making all of the methods below call this one.
+        // TODO: Validate that we're positioned on a row.
         /// <inheritdoc />
         public override T GetFieldValue<T>(int ordinal) =>
             GetSpannerFieldType(ordinal).ConvertToClrType<T>(_innerList[ordinal], _conversionOptions);


### PR DESCRIPTION
I missed a ReadAsync call in #2222.

The exception thrown here was pretty bizarre though, and could be a
lot better. (We should probably throw InvalidOperationException if
you ask for a field value when not positioned on a row.)