### PR TITLE
Adding labels to all job creation operation options.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/JobsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/JobsTest.cs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Storage.V1;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using static Google.Apis.Bigquery.v2.JobsResource.ListRequest;
@@ -22,6 +24,18 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
     [Collection(nameof(BigQueryFixture))]
     public class JobsTest
     {
+        internal static IDictionary<string, string> JobLabels =>
+            new Dictionary<string, string>()
+            {
+                // This one is a little absurd for jobs because labels can only be set
+                // on job creation. This means not to set the label because this is copying
+                // the behaviour of labels for other resources like DataSets and Table.
+                // Testing for it anyways because the api allows is.
+                { "one_label", null },
+                { "another-label-2", "label_value_2" },
+                { "yet_another_label", "" }
+            };
+
         private readonly BigQueryFixture _fixture;
 
         public JobsTest(BigQueryFixture fixture)
@@ -34,18 +48,25 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
         private long ToMillisecondsSinceEpoch(DateTime dateTime) =>
             (long) (dateTime - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds;
 
+        /// <summary>
+        /// There's an equivalent snippet for this integration test but, where the snippet
+        /// tests for ListJobs listing some jobs, this test tests for ListJobs listing an
+        /// specific job that was just created.
+        /// </summary>
         [Fact]
         public void ListJobs()
         {
             var client = BigQueryClient.Create(_fixture.ProjectId);
 
             var table = client.GetTable(_fixture.ProjectId, _fixture.DatasetId, _fixture.HighScoreTableId);
-            var jobToFind = client.CreateQueryJob("SELECT * FROM {table}", parameters: null);
+            var jobToFind = client.CreateQueryJob($"SELECT * FROM {table}", parameters: null);
 
             var oneMinuteAgo = ToMillisecondsSinceEpoch(DateTime.UtcNow.AddMinutes(-1));
 
             // Find all jobs started in the last minute.
-            var recentJobs = client.ListJobs().TakeWhile(job => job.Statistics.CreationTime >= jobToFind.Statistics.CreationTime).ToList();
+            // Using TakeWhile because, as documented:
+            // The job list is sorted in reverse chronological order, by job creation time.
+            var recentJobs = client.ListJobs().TakeWhile(job => job.Statistics.CreationTime >= oneMinuteAgo).ToList();
 
             // Note: can't find the job reference itself, as that would check equality by reference :(
             var jobIds = recentJobs.Select(job => job.Reference.JobId).ToList();
@@ -58,14 +79,176 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var client = BigQueryClient.Create(_fixture.ProjectId);
 
             var table = client.GetTable(_fixture.ProjectId, _fixture.DatasetId, _fixture.HighScoreTableId);
-            var jobToFind = client.CreateQueryJob("SELECT * FROM {table}", parameters: null);
+            var jobToFind = client.CreateQueryJob($"SELECT * FROM {table}", parameters: null);
 
             // Find the job after listing with full projection.
-            var jobFound = (from job in client.ListJobs(new ListJobsOptions() { Projection = ProjectionEnum.Full })
-                            where job.Reference.JobId == jobToFind.Reference.JobId
-                            select job).Single();
+            var options = new ListJobsOptions { Projection = ProjectionEnum.Full };
+            var jobFound = client.ListJobs(options).Single(job => job.Reference.JobId == jobToFind.Reference.JobId);
 
             Assert.NotNull(jobFound.Resource.Configuration);
+        }
+
+        [Fact]
+        public void ListJobs_JobLabels()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+
+            var table = client.GetTable(_fixture.ProjectId, _fixture.DatasetId, _fixture.HighScoreTableId);
+            var jobToFind = client.CreateQueryJob($"SELECT * FROM {table}", null, new QueryOptions() { Labels = JobLabels});
+
+            // Find the job after listing with full projection.
+            var options = new ListJobsOptions { Projection = ProjectionEnum.Full };
+            var jobFound = client.ListJobs(options).Single(job => job.Reference.JobId == jobToFind.Reference.JobId);
+
+            VerifyJobLabels(jobFound.Resource.Configuration.Labels);
+        }
+
+        /// <summary>
+        /// There's an equivalent snippet for this integration test but, where the snippet
+        /// tests for GetJob getting a job, this test tests for GetJob getting an
+        /// specific job that was just created.
+        /// </summary>
+        [Fact]
+        public void GetJob()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var table = client.GetTable(_fixture.ProjectId, _fixture.DatasetId, _fixture.HighScoreTableId);
+            var jobToFind = client.CreateQueryJob($"SELECT * FROM {table}", parameters: null);
+
+            var jobFound = client.GetJob(jobToFind.Reference);
+
+            Assert.Equal(jobToFind.Reference.JobId, jobFound.Reference.JobId);
+        }
+
+        [Fact]
+        public void GetJob_JobLabels()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var table = client.GetTable(_fixture.ProjectId, _fixture.DatasetId, _fixture.HighScoreTableId);
+            var options = new QueryOptions { Labels = JobLabels };
+            var jobToFind = client.CreateQueryJob($"SELECT * FROM {table}", null, options);
+            
+            var jobFound = client.GetJob(jobToFind.Reference);
+
+            VerifyJobLabels(jobFound?.Resource?.Configuration.Labels);
+        }
+
+        /// <summary>
+        /// There's an equivalent snippet for this integration test but, where the snippet
+        /// tests for the extract job not failing, this test tests for the extract job
+        /// actually having extracted some info into the bucket object.
+        /// </summary>
+        [Fact]
+        public void ExtractJob()
+        {
+            var bqClient = BigQueryClient.Create(_fixture.ProjectId);
+            var originReference = bqClient.GetTableReference(_fixture.DatasetId, _fixture.HighScoreTableId);
+            var destinationBucket = _fixture.StorageBucketName;
+            var destinationObject = _fixture.GenerateStorageObjectName();
+            var destinationUri = $"gs://{destinationBucket}/{destinationObject}";
+
+            var extractJob = bqClient.CreateExtractJob(originReference, destinationUri);
+            extractJob = extractJob.PollUntilCompleted().ThrowOnAnyError();
+
+            var storageClient = StorageClient.Create();
+            var extracted = storageClient.GetObject(destinationBucket, destinationObject);
+
+            Assert.True(extracted.Size > 0);
+        }
+
+        [Fact]
+        public void ExtractJob_Labels()
+        {
+            var bqClient = BigQueryClient.Create(_fixture.ProjectId);
+            var originReference = bqClient.GetTableReference(_fixture.DatasetId, _fixture.HighScoreTableId);
+            var destinationBucket = _fixture.StorageBucketName;
+            var destinationObject = _fixture.GenerateStorageObjectName();
+            var destinationUri = $"gs://{destinationBucket}/{destinationObject}";
+            var options = new CreateExtractJobOptions { Labels = JobLabels };
+
+            var extractJob = bqClient.CreateExtractJob(originReference, destinationUri, options);
+            VerifyJobLabels(extractJob?.Resource?.Configuration?.Labels);
+
+            extractJob = extractJob.PollUntilCompleted().ThrowOnAnyError();
+            VerifyJobLabels(extractJob?.Resource?.Configuration?.Labels);
+        }
+
+        [Fact]
+        public void CopyJob_Labels()
+        {
+            var bqClient = BigQueryClient.Create(_fixture.ProjectId);
+            var originReference = bqClient.GetTableReference(_fixture.DatasetId, _fixture.PeopleTableId);
+            var destinationReference = bqClient.GetTableReference(_fixture.DatasetId, _fixture.CreateTableId());
+            var options = new CreateCopyJobOptions { Labels = JobLabels };
+
+            var copyJob = bqClient.CreateCopyJob(originReference, destinationReference, options);
+            VerifyJobLabels(copyJob?.Resource?.Configuration?.Labels);
+
+            copyJob = copyJob.PollUntilCompleted().ThrowOnAnyError();
+            VerifyJobLabels(copyJob?.Resource?.Configuration?.Labels);
+        }
+
+        [Fact]
+        public void LoadJob_Labels()
+        {
+            var bqClient = BigQueryClient.Create(_fixture.ProjectId);
+            var originTable = bqClient.GetTable(_fixture.DatasetId, _fixture.HighScoreTableId);
+            var destinationBucket = _fixture.StorageBucketName;
+            var destinationObject = _fixture.GenerateStorageObjectName();
+            var destinationUri = $"gs://{destinationBucket}/{destinationObject}";
+            var destinationReference = bqClient.GetTableReference(_fixture.DatasetId, _fixture.CreateTableId());
+
+            // Just extracting the data into GCS
+            var extractJob = originTable.CreateExtractJob(destinationUri);
+            extractJob = extractJob.PollUntilCompleted().ThrowOnAnyError();
+
+            var loadJob = bqClient.CreateLoadJob(
+                destinationUri, destinationReference, originTable.Schema, 
+                new CreateLoadJobOptions { SkipLeadingRows = 1, Labels = JobLabels });
+            VerifyJobLabels(loadJob?.Resource?.Configuration?.Labels);
+
+            loadJob = loadJob.PollUntilCompleted().ThrowOnAnyError();
+            VerifyJobLabels(loadJob?.Resource?.Configuration?.Labels);
+        }
+
+        [Fact]
+        public void JobLabels_InvalidCharactersKey()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var table = client.GetTable(_fixture.ProjectId, _fixture.DatasetId, _fixture.HighScoreTableId);
+            var options = new QueryOptions
+            {
+                Labels = new Dictionary<string, string>()
+                {
+                    {"This is Invalid & throws", "this_is_valid-2" }
+                }
+            };
+
+            Assert.ThrowsAny<GoogleApiException>(() => client.CreateQueryJob($"SELECT * FROM {table}", null, options));
+        }
+
+        [Fact]
+        public void JobLabels_InvalidCharactersValue()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var table = client.GetTable(_fixture.ProjectId, _fixture.DatasetId, _fixture.HighScoreTableId);
+            var options = new QueryOptions
+            {
+                Labels = new Dictionary<string, string>()
+                {
+                    {"this_is_valid-2", "This is Invalid & throws" }
+                }
+            };
+
+            Assert.ThrowsAny<GoogleApiException>(() => client.CreateQueryJob($"SELECT * FROM {table}", null, options));
+        }
+
+        internal static void VerifyJobLabels(IDictionary<string, string> actual)
+        {
+            Assert.NotNull(actual);
+            Assert.Equal(2, actual.Count);
+            Assert.Equal("label_value_2", actual["another-label-2"]);
+            Assert.Equal("", actual["yet_another_label"]);
         }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
@@ -53,6 +53,23 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
         }
 
         [Fact]
+        public void SynchronousTemporaryQuery_JobLabels()
+        {
+            var projectId = _fixture.ProjectId;
+            var client = BigQueryClient.Create(projectId);
+            var table = client.GetTable(PublicDatasetsProject, PublicDatasetsDataset, ShakespeareTable);
+
+            var sql = $"SELECT corpus as title, COUNT(word) as unique_words FROM {table} GROUP BY title ORDER BY unique_words DESC LIMIT 10";
+            var options = new QueryOptions { Labels = JobsTest.JobLabels };
+
+            var queryJob = client.CreateQueryJob(sql, null, options);
+            JobsTest.VerifyJobLabels(queryJob?.Resource?.Configuration?.Labels);
+
+            queryJob.PollUntilCompleted().ThrowOnAnyError();
+            JobsTest.VerifyJobLabels(queryJob?.Resource?.Configuration?.Labels);
+        }
+
+        [Fact]
         public void AsynchronousTemporaryQuery()
         {
             // We create the client using our user, but then access a dataset in a public data

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/UploadTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/UploadTest.cs
@@ -185,6 +185,32 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
         }
 
         [Fact]
+        public void UploadCsv_JobLabels()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+
+            var tableReference = client.GetTableReference(_fixture.DatasetId, _fixture.CreateTableId());
+
+            string[] csvRows =
+            {
+                "Name,GameStarted",
+                "Ben,2014-08-19T12:41:35.220Z",
+                "Lucy,2014-08-20T12:41:35.220Z",
+                "Rohit,2014-08-21T12:41:35.220Z"
+            };
+
+            var bytes = Encoding.UTF8.GetBytes(string.Join("\n", csvRows));
+            TableSchema schema = null;
+
+            var job = client.UploadCsv(tableReference, schema, new MemoryStream(bytes),
+                new UploadCsvOptions { Autodetect = true, Labels = JobsTest.JobLabels });
+            JobsTest.VerifyJobLabels(job?.Resource?.Configuration?.Labels);
+
+            job = job.PollUntilCompleted().ThrowOnAnyError();
+            JobsTest.VerifyJobLabels(job?.Resource?.Configuration?.Labels);
+        }
+
+        [Fact]
         public void UploadAvro()
         {
             var client = BigQueryClient.Create(_fixture.ProjectId);

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/JobCreationOptionsSnippets.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/JobCreationOptionsSnippets.cs
@@ -1,0 +1,88 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.ClientTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using static Google.Apis.Bigquery.v2.JobsResource.ListRequest;
+
+namespace Google.Cloud.BigQuery.V2.Snippets
+{
+    [SnippetOutputCollector]
+    [Collection(nameof(BigQuerySnippetFixture))]
+    public class JobCreationOptionsSnippets
+    {
+        private readonly BigQuerySnippetFixture _fixture;
+
+        public JobCreationOptionsSnippets(BigQuerySnippetFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public void ListJobs_FilterByLabels()
+        {
+            string bucketName = _fixture.StorageBucketName;
+            string objectName = _fixture.GenerateStorageObjectName();
+
+            string projectId = _fixture.ProjectId;
+            string datasetId = _fixture.GameDatasetId;
+            string tableId = _fixture.HistoryTableId;
+
+            // Snippet: Labels
+            IDictionary<string, string> labels = new Dictionary<string, string>()
+            {
+                {"label-key", "label-value" }
+            };
+
+            BigQueryClient client = BigQueryClient.Create(projectId);
+            BigQueryTable table = client.GetTable(projectId, datasetId, tableId);
+            string destinationUri = $"gs://{bucketName}/{objectName}";
+
+            // Just a couple examples of jobs marked with labels:
+            // (These jobs will most certainly be created somewhere else.)
+            // Running a query on a given table.
+            BigQueryJob oneLabeledJob = client.CreateQueryJob(
+                $"SELECT * FROM {table}", null,
+                new QueryOptions { Labels = labels });
+            // Extracting data from a table to GCS.
+            BigQueryJob anotherLabeledJob = client.CreateExtractJob(
+                projectId, datasetId, tableId, destinationUri,
+                new CreateExtractJobOptions { Labels = labels });
+
+            // Find jobs marked with a certain label.
+            KeyValuePair<string, string> labelToBeFound = labels.First();
+            List<BigQueryJob> jobs = client
+                .ListJobs(new ListJobsOptions
+                {
+                    // Specify full projection to make sure that
+                    // label information, if it exists, is returned for listed jobs.
+                    Projection = ProjectionEnum.Full
+                })
+                .Where(job => job.Resource.Configuration.Labels?.Contains(labelToBeFound) ?? false)
+                .ToList();
+            foreach (BigQueryJob job in jobs)
+            {
+                Console.WriteLine(job.Reference.JobId);
+            }
+            // End snippet
+
+            // This test added two jobs with such labels, other tests might have
+            // added more.
+            Assert.True(jobs.Count >= 2);
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryClientImplTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryClientImplTest.cs
@@ -521,6 +521,8 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.StartsWith(BigQueryClientImpl.DefaultJobIdPrefix, job.JobReference.JobId);
             Assert.NotEqual(BigQueryClientImpl.DefaultJobIdPrefix, job.JobReference.JobId);
             Assert.Equal(DefaultLocation, job.JobReference.Location);
+            // Don't really care if Configuration is null or not, Labels needs to be null.
+            Assert.Null(job.Configuration?.Labels);
         }
 
         [Fact]
@@ -530,6 +532,8 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.Equal("project", job.JobReference.ProjectId);
             Assert.StartsWith(BigQueryClientImpl.DefaultJobIdPrefix, job.JobReference.JobId);
             Assert.Equal(DefaultLocation, job.JobReference.Location);
+            // Don't really care if Configuration is null or not, Labels needs to be null.
+            Assert.Null(job.Configuration?.Labels);
         }
 
         [Fact]
@@ -570,6 +574,24 @@ namespace Google.Cloud.BigQuery.V2.Tests
         {
             var job = CreateJobWithSampleConfiguration(new UploadCsvOptions { JobLocation = "custom-location" });
             Assert.Equal("custom-location", job.JobReference.Location);
+        }
+
+        [Fact]
+        public void CreateJob_Labels()
+        {
+            var options = new UploadCsvOptions
+            {
+                Labels = new Dictionary<string, string>()
+                {
+                    { "one_label", "one-label-value" },
+                    { "another-label_2", "label_value_2" }
+                }
+            };
+            var job = CreateJobWithSampleConfiguration(options);
+
+            Assert.Equal(2, job.Configuration.Labels.Count);
+            Assert.Equal("one-label-value", job.Configuration.Labels["one_label"]);
+            Assert.Equal("label_value_2", job.Configuration.Labels["another-label_2"]);
         }
 
         [Fact]

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.JobCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.JobCrud.cs
@@ -176,6 +176,7 @@ namespace Google.Cloud.BigQuery.V2
             string projectId = options?.ProjectId ?? ProjectId;
             string jobId = options?.JobId;
             string jobIdPrefix = options?.JobIdPrefix;
+            IDictionary<string, string> jobLabels = options?.Labels;
             if (jobId != null && jobIdPrefix != null)
             {
                 throw new ArgumentException("Only one of JobId or JobIdPrefix can be specified for a single operation.");
@@ -186,6 +187,10 @@ namespace Google.Cloud.BigQuery.V2
                 jobId = prefix + Guid.NewGuid().ToString().Replace("-", "_");
             }
             string location = options?.JobLocation ?? DefaultLocation;
+            if (jobLabels != null && jobLabels.Count > 0)
+            {
+                configuration.Labels = jobLabels;
+            }
             return new Job { Configuration = configuration, JobReference = GetJobReference(projectId, jobId, location) };
         }
 

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/JobCreationOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/JobCreationOptions.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Generic;
+
 namespace Google.Cloud.BigQuery.V2
 {
     /// <summary>
@@ -44,5 +46,18 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         /// <seealso cref="BigQueryClient.WithDefaultLocation(string)"/>
         public string JobLocation { get; set; }
+
+        /// <summary>
+        /// The labels associated with the job to be created.
+        /// Labels are key-value pairs.
+        /// You can use these to organize and group your jobs.
+        /// Label keys and values can be no longer than 63 characters,
+        /// can only contain lowercase letters, numeric characters,
+        /// underscores and dashes. International characters are allowed.
+        /// If a label value is <code>null</code>, it won't be added to the job's labels.
+        /// A label value can be <see cref="string.Empty"/>.
+        /// Label keys must start with a letter.
+        /// </summary>
+        public IDictionary<string, string> Labels { get; set; }
     }
 }


### PR DESCRIPTION
A couple of notes for this PR:

- Labels have not been added as filters for the list jobs operation.
- The list jobs operation only populates job#configuration (and hence job#configuration.labels) if projection is set to full on the request parameters.
- We haven't yet surfaced projection as a parameter for list jobs operation, so we cannot even use the labels to filter the jobs client side.
- I didn't write snippets for labels because as long as we cannot filter there's no much use we can show, snippets would be only of setting labels.
- Is it OK if I surface projection, seems simple enough, anything I might have missed. (There's a TODO to do so on the list jobs options class).
- I'm adding an inline note on a piece of code I changed that has nothing to do with labels.
- Marking this PR as not for submission until I surface projection and can write a snippet.