### PR TITLE
Surfacing Projection for list jobs operation.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/ListJobsOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/ListJobsOptionsTest.cs
@@ -28,13 +28,15 @@ namespace Google.Cloud.BigQuery.V2.Tests
             {
                 PageSize = 25,
                 StateFilter = JobState.Pending,
-                AllUsers = true
+                AllUsers = true,
+                Projection = ProjectionEnum.Full
             };
             ListRequest request = new ListRequest(new BigqueryService(), "project");
             options.ModifyRequest(request);
             Assert.Equal(25, request.MaxResults);
             Assert.Equal(StateFilterEnum.Pending, request.StateFilter);
             Assert.Equal(true, request.AllUsers);
+            Assert.Equal(ProjectionEnum.Full, request.Projection);
         }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/ListJobsOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/ListJobsOptions.cs
@@ -39,6 +39,11 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         public bool? AllUsers { get; set; }
 
+        /// <summary>
+        /// The information to retrieve for listed jobs.
+        /// </summary>
+        public ProjectionEnum? Projection { get; set; }
+
         internal void ModifyRequest(ListRequest request)
         {
             if (StateFilter != null)
@@ -56,7 +61,10 @@ namespace Google.Cloud.BigQuery.V2
                 request.AllUsers = AllUsers;
             }
 
-            // TODO: Projection?
+            if (Projection != null)
+            {
+                request.Projection = Projection;
+            }
         }
     }
 }


### PR DESCRIPTION
This will make work on #2245 more meaningful. Given that something like this is not supported by the api:

`bqClient.ListJobs(new ListJobsOptions() { WithLabels = labels} );`

then, by surfacing projection something like this is possible:

```
bqClient.ListJobs(new ListJobsOptions() { Projection = ProjectionEnum.Full} )
              .Where(job => job.Resource.Configuration.Labels.Contains(label));
```