### PR TITLE
Fixing Jenkin failures

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
@@ -10,9 +10,11 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp1.0|AnyCPU'">
-    <DebugType>pdbonly</DebugType>
+  <PropertyGroup>
     <DebugSymbols>true</DebugSymbols>
+    <DebugType Condition="'$(TargetFramework)' == 'netcoreapp1.0'">pdbonly</DebugType>
+    <DebugType Condition="'$(TargetFramework)' == 'net46'">pdbonly</DebugType>
+    <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.0'">portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Testing" Version="2.4.0" />


### PR DESCRIPTION
Include the *.pdbs properly for each framework so that error items hold the correct info on where the error occurred, we are testing for that.