### PR TITLE
Fixing flakiness in Diagnostics.AspNetCore Integration and Snippets tests.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
@@ -99,7 +99,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
         private static async Task TestLogging(string testId, DateTime startTime, HttpClient client)
         {
-            var polling = new LogEntryPolling(TimeSpan.FromSeconds(60));
+            var polling = new LogEntryPolling();
             await client.GetAsync($"/Main/Warning/{testId}");
             var results = polling.GetEntries(startTime, testId, 1, LogSeverity.Warning);
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 {
     public class LoggingTest
     {
-        private readonly LogEntryPolling _polling = new LogEntryPolling(TimeSpan.FromSeconds(120));
+        private readonly LogEntryPolling _polling = new LogEntryPolling();
 
         [Fact]
         public async Task Logging_SizedBufferNoLogs()

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
@@ -12,6 +12,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <DebugSymbols>true</DebugSymbols>
+    <Optimize Condition="'$(TargetFramework)' == 'netcoreapp1.0'">false</Optimize>
+    <Optimize Condition="'$(TargetFramework)' == 'net46'">false</Optimize>
     <DebugType Condition="'$(TargetFramework)' == 'netcoreapp1.0'">pdbonly</DebugType>
     <DebugType Condition="'$(TargetFramework)' == 'net46'">pdbonly</DebugType>
     <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.0'">portable</DebugType>
@@ -36,21 +38,15 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.0.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.0.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/LoggingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/LoggingSnippets.cs
@@ -34,7 +34,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
     public class LoggingSnippetsTests : IDisposable
     {
         private static readonly string ProjectId = Utils.GetProjectIdFromEnvironment();
-        private static readonly LogEntryPolling s_polling = new LogEntryPolling(TimeSpan.FromSeconds(120));
+        private static readonly LogEntryPolling s_polling = new LogEntryPolling();
 
         private readonly string _testId;
 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryPolling.cs
@@ -37,7 +37,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         private readonly ProjectName _projectName = new ProjectName(Utils.GetProjectIdFromEnvironment());
 
         // Give the error reporting events a little extra time to be processed.
-        internal ErrorEventEntryPolling() : base(TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(20)) { }
+        internal ErrorEventEntryPolling() : base(TimeSpan.FromSeconds(120), TimeSpan.FromSeconds(30)) { }
 
         /// <summary>
         /// Gets error events that contain the passed in testId in the message.  Will poll

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Logging/LogEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Logging/LogEntryPolling.cs
@@ -26,13 +26,28 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
     /// </summary>
     internal class LogEntryPolling : BaseEntryPolling<LogEntry>
     {
+        /// <summary>
+        /// Default total time to spend sleeping when looking for entries.
+        /// More than what <see cref="BaseEntryPolling{T}._defaultTimeout"/>
+        /// because logs are taking longer to process.
+        /// </summary>
+        private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(180);
+
+        /// <summary>
+        /// Default time to sleep between checks for entries.
+        /// Consistent with the <see cref="_defaultTimeout"/>.
+        /// </summary>
+        private static readonly TimeSpan _defaultSleepInterval = TimeSpan.FromSeconds(40);
+
         /// <summary>Project id to run the test on.</summary>
         private readonly string _projectId = Utils.GetProjectIdFromEnvironment();
 
         /// <summary>Client to use to send RPCs.</summary>
         private readonly LoggingServiceV2Client _client = LoggingServiceV2Client.Create();
 
-        internal LogEntryPolling(TimeSpan timeout) : base(timeout) { }
+        internal LogEntryPolling(TimeSpan timeout = default) 
+            : base(timeout == default ? _defaultTimeout : timeout, timeout == default ? _defaultSleepInterval : default)
+        { }
 
         /// <summary>
         /// Gets log entries that contain the passed in testId in the log message.  Will poll


### PR DESCRIPTION
Fixing or improving several issues:

- Lack of .pdb info to report error location in Snippets Error Reporting tests for `net4.6` and `netcoreapp1.0`. Only affected Snippets because in one of the tests an exception is thrown from within a nested method call, no such scenario in integration tests. To fix this I added an extra build option.
- Reaching read quota both for Logging and Error Reporting. Started happening after adding the Snippets tests and happens in both Snippets and Integration tests, which makes sense because Snippets are also reading logs now. To fix this, I increased the waiting time between reads (`LogEntryPolling` and `ErrorEventEntryPolling`). It's possible that this can still happen, specially after adding new tests (we do have two test environments running at the same time), if it happens very often, we'll need to increase the waiting time further, but then tests will take longer to execute.
- Log entries not available for listing after written. This apparently started happening after adding the Snippets' tests, but I don't have a good explanation as to why. It affects random Logging Integration and Snippets' tests. After the tests fail I've manually checked several of the Log entries that should have been written on the logs and I've found them there and available for reading. Only docs I've found about availability of entries [are these](https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.v2#google.logging.v2.WriteLogEntriesRequest) and what's described there as unavailable entries (older than 30 days or timestamped more than 24 hours in the future) doesn't match our case. I've reduced these errors from happening 4 or 5 times in a test run, to happening once in 3 test runs by increasing the amount of time we spend trying to read the entries (`LogEntryPolling`). We can increase this time further but then tests will take longer to execute.