### PR TITLE
Remove files during AppVeyor builds to help free up space.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,10 @@ branches:
 
 init:
   - git config --global core.autocrlf true
+  # This change was recommended by the AppVeyor team to save space.
+  - rmdir C:\cygwin /s /q
+  - rmdir C:\QT /s /q
+
   
 environment:
   COVERALLS_REPO_TOKEN:


### PR DESCRIPTION
This was recommended by the AppVeyor team as we hit an internal limit that caused an automated system to ban our account.