### PR TITLE
Make the AppVeyor shell script stop on error

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
@@ -21,7 +21,6 @@
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Testing" Version="2.4.0" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
-    <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore\Google.Cloud.Diagnostics.AspNetCore.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.Tests\Google.Cloud.Diagnostics.Common.Tests.csproj" />

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 dotnet --info
 echo "Regenerating projects: if this fails, run generateprojects.sh and commit changes"
 bash generateprojects.sh && git diff --exit-code


### PR DESCRIPTION
(Currently it *should* be failing on generateprojects.sh, but it's not)

This PR will include a follow-up PR to make it *stop* failing, but I want to see it fail first.