### PR TITLE
Add cancellation tokens to commit and rollback operations

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SessionPoolTests.cs
@@ -137,7 +137,7 @@ namespace Google.Cloud.Spanner.Data.Tests
                 {
                     var transaction = await client.BeginPooledTransactionAsync(session, readWriteOptions)
                         .ConfigureAwait(false);
-                    await transaction.CommitAsync(session, null, SpannerOptions.Instance.Timeout).ConfigureAwait(false);
+                    await transaction.CommitAsync(session, null, SpannerOptions.Instance.Timeout, CancellationToken.None).ConfigureAwait(false);
                     pool.ReleaseToPool(client, session);
                 }
             }
@@ -409,7 +409,7 @@ namespace Google.Cloud.Spanner.Data.Tests
                 Transaction transaction;
                 Assert.True(_transactions.TryPop(out transaction));
                 Assert.Same(transaction, transactionAwaited);
-                await transaction.CommitAsync(session1, null, SpannerOptions.Instance.Timeout).ConfigureAwait(false);
+                await transaction.CommitAsync(session1, null, SpannerOptions.Instance.Timeout, CancellationToken.None).ConfigureAwait(false);
 
                 //Releasing should start the tx prewarm
                 pool.ReleaseToPool(client.Object, session1);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/EphemeralTransaction.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/EphemeralTransaction.cs
@@ -71,7 +71,7 @@ namespace Google.Cloud.Spanner.Data
                         count = await ((ISpannerTransaction) transaction)
                             .ExecuteMutationsAsync(mutations, cancellationToken, timeoutSeconds)
                             .ConfigureAwait(false);
-                        await transaction.CommitAsync().ConfigureAwait(false);
+                        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
                     }
                     return count;
                 }, "EphemeralTransaction.ExecuteMutations", Logger);


### PR DESCRIPTION
Fixes #2271.

This is a breaking change in the following ways:

- Source and binary breaking change for TransactionPool, which we
  expect not to be used by 3rd party code anyway. Making the
  CancellationToken parameter required here helps to avoid errors.
- Binary-only breaking change for SpannerTransaction, which is much
  more likely to be called directly by clients.

In other words, we're unlikely to break real 3rd party code in
source terms, but all users would need to recompile. This is in line
with what we've done elsewhere.