### PR TITLE
Making HttpContextWrapper support HttpContext.Current == null

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/ErrorReporting/GoogleExceptionLoggerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/ErrorReporting/GoogleExceptionLoggerTest.cs
@@ -52,6 +52,17 @@ namespace Google.Cloud.Diagnostics.AspNet.Tests
         }
 
         [Fact]
+        public void Log_NullContext()
+        {
+            var mockContextLogger = new Mock<IContextExceptionLogger>();
+            var logger = new GoogleExceptionLogger(mockContextLogger.Object);
+            HttpContext.Current = null;
+
+            logger.Log(_exception);
+            mockContextLogger.Verify(lb => lb.Log(_exception, It.IsAny<HttpContextWrapper>()));
+        }
+
+        [Fact]
         public async Task LogAsync()
         {
             var mockContextLogger = new Mock<IContextExceptionLogger>();
@@ -73,6 +84,20 @@ namespace Google.Cloud.Diagnostics.AspNet.Tests
                 It.IsAny<Exception>(), It.IsAny<IContextWrapper>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
             HttpContext.Current = _context;
+
+            await logger.LogAsync(_exception);
+            mockContextLogger.Verify(lb => lb.LogAsync(_exception, It.IsAny<HttpContextWrapper>(), It.IsAny<CancellationToken>()));
+        }
+
+        [Fact]
+        public async Task LogAsync_NullContext()
+        {
+            var mockContextLogger = new Mock<IContextExceptionLogger>();
+            var logger = new GoogleExceptionLogger(mockContextLogger.Object);
+            mockContextLogger.Setup(lb => lb.LogAsync(
+                It.IsAny<Exception>(), It.IsAny<IContextWrapper>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(true));
+            HttpContext.Current = null;
 
             await logger.LogAsync(_exception);
             mockContextLogger.Verify(lb => lb.LogAsync(_exception, It.IsAny<HttpContextWrapper>(), It.IsAny<CancellationToken>()));

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/ErrorReporting/HttpContextWrapperTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/ErrorReporting/HttpContextWrapperTest.cs
@@ -34,5 +34,15 @@ namespace Google.Cloud.Diagnostics.AspNet.Tests
             Assert.Null(wrapper.GetUserAgent());
             Assert.Equal(200, wrapper.GetStatusCode());
         }
+
+        [Fact]
+        public void HttpContextWrapper_NullHttpContext()
+        {
+            var wrapper = new HttpContextWrapper(null);
+            Assert.Null(wrapper.GetHttpMethod());
+            Assert.Null(wrapper.GetUri());
+            Assert.Null(wrapper.GetUserAgent());
+            Assert.Equal(0, wrapper.GetStatusCode());
+        }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/HttpContextWrapper.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/HttpContextWrapper.cs
@@ -27,19 +27,19 @@ namespace Google.Cloud.Diagnostics.AspNet
 
         internal HttpContextWrapper(HttpContext context)
         {
-            _context = GaxPreconditions.CheckNotNull(context, nameof(context));
+            _context = context;
         }
 
         /// <inheritdoc />
-        public string GetHttpMethod() => _context.Request?.HttpMethod;
+        public string GetHttpMethod() => _context?.Request?.HttpMethod;
 
         /// <inheritdoc />
-        public string GetUri() => _context.Request?.Url?.ToString();
+        public string GetUri() => _context?.Request?.Url?.ToString();
 
         /// <inheritdoc />
-        public string GetUserAgent() => _context.Request?.UserAgent;
+        public string GetUserAgent() => _context?.Request?.UserAgent;
 
         /// <inheritdoc />
-        public int GetStatusCode() => _context.Response?.StatusCode ?? 0;
+        public int GetStatusCode() => _context?.Response?.StatusCode ?? 0;
     }
 }


### PR DESCRIPTION
Solution 1 for #2292 .
This will stop manual logging from failing for self hosted ASP.Net Web Api applications.
HttpContext information won't be logged in this case but at least it won't fail and Exception information will be logged.