### PR TITLE
Adding a Web Api exception logger that uses HttpActionContext to get http context information from.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/ErrorReporting/GoogleExceptionLoggerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/ErrorReporting/GoogleExceptionLoggerTest.cs
@@ -25,7 +25,7 @@ namespace Google.Cloud.Diagnostics.AspNet.Tests
 {
     public class GoogleExceptionLoggerTest
     {
-        private static readonly Exception _exception = new Exception("opps...");
+        private static readonly Exception _exception = new Exception("oops...");
         private static readonly HttpRequest _request = new HttpRequest("filename.cs", "http://google.com", "");
         private static readonly HttpResponse _response = new HttpResponse(new StreamWriter(new MemoryStream()));
         private static readonly HttpContext _context = new HttpContext(_request, _response);

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/ErrorReporting/GoogleWebApiExceptionLoggerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/ErrorReporting/GoogleWebApiExceptionLoggerTest.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Diagnostics.Common;
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http.Controllers;
+using Xunit;
+
+namespace Google.Cloud.Diagnostics.AspNet.Tests
+{
+    public class GoogleWebApiExceptionLoggerTest
+    {
+        private static readonly Exception _exception = new Exception("oops...");
+        private static readonly HttpActionContext _context = new HttpActionContext();
+
+        [Fact]
+        public void Log()
+        {
+            var mockContextLogger = new Mock<IContextExceptionLogger>();
+            var logger = new GoogleWebApiExceptionLogger(mockContextLogger.Object);
+
+            logger.Log(_exception, _context);
+            mockContextLogger.Verify(lb => lb.Log(_exception, It.IsNotNull<HttpActionContextWrapper>()));
+        }
+
+        [Fact]
+        public void Log_NoContext()
+        {
+            var mockContextLogger = new Mock<IContextExceptionLogger>();
+            var logger = new GoogleWebApiExceptionLogger(mockContextLogger.Object);
+
+            logger.Log(_exception);
+            mockContextLogger.Verify(lb => lb.Log(_exception, It.IsNotNull<HttpActionContextWrapper>()));
+        }
+
+        [Fact]
+        public async Task LogAsync()
+        {
+            var mockContextLogger = new Mock<IContextExceptionLogger>();
+            var logger = new GoogleWebApiExceptionLogger(mockContextLogger.Object);
+            mockContextLogger.Setup(lb => lb.LogAsync(
+                It.IsAny<Exception>(), It.IsAny<IContextWrapper>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(true));
+
+            await logger.LogAsync(_exception, _context);
+            mockContextLogger.Verify(lb => lb.LogAsync(_exception, It.IsNotNull<HttpActionContextWrapper>(), It.IsAny<CancellationToken>()));
+        }
+
+        [Fact]
+        public async Task LogAsync_NoContext()
+        {
+            var mockContextLogger = new Mock<IContextExceptionLogger>();
+            var logger = new GoogleWebApiExceptionLogger(mockContextLogger.Object);
+            mockContextLogger.Setup(lb => lb.LogAsync(
+                It.IsAny<Exception>(), It.IsAny<IContextWrapper>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(true));
+
+            await logger.LogAsync(_exception);
+            mockContextLogger.Verify(lb => lb.LogAsync(_exception, It.IsNotNull<HttpActionContextWrapper>(), It.IsAny<CancellationToken>()));
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/ErrorReporting/HttpActionContextWrapperTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/ErrorReporting/HttpActionContextWrapperTest.cs
@@ -1,0 +1,62 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using System.Net.Http;
+using System.Web.Http.Controllers;
+using Xunit;
+
+namespace Google.Cloud.Diagnostics.AspNet.Tests
+{
+    public class HttpActionContextWrapperTest
+    {
+        [Fact]
+        public void HttpActionContextWrapper()
+        {
+            var uri = "http://google.com/";
+            var userAgent1 = "user_agent_1";
+            var userAgent2 = "user_agent_2";
+
+            var requestMessage = new HttpRequestMessage(HttpMethod.Get, uri);
+            requestMessage.Headers.UserAgent.ParseAdd(userAgent1);
+            requestMessage.Headers.UserAgent.ParseAdd(userAgent2);
+
+            var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+
+            var controllerContext = new HttpControllerContext();
+            controllerContext.Request = requestMessage;
+
+            var actionContext = new HttpActionContext();
+            actionContext.ControllerContext = controllerContext;
+            actionContext.Response = responseMessage;
+
+            var wrapper = new HttpActionContextWrapper(actionContext);
+            Assert.Equal(HttpMethod.Get.Method, wrapper.GetHttpMethod());
+            Assert.Equal(uri, wrapper.GetUri());
+            Assert.Contains(userAgent1, wrapper.GetUserAgent());
+            Assert.Contains(userAgent2, wrapper.GetUserAgent());
+            Assert.Equal((int)HttpStatusCode.OK, wrapper.GetStatusCode());
+        }
+
+        [Fact]
+        public void HttpActionContextWrapper_NullHttpActionContext()
+        {
+            var wrapper = new HttpActionContextWrapper(null);
+            Assert.Null(wrapper.GetHttpMethod());
+            Assert.Null(wrapper.GetUri());
+            Assert.Null(wrapper.GetUserAgent());
+            Assert.Equal(0, wrapper.GetStatusCode());
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/GoogleWebApiExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/GoogleWebApiExceptionLogger.cs
@@ -1,0 +1,110 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Cloud.Diagnostics.Common;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http.Controllers;
+
+namespace Google.Cloud.Diagnostics.AspNet
+{
+    /// <summary>
+    /// Google Cloud Error Reporting Logger for Web API applications.
+    /// Reports exceptions to Stackdriver Error Reporting API.
+    /// </summary>
+    /// 
+    /// <example>
+    /// <code>
+    /// string projectId = "[Google Cloud Platform project ID]";
+    /// string serviceName = "[Name of service]";
+    /// string version = "[Version of service]";
+    /// var exceptionLogger = GoogleWebApiExceptionLogger.Create(projectId, serviceName, version);
+    ///
+    /// try
+    /// {
+    ///     string scores = File.ReadAllText(@"C:\Scores.txt");
+    ///     Console.WriteLine(scores);
+    /// }
+    /// catch (IOException e)
+    /// {
+    ///     exceptionLogger.Log(e, ActionContext);
+    /// }
+    /// </code>
+    /// </example>
+    public class GoogleWebApiExceptionLogger : IWebApiExceptionLogger, IDisposable
+    {
+        private readonly IContextExceptionLogger _logger;
+
+        internal GoogleWebApiExceptionLogger(IContextExceptionLogger logger)
+        {
+            _logger = GaxPreconditions.CheckNotNull(logger, nameof(logger));
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="GoogleWebApiExceptionLogger"/>.
+        /// </summary>
+        /// <param name="projectId">The Google Cloud Platform project ID. Cannot be null.</param>
+        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
+        ///     Cannot be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. 
+        ///     Cannot be null.</param>
+        /// <param name="options">Optional, error reporting options.</param>
+        public static GoogleWebApiExceptionLogger Create(string projectId, string serviceName, string version,
+            ErrorReportingOptions options = null)
+        {
+            GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId));
+            var contextLogger = ContextExceptionLogger.Create(projectId, serviceName, version, options);
+            return new GoogleWebApiExceptionLogger(contextLogger);
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="GoogleWebApiExceptionLogger"/>.
+        /// <para>
+        /// Can be used when running on Google App Engine or Google Compute Engine.
+        /// The Google Cloud Platform project to report errors to will detected from the
+        /// current platform.
+        /// </para>
+        /// </summary>
+        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
+        ///     Cannot be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. 
+        ///     Cannot be null.</param>
+        /// <param name="options">Optional, error reporting options.</param>
+        public static GoogleWebApiExceptionLogger Create(string serviceName, string version,
+            ErrorReportingOptions options = null)
+        {
+            var contextLogger = ContextExceptionLogger.Create(null, serviceName, version, options);
+            return new GoogleWebApiExceptionLogger(contextLogger);
+        }
+
+        /// <inheritdoc />
+        public void Log(Exception exception, HttpActionContext context = null)
+        {
+            var contextWrapper = new HttpActionContextWrapper(context);
+            _logger.Log(exception, contextWrapper);
+        }
+
+        /// <inheritdoc />
+        public Task LogAsync(Exception exception, HttpActionContext context = null, CancellationToken cancellationToken = default)
+        {
+            var contextWrapper = new HttpActionContextWrapper(context);
+            return _logger.LogAsync(exception, contextWrapper, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public void Dispose() => _logger.Dispose();
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/HttpActionContextWrapper.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/HttpActionContextWrapper.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Diagnostics.Common;
+using System.Web.Http.Controllers;
+
+namespace Google.Cloud.Diagnostics.AspNet
+{
+    /// <summary>
+    /// An <see cref="IContextWrapper"/> for an <see cref="HttpActionContext"/>.
+    /// </summary>
+    internal class HttpActionContextWrapper : IContextWrapper
+    {
+        private readonly HttpActionContext _context;
+
+        internal HttpActionContextWrapper(HttpActionContext context)
+        {
+            _context = context;
+        }
+
+        /// <inheritdoc />
+        public string GetHttpMethod() => _context?.Request?.Method?.Method;
+
+        /// <inheritdoc />
+        public string GetUri() => _context?.Request?.RequestUri?.ToString();
+
+        /// <inheritdoc />
+        public string GetUserAgent() => _context?.Request?.Headers?.UserAgent?.ToString();
+
+        /// <inheritdoc />
+        public int GetStatusCode() => ((int?)_context?.Response?.StatusCode) ?? 0;
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/IWebApiExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/IWebApiExceptionLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,33 +15,31 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
+using System.Web.Http.Controllers;
 
 namespace Google.Cloud.Diagnostics.AspNet
 {
     /// <summary>
-    /// A general purpose exception logger. If used from within Web API controllers
-    /// is possible that HTTP context information is not logged alongside error information.
-    /// Please use <see cref="IWebApiExceptionLogger"/> instead.
+    /// An exception logger for use from withing a Web Api application.
     /// </summary>
-    public interface IExceptionLogger
+    public interface IWebApiExceptionLogger
     {
         /// <summary>
         /// Logs an exception that occurred.
         /// </summary>
         /// <param name="exception">The exception to log. Cannot be null.</param>
-        /// <param name="context">Optional, the current HTTP context. If unset the
-        ///     current context will be retrieved automatically.</param>
-        void Log(Exception exception, HttpContext context = null);
+        /// <param name="context">Optional, the current HTTP action context from which to get HTTP context information.
+        /// If it is not set, no HTTP context information will be logged alongside exception information.</param>
+        void Log(Exception exception, HttpActionContext context = null);
 
         /// <summary>
         /// Asynchronously logs an exception that occurred.
         /// </summary>
         /// <param name="exception">The exception to log. Cannot be null.</param>
-        /// <param name="context">Optional, the current HTTP context. If unset the
-        ///     current context will be retrieved automatically.</param>
-        /// <param name="cancellationToken">Optional, The token to monitor for cancellation requests.</param>
+        /// <param name="context">Optional, the current HTTP action context from which to get HTTP context information.
+        /// If it is not set, no HTTP context information will be logged alongside exception information.</param>
+        /// <param name="cancellationToken">Optional, the token to monitor for cancellation requests.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        Task LogAsync(Exception exception, HttpContext context = null, CancellationToken cancellationToken = default);
+        Task LogAsync(Exception exception, HttpActionContext context = null, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
Solves #2292. Although it was my suggestion, I found the proposed second solution in #2292 (adding an overload for `Google.Cloud.Diagnostics.AspNet.GoogleExceptionLogger.Create` that takes a function returning the `HttpActionContext` ) ugly and confusing for clients, who would have to use the same class for Web Api and MVC but passing a function returning `HttpActionContext` on creation or an `HttpContext` to the `Log` method respectively.
Given that, although `HttpContext.Current` can be available in some Web Api contexts, [it is not the recommended way](https://stackoverflow.com/questions/14349557/getting-httprequest-context-in-self-hosted-webapi/14350128#14350128) to obtain http context information, I implemented a Google Web Api Logger that relies on `HttpActionContext` to get said information when manually logging exceptions from within Web Apis. I think this is the cleanest we can do without introducing breaking changes.