### PR TITLE
Replacing 'Cannot be null' by 'Must not be null' in docstrings in Diagnostics.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/ErrorReportingExceptionFilter.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/ErrorReportingExceptionFilter.cs
@@ -53,11 +53,11 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// Creates an instance of <see cref="ErrorReportingExceptionFilter"/> using credentials as
         /// defined by <see cref="GoogleCredential.GetApplicationDefaultAsync"/>.
         /// </summary>
-        /// <param name="projectId">The Google Cloud Platform project ID. Cannot be null.</param>
+        /// <param name="projectId">The Google Cloud Platform project ID. Must not be null.</param>
         /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
-        ///     Cannot be null.</param>
+        ///     Must not be null.</param>
         /// <param name="version">Represents the source code version that the developer provided. 
-        ///     Cannot be null.</param>
+        ///     Must not be null.</param>
         /// <param name="options">Optional, error reporting options.</param>
         public static ErrorReportingExceptionFilter Create(string projectId, string serviceName, string version,
             ErrorReportingOptions options = null)
@@ -77,9 +77,9 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// </para>
         /// </summary>
         /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
-        ///     Cannot be null.</param>
+        ///     Must not be null.</param>
         /// <param name="version">Represents the source code version that the developer provided. 
-        ///     Cannot be null.</param>
+        ///     Must not be null.</param>
         /// <param name="options">Optional, error reporting options.</param>
         public static ErrorReportingExceptionFilter Create(
             string serviceName, string version, ErrorReportingOptions options = null)

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/ErrorReportingExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/ErrorReportingExceptionLogger.cs
@@ -53,9 +53,9 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// Creates an instance of <see cref="ErrorReportingExceptionLogger"/> using credentials as
         /// defined by <see cref="GoogleCredential.GetApplicationDefaultAsync"/>.
         /// </summary>
-        /// <param name="projectId">The Google Cloud Platform project ID. Cannot be null.</param>
-        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. Cannot be null.</param>
-        /// <param name="version">Represents the source code version that the developer provided. Cannot be null.</param> 
+        /// <param name="projectId">The Google Cloud Platform project ID. Must not be null.</param>
+        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. Must not be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. Must not be null.</param> 
         ///  <param name="options">Optional, error reporting options.</param>
         public static ErrorReportingExceptionLogger Create(string projectId, string serviceName, string version,
             ErrorReportingOptions options = null)
@@ -74,8 +74,8 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// current platform.
         /// </para>
         /// </summary>
-        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. Cannot be null.</param>
-        /// <param name="version">Represents the source code version that the developer provided. Cannot be null.</param> 
+        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. Must not be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. Must not be null.</param> 
         ///  <param name="options">Optional, error reporting options.</param>
         public static ErrorReportingExceptionLogger Create(
             string serviceName, string version, ErrorReportingOptions options = null)

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/GoogleExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/GoogleExceptionLogger.cs
@@ -54,11 +54,11 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// <summary>
         /// Creates an instance of <see cref="GoogleExceptionLogger"/>.
         /// </summary>
-        /// <param name="projectId">The Google Cloud Platform project ID. Cannot be null.</param>
+        /// <param name="projectId">The Google Cloud Platform project ID. Must not be null.</param>
         /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
-        ///     Cannot be null.</param>
+        ///     Must not be null.</param>
         /// <param name="version">Represents the source code version that the developer provided. 
-        ///     Cannot be null.</param>
+        ///     Must not be null.</param>
         /// <param name="options">Optional, error reporting options.</param>
         public static GoogleExceptionLogger Create(string projectId, string serviceName, string version,
             ErrorReportingOptions options = null)
@@ -77,9 +77,9 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// </para>
         /// </summary>
         /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
-        ///     Cannot be null.</param>
+        ///     Must not be null.</param>
         /// <param name="version">Represents the source code version that the developer provided. 
-        ///     Cannot be null.</param>
+        ///     Must not be null.</param>
         /// <param name="options">Optional, error reporting options.</param>
         public static GoogleExceptionLogger Create(string serviceName, string version,
             ErrorReportingOptions options = null)

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/GoogleWebApiExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/GoogleWebApiExceptionLogger.cs
@@ -56,11 +56,11 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// <summary>
         /// Creates an instance of <see cref="GoogleWebApiExceptionLogger"/>.
         /// </summary>
-        /// <param name="projectId">The Google Cloud Platform project ID. Cannot be null.</param>
+        /// <param name="projectId">The Google Cloud Platform project ID. Must not be null.</param>
         /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
-        ///     Cannot be null.</param>
+        ///     Must not be null.</param>
         /// <param name="version">Represents the source code version that the developer provided. 
-        ///     Cannot be null.</param>
+        ///     Must not be null.</param>
         /// <param name="options">Optional, error reporting options.</param>
         public static GoogleWebApiExceptionLogger Create(string projectId, string serviceName, string version,
             ErrorReportingOptions options = null)
@@ -79,9 +79,9 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// </para>
         /// </summary>
         /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
-        ///     Cannot be null.</param>
+        ///     Must not be null.</param>
         /// <param name="version">Represents the source code version that the developer provided. 
-        ///     Cannot be null.</param>
+        ///     Must not be null.</param>
         /// <param name="options">Optional, error reporting options.</param>
         public static GoogleWebApiExceptionLogger Create(string serviceName, string version,
             ErrorReportingOptions options = null)

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/IExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/IExceptionLogger.cs
@@ -29,7 +29,7 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// <summary>
         /// Logs an exception that occurred.
         /// </summary>
-        /// <param name="exception">The exception to log. Cannot be null.</param>
+        /// <param name="exception">The exception to log. Must not be null.</param>
         /// <param name="context">Optional, the current HTTP context. If unset the
         ///     current context will be retrieved automatically.</param>
         void Log(Exception exception, HttpContext context = null);
@@ -37,7 +37,7 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// <summary>
         /// Asynchronously logs an exception that occurred.
         /// </summary>
-        /// <param name="exception">The exception to log. Cannot be null.</param>
+        /// <param name="exception">The exception to log. Must not be null.</param>
         /// <param name="context">Optional, the current HTTP context. If unset the
         ///     current context will be retrieved automatically.</param>
         /// <param name="cancellationToken">Optional, The token to monitor for cancellation requests.</param>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/IWebApiExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/IWebApiExceptionLogger.cs
@@ -27,7 +27,7 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// <summary>
         /// Logs an exception that occurred.
         /// </summary>
-        /// <param name="exception">The exception to log. Cannot be null.</param>
+        /// <param name="exception">The exception to log. Must not be null.</param>
         /// <param name="context">Optional, the current HTTP action context from which to get HTTP context information.
         /// If it is not set, no HTTP context information will be logged alongside exception information.</param>
         void Log(Exception exception, HttpActionContext context = null);
@@ -35,7 +35,7 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// <summary>
         /// Asynchronously logs an exception that occurred.
         /// </summary>
-        /// <param name="exception">The exception to log. Cannot be null.</param>
+        /// <param name="exception">The exception to log. Must not be null.</param>
         /// <param name="context">Optional, the current HTTP action context from which to get HTTP context information.
         /// If it is not set, no HTTP context information will be logged alongside exception information.</param>
         /// <param name="cancellationToken">Optional, the token to monitor for cancellation requests.</param>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/TraceDecisionPredicate.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Trace/TraceDecisionPredicate.cs
@@ -57,7 +57,7 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// <param name="traceDecisionPredicate">Used to determine if a request should be traced.
         /// Takes an <see cref="HttpRequest"/>.  It should return true if the request should be traced,
         /// false if the request should not be traced and null if the decision should be left to other
-        /// sampling mechanisms. Cannot be null.</param>
+        /// sampling mechanisms. Must not be null.</param>
         /// <param name="ignoreHealthChecks">Optional. True if Google App Engine health check requests should
         /// not be traced. Defaults to true.</param>
         public static TraceDecisionPredicate Create(

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerExtension.cs
@@ -62,7 +62,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// Uses middleware that will report all uncaught exceptions to the Stackdriver
         /// Error Reporting API.
         /// </summary>
-        /// <param name="app">The application builder. Cannot be null.</param>   
+        /// <param name="app">The application builder. Must not be null.</param>   
         public static IApplicationBuilder UseGoogleExceptionLogging(this IApplicationBuilder app)
         {
             GaxPreconditions.CheckNotNull(app, nameof(app));
@@ -78,8 +78,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// current platform.
         /// </para>
         /// </summary>
-        /// <param name="services">The service collection. Cannot be null.</param>
-        /// <param name="setupAction">Action to set up options. Cannot be null.</param>
+        /// <param name="services">The service collection. Must not be null.</param>
+        /// <param name="setupAction">Action to set up options. Must not be null.</param>
         /// <remarks>
         /// If <see cref="RetryOptions.ExceptionHandling"/> is set to <see cref="ExceptionHandling.Propagate"/>
         /// and the <see cref="RequestDelegate"/> executed by this middleware throws an exception and this

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerMiddleware.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerMiddleware.cs
@@ -33,8 +33,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <summary>
         /// Create a new instance of <see cref="ErrorReportingExceptionLoggerMiddleware"/>.
         /// </summary>
-        /// <param name="next">The next request delegate. Cannot be null.</param>
-        /// <param name="logger">A logger that will report exceptions. Cannot be null.</param>
+        /// <param name="next">The next request delegate. Must not be null.</param>
+        /// <param name="logger">A logger that will report exceptions. Must not be null.</param>
         public ErrorReportingExceptionLoggerMiddleware(RequestDelegate next, IExceptionLogger logger)
         {
             _next = GaxPreconditions.CheckNotNull(next, nameof(next));

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingServiceOptions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingServiceOptions.cs
@@ -28,12 +28,12 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         public string ProjectId { get; set; }
 
         /// <summary>
-        /// An identifier of the service, such as the name of the executable or job. Cannot be null.
+        /// An identifier of the service, such as the name of the executable or job. Must not be null.
         /// </summary>
         public string ServiceName { get; set; }
 
         /// <summary>
-        /// Represents the source code version that the developer provided. Cannot be null.
+        /// Represents the source code version that the developer provided. Must not be null.
         /// </summary>
         public string Version { get; set; }
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/IExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/IExceptionLogger.cs
@@ -27,7 +27,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <summary>
         /// Logs an exception that occurred.
         /// </summary>
-        /// <param name="exception">The exception to log. Cannot be null.</param>
+        /// <param name="exception">The exception to log. Must not be null.</param>
         /// <param name="context">Optional, the current HTTP context. If unset the
         ///     current context will be retrieved automatically.</param>
         void Log(Exception exception, HttpContext context = null);
@@ -35,7 +35,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <summary>
         /// Asynchronously logs an exception that occurred.
         /// </summary>
-        /// <param name="exception">The exception to log. Cannot be null.</param>
+        /// <param name="exception">The exception to log. Must not be null.</param>
         /// <param name="context">Optional, the current HTTP context. If unset the
         ///     current context will be retrieved automatically.</param>
         /// <param name="cancellationToken">Optional, The token to monitor for cancellation requests.</param>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerFactoryExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerFactoryExtensions.cs
@@ -45,7 +45,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <summary>
         /// Adds a <see cref="GoogleLoggerProvider"/> for <see cref="GoogleLogger"/>s.
         /// </summary>
-        /// <param name="factory">The logger factory. Cannot be null.</param>
+        /// <param name="factory">The logger factory. Must not be null.</param>
         /// <param name="serviceProvider">The service provider to resolve additional services from.</param>
         /// <param name="projectId">Optional if running on Google App Engine or Google Compute Engine.
         ///     The Google Cloud Platform project ID. If unspecified and running on GAE or GCE the project ID will be
@@ -64,8 +64,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <summary>
         /// Adds a <see cref="GoogleLoggerProvider"/> for <see cref="GoogleLogger"/>s.
         /// </summary>
-        /// <param name="factory">The logger factory. Cannot be null.</param>
-        /// <param name="logTarget">Where to log to. Cannot be null.</param>
+        /// <param name="factory">The logger factory. Must not be null.</param>
+        /// <param name="logTarget">Where to log to. Must not be null.</param>
         /// <param name="serviceProvider">The service provider to resolve additional services from.</param>
         /// <param name="options">Optional, options for the logger.</param>
         /// <param name="client">Optional, logging client.</param>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerProvider.cs
@@ -40,9 +40,9 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <summary>
         /// <see cref="ILoggerProvider"/> for Google Stackdriver Logging.
         /// </summary>
-        /// <param name="consumer">The consumer to push logs to. Cannot be null.</param>
-        /// <param name="logTarget">Where to log to. Cannot be null.</param>
-        /// <param name="loggerOptions">The logger options. Cannot be null.</param>
+        /// <param name="consumer">The consumer to push logs to. Must not be null.</param>
+        /// <param name="logTarget">Where to log to. Must not be null.</param>
+        /// <param name="loggerOptions">The logger options. Must not be null.</param>
         /// <param name="serviceProvider">The service provider to resolve additional services from.</param>
         internal GoogleLoggerProvider(IConsumer<LogEntry> consumer, LogTarget logTarget, LoggerOptions loggerOptions,  IServiceProvider serviceProvider)
         {
@@ -72,7 +72,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <summary>
         /// Create an <see cref="ILoggerProvider"/> for Google Stackdriver Logging.
         /// </summary>
-        /// <param name="logTarget">Where to log to. Cannot be null.</param>
+        /// <param name="logTarget">Where to log to. Must not be null.</param>
         /// <param name="serviceProvider">The service provider to resolve additional services from.</param>
         /// <param name="options">Optional, options for the logger.</param>
         /// <param name="client">Optional, logging client.</param>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
@@ -87,8 +87,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <summary>
         /// Adds the needed services for Google Cloud Tracing. Used with <see cref="UseGoogleTrace"/>.
         /// </summary>
-        /// <param name="services">The service collection. Cannot be null.</param>
-        /// <param name="setupAction">Action to set up options. Cannot be null.</param>
+        /// <param name="services">The service collection. Must not be null.</param>
+        /// <param name="setupAction">Action to set up options. Must not be null.</param>
         /// <remarks>
         /// If <see cref="RetryOptions.ExceptionHandling"/> is set to <see cref="ExceptionHandling.Propagate"/>
         /// and the <see cref="RequestDelegate"/> executed by this middleware throws ad exception and this

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceMiddleware.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceMiddleware.cs
@@ -34,8 +34,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <summary>
         /// Create a new instance of <see cref="CloudTraceMiddleware"/>.
         /// </summary>
-        /// <param name="next">The next request delegate. Cannot be null.</param>
-        /// <param name="tracerFactory">A factory to create <see cref="IManagedTracer"/>s. Cannot be null.</param>
+        /// <param name="next">The next request delegate. Must not be null.</param>
+        /// <param name="tracerFactory">A factory to create <see cref="IManagedTracer"/>s. Must not be null.</param>
         public CloudTraceMiddleware(
             RequestDelegate next, Func<TraceHeaderContext, IManagedTracer> tracerFactory)
         {
@@ -49,7 +49,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// Stackdriver Trace API.
         /// </summary>
         /// <param name="httpContext">The current HTTP context.</param>
-        /// <param name="traceHeaderContext">Information from the current request header. Cannot be null.</param>
+        /// <param name="traceHeaderContext">Information from the current request header. Must not be null.</param>
         public async Task Invoke(HttpContext httpContext, TraceHeaderContext traceHeaderContext)
         {
             GaxPreconditions.CheckNotNull(traceHeaderContext, nameof(traceHeaderContext));

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/TraceDecisionPredicate.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/TraceDecisionPredicate.cs
@@ -58,7 +58,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <param name="traceDecisionPredicate">Used to determine if a request should be traced.
         /// Takes an <see cref="HttpRequest"/>.  It should return true if the request should be traced,
         /// false if the request should not be traced and null if the decision should be left to other
-        /// sampling mechanisms. Cannot be null.</param>
+        /// sampling mechanisms. Must not be null.</param>
         /// <param name="ignoreHealthChecks">Optional. True if Google App Engine health check requests should
         /// not be traced. Defaults to true.</param>
         public static TraceDecisionPredicate Create(

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/ContextExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/ContextExceptionLogger.cs
@@ -26,8 +26,8 @@ namespace Google.Cloud.Diagnostics.Common
         /// </summary>
         /// <param name="projectId">The Google Cloud Platform project ID.  If unspecified and running
         /// on GAE or GCE the project ID will be detected from the platform.</param>
-        /// <param name="serviceName"> An identifier of the service, such as the name of the executable or job. Cannot be null.</param>
-        /// <param name="version">Represents the source code version that the developer provided. Cannot be null.</param>
+        /// <param name="serviceName"> An identifier of the service, such as the name of the executable or job. Must not be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. Must not be null.</param>
         /// <param name="options">The error reporting options. Can be null, if null default options will be used.</param>
         /// <returns>An <see cref="IContextExceptionLogger"/> for the given options.</returns>
         public static IContextExceptionLogger Create(string projectId, string serviceName,

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/ErrorReportingContextExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/ErrorReportingContextExceptionLogger.cs
@@ -62,9 +62,9 @@ namespace Google.Cloud.Diagnostics.Common
         /// </summary>
         /// <param name="projectId">The Google Cloud Platform project ID. Can be null.</param>
         /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
-        ///     Cannot be null.</param>
+        ///     Must not be null.</param>
         /// <param name="version">Represents the source code version that the developer provided. 
-        ///     Cannot be null.</param>
+        ///     Must not be null.</param>
         /// <param name="options">Optional, error reporting options.</param>
         internal static IContextExceptionLogger Create(string projectId, string serviceName, string version,
             ErrorReportingOptions options = null)

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/ErrorReportingOptions.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/ErrorReportingOptions.cs
@@ -44,7 +44,7 @@ namespace Google.Cloud.Diagnostics.Common
         /// <summary>
         /// Creates an <see cref="ErrorReportingOptions"/>.
         /// </summary>
-        /// <param name="eventTarget">Where the error events should be sent. Cannot be null.</param>
+        /// <param name="eventTarget">Where the error events should be sent. Must not be null.</param>
         /// <param name="bufferOptions">The buffer options for the error reporter. Defaults to no buffer.</param>
         /// <param name="retryOptions">The retry options for the error reporter. Defaults to no retry.</param>
         public static ErrorReportingOptions Create(

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/EventTarget.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/EventTarget.cs
@@ -66,7 +66,7 @@ namespace Google.Cloud.Diagnostics.Common
         /// <param name="projectId">Optional if running on Google App Engine or Google Compute Engine.
         ///     The Google Cloud Platform project ID. If running on GAE or GCE the project ID will be
         ///     detected from the platform.</param>
-        /// <param name="logName">The log name.  Cannot be null.</param>
+        /// <param name="logName">The log name.  Must not be null.</param>
         /// <param name="loggingClient">The logging client.</param>
         /// <param name="monitoredResource">Optional, the monitored resource.  The monitored resource will
         ///     be automatically detected if it is not set and will default to the global resource if the detection fails.
@@ -88,8 +88,8 @@ namespace Google.Cloud.Diagnostics.Common
         /// For more information see "Formatting Log Error Messages"
         /// (https://cloud.google.com/error-reporting/docs/formatting-error-messages).
         /// </remarks>
-        /// <param name="logTarget">Where to log to, such as a project or organization. Cannot be null.</param>
-        /// <param name="logName">The log name.  Cannot be null.</param>
+        /// <param name="logTarget">Where to log to, such as a project or organization. Must not be null.</param>
+        /// <param name="logName">The log name.  Must not be null.</param>
         /// <param name="loggingClient">The logging client.</param>
         /// <param name="monitoredResource">Optional, the monitored resource.  The monitored resource will
         ///     be automatically detected if it is not set and will default to the global resource if the detection fails.

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/IContextExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/IContextExceptionLogger.cs
@@ -26,15 +26,15 @@ namespace Google.Cloud.Diagnostics.Common
         /// <summary>
         /// Logs an exception that occurred.
         /// </summary>
-        /// <param name="exception">The exception to log. Cannot be null.</param>
-        /// <param name="context">The current context. Cannot be null.</param>
+        /// <param name="exception">The exception to log. Must not be null.</param>
+        /// <param name="context">The current context. Must not be null.</param>
         void Log(Exception exception, IContextWrapper context);
 
         /// <summary>
         /// Asynchronously logs an exception that occurred.
         /// </summary>
-        /// <param name="exception">The exception to log. Cannot be null.</param>
-        /// <param name="context">The current context. Cannot be null.</param>
+        /// <param name="exception">The exception to log. Must not be null.</param>
+        /// <param name="context">The current context. Must not be null.</param>
         /// <param name="cancellationToken">Optional, The token to monitor for cancellation requests.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         Task LogAsync(Exception exception, IContextWrapper context, CancellationToken cancellationToken = default);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/FlushableConsumerBase.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/FlushableConsumerBase.cs
@@ -30,13 +30,13 @@ namespace Google.Cloud.Diagnostics.Common
         /// <summary>
         /// Accepts an enumerable of items while the semaphore is held.
         /// </summary>
-        /// <param name="items">The items to receive. Cannot be null.</param>
+        /// <param name="items">The items to receive. Must not be null.</param>
         protected abstract void ReceiveWithSemaphoreHeld(IEnumerable<T> items);
 
         /// <summary>
         /// Accepts an enumerable of items asynchronously while the semaphore is held.
         /// </summary>
-        /// <param name="items">The items to receive. Cannot be null.</param>
+        /// <param name="items">The items to receive. Must not be null.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         protected abstract Task ReceiveAsyncWithSemaphoreHeldAsync(

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/IConsumer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/IConsumer.cs
@@ -27,13 +27,13 @@ namespace Google.Cloud.Diagnostics.Common
         /// <summary>
         /// Accepts an enumerable of items.
         /// </summary>
-        /// <param name="items">The items to receive. Cannot be null.</param>
+        /// <param name="items">The items to receive. Must not be null.</param>
         void Receive(IEnumerable<T> items);
 
         /// <summary>
         /// Accepts an enumerable of items asynchronously.
         /// </summary>
-        /// <param name="items">The items to receive. Cannot be null.</param>
+        /// <param name="items">The items to receive. Must not be null.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         Task ReceiveAsync(IEnumerable<T> items, CancellationToken cancellationToken = default);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Logging/LogConsumer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Logging/LogConsumer.cs
@@ -25,9 +25,9 @@ namespace Google.Cloud.Diagnostics.Common
         /// <summary>
         /// Creates an <see cref="IConsumer{LogEntry}"/> based on the client and options.
         /// </summary>
-        /// <param name="client">A client to send log entries with. Cannot be null.</param>
-        /// <param name="bufferOptions">The buffering options. Cannot be null.</param>
-        /// <param name="retryOptions">The retry options. Cannot be null.</param>
+        /// <param name="client">A client to send log entries with. Must not be null.</param>
+        /// <param name="bufferOptions">The buffering options. Must not be null.</param>
+        /// <param name="retryOptions">The retry options. Must not be null.</param>
         public static IConsumer<LogEntry> Create(LoggingServiceV2Client client,
             BufferOptions bufferOptions, RetryOptions retryOptions)
         {

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/SizedBufferingConsumer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/SizedBufferingConsumer.cs
@@ -59,7 +59,7 @@ namespace Google.Cloud.Diagnostics.Common
         /// Creates a new <see cref="SizedBufferingConsumer{T}"/> that will flush to the
         /// given <see cref="IConsumer{T}"/>. 
         /// </summary>
-        /// <param name="consumer">The consumer to flush to, cannot be null.</param>
+        /// <param name="consumer">The consumer to flush to. Must not be null.</param>
         /// <param name="bufferSize">The buffer size in bytes.</param>
         /// <param name="sizer">A function to obtain the size of an item in bytes.</param>
         public static SizedBufferingConsumer<T> Create(IConsumer<T> consumer, Func<T, int> sizer, int bufferSize)

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/TimedBufferingConsumer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/TimedBufferingConsumer.cs
@@ -60,7 +60,7 @@ namespace Google.Cloud.Diagnostics.Common
         /// Creates a new <see cref="TimedBufferingConsumer{T}"/> that will automatically flush the 
         /// buffer to the <see cref="IConsumer{T}"/> after the given wait time.
         /// </summary>
-        /// <param name="consumer">The consumer to flush to, cannot be null.</param>
+        /// <param name="consumer">The consumer to flush to. Must not be null.</param>
         /// <param name="waitTime">The amount of time between automatic flushes.</param>
         public static TimedBufferingConsumer<T> Create(IConsumer<T> consumer, TimeSpan waitTime)
             => new TimedBufferingConsumer<T>(consumer, waitTime, new SimpleThreadingTimer());

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/IManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/IManagedTracer.cs
@@ -27,7 +27,7 @@ namespace Google.Cloud.Diagnostics.Common
         /// <summary>
         /// Starts a new span using the most recent (if any) unfinished span as the parent.
         /// </summary>
-        /// <param name="name">The name of the span, cannot be null.</param>
+        /// <param name="name">The name of the span. Must not be null.</param>
         /// <param name="options">The span options to override default values.</param>
         /// <returns>
         /// An <see cref="ISpan"/> that will end the current span when disposed.
@@ -39,7 +39,7 @@ namespace Google.Cloud.Diagnostics.Common
         /// exception (the exception will be re-thrown) to the span.
         /// </summary>
         /// <param name="action">The action to run in a span.</param>
-        /// <param name="name">The name of the span, cannot be null.</param>
+        /// <param name="name">The name of the span. Must not be null.</param>
         /// <param name="options">The span options to override default values.</param>
         void RunInSpan(Action action, string name, StartSpanOptions options = null);
 
@@ -48,7 +48,7 @@ namespace Google.Cloud.Diagnostics.Common
         /// exception (the exception will be re-thrown) to the span.
         /// </summary>
         /// <param name="func">The function to run in a span.</param>
-        /// <param name="name">The name of the span, cannot be null.</param>
+        /// <param name="name">The name of the span. Must not be null.</param>
         /// <param name="options">The span options to override default values.</param>
         /// <returns>The result from the call to <paramref name="func"/></returns>
         T RunInSpan<T>(Func<T> func, string name, StartSpanOptions options = null);
@@ -58,7 +58,7 @@ namespace Google.Cloud.Diagnostics.Common
         /// from a thrown exception (the exception will be re-thrown) to the span.
         /// </summary>
         /// <param name="func">The function to run in a span.</param>
-        /// <param name="name">The name of the span, cannot be null.</param>
+        /// <param name="name">The name of the span. Must not be null.</param>
         /// <param name="options">The span options to override default values.</param>
         /// <returns>The result from the call to <paramref name="func"/></returns>
         Task<T> RunInSpanAsync<T>(Func<Task<T>> func, string name, StartSpanOptions options = null);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ManagedTracer.cs
@@ -27,8 +27,8 @@ namespace Google.Cloud.Diagnostics.Common
         /// <summary>
         /// Creates a trace consumer for a <see cref="TraceServiceClient"/> and options.
         /// </summary>
-        /// <param name="client">The trace client. Cannot be null.</param>
-        /// <param name="options">Trace options. Cannot be null.</param>
+        /// <param name="client">The trace client. Must not be null.</param>
+        /// <param name="options">Trace options. Must not be null.</param>
         public static IConsumer<TraceProto> CreateConsumer(TraceServiceClient client, TraceOptions options)
         {
             GaxPreconditions.CheckNotNull(client, nameof(client));
@@ -42,9 +42,9 @@ namespace Google.Cloud.Diagnostics.Common
         /// <summary>
         /// Create a factory to generate an <see cref="IManagedTracer"/> from a <see cref="TraceHeaderContext"/>.
         /// </summary>
-        /// <param name="projectId">The Google Cloud Platform project ID. Cannot be null</param>
-        /// <param name="consumer">The trace consumer.  Cannot be null.</param>
-        /// <param name="options">Trace options. Cannot be null.</param>
+        /// <param name="projectId">The Google Cloud Platform project ID. Must not be null</param>
+        /// <param name="consumer">The trace consumer.  Must not be null.</param>
+        /// <param name="options">Trace options. Must not be null.</param>
         public static Func<TraceHeaderContext, IManagedTracer> CreateTracerFactory(string projectId, IConsumer<TraceProto> consumer, TraceOptions options)
         {
             GaxPreconditions.CheckNotNull(projectId, nameof(projectId));

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ManagedTracerFactory.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ManagedTracerFactory.cs
@@ -34,11 +34,11 @@ namespace Google.Cloud.Diagnostics.Common
         /// <summary>
         /// Creates a new <see cref="ManagedTracerFactory"/>.
         /// </summary>
-        /// <param name="projectId">The Google Cloud Platform project ID. Cannot be null.</param>
-        /// <param name="consumer">A trace consumer for the tracer. Cannot be null.</param>
+        /// <param name="projectId">The Google Cloud Platform project ID. Must not be null.</param>
+        /// <param name="consumer">A trace consumer for the tracer. Must not be null.</param>
         /// <param name="optionsFactory">An options factory to fall back to if the 
-        ///     <see cref="TraceHeaderContext"/> does not provide enough context. Cannot be null.</param>
-        /// <param name="traceIdFactory">A trace Id factory. Cannot be null.</param>
+        ///     <see cref="TraceHeaderContext"/> does not provide enough context. Must not be null.</param>
+        /// <param name="traceIdFactory">A trace Id factory. Must not be null.</param>
         internal ManagedTracerFactory(
             string projectId,
             IConsumer<TraceProto> consumer,

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
@@ -148,9 +148,9 @@ namespace Google.Cloud.Diagnostics.Common
         /// <summary>
         /// Creates a <see cref="SimpleManagedTracer"/>>
         /// </summary>
-        /// <param name="consumer">The consumer to push finished traces to. Cannot be null.</param>
-        /// <param name="projectId">The Google Cloud Platform project ID. Cannot be null.</param>
-        /// <param name="traceId">The id of the current trace. Cannot be null.</param>
+        /// <param name="consumer">The consumer to push finished traces to. Must not be null.</param>
+        /// <param name="projectId">The Google Cloud Platform project ID. Must not be null.</param>
+        /// <param name="traceId">The id of the current trace. Must not be null.</param>
         /// <param name="rootSpanParentId">Optional, the parent span id of the root span of the passed in trace.</param>
         public static SimpleManagedTracer Create(IConsumer<TraceProto> consumer, string projectId,
             string traceId, ulong? rootSpanParentId = null)


### PR DESCRIPTION
For both Asp.Net Diagnostics and Asp.Net Core Diagnostics