### PR TITLE
More flexible URI signing

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
@@ -11,6 +11,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Google.Apis.Iam.v1" Version="1.34.0.1240" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="1.0.0" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
@@ -11,6 +11,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Google.Apis.Iam.v1" Version="1.34.0.1240" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="1.0.0" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
@@ -11,6 +11,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Google.Apis.Iam.v1" Version="1.34.0.1240" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="1.0.0" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/docs/index.md
+++ b/apis/Google.Cloud.Storage.V1/docs/index.md
@@ -44,6 +44,34 @@ Or write-only access to put specific object content into a bucket:
 
 [!code-cs[](obj/snippets/Google.Cloud.Storage.V1.UrlSigner.txt#SignedURLPut)]
 
+### Signing URLs without a service account credential file
+
+If you need to sign URLs but don't have a full service account
+credential file (with private keys) available, you can create a
+`UrlSigner.IBlobSigner` implementation to perform the signing part.
+The most common implementation of this is likely to be to use the
+IAM service to perform the signing, with the
+[Google.Apis.Iam.v1](https://www.nuget.org/packages/Google.Apis.Iam.v1/)
+package. Here's a sample implementation:
+
+[!code-cs[](obj/snippets/Google.Cloud.Storage.V1.UrlSigner.txt#IamServiceBlobSigner)]
+
+(We may make this available in its own package at some point in the
+future.)
+
+To make use of this, the account making the request needs the
+`iam.serviceAccounts.signBlob` permission, which is usually granted
+via the "Service Account Token Creator" role.
+
+Here's an example showing how you could use this to sign a
+URL on behalf of the default Compute Engine credential on an
+instance. (This example will only work when running on Google Cloud
+Platform, as it relies on information from the metadata server.) If
+you want to use a different service account, you could include the
+account ID as part of your application configuration.
+
+[!code-cs[](obj/snippets/Google.Cloud.Storage.V1.UrlSigner.txt#IamServiceBlobSignerUsage)]
+
 ## Upload URIs
 
 In some cases, it may not make sense for client applications to have permissions

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -655,7 +655,8 @@
     },
     "testDependencies": {
       "Google.Cloud.Iam.V1": "1.0.0",
-      "Google.Cloud.PubSub.V1": "project"
+      "Google.Cloud.PubSub.V1": "project",
+      "Google.Apis.Iam.v1": "1.34.0.1240"
     },
     "tags": [ "Storage" ]
   },


### PR DESCRIPTION
This addresses #2316 by creating a seam for the signing part of
UrlSigner.

In the future we may want to release a package specifically to make
the IAM integration simple, but for the moment we've just got a
sample in the docs.

(Another possibility would be to add a dependency on the IAM
package and include the IAM signer here, but I'd prefer not to do
that.)