### PR TITLE
Release 1.0.0-beta19 of pubsub, with updated gRPC dependency

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta18</Version>
+    <Version>1.0.0-beta19</Version>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -25,7 +25,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.4.0" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="1.0.0" />
-    <PackageReference Include="Grpc.Core" Version="1.12.0" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="1.13.1" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -493,12 +493,13 @@
     "id": "Google.Cloud.PubSub.V1",
     "productName": "Cloud Pub/Sub",
     "productUrl": "https://cloud.google.com/pubsub/",
-    "version": "1.0.0-beta18",
+    "version": "1.0.0-beta19",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",
     "dependencies": {
       "Google.Cloud.Iam.V1": "1.0.0",
-      "Google.Api.Gax.Grpc": "2.4.0"
+      "Google.Api.Gax.Grpc": "2.4.0",
+      "Grpc.Core": "1.13.1", // Remove once the gax dep has been updated.
     },
     "testDependencies": {
       "System.ValueTuple": "4.3.1"


### PR DESCRIPTION
The updated gRPC dependency fixes the kubernetes shutdown issue