### PR TITLE
Move Utils.GetTestProjectIdFromEnvironment and Utils.IsWindows

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
 using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Cloud.ErrorReporting.V1Beta1;
@@ -183,7 +184,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
             Assert.Contains(functionName, errorEvent.Message);
             Assert.Contains(testId, errorEvent.Message);
 
-            if (Utils.IsWindows())
+            if (TestEnvironment.IsWindows())
             {
                 Assert.False(string.IsNullOrWhiteSpace(errorEvent.Context.ReportLocation.FilePath));
                 Assert.True(errorEvent.Context.ReportLocation.LineNumber > 0);
@@ -256,7 +257,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
     {
         public const string Service = "service-name";
         public const string Version = "version-id";
-        public static readonly string ProjectId = Utils.GetProjectIdFromEnvironment();
+        public static readonly string ProjectId = TestEnvironment.GetTestProjectId();
 
         /// <summary>Throws and catches exception.</summary>
         [HttpGet]

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/CloudTraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/CloudTraceTest.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
 using Google.Cloud.Diagnostics.Common.Tests;
@@ -35,7 +36,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
 
         public CloudTraceTest()
         {
-            _projectId = Utils.GetProjectIdFromEnvironment();
+            _projectId = TestEnvironment.GetTestProjectId();
             _testId = Utils.GetTestId();
             _startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
 using Google.Api;
+using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
 using Google.Cloud.Diagnostics.Common.Tests;
@@ -27,6 +24,10 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
@@ -76,7 +77,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 Type = "global",
                 Labels =
                 {
-                    { "project_id", Utils.GetProjectIdFromEnvironment() },
+                    { "project_id", TestEnvironment.GetTestProjectId() },
                     { "module_id", "some-service" },
                     { "version_id", "1.0.0" },
                     { "build_id", "some-build-id" }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Cloud.Diagnostics.Common;
+using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
 using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Cloud.ErrorReporting.V1Beta1;
@@ -159,7 +159,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         {
             public const string Service = "service-name";
             public const string Version = "version-id";
-            protected readonly string ProjectId = Utils.GetProjectIdFromEnvironment();
+            protected readonly string ProjectId = TestEnvironment.GetTestProjectId();
 
             public void ConfigureServices(IServiceCollection services)
             {

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Google.Api;
+using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
 using Google.Cloud.Diagnostics.Common.Tests;
@@ -250,7 +251,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                     TraceHeaderContext.Create(traceId, 81237123, null).ToString());
                 await client.GetAsync($"/Main/Critical/{testId}");
                 var results = _polling.GetEntries(startTime, testId, 1, LogSeverity.Critical);
-                Assert.Contains(Utils.GetProjectIdFromEnvironment(), results.Single().Trace);
+                Assert.Contains(TestEnvironment.GetTestProjectId(), results.Single().Trace);
                 Assert.Contains(traceId, results.Single().Trace);
             }
         }
@@ -285,7 +286,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
         public LoggerTestApplication()
         {
-            ProjectId = Utils.GetProjectIdFromEnvironment();
+            ProjectId = TestEnvironment.GetTestProjectId();
         }
 
         public virtual void ConfigureServices(IServiceCollection services)

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
 using Google.Cloud.Diagnostics.Common.Tests;
@@ -293,7 +294,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
         public AbstractTraceTestApplication()
         {
-            _projectId = Utils.GetProjectIdFromEnvironment();
+            _projectId = TestEnvironment.GetTestProjectId();
         }
 
         public abstract double GetSampleRate();

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/DiagnosticsSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/DiagnosticsSnippets.cs
@@ -29,7 +29,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
     {
         private const string Service = "service-name";
         private const string Version = "version-id";
-        private static readonly string ProjectId = Utils.GetProjectIdFromEnvironment();
+        private static readonly string ProjectId = TestEnvironment.GetTestProjectId();
 
         private readonly string _testId;
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/ErrorReportingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/ErrorReportingSnippets.cs
@@ -31,7 +31,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
     [SnippetOutputCollector]
     public class ErrorReportingSnippetsTests : IDisposable
     {
-        private static readonly bool s_isWindows = Utils.IsWindows();
+        private static readonly bool s_isWindows = TestEnvironment.IsWindows();
         private static readonly ErrorEventEntryPolling s_polling = new ErrorEventEntryPolling();
 
         private readonly string _testId;
@@ -120,7 +120,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
     {
         public const string Service = "service-name";
         public const string Version = "version-id";
-        private static readonly string ProjectId = Utils.GetProjectIdFromEnvironment();
+        private static readonly string ProjectId = TestEnvironment.GetTestProjectId();
 
         // Sample: ReportUnhandledExceptions
         public void ConfigureServices(IServiceCollection services)

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/LoggingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/LoggingSnippets.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
     [SnippetOutputCollector]
     public class LoggingSnippetsTests : IDisposable
     {
-        private static readonly string ProjectId = Utils.GetProjectIdFromEnvironment();
+        private static readonly string ProjectId = TestEnvironment.GetTestProjectId();
         private static readonly LogEntryPolling s_polling = new LogEntryPolling();
 
         private readonly string _testId;
@@ -105,7 +105,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
     /// </summary>
     internal class LoggingTestApplication
     {
-        private static readonly string ProjectId = Utils.GetProjectIdFromEnvironment();
+        private static readonly string ProjectId = TestEnvironment.GetTestProjectId();
 
         // Sample: RegisterGoogleLogger
         public void ConfigureServices(IServiceCollection services)

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/TraceSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/TraceSnippets.cs
@@ -134,7 +134,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
     /// </summary>
     internal class TraceTestApplication
     {
-        private static readonly string ProjectId = Utils.GetProjectIdFromEnvironment();
+        private static readonly string ProjectId = TestEnvironment.GetTestProjectId();
 
         // Sample: RegisterGoogleTracer
         public void ConfigureServices(IServiceCollection services)

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryPolling.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax.ResourceNames;
+using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Cloud.ErrorReporting.V1Beta1;
 using System;
@@ -34,7 +35,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         private readonly ErrorStatsServiceClient _client = ErrorStatsServiceClient.Create();
 
         /// <summary>Project to run the test on.</summary>
-        private readonly ProjectName _projectName = new ProjectName(Utils.GetProjectIdFromEnvironment());
+        private readonly ProjectName _projectName = new ProjectName(TestEnvironment.GetTestProjectId());
 
         // Give the error reporting events a little extra time to be processed.
         internal ErrorEventEntryPolling() : base(TimeSpan.FromSeconds(120), TimeSpan.FromSeconds(30)) { }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Logging/LogEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Logging/LogEntryPolling.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Cloud.Diagnostics.Common.Tests;
+using Google.Cloud.ClientTesting;
 using Google.Cloud.Logging.Type;
 using Google.Cloud.Logging.V2;
 using System;
@@ -40,7 +40,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         private static readonly TimeSpan _defaultSleepInterval = TimeSpan.FromSeconds(40);
 
         /// <summary>Project id to run the test on.</summary>
-        private readonly string _projectId = Utils.GetProjectIdFromEnvironment();
+        private readonly string _projectId = TestEnvironment.GetTestProjectId();
 
         /// <summary>Client to use to send RPCs.</summary>
         private readonly LoggingServiceV2Client _client = LoggingServiceV2Client.Create();

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/SimpleManagedTracerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/SimpleManagedTracerTest.cs
@@ -12,17 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Cloud.Trace.V1;
+using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common.Tests;
+using Google.Cloud.Trace.V1;
 using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
-
 using TraceProto = Google.Cloud.Trace.V1.Trace;
 
 namespace Google.Cloud.Diagnostics.Common.IntegrationTests
@@ -34,7 +33,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         private readonly TraceEntryPolling _polling = new TraceEntryPolling();
 
         /// <summary>Project id to run the test on.</summary>
-        private readonly string _projectId = Utils.GetProjectIdFromEnvironment();
+        private readonly string _projectId = TestEnvironment.GetTestProjectId();
 
         /// <summary>Unique id of the test.</summary>
         private readonly string _testId = Utils.GetTestId();

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceEntryPolling.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Cloud.Diagnostics.Common.Tests;
+using Google.Cloud.ClientTesting;
 using Google.Cloud.Trace.V1;
 using Google.Protobuf.WellKnownTypes;
 using System;
@@ -28,7 +28,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
     internal class TraceEntryPolling : BaseEntryPolling<TraceProto>
     {
         /// <summary>Project id to run the test on.</summary>
-        private readonly string _projectId = Utils.GetProjectIdFromEnvironment();
+        private readonly string _projectId = TestEnvironment.GetTestProjectId();
 
         /// <summary>Client to use to send RPCs.</summary>
         private readonly TraceServiceClient _client = TraceServiceClient.Create();

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceHeaderPropagatingHandlerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceHeaderPropagatingHandlerTest.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Cloud.Trace.V1;
 using Google.Protobuf.WellKnownTypes;
@@ -28,7 +29,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
     public class TraceHeaderPropagatingHandlerTest
     {
         /// <summary>Project id to run the test on.</summary>
-        private readonly string _projectId = Utils.GetProjectIdFromEnvironment();
+        private readonly string _projectId = TestEnvironment.GetTestProjectId();
 
         private static readonly TraceIdFactory _traceIdFactory = TraceIdFactory.Create();
         private static readonly SpanIdFactory _spanIdFactory = SpanIdFactory.Create();

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/ErrorReporting/ErrorReportingContextExceptionLoggerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/ErrorReporting/ErrorReportingContextExceptionLoggerTest.cs
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
+using Google.Cloud.ClientTesting;
+using Google.Cloud.Logging.V2;
+using Google.Protobuf.WellKnownTypes;
 using Moq;
-using Xunit;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Google.Protobuf.WellKnownTypes;
 using System.Threading;
 using System.Threading.Tasks;
-using Google.Cloud.Logging.V2;
+using Xunit;
 
 namespace Google.Cloud.Diagnostics.Common.Tests
 {
@@ -34,7 +35,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         private const string _userAgent = "user-agent";
         private const int _statusCode = 409;
 
-        private static readonly bool _isWindows = Utils.IsWindows();
+        private static readonly bool _isWindows = TestEnvironment.IsWindows();
 
         [Fact]
         public void Log()

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Utils.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Utils.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,32 +21,6 @@ namespace Google.Cloud.Diagnostics.Common.Tests
 {
     internal class Utils
     {
-        private const string _projectEnvironmentVariable = "TEST_PROJECT";
-
-        /// <returns>The test project Id.</returns>
-        /// <exception cref="InvalidOperationException">If the 'TEST_PROJECT' environment
-        /// variable is not set or empty</exception>
-        public static string GetProjectIdFromEnvironment()
-        {
-            string projectId = Environment.GetEnvironmentVariable(_projectEnvironmentVariable);
-            if (string.IsNullOrEmpty(projectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {_projectEnvironmentVariable} environment variable before running tests");
-            }
-            return projectId;
-        }
-
-        public static bool IsWindows()
-        {
-#if NET452
-            return Environment.OSVersion.ToString().Contains("Windows");
-#else
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-#endif
-
-        }
-
         /// <summary>A unique test Id.</summary>
         public static string GetTestId()
         {

--- a/tools/Google.Cloud.ClientTesting/CloudProjectFixtureBase.cs
+++ b/tools/Google.Cloud.ClientTesting/CloudProjectFixtureBase.cs
@@ -23,8 +23,6 @@ namespace Google.Cloud.ClientTesting
     /// </summary>
     public abstract class CloudProjectFixtureBase : IDisposable
     {
-        public const string TestProjectEnvironmentVariable = "TEST_PROJECT";
-
         // We don't care about the value beyond whether it's absent/empty or non-empty.
         private static bool s_allowedToSkip = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MUST_NOT_SKIP_TESTS"));
 
@@ -33,14 +31,9 @@ namespace Google.Cloud.ClientTesting
         /// </summary>
         public string ProjectId { get; }
 
-        protected CloudProjectFixtureBase(string testProjectEnvironmentVariable = TestProjectEnvironmentVariable)
+        protected CloudProjectFixtureBase(string testProjectEnvironmentVariable = TestEnvironment.TestProjectEnvironmentVariable)
         {
-            ProjectId = Environment.GetEnvironmentVariable(testProjectEnvironmentVariable);
-            if (string.IsNullOrEmpty(ProjectId))
-            {
-                throw new InvalidOperationException(
-                    $"Please set the {testProjectEnvironmentVariable} environment variable to your test project ID before running tests");
-            }
+            ProjectId = TestEnvironment.GetTestProjectId(testProjectEnvironmentVariable);
         }
 
         /// <summary>

--- a/tools/Google.Cloud.ClientTesting/TestEnvironment.cs
+++ b/tools/Google.Cloud.ClientTesting/TestEnvironment.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2018 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Google.Cloud.ClientTesting
+{
+    /// <summary>
+    /// Utility methods for determining aspects of the test environment,
+    /// typically through environment variables.
+    /// </summary>
+    public static class TestEnvironment
+    {
+        public const string TestProjectEnvironmentVariable = "TEST_PROJECT";
+
+        /// <summary>
+        /// Returns the project ID to use for testing.
+        /// </summary>
+        /// <param name="testProjectEnvironmentVariable">The environment variable to check, defaulting to TEST_PROJECT</param>
+        /// <returns>The project ID, which is validated to be non-null and non-empty.</returns>
+        public static string GetTestProjectId(string testProjectEnvironmentVariable = TestProjectEnvironmentVariable)
+        {
+            string projectId = Environment.GetEnvironmentVariable(testProjectEnvironmentVariable);
+            if (string.IsNullOrEmpty(projectId))
+            {
+                throw new InvalidOperationException(
+                    $"Please set the {testProjectEnvironmentVariable} environment variable to your test project ID before running tests");
+            }
+            return projectId;
+        }
+
+        /// <summary>
+        /// Determines whether or not the test is running on Windows.
+        /// </summary>
+        /// <returns></returns>
+        public static bool IsWindows()
+        {
+#if NET452
+            return Environment.OSVersion.ToString().Contains("Windows");
+#else
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#endif
+
+        }
+    }
+}


### PR DESCRIPTION
The test ID generation will come separately.

Initially I wanted to use fixtures as we do elsewhere, but that
would have been a more invasive change for very little benefit.

(This is the first part of addressing #2198)