### PR TITLE
Changes so that Google.Cloud.Diagnostics uses the new ID generator.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
@@ -14,7 +14,6 @@
 
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Cloud.ErrorReporting.V1Beta1;
 using Microsoft.Owin.Testing;
 using Owin;
@@ -37,7 +36,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         [Fact]
         public async Task NoExceptions()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             using (TestServer server = TestServer.Create<ErrorReportingTestApplication>())
@@ -53,7 +52,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         [Fact]
         public async Task LogsException()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             using (TestServer server = TestServer.Create<ErrorReportingTestApplication>())
@@ -76,7 +75,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         [Fact]
         public async Task LogsMultipleExceptions()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             using (TestServer server = TestServer.Create<ErrorReportingTestApplication>())
@@ -116,7 +115,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         [Fact]
         public async Task LogsThrownInHttpMessageHandler()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             using (TestServer server = TestServer.Create<ErrorReportingTestApplication>())
@@ -133,7 +132,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         [Fact]
         public async Task ManualLog_GoogleLogger()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             using (TestServer server = TestServer.Create<ErrorReportingTestApplication>())
@@ -150,7 +149,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         [Fact]
         public async Task ManualLog_GoogleWebApiLogger()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             using (TestServer server = TestServer.Create<ErrorReportingTestApplication>())

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Google.Cloud.Diagnostics.AspNet.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Google.Cloud.Diagnostics.AspNet.IntegrationTests.csproj
@@ -34,4 +34,8 @@
     <PackageReference Include="Microsoft.Owin.Testing" Version="3.0.1" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNet.Tests\Google.Cloud.Diagnostics.AspNet.Tests.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/CloudTraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Trace/CloudTraceTest.cs
@@ -15,7 +15,6 @@
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Protobuf.WellKnownTypes;
 using System;
 using System.IO;
@@ -37,7 +36,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         public CloudTraceTest()
         {
             _projectId = TestEnvironment.GetTestProjectId();
-            _testId = Utils.GetTestId();
+            _testId = IdGenerator.FromDateTime();
             _startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
             // Set up a fake HttpContext to trace with.

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
@@ -16,7 +16,6 @@ using Google.Api;
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Cloud.Logging.Type;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
@@ -70,7 +69,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task UseGoogleDiagnostics_ConfiguresComponents()
         {
-            var testId = Utils.GetTestId();
+            var testId = IdGenerator.FromDateTime();
             var startTime = DateTime.UtcNow;
             var resource = new MonitoredResource
             {

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
@@ -14,7 +14,6 @@
 
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Cloud.ErrorReporting.V1Beta1;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -39,7 +38,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task NoExceptions()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             var builder = new WebHostBuilder().UseStartup<ErrorReportingTestApplication>();
@@ -56,7 +55,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task ManualLog()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             var builder = new WebHostBuilder().UseStartup<ErrorReportingTestApplication>();
@@ -74,7 +73,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task LogsException()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             var builder = new WebHostBuilder().UseStartup<ErrorReportingTestApplication>();
@@ -93,7 +92,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task LogsMultipleExceptions()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             var builder = new WebHostBuilder().UseStartup<ErrorReportingTestApplication>();

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -12,16 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Google.Api;
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Cloud.Logging.Type;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -31,6 +25,11 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
@@ -42,7 +41,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Logging_SizedBufferNoLogs()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             var builder = new WebHostBuilder().UseStartup<SizedBufferErrorLoggerTestApplication>();
@@ -62,7 +61,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Logging_DisposeFlush()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             var builder = new WebHostBuilder().UseStartup<SizedBufferErrorLoggerTestApplication>();
@@ -85,7 +84,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Logging_NoBuffer()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             var builder = new WebHostBuilder().UseStartup<NoBufferWarningLoggerTestApplication>();
@@ -110,7 +109,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Logging_SizedBuffer()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             var builder = new WebHostBuilder().UseStartup<SizedBufferErrorLoggerTestApplication>();
@@ -147,7 +146,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             // flush itself we use custom polling to check for the initial check that no
             // entries exist.
             var quickPolling = new LogEntryPolling(TimeSpan.FromSeconds(10));
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             var builder = new WebHostBuilder().UseStartup<TimedBufferWarningLoggerTestApplication>();
@@ -175,7 +174,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Logging_MonitoredResource()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             var builder = new WebHostBuilder().UseStartup<NoBufferResourceLoggerTestApplication>();
@@ -197,7 +196,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Logging_Scope()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             var builder = new WebHostBuilder().UseStartup<NoBufferResourceLoggerTestApplication>();
@@ -215,7 +214,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Logging_FormatParameter()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             var builder = new WebHostBuilder().UseStartup<NoBufferResourceLoggerTestApplication>();
@@ -240,7 +239,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         public async Task Logging_Trace()
         {
             string traceId = "105445aa7843bc8bf206b12000100f00";
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             var builder = new WebHostBuilder().UseStartup<NoBufferWarningLoggerTestApplication>();
@@ -259,7 +258,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Logging_Labels()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             DateTime startTime = DateTime.UtcNow;
 
             var builder = new WebHostBuilder().UseStartup<WarningWithLabelsLoggerTestApplication>();

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
@@ -15,7 +15,6 @@
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -47,7 +46,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Trace()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
             using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestNoBufferHighQpsApplication>()))
@@ -72,7 +71,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Trace_Label()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
             using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestNoBufferHighQpsApplication>()))
@@ -94,7 +93,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Trace_StackTrace()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
             using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestNoBufferHighQpsApplication>()))
@@ -120,7 +119,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             string traceId = TraceIdFactory.Create().NextId();
             ulong spanId = SpanIdFactory.Create().NextId();
 
-            string testId = Utils.GetTestId();           
+            string testId = IdGenerator.FromDateTime();
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
             using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestNoBufferLowQpsApplication>()))
@@ -151,7 +150,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public void Trace_QPS()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
             using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestNoBufferApplication>()))
@@ -173,7 +172,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Trace_Buffer()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
             var spanName = TraceController.GetMessage(nameof(TraceController.Trace), testId);
@@ -197,7 +196,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Trace_Exception()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
             using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestNoBufferHighQpsApplication>()))
@@ -227,7 +226,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Trace_IgnoreHealthChecks()
         {
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             var startTime = Timestamp.FromDateTime(DateTime.UtcNow);
 
             using (var server = new TestServer(new WebHostBuilder().UseStartup<TraceTestNoBufferHighQpsApplication>()))

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/DiagnosticsSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/DiagnosticsSnippets.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Google.Cloud.ClientTesting;
-using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
@@ -52,7 +51,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             _server = new TestServer(webHostBuilder);
             _client = _server.CreateClient();
 
-            _testId = Utils.GetTestId();
+            _testId = IdGenerator.FromDateTime();
             _startTime = DateTime.UtcNow;
         }
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/ErrorReportingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/ErrorReportingSnippets.cs
@@ -14,7 +14,6 @@
 
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Cloud.Diagnostics.Common.Tests;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -43,7 +42,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
 
         public ErrorReportingSnippetsTests()
         {
-            _testId = Utils.GetTestId();
+            _testId = IdGenerator.FromDateTime();
 
             var builder = new WebHostBuilder().UseStartup<ErrorReportingTestApplication>();
             _server = new TestServer(builder);

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/LoggingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/LoggingSnippets.cs
@@ -14,7 +14,6 @@
 
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Cloud.Logging.Type;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -45,7 +44,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
 
         public LoggingSnippetsTests()
         {
-            _testId = Utils.GetTestId();
+            _testId = IdGenerator.FromDateTime();
             IWebHostBuilder builder;
 #if NETCOREAPP2_0
             // Sample: RegisterGoogleLogger2

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/TraceSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/TraceSnippets.cs
@@ -15,7 +15,6 @@
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -46,7 +45,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
 
         public TraceSnippetsTests()
         {
-            _testId = Utils.GetTestId();
+            _testId = IdGenerator.FromDateTime();
 
             var builder = new WebHostBuilder().UseStartup<TraceTestApplication>();
             _server = new TestServer(builder);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/SimpleManagedTracerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/SimpleManagedTracerTest.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         private readonly string _projectId = TestEnvironment.GetTestProjectId();
 
         /// <summary>Unique id of the test.</summary>
-        private readonly string _testId = Utils.GetTestId();
+        private readonly string _testId = IdGenerator.FromDateTime();
 
         /// <summary>Test start time to allow for easier querying of traces.</summary>
         private readonly Timestamp _startTime = Timestamp.FromDateTime(DateTime.UtcNow);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceHeaderPropagatingHandlerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceHeaderPropagatingHandlerTest.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Google.Cloud.ClientTesting;
-using Google.Cloud.Diagnostics.Common.Tests;
 using Google.Cloud.Trace.V1;
 using Google.Protobuf.WellKnownTypes;
 using System;
@@ -39,7 +38,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         public async Task TraceOutGoing()
         {
             string googleUri = "https://google.com/";
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             var spanName = $"{nameof(TraceOutGoing)}-{testId}";
 
             var trace = await TestTracingOutGoingRequest(googleUri, spanName, exceptionExpected: false);
@@ -53,7 +52,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         public async Task TraceOutGoing_Exception()
         {
             string fakeUri = "http://www.thiscannotpossiblyexist934719238.com/";
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             var spanName = $"{nameof(TraceOutGoing_Exception)}-{testId}";
 
             var trace = await TestTracingOutGoingRequest(fakeUri, spanName, exceptionExpected: true);
@@ -67,7 +66,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         public async Task TraceOutGoing_HttpError()
         {
             string fakeUri = "https://google.com/404";
-            string testId = Utils.GetTestId();
+            string testId = IdGenerator.FromDateTime();
             var spanName = $"{nameof(TraceOutGoing_Exception)}-{testId}";
 
             var trace = await TestTracingOutGoingRequest(fakeUri, spanName, exceptionExpected: false);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Utils.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Utils.cs
@@ -21,12 +21,6 @@ namespace Google.Cloud.Diagnostics.Common.Tests
 {
     internal class Utils
     {
-        /// <summary>A unique test Id.</summary>
-        public static string GetTestId()
-        {
-            return Guid.NewGuid().ToString();
-        }
-
         public static class ConstantSizer<T>
         {
             /// <summary>Always returns 2.</summary>


### PR DESCRIPTION
Next and last step to addressing #2198 

This PR changes the diagnostics solutions so that it used the new ID Generator from #2363.

I've changed from a Guid base ID to a datetime base ID, which will help with diagnosing issues.