### PR TITLE
Change how to 'cd' into the proper directory for scripts

### DIFF
--- a/.kokoro/builddocs.sh
+++ b/.kokoro/builddocs.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+SCRIPT=$(readlink -f "$0")
+ROOT_DIR=$(dirname "$SCRIPT")
+
+cd $ROOT_DIR
 cd ..
 
 # Build the libraries w/o running unit tests.

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -2,11 +2,15 @@
 
 set -e
 
+SCRIPT=$(readlink -f "$0")
+ROOT_DIR=$(dirname "$SCRIPT")
+
+cd $ROOT_DIR
+cd ..
+
 export GOOGLE_APPLICATION_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73609_cloud-sharp-jenkins-compute-service-account"
 export REQUESTER_PAYS_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73609_gcloud-devel-service-account"
 export NUGET_API_KEY="$(cat "$KOKORO_KEYSTORE_DIR"/73609_google-cloud-nuget-api-key)"
-
-cd ..
 
 # Build the release and run the tests.
 ./buildrelease.sh --ssh $(git rev-parse HEAD)

--- a/.kokoro/runintegrationtests.sh
+++ b/.kokoro/runintegrationtests.sh
@@ -2,15 +2,19 @@
 
 set -e
 
+SCRIPT=$(readlink -f "$0")
+ROOT_DIR=$(dirname "$SCRIPT")
+
+cd $ROOT_DIR
+cd ..
+
 export GOOGLE_APPLICATION_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73609_cloud-sharp-jenkins-compute-service-account"
 export REQUESTER_PAYS_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73609_gcloud-devel-service-account"
-
-cd ..
 
 # Build the libraries and run unit tests.
 ./build.sh
 
 # Allow each integration test 3 chances to pass.
-./runintegrationtests.sh || true
-./runintegrationtests.sh --retry || true
-./runintegrationtests.sh --retry
+#./runintegrationtests.sh || true
+#./runintegrationtests.sh --retry || true
+#./runintegrationtests.sh --retry

--- a/.kokoro/runintegrationtests.sh
+++ b/.kokoro/runintegrationtests.sh
@@ -15,6 +15,6 @@ export REQUESTER_PAYS_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73609_gcloud-devel-servi
 ./build.sh
 
 # Allow each integration test 3 chances to pass.
-#./runintegrationtests.sh || true
-#./runintegrationtests.sh --retry || true
-#./runintegrationtests.sh --retry
+./runintegrationtests.sh || true
+./runintegrationtests.sh --retry || true
+./runintegrationtests.sh --retry


### PR DESCRIPTION
On the CI/CD the script is not run from the same location it exists.  We instead need to grab the script location and 'cd' into the right location to run scripts.