### PR TITLE
Change how to 'cd' into the proper directory for scripts

### DIFF
--- a/.kokoro/builddocs.sh
+++ b/.kokoro/builddocs.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+SCRIPT=$(readlink -f "$0")
+ROOT_DIR=$(dirname "$SCRIPT")
+
+cd $ROOT_DIR
 cd ..
 
 # Build the libraries w/o running unit tests.

--- a/.kokoro/builddocs.sh
+++ b/.kokoro/builddocs.sh
@@ -3,9 +3,9 @@
 set -e
 
 SCRIPT=$(readlink -f "$0")
-ROOT_DIR=$(dirname "$SCRIPT")
+SCRIPT_DIR=$(dirname "$SCRIPT")
 
-cd $ROOT_DIR
+cd $SCRIPT_DIR
 cd ..
 
 # Build the libraries w/o running unit tests.

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -2,11 +2,15 @@
 
 set -e
 
+SCRIPT=$(readlink -f "$0")
+ROOT_DIR=$(dirname "$SCRIPT")
+
+cd $ROOT_DIR
+cd ..
+
 export GOOGLE_APPLICATION_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73609_cloud-sharp-jenkins-compute-service-account"
 export REQUESTER_PAYS_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73609_gcloud-devel-service-account"
 export NUGET_API_KEY="$(cat "$KOKORO_KEYSTORE_DIR"/73609_google-cloud-nuget-api-key)"
-
-cd ..
 
 # Build the release and run the tests.
 ./buildrelease.sh --ssh $(git rev-parse HEAD)

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -3,9 +3,9 @@
 set -e
 
 SCRIPT=$(readlink -f "$0")
-ROOT_DIR=$(dirname "$SCRIPT")
+SCRIPT_DIR=$(dirname "$SCRIPT")
 
-cd $ROOT_DIR
+cd $SCRIPT_DIR
 cd ..
 
 export GOOGLE_APPLICATION_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73609_cloud-sharp-jenkins-compute-service-account"

--- a/.kokoro/runintegrationtests.sh
+++ b/.kokoro/runintegrationtests.sh
@@ -3,9 +3,9 @@
 set -e
 
 SCRIPT=$(readlink -f "$0")
-ROOT_DIR=$(dirname "$SCRIPT")
+SCRIPT_DIR=$(dirname "$SCRIPT")
 
-cd $ROOT_DIR
+cd $SCRIPT_DIR
 cd ..
 
 export GOOGLE_APPLICATION_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73609_cloud-sharp-jenkins-compute-service-account"

--- a/.kokoro/runintegrationtests.sh
+++ b/.kokoro/runintegrationtests.sh
@@ -2,10 +2,14 @@
 
 set -e
 
+SCRIPT=$(readlink -f "$0")
+ROOT_DIR=$(dirname "$SCRIPT")
+
+cd $ROOT_DIR
+cd ..
+
 export GOOGLE_APPLICATION_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73609_cloud-sharp-jenkins-compute-service-account"
 export REQUESTER_PAYS_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73609_gcloud-devel-service-account"
-
-cd ..
 
 # Build the libraries and run unit tests.
 ./build.sh


### PR DESCRIPTION
On the CI/CD the script is not run from the same location it exists. We instead need to grab the script location and 'cd' into the right location to run scripts.