### PR TITLE
Fix build dependencies

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/Google.Cloud.Spanner.Data.CommonTesting.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/Google.Cloud.Spanner.Data.CommonTesting.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/tools/Google.Cloud.ClientTesting/Google.Cloud.ClientTesting.csproj
+++ b/tools/Google.Cloud.ClientTesting/Google.Cloud.ClientTesting.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.assert" Version="2.3.1" />
-    <PackageReference Include="xunit.core" Version="2.3.1" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.3.3" />
-    <PackageReference Include="Google.Apis" Version="1.25.0" />
+    <PackageReference Include="xunit.assert" Version="2.4.0" />
+    <PackageReference Include="xunit.core" Version="2.4.0" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
+    <PackageReference Include="Google.Apis" Version="1.34.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='Net451'">

--- a/tools/Google.Cloud.Docs.Snippets/Google.Cloud.Docs.Snippets.csproj
+++ b/tools/Google.Cloud.Docs.Snippets/Google.Cloud.Docs.Snippets.csproj
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">


### PR DESCRIPTION
Our dependencies in both Google.Cloud.Docs.Snippets and
Google.Cloud.ClientTesting were extremely old. The Spanner one was
just a bit out of date, missed when I updated the rest.