### PR TITLE
Removing the ErrorReporting part of the namespace where the ErrorEventEntryVerifiers lived.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
@@ -14,7 +14,6 @@
 
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Cloud.Diagnostics.Common.IntegrationTests.ErrorReporting;
 using Microsoft.Owin.Testing;
 using Owin;
 using System;

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/ErrorReportingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/ErrorReportingSnippets.cs
@@ -14,7 +14,6 @@
 
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Cloud.Diagnostics.Common.IntegrationTests.ErrorReporting;
 using Microsoft.Owin.Testing;
 using Owin;
 using System;

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
@@ -14,7 +14,6 @@
 
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Cloud.Diagnostics.Common.IntegrationTests.ErrorReporting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/DiagnosticsSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/DiagnosticsSnippets.cs
@@ -14,7 +14,6 @@
 
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Cloud.Diagnostics.Common.IntegrationTests.ErrorReporting;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/ErrorReportingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/ErrorReportingSnippets.cs
@@ -14,7 +14,6 @@
 
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
-using Google.Cloud.Diagnostics.Common.IntegrationTests.ErrorReporting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryVerifiers.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryVerifiers.cs
@@ -17,7 +17,7 @@ using Google.Cloud.ErrorReporting.V1Beta1;
 using System.Net.Http;
 using Xunit;
 
-namespace Google.Cloud.Diagnostics.Common.IntegrationTests.ErrorReporting
+namespace Google.Cloud.Diagnostics.Common.IntegrationTests
 {
     public static class ErrorEventEntryVerifiers
     {


### PR DESCRIPTION
This is a very minor thing, but none of the other classes in this project lives in a specific namespace, and this one I created in #2372 does. It's been bothering me since I discovered it.