### PR TITLE
Add Windows bat files to Kokoro to ensure we can see output when running shell scripts.

### DIFF
--- a/.kokoro/build.bat
+++ b/.kokoro/build.bat
@@ -1,0 +1,3 @@
+:: See documentation in type-shell-output.bat
+
+%~dp0type-shell-output.bat build

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT=$(readlink -f "$0")
+SCRIPT_DIR=$(dirname "$SCRIPT")
+
+cd $SCRIPT_DIR
+cd ..
+
+./build.sh
+

--- a/.kokoro/builddocs.bat
+++ b/.kokoro/builddocs.bat
@@ -1,0 +1,3 @@
+:: See documentation in type-shell-output.bat
+
+%~dp0type-shell-output.bat builddocs

--- a/.kokoro/cleantestdata.bat
+++ b/.kokoro/cleantestdata.bat
@@ -1,0 +1,3 @@
+:: See documentation in type-shell-output.bat
+
+%~dp0type-shell-output.bat cleantestdata

--- a/.kokoro/cleantestdata.sh
+++ b/.kokoro/cleantestdata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT=$(readlink -f "$0")
+SCRIPT_DIR=$(dirname "$SCRIPT")
+
+cd $SCRIPT_DIR
+cd ..
+
+./cleantestdata.sh
+

--- a/.kokoro/release.bat
+++ b/.kokoro/release.bat
@@ -1,0 +1,3 @@
+:: See documentation in type-shell-output.bat
+
+%~dp0type-shell-output.bat release

--- a/.kokoro/runintegrationtests.bat
+++ b/.kokoro/runintegrationtests.bat
@@ -1,0 +1,3 @@
+:: See documentation in type-shell-output.bat
+
+%~dp0type-shell-output.bat runintegrationtests

--- a/.kokoro/type-shell-output.bat
+++ b/.kokoro/type-shell-output.bat
@@ -1,0 +1,13 @@
+:: This takes the name of a shell script located in this directory
+:: runs the script, output the results to a file and then
+:: types the file back to the user.
+::
+:: This is needed to be able to see shell output on the
+:: Windows Kokoro machines.
+
+del %~dp0%1.txt
+
+%~dp0write-output-to-file.sh %~dp0%1
+
+type %~dp0%1.txt
+del %~dp0%1.txt

--- a/.kokoro/write-output-to-file.sh
+++ b/.kokoro/write-output-to-file.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# See documentation in type-shell-output.bat
+
+set -e
+
+$1.sh > $1.txt


### PR DESCRIPTION
Currently the shell scripts run but we don't get any output.  This will allow us to see the output and diagnose errors.

I'm not the biggest fan of this solution but seems like the easiest.  It looks like other have had the same issue and just wrote all scripts in PowerShell