### PR TITLE
Add format parameters for logging scopes

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -247,7 +247,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             {
                 await client.GetAsync($"/Main/ScopeFormatParameters/{testId}");
                 var results = _polling.GetEntries(startTime, testId, 1, LogSeverity.Critical);
-                var message = MainController.GetMessage(nameof(MainController.Scope), testId);
+                var message = MainController.GetMessage(nameof(MainController.ScopeFormatParameters), testId);
                 var json = results.Single().JsonPayload.Fields;
                 Assert.Equal(message, json["message"].StringValue);
 
@@ -501,9 +501,9 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
         public string ScopeFormatParameters(string id)
         {
-            using (_logger.BeginScope(nameof(ScopeFormatParameters) + " - {id}"))
+            using (_logger.BeginScope(nameof(ScopeFormatParameters) + " - {id}", id))
             {
-                string message = GetMessage(nameof(Scope), id);
+                string message = GetMessage(nameof(ScopeFormatParameters), id);
                 _logger.LogCritical(message);
                 return message;
             }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/GoogleLoggerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/GoogleLoggerTest.cs
@@ -76,8 +76,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             Predicate<IEnumerable<LogEntry>> matcher = l =>
             {
                 var json = l.Single().JsonPayload.Fields;
-                var parentScopes = json["parent_scopes"].StructValue.Fields;
-                var parentScope0 = parentScopes["0"].StructValue.Fields;
+                var parentScopes = json["parent_scopes"].ListValue.Values;
+                var parentScope0 = parentScopes[0].StructValue.Fields;
                 return json["message"].StringValue == _logMessage &&
                        json["scope"].StringValue == "scope 42, Baz => " &&
                        parentScopes.Count == 1 &&
@@ -104,9 +104,9 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             Predicate<IEnumerable<LogEntry>> matcher = l =>
             {
                 var json = l.Single().JsonPayload.Fields;
-                var parentScopes = json["parent_scopes"].StructValue.Fields;
-                var scope0 = parentScopes["0"].StructValue.Fields;
-                var scope1 = parentScopes["1"].StructValue.Fields;
+                var parentScopes = json["parent_scopes"].ListValue.Values;
+                var scope0 = parentScopes[0].StructValue.Fields;
+                var scope1 = parentScopes[1].StructValue.Fields;
 
                 return json["message"].StringValue == _logMessage &&
                        json["scope"].StringValue == "first 42 => second Baz => " &&
@@ -143,8 +143,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             {
                 var json = l.Single().JsonPayload.Fields;
                 var formatParams = json["format_parameters"].StructValue.Fields;
-                var parentScopes = json["parent_scopes"].StructValue.Fields;
-                var parentScope0 = parentScopes["0"].StructValue.Fields;
+                var parentScopes = json["parent_scopes"].ListValue.Values;
+                var parentScope0 = parentScopes[0].StructValue.Fields;
                 return json["message"].StringValue == "a log message with stuff" &&
                        json["scope"].StringValue == "scope 42 => " &&
                        formatParams.Count == 2 &&

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
@@ -19,6 +19,7 @@ using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Internal;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -151,7 +152,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             while (currentLogScope != null)
             {
                 // Determine if the state of the scope are format params
-                if (currentLogScope.State is IEnumerable<KeyValuePair<string, object>> scopeFormatParams)
+                if (currentLogScope.State is FormattedLogValues scopeFormatParams)
                 {
                     var scopeParams = new Struct();
                     foreach (var pair in scopeFormatParams)

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
@@ -139,7 +139,10 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             if (currentLogScope != null)
             {
                 jsonStruct.Fields.Add("scope", Value.ForString(currentLogScope.ToString()));
+            }
 
+            while (currentLogScope != null)
+            {
                 // Determine if the state of the scope are format params
                 if (currentLogScope.State is IEnumerable<KeyValuePair<string, object>> scopeFormatParams)
                 {
@@ -150,11 +153,17 @@ namespace Google.Cloud.Diagnostics.AspNetCore
 
                     foreach (var pair in scopeFormatParams)
                     {
-                        // Prevent conflicts with the {OriginalFormat} parameter from the regular log message
-                        var key = pair.Key == "{OriginalFormat}" ? "{ScopeOriginalFormat}" : pair.Key;
-                        paramStruct.Fields[key] = Value.ForString(pair.Value?.ToString() ?? "");
+                        if (pair.Key == "{OriginalFormat}")
+                        {
+                            // Skip the {OriginalFormat} parameter for scopes
+                            continue;
+                        }
+
+                        paramStruct.Fields[pair.Key] = Value.ForString(pair.Value?.ToString() ?? "");
                     }
                 }
+
+                currentLogScope = currentLogScope.Parent;
             }
 
             if (paramStruct?.Fields.Count > 0)

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
@@ -147,8 +147,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
 
             // Create a map of format parameters of all the parent scopes,
             // starting from the most inner scope to the top-level scope.
-            var scopeIndex = 0;
-            var scopeParamArray = new Struct();
+            var scopeParamsList = new List<Value>();
             while (currentLogScope != null)
             {
                 // Determine if the state of the scope are format params
@@ -160,16 +159,15 @@ namespace Google.Cloud.Diagnostics.AspNetCore
                         scopeParams.Fields[pair.Key] = Value.ForString(pair.Value?.ToString() ?? "");
                     }
 
-                    scopeParamArray.Fields.Add(scopeIndex.ToString(), Value.ForStruct(scopeParams));
-                    scopeIndex++;
+                    scopeParamsList.Add(Value.ForStruct(scopeParams));
                 }
 
                 currentLogScope = currentLogScope.Parent;
             }
 
-            if (scopeParamArray.Fields.Count > 0)
+            if (scopeParamsList.Count > 0)
             {
-                jsonStruct.Fields.Add("parent_scopes", Value.ForStruct(scopeParamArray));
+                jsonStruct.Fields.Add("parent_scopes", Value.ForList(scopeParamsList.ToArray()));
             }
 
             Dictionary<string, string> labels;


### PR DESCRIPTION
This change adds format parameters from logging scopes with structured log messages.

Consider this example:

```cs
using (logger.BeginScope("Processing item {ItemId}", item.Id))
{
    logger.LogInformation("Mailing customer {CustomerId}",  customer.Id);
    // ...

    logger.LogInformation("Updating database record");
    // ...
}
```

With this change, the `{ItemId}`  format parameter will be added to each subsequent log entry in stead having to add it again to each individual log message.

I've decided to add them to the existing `format_parameters` node in the log entry. There is one caveat with this: both the regular log message and the scope log message contain a `{OriginalFormat}` parameter. I've renamed the parameter of the scope log message to `{ScopeOriginalFormat}`.

Please let me know what you think. I can add more tests if necessary.

/cc @iantalarico 