### PR TITLE
Regenerate clients with Create overload accepting CallInvoker

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DataTransferServiceClient.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DataTransferServiceClient.cs
@@ -639,7 +639,19 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         public static DataTransferServiceClient Create(grpccore::Channel channel, DataTransferServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            DataTransferService.DataTransferServiceClient grpcClient = new DataTransferService.DataTransferServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="DataTransferServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="DataTransferServiceSettings"/>.</param>
+        /// <returns>The created <see cref="DataTransferServiceClient"/>.</returns>
+        public static DataTransferServiceClient Create(grpccore::CallInvoker callInvoker, DataTransferServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            DataTransferService.DataTransferServiceClient grpcClient = new DataTransferService.DataTransferServiceClient(callInvoker);
             return new DataTransferServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableInstanceAdminClient.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableInstanceAdminClient.cs
@@ -924,7 +924,19 @@ namespace Google.Cloud.Bigtable.Admin.V2
         public static BigtableInstanceAdminClient Create(grpccore::Channel channel, BigtableInstanceAdminSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            BigtableInstanceAdmin.BigtableInstanceAdminClient grpcClient = new BigtableInstanceAdmin.BigtableInstanceAdminClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="BigtableInstanceAdminClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="BigtableInstanceAdminSettings"/>.</param>
+        /// <returns>The created <see cref="BigtableInstanceAdminClient"/>.</returns>
+        public static BigtableInstanceAdminClient Create(grpccore::CallInvoker callInvoker, BigtableInstanceAdminSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            BigtableInstanceAdmin.BigtableInstanceAdminClient grpcClient = new BigtableInstanceAdmin.BigtableInstanceAdminClient(callInvoker);
             return new BigtableInstanceAdminClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableTableAdminClient.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableTableAdminClient.cs
@@ -778,7 +778,19 @@ namespace Google.Cloud.Bigtable.Admin.V2
         public static BigtableTableAdminClient Create(grpccore::Channel channel, BigtableTableAdminSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            BigtableTableAdmin.BigtableTableAdminClient grpcClient = new BigtableTableAdmin.BigtableTableAdminClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="BigtableTableAdminClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="BigtableTableAdminSettings"/>.</param>
+        /// <returns>The created <see cref="BigtableTableAdminClient"/>.</returns>
+        public static BigtableTableAdminClient Create(grpccore::CallInvoker callInvoker, BigtableTableAdminSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            BigtableTableAdmin.BigtableTableAdminClient grpcClient = new BigtableTableAdmin.BigtableTableAdminClient(callInvoker);
             return new BigtableTableAdminClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.cs
@@ -372,7 +372,19 @@ namespace Google.Cloud.Bigtable.V2
         public static BigtableServiceApiClient Create(grpccore::Channel channel, BigtableServiceApiSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Bigtable.BigtableClient grpcClient = new Bigtable.BigtableClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="BigtableServiceApiClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="BigtableServiceApiSettings"/>.</param>
+        /// <returns>The created <see cref="BigtableServiceApiClient"/>.</returns>
+        public static BigtableServiceApiClient Create(grpccore::CallInvoker callInvoker, BigtableServiceApiSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Bigtable.BigtableClient grpcClient = new Bigtable.BigtableClient(callInvoker);
             return new BigtableServiceApiClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterManagerClient.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterManagerClient.cs
@@ -1148,7 +1148,19 @@ namespace Google.Cloud.Container.V1
         public static ClusterManagerClient Create(grpccore::Channel channel, ClusterManagerSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            ClusterManager.ClusterManagerClient grpcClient = new ClusterManager.ClusterManagerClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ClusterManagerClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="ClusterManagerSettings"/>.</param>
+        /// <returns>The created <see cref="ClusterManagerClient"/>.</returns>
+        public static ClusterManagerClient Create(grpccore::CallInvoker callInvoker, ClusterManagerSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            ClusterManager.ClusterManagerClient grpcClient = new ClusterManager.ClusterManagerClient(callInvoker);
             return new ClusterManagerClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ClusterControllerClient.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ClusterControllerClient.cs
@@ -511,7 +511,19 @@ namespace Google.Cloud.Dataproc.V1
         public static ClusterControllerClient Create(grpccore::Channel channel, ClusterControllerSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            ClusterController.ClusterControllerClient grpcClient = new ClusterController.ClusterControllerClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ClusterControllerClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="ClusterControllerSettings"/>.</param>
+        /// <returns>The created <see cref="ClusterControllerClient"/>.</returns>
+        public static ClusterControllerClient Create(grpccore::CallInvoker callInvoker, ClusterControllerSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            ClusterController.ClusterControllerClient grpcClient = new ClusterController.ClusterControllerClient(callInvoker);
             return new ClusterControllerClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/JobControllerClient.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/JobControllerClient.cs
@@ -422,7 +422,19 @@ namespace Google.Cloud.Dataproc.V1
         public static JobControllerClient Create(grpccore::Channel channel, JobControllerSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            JobController.JobControllerClient grpcClient = new JobController.JobControllerClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="JobControllerClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="JobControllerSettings"/>.</param>
+        /// <returns>The created <see cref="JobControllerClient"/>.</returns>
+        public static JobControllerClient Create(grpccore::CallInvoker callInvoker, JobControllerSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            JobController.JobControllerClient grpcClient = new JobController.JobControllerClient(callInvoker);
             return new JobControllerClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClient.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClient.cs
@@ -454,7 +454,19 @@ namespace Google.Cloud.Datastore.V1
         public static DatastoreClient Create(grpccore::Channel channel, DatastoreSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Datastore.DatastoreClient grpcClient = new Datastore.DatastoreClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="DatastoreClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="DatastoreSettings"/>.</param>
+        /// <returns>The created <see cref="DatastoreClient"/>.</returns>
+        public static DatastoreClient Create(grpccore::CallInvoker callInvoker, DatastoreSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Datastore.DatastoreClient grpcClient = new Datastore.DatastoreClient(callInvoker);
             return new DatastoreClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Controller2Client.cs
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Controller2Client.cs
@@ -333,7 +333,19 @@ namespace Google.Cloud.Debugger.V2
         public static Controller2Client Create(grpccore::Channel channel, Controller2Settings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Controller2.Controller2Client grpcClient = new Controller2.Controller2Client(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Controller2Client"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="Controller2Settings"/>.</param>
+        /// <returns>The created <see cref="Controller2Client"/>.</returns>
+        public static Controller2Client Create(grpccore::CallInvoker callInvoker, Controller2Settings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Controller2.Controller2Client grpcClient = new Controller2.Controller2Client(callInvoker);
             return new Controller2ClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Debugger2Client.cs
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Debugger2Client.cs
@@ -395,7 +395,19 @@ namespace Google.Cloud.Debugger.V2
         public static Debugger2Client Create(grpccore::Channel channel, Debugger2Settings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Debugger2.Debugger2Client grpcClient = new Debugger2.Debugger2Client(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Debugger2Client"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="Debugger2Settings"/>.</param>
+        /// <returns>The created <see cref="Debugger2Client"/>.</returns>
+        public static Debugger2Client Create(grpccore::CallInvoker callInvoker, Debugger2Settings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Debugger2.Debugger2Client grpcClient = new Debugger2.Debugger2Client(callInvoker);
             return new Debugger2ClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentsClient.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentsClient.cs
@@ -514,7 +514,19 @@ namespace Google.Cloud.Dialogflow.V2
         public static AgentsClient Create(grpccore::Channel channel, AgentsSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Agents.AgentsClient grpcClient = new Agents.AgentsClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="AgentsClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="AgentsSettings"/>.</param>
+        /// <returns>The created <see cref="AgentsClient"/>.</returns>
+        public static AgentsClient Create(grpccore::CallInvoker callInvoker, AgentsSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Agents.AgentsClient grpcClient = new Agents.AgentsClient(callInvoker);
             return new AgentsClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextsClient.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextsClient.cs
@@ -423,7 +423,19 @@ namespace Google.Cloud.Dialogflow.V2
         public static ContextsClient Create(grpccore::Channel channel, ContextsSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Contexts.ContextsClient grpcClient = new Contexts.ContextsClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ContextsClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="ContextsSettings"/>.</param>
+        /// <returns>The created <see cref="ContextsClient"/>.</returns>
+        public static ContextsClient Create(grpccore::CallInvoker callInvoker, ContextsSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Contexts.ContextsClient grpcClient = new Contexts.ContextsClient(callInvoker);
             return new ContextsClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypesClient.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypesClient.cs
@@ -655,7 +655,19 @@ namespace Google.Cloud.Dialogflow.V2
         public static EntityTypesClient Create(grpccore::Channel channel, EntityTypesSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            EntityTypes.EntityTypesClient grpcClient = new EntityTypes.EntityTypesClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="EntityTypesClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="EntityTypesSettings"/>.</param>
+        /// <returns>The created <see cref="EntityTypesClient"/>.</returns>
+        public static EntityTypesClient Create(grpccore::CallInvoker callInvoker, EntityTypesSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            EntityTypes.EntityTypesClient grpcClient = new EntityTypes.EntityTypesClient(callInvoker);
             return new EntityTypesClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentsClient.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentsClient.cs
@@ -498,7 +498,19 @@ namespace Google.Cloud.Dialogflow.V2
         public static IntentsClient Create(grpccore::Channel channel, IntentsSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Intents.IntentsClient grpcClient = new Intents.IntentsClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IntentsClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="IntentsSettings"/>.</param>
+        /// <returns>The created <see cref="IntentsClient"/>.</returns>
+        public static IntentsClient Create(grpccore::CallInvoker callInvoker, IntentsSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Intents.IntentsClient grpcClient = new Intents.IntentsClient(callInvoker);
             return new IntentsClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypesClient.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypesClient.cs
@@ -392,7 +392,19 @@ namespace Google.Cloud.Dialogflow.V2
         public static SessionEntityTypesClient Create(grpccore::Channel channel, SessionEntityTypesSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            SessionEntityTypes.SessionEntityTypesClient grpcClient = new SessionEntityTypes.SessionEntityTypesClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SessionEntityTypesClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="SessionEntityTypesSettings"/>.</param>
+        /// <returns>The created <see cref="SessionEntityTypesClient"/>.</returns>
+        public static SessionEntityTypesClient Create(grpccore::CallInvoker callInvoker, SessionEntityTypesSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            SessionEntityTypes.SessionEntityTypesClient grpcClient = new SessionEntityTypes.SessionEntityTypesClient(callInvoker);
             return new SessionEntityTypesClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionsClient.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionsClient.cs
@@ -290,7 +290,19 @@ namespace Google.Cloud.Dialogflow.V2
         public static SessionsClient Create(grpccore::Channel channel, SessionsSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Sessions.SessionsClient grpcClient = new Sessions.SessionsClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SessionsClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="SessionsSettings"/>.</param>
+        /// <returns>The created <see cref="SessionsClient"/>.</returns>
+        public static SessionsClient Create(grpccore::CallInvoker callInvoker, SessionsSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Sessions.SessionsClient grpcClient = new Sessions.SessionsClient(callInvoker);
             return new SessionsClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpServiceClient.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpServiceClient.cs
@@ -1006,7 +1006,19 @@ namespace Google.Cloud.Dlp.V2
         public static DlpServiceClient Create(grpccore::Channel channel, DlpServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            DlpService.DlpServiceClient grpcClient = new DlpService.DlpServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="DlpServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="DlpServiceSettings"/>.</param>
+        /// <returns>The created <see cref="DlpServiceClient"/>.</returns>
+        public static DlpServiceClient Create(grpccore::CallInvoker callInvoker, DlpServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            DlpService.DlpServiceClient grpcClient = new DlpService.DlpServiceClient(callInvoker);
             return new DlpServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceClient.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceClient.cs
@@ -301,7 +301,19 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         public static ErrorGroupServiceClient Create(grpccore::Channel channel, ErrorGroupServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            ErrorGroupService.ErrorGroupServiceClient grpcClient = new ErrorGroupService.ErrorGroupServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ErrorGroupServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="ErrorGroupServiceSettings"/>.</param>
+        /// <returns>The created <see cref="ErrorGroupServiceClient"/>.</returns>
+        public static ErrorGroupServiceClient Create(grpccore::CallInvoker callInvoker, ErrorGroupServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            ErrorGroupService.ErrorGroupServiceClient grpcClient = new ErrorGroupService.ErrorGroupServiceClient(callInvoker);
             return new ErrorGroupServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.cs
@@ -333,7 +333,19 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         public static ErrorStatsServiceClient Create(grpccore::Channel channel, ErrorStatsServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            ErrorStatsService.ErrorStatsServiceClient grpcClient = new ErrorStatsService.ErrorStatsServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ErrorStatsServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="ErrorStatsServiceSettings"/>.</param>
+        /// <returns>The created <see cref="ErrorStatsServiceClient"/>.</returns>
+        public static ErrorStatsServiceClient Create(grpccore::CallInvoker callInvoker, ErrorStatsServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            ErrorStatsService.ErrorStatsServiceClient grpcClient = new ErrorStatsService.ErrorStatsServiceClient(callInvoker);
             return new ErrorStatsServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceClient.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceClient.cs
@@ -270,7 +270,19 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         public static ReportErrorsServiceClient Create(grpccore::Channel channel, ReportErrorsServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            ReportErrorsService.ReportErrorsServiceClient grpcClient = new ReportErrorsService.ReportErrorsServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ReportErrorsServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="ReportErrorsServiceSettings"/>.</param>
+        /// <returns>The created <see cref="ReportErrorsServiceClient"/>.</returns>
+        public static ReportErrorsServiceClient Create(grpccore::CallInvoker callInvoker, ReportErrorsServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            ReportErrorsService.ReportErrorsServiceClient grpcClient = new ReportErrorsService.ReportErrorsServiceClient(callInvoker);
             return new ReportErrorsServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/FirestoreClient.cs
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/FirestoreClient.cs
@@ -619,7 +619,19 @@ namespace Google.Cloud.Firestore.V1Beta1
         public static FirestoreClient Create(grpccore::Channel channel, FirestoreSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Firestore.FirestoreClient grpcClient = new Firestore.FirestoreClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="FirestoreClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="FirestoreSettings"/>.</param>
+        /// <returns>The created <see cref="FirestoreClient"/>.</returns>
+        public static FirestoreClient Create(grpccore::CallInvoker callInvoker, FirestoreSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Firestore.FirestoreClient grpcClient = new Firestore.FirestoreClient(callInvoker);
             return new FirestoreClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/KeyManagementServiceClient.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/KeyManagementServiceClient.cs
@@ -817,7 +817,19 @@ namespace Google.Cloud.Kms.V1
         public static KeyManagementServiceClient Create(grpccore::Channel channel, KeyManagementServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            KeyManagementService.KeyManagementServiceClient grpcClient = new KeyManagementService.KeyManagementServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="KeyManagementServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="KeyManagementServiceSettings"/>.</param>
+        /// <returns>The created <see cref="KeyManagementServiceClient"/>.</returns>
+        public static KeyManagementServiceClient Create(grpccore::CallInvoker callInvoker, KeyManagementServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            KeyManagementService.KeyManagementServiceClient grpcClient = new KeyManagementService.KeyManagementServiceClient(callInvoker);
             return new KeyManagementServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.cs
@@ -425,7 +425,19 @@ namespace Google.Cloud.Language.V1
         public static LanguageServiceClient Create(grpccore::Channel channel, LanguageServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            LanguageService.LanguageServiceClient grpcClient = new LanguageService.LanguageServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="LanguageServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="LanguageServiceSettings"/>.</param>
+        /// <returns>The created <see cref="LanguageServiceClient"/>.</returns>
+        public static LanguageServiceClient Create(grpccore::CallInvoker callInvoker, LanguageServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            LanguageService.LanguageServiceClient grpcClient = new LanguageService.LanguageServiceClient(callInvoker);
             return new LanguageServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ConfigServiceV2Client.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ConfigServiceV2Client.cs
@@ -602,7 +602,19 @@ namespace Google.Cloud.Logging.V2
         public static ConfigServiceV2Client Create(grpccore::Channel channel, ConfigServiceV2Settings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            ConfigServiceV2.ConfigServiceV2Client grpcClient = new ConfigServiceV2.ConfigServiceV2Client(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ConfigServiceV2Client"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="ConfigServiceV2Settings"/>.</param>
+        /// <returns>The created <see cref="ConfigServiceV2Client"/>.</returns>
+        public static ConfigServiceV2Client Create(grpccore::CallInvoker callInvoker, ConfigServiceV2Settings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            ConfigServiceV2.ConfigServiceV2Client grpcClient = new ConfigServiceV2.ConfigServiceV2Client(callInvoker);
             return new ConfigServiceV2ClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingServiceV2Client.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingServiceV2Client.cs
@@ -447,7 +447,19 @@ namespace Google.Cloud.Logging.V2
         public static LoggingServiceV2Client Create(grpccore::Channel channel, LoggingServiceV2Settings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            LoggingServiceV2.LoggingServiceV2Client grpcClient = new LoggingServiceV2.LoggingServiceV2Client(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="LoggingServiceV2Client"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="LoggingServiceV2Settings"/>.</param>
+        /// <returns>The created <see cref="LoggingServiceV2Client"/>.</returns>
+        public static LoggingServiceV2Client Create(grpccore::CallInvoker callInvoker, LoggingServiceV2Settings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            LoggingServiceV2.LoggingServiceV2Client grpcClient = new LoggingServiceV2.LoggingServiceV2Client(callInvoker);
             return new LoggingServiceV2ClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/MetricsServiceV2Client.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/MetricsServiceV2Client.cs
@@ -406,7 +406,19 @@ namespace Google.Cloud.Logging.V2
         public static MetricsServiceV2Client Create(grpccore::Channel channel, MetricsServiceV2Settings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            MetricsServiceV2.MetricsServiceV2Client grpcClient = new MetricsServiceV2.MetricsServiceV2Client(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="MetricsServiceV2Client"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="MetricsServiceV2Settings"/>.</param>
+        /// <returns>The created <see cref="MetricsServiceV2Client"/>.</returns>
+        public static MetricsServiceV2Client Create(grpccore::CallInvoker callInvoker, MetricsServiceV2Settings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            MetricsServiceV2.MetricsServiceV2Client grpcClient = new MetricsServiceV2.MetricsServiceV2Client(callInvoker);
             return new MetricsServiceV2ClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertPolicyServiceClient.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertPolicyServiceClient.cs
@@ -398,7 +398,19 @@ namespace Google.Cloud.Monitoring.V3
         public static AlertPolicyServiceClient Create(grpccore::Channel channel, AlertPolicyServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            AlertPolicyService.AlertPolicyServiceClient grpcClient = new AlertPolicyService.AlertPolicyServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="AlertPolicyServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="AlertPolicyServiceSettings"/>.</param>
+        /// <returns>The created <see cref="AlertPolicyServiceClient"/>.</returns>
+        public static AlertPolicyServiceClient Create(grpccore::CallInvoker callInvoker, AlertPolicyServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            AlertPolicyService.AlertPolicyServiceClient grpcClient = new AlertPolicyService.AlertPolicyServiceClient(callInvoker);
             return new AlertPolicyServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceClient.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceClient.cs
@@ -431,7 +431,19 @@ namespace Google.Cloud.Monitoring.V3
         public static GroupServiceClient Create(grpccore::Channel channel, GroupServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            GroupService.GroupServiceClient grpcClient = new GroupService.GroupServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="GroupServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="GroupServiceSettings"/>.</param>
+        /// <returns>The created <see cref="GroupServiceClient"/>.</returns>
+        public static GroupServiceClient Create(grpccore::CallInvoker callInvoker, GroupServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            GroupService.GroupServiceClient grpcClient = new GroupService.GroupServiceClient(callInvoker);
             return new GroupServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceClient.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceClient.cs
@@ -492,7 +492,19 @@ namespace Google.Cloud.Monitoring.V3
         public static MetricServiceClient Create(grpccore::Channel channel, MetricServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            MetricService.MetricServiceClient grpcClient = new MetricService.MetricServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="MetricServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="MetricServiceSettings"/>.</param>
+        /// <returns>The created <see cref="MetricServiceClient"/>.</returns>
+        public static MetricServiceClient Create(grpccore::CallInvoker callInvoker, MetricServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            MetricService.MetricServiceClient grpcClient = new MetricService.MetricServiceClient(callInvoker);
             return new MetricServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationChannelServiceClient.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationChannelServiceClient.cs
@@ -460,7 +460,19 @@ namespace Google.Cloud.Monitoring.V3
         public static NotificationChannelServiceClient Create(grpccore::Channel channel, NotificationChannelServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            NotificationChannelService.NotificationChannelServiceClient grpcClient = new NotificationChannelService.NotificationChannelServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="NotificationChannelServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="NotificationChannelServiceSettings"/>.</param>
+        /// <returns>The created <see cref="NotificationChannelServiceClient"/>.</returns>
+        public static NotificationChannelServiceClient Create(grpccore::CallInvoker callInvoker, NotificationChannelServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            NotificationChannelService.NotificationChannelServiceClient grpcClient = new NotificationChannelService.NotificationChannelServiceClient(callInvoker);
             return new NotificationChannelServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeCheckServiceClient.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeCheckServiceClient.cs
@@ -429,7 +429,19 @@ namespace Google.Cloud.Monitoring.V3
         public static UptimeCheckServiceClient Create(grpccore::Channel channel, UptimeCheckServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            UptimeCheckService.UptimeCheckServiceClient grpcClient = new UptimeCheckService.UptimeCheckServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="UptimeCheckServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="UptimeCheckServiceSettings"/>.</param>
+        /// <returns>The created <see cref="UptimeCheckServiceClient"/>.</returns>
+        public static UptimeCheckServiceClient Create(grpccore::CallInvoker callInvoker, UptimeCheckServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            UptimeCheckService.UptimeCheckServiceClient grpcClient = new UptimeCheckService.UptimeCheckServiceClient(callInvoker);
             return new UptimeCheckServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/OsLoginServiceClient.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/OsLoginServiceClient.cs
@@ -432,7 +432,19 @@ namespace Google.Cloud.OsLogin.V1
         public static OsLoginServiceClient Create(grpccore::Channel channel, OsLoginServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            OsLoginService.OsLoginServiceClient grpcClient = new OsLoginService.OsLoginServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="OsLoginServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="OsLoginServiceSettings"/>.</param>
+        /// <returns>The created <see cref="OsLoginServiceClient"/>.</returns>
+        public static OsLoginServiceClient Create(grpccore::CallInvoker callInvoker, OsLoginServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            OsLoginService.OsLoginServiceClient grpcClient = new OsLoginService.OsLoginServiceClient(callInvoker);
             return new OsLoginServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/OsLoginServiceClient.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/OsLoginServiceClient.cs
@@ -432,7 +432,19 @@ namespace Google.Cloud.OsLogin.V1Beta
         public static OsLoginServiceClient Create(grpccore::Channel channel, OsLoginServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            OsLoginService.OsLoginServiceClient grpcClient = new OsLoginService.OsLoginServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="OsLoginServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="OsLoginServiceSettings"/>.</param>
+        /// <returns>The created <see cref="OsLoginServiceClient"/>.</returns>
+        public static OsLoginServiceClient Create(grpccore::CallInvoker callInvoker, OsLoginServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            OsLoginService.OsLoginServiceClient grpcClient = new OsLoginService.OsLoginServiceClient(callInvoker);
             return new OsLoginServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherServiceApiClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherServiceApiClient.cs
@@ -615,7 +615,19 @@ namespace Google.Cloud.PubSub.V1
         public static PublisherServiceApiClient Create(grpccore::Channel channel, PublisherServiceApiSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Publisher.PublisherClient grpcClient = new Publisher.PublisherClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="PublisherServiceApiClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="PublisherServiceApiSettings"/>.</param>
+        /// <returns>The created <see cref="PublisherServiceApiClient"/>.</returns>
+        public static PublisherServiceApiClient Create(grpccore::CallInvoker callInvoker, PublisherServiceApiSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Publisher.PublisherClient grpcClient = new Publisher.PublisherClient(callInvoker);
             return new PublisherServiceApiClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClient.cs
@@ -885,7 +885,19 @@ namespace Google.Cloud.PubSub.V1
         public static SubscriberServiceApiClient Create(grpccore::Channel channel, SubscriberServiceApiSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Subscriber.SubscriberClient grpcClient = new Subscriber.SubscriberClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SubscriberServiceApiClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="SubscriberServiceApiSettings"/>.</param>
+        /// <returns>The created <see cref="SubscriberServiceApiClient"/>.</returns>
+        public static SubscriberServiceApiClient Create(grpccore::CallInvoker callInvoker, SubscriberServiceApiSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Subscriber.SubscriberClient grpcClient = new Subscriber.SubscriberClient(callInvoker);
             return new SubscriberServiceApiClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisClient.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisClient.cs
@@ -456,7 +456,19 @@ namespace Google.Cloud.Redis.V1Beta1
         public static CloudRedisClient Create(grpccore::Channel channel, CloudRedisSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            CloudRedis.CloudRedisClient grpcClient = new CloudRedis.CloudRedisClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="CloudRedisClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="CloudRedisSettings"/>.</param>
+        /// <returns>The created <see cref="CloudRedisClient"/>.</returns>
+        public static CloudRedisClient Create(grpccore::CallInvoker callInvoker, CloudRedisSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            CloudRedis.CloudRedisClient grpcClient = new CloudRedis.CloudRedisClient(callInvoker);
             return new CloudRedisClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.cs
@@ -564,7 +564,19 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         public static DatabaseAdminClient Create(grpccore::Channel channel, DatabaseAdminSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            DatabaseAdmin.DatabaseAdminClient grpcClient = new DatabaseAdmin.DatabaseAdminClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="DatabaseAdminClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="DatabaseAdminSettings"/>.</param>
+        /// <returns>The created <see cref="DatabaseAdminClient"/>.</returns>
+        public static DatabaseAdminClient Create(grpccore::CallInvoker callInvoker, DatabaseAdminSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            DatabaseAdmin.DatabaseAdminClient grpcClient = new DatabaseAdmin.DatabaseAdminClient(callInvoker);
             return new DatabaseAdminClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClient.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClient.cs
@@ -595,7 +595,19 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         public static InstanceAdminClient Create(grpccore::Channel channel, InstanceAdminSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            InstanceAdmin.InstanceAdminClient grpcClient = new InstanceAdmin.InstanceAdminClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="InstanceAdminClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="InstanceAdminSettings"/>.</param>
+        /// <returns>The created <see cref="InstanceAdminClient"/>.</returns>
+        public static InstanceAdminClient Create(grpccore::CallInvoker callInvoker, InstanceAdminSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            InstanceAdmin.InstanceAdminClient grpcClient = new InstanceAdmin.InstanceAdminClient(callInvoker);
             return new InstanceAdminClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.cs
@@ -655,7 +655,19 @@ namespace Google.Cloud.Spanner.V1
         public static SpannerClient Create(grpccore::Channel channel, SpannerSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Spanner.SpannerClient grpcClient = new Spanner.SpannerClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SpannerClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="SpannerSettings"/>.</param>
+        /// <returns>The created <see cref="SpannerClient"/>.</returns>
+        public static SpannerClient Create(grpccore::CallInvoker callInvoker, SpannerSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Spanner.SpannerClient grpcClient = new Spanner.SpannerClient(callInvoker);
             return new SpannerClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.cs
@@ -344,7 +344,19 @@ namespace Google.Cloud.Speech.V1
         public static SpeechClient Create(grpccore::Channel channel, SpeechSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Speech.SpeechClient grpcClient = new Speech.SpeechClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SpeechClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="SpeechSettings"/>.</param>
+        /// <returns>The created <see cref="SpeechClient"/>.</returns>
+        public static SpeechClient Create(grpccore::CallInvoker callInvoker, SpeechSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Speech.SpeechClient grpcClient = new Speech.SpeechClient(callInvoker);
             return new SpeechClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/SpeechClient.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/SpeechClient.cs
@@ -344,7 +344,19 @@ namespace Google.Cloud.Speech.V1P1Beta1
         public static SpeechClient Create(grpccore::Channel channel, SpeechSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Speech.SpeechClient grpcClient = new Speech.SpeechClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SpeechClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="SpeechSettings"/>.</param>
+        /// <returns>The created <see cref="SpeechClient"/>.</returns>
+        public static SpeechClient Create(grpccore::CallInvoker callInvoker, SpeechSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Speech.SpeechClient grpcClient = new Speech.SpeechClient(callInvoker);
             return new SpeechClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Tasks.V2Beta2/Google.Cloud.Tasks.V2Beta2/CloudTasksClient.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta2/Google.Cloud.Tasks.V2Beta2/CloudTasksClient.cs
@@ -848,7 +848,19 @@ namespace Google.Cloud.Tasks.V2Beta2
         public static CloudTasksClient Create(grpccore::Channel channel, CloudTasksSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            CloudTasks.CloudTasksClient grpcClient = new CloudTasks.CloudTasksClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="CloudTasksClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="CloudTasksSettings"/>.</param>
+        /// <returns>The created <see cref="CloudTasksClient"/>.</returns>
+        public static CloudTasksClient Create(grpccore::CallInvoker callInvoker, CloudTasksSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            CloudTasks.CloudTasksClient grpcClient = new CloudTasks.CloudTasksClient(callInvoker);
             return new CloudTasksClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/TextToSpeechClient.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/TextToSpeechClient.cs
@@ -301,7 +301,19 @@ namespace Google.Cloud.TextToSpeech.V1
         public static TextToSpeechClient Create(grpccore::Channel channel, TextToSpeechSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            TextToSpeech.TextToSpeechClient grpcClient = new TextToSpeech.TextToSpeechClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="TextToSpeechClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="TextToSpeechSettings"/>.</param>
+        /// <returns>The created <see cref="TextToSpeechClient"/>.</returns>
+        public static TextToSpeechClient Create(grpccore::CallInvoker callInvoker, TextToSpeechSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            TextToSpeech.TextToSpeechClient grpcClient = new TextToSpeech.TextToSpeechClient(callInvoker);
             return new TextToSpeechClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/TraceServiceClient.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/TraceServiceClient.cs
@@ -336,7 +336,19 @@ namespace Google.Cloud.Trace.V1
         public static TraceServiceClient Create(grpccore::Channel channel, TraceServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            TraceService.TraceServiceClient grpcClient = new TraceService.TraceServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="TraceServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="TraceServiceSettings"/>.</param>
+        /// <returns>The created <see cref="TraceServiceClient"/>.</returns>
+        public static TraceServiceClient Create(grpccore::CallInvoker callInvoker, TraceServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            TraceService.TraceServiceClient grpcClient = new TraceService.TraceServiceClient(callInvoker);
             return new TraceServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceServiceClient.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceServiceClient.cs
@@ -303,7 +303,19 @@ namespace Google.Cloud.Trace.V2
         public static TraceServiceClient Create(grpccore::Channel channel, TraceServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            TraceService.TraceServiceClient grpcClient = new TraceService.TraceServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="TraceServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="TraceServiceSettings"/>.</param>
+        /// <returns>The created <see cref="TraceServiceClient"/>.</returns>
+        public static TraceServiceClient Create(grpccore::CallInvoker callInvoker, TraceServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            TraceService.TraceServiceClient grpcClient = new TraceService.TraceServiceClient(callInvoker);
             return new TraceServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/VideoIntelligenceServiceClient.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/VideoIntelligenceServiceClient.cs
@@ -294,7 +294,19 @@ namespace Google.Cloud.VideoIntelligence.V1
         public static VideoIntelligenceServiceClient Create(grpccore::Channel channel, VideoIntelligenceServiceSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            VideoIntelligenceService.VideoIntelligenceServiceClient grpcClient = new VideoIntelligenceService.VideoIntelligenceServiceClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="VideoIntelligenceServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="VideoIntelligenceServiceSettings"/>.</param>
+        /// <returns>The created <see cref="VideoIntelligenceServiceClient"/>.</returns>
+        public static VideoIntelligenceServiceClient Create(grpccore::CallInvoker callInvoker, VideoIntelligenceServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            VideoIntelligenceService.VideoIntelligenceServiceClient grpcClient = new VideoIntelligenceService.VideoIntelligenceServiceClient(callInvoker);
             return new VideoIntelligenceServiceClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.cs
@@ -326,7 +326,19 @@ namespace Google.Cloud.Vision.V1
         public static ImageAnnotatorClient Create(grpccore::Channel channel, ImageAnnotatorSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            ImageAnnotator.ImageAnnotatorClient grpcClient = new ImageAnnotator.ImageAnnotatorClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ImageAnnotatorClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="ImageAnnotatorSettings"/>.</param>
+        /// <returns>The created <see cref="ImageAnnotatorClient"/>.</returns>
+        public static ImageAnnotatorClient Create(grpccore::CallInvoker callInvoker, ImageAnnotatorSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            ImageAnnotator.ImageAnnotatorClient grpcClient = new ImageAnnotator.ImageAnnotatorClient(callInvoker);
             return new ImageAnnotatorClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1/ImageAnnotatorClient.cs
+++ b/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1/ImageAnnotatorClient.cs
@@ -272,7 +272,19 @@ namespace Google.Cloud.Vision.V1P1Beta1
         public static ImageAnnotatorClient Create(grpccore::Channel channel, ImageAnnotatorSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            ImageAnnotator.ImageAnnotatorClient grpcClient = new ImageAnnotator.ImageAnnotatorClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ImageAnnotatorClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="ImageAnnotatorSettings"/>.</param>
+        /// <returns>The created <see cref="ImageAnnotatorClient"/>.</returns>
+        public static ImageAnnotatorClient Create(grpccore::CallInvoker callInvoker, ImageAnnotatorSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            ImageAnnotator.ImageAnnotatorClient grpcClient = new ImageAnnotator.ImageAnnotatorClient(callInvoker);
             return new ImageAnnotatorClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1/ImageAnnotatorClient.cs
+++ b/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1/ImageAnnotatorClient.cs
@@ -326,7 +326,19 @@ namespace Google.Cloud.Vision.V1P2Beta1
         public static ImageAnnotatorClient Create(grpccore::Channel channel, ImageAnnotatorSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            ImageAnnotator.ImageAnnotatorClient grpcClient = new ImageAnnotator.ImageAnnotatorClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ImageAnnotatorClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="ImageAnnotatorSettings"/>.</param>
+        /// <returns>The created <see cref="ImageAnnotatorClient"/>.</returns>
+        public static ImageAnnotatorClient Create(grpccore::CallInvoker callInvoker, ImageAnnotatorSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            ImageAnnotator.ImageAnnotatorClient grpcClient = new ImageAnnotator.ImageAnnotatorClient(callInvoker);
             return new ImageAnnotatorClientImpl(grpcClient, settings);
         }
 

--- a/apis/Google.LongRunning/Google.LongRunning/OperationsClient.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/OperationsClient.cs
@@ -361,7 +361,19 @@ namespace Google.LongRunning
         public static OperationsClient Create(grpccore::Channel channel, OperationsSettings settings = null)
         {
             gax::GaxPreconditions.CheckNotNull(channel, nameof(channel));
-            Operations.OperationsClient grpcClient = new Operations.OperationsClient(channel);
+            return Create(new grpccore::DefaultCallInvoker(channel), settings);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="OperationsClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.</param>
+        /// <param name="settings">Optional <see cref="OperationsSettings"/>.</param>
+        /// <returns>The created <see cref="OperationsClient"/>.</returns>
+        public static OperationsClient Create(grpccore::CallInvoker callInvoker, OperationsSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            Operations.OperationsClient grpcClient = new Operations.OperationsClient(callInvoker);
             return new OperationsClientImpl(grpcClient, settings);
         }
 


### PR DESCRIPTION
This PR *only* contains those changes. A future PR will contain commits for other API changes.
A later PR (currently scheduled for August 2nd) will contain another change within the new overload, to use the Interceptor property from GAX gRPC 2.5.0, when that's released.