### PR TITLE
Prepare for BigQuery 1.3.0-beta03 release

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0-beta02</Version>
+    <Version>1.3.0-beta03</Version>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,6 +1,6 @@
 # Version history
 
-# 1.3.0-beta02, 2018-07-18
+# 1.3.0-beta03, 2018-08-01
 
 New features since 1.2.0:
 

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -35,7 +35,7 @@
     "id": "Google.Cloud.BigQuery.V2",
     "productName": "Google BigQuery",
     "productUrl": "https://cloud.google.com/bigquery/",
-    "version": "1.3.0-beta02",
+    "version": "1.3.0-beta03",
     "type": "rest",
     "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
     "dependencies": {


### PR DESCRIPTION
The only change is for SchemaUpdateOptions to be supported in load
jobs.