### PR TITLE
Generate datasets using date/time instead of GUIDs

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/BigQuerySnippetFixture.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/BigQuerySnippetFixture.cs
@@ -89,7 +89,7 @@ namespace Google.Cloud.BigQuery.V2.Snippets
         private string CreateHistoryRow(string player, int score, int level, string gameStartedIso) =>
             $"{player},{score},{level},{gameStartedIso}";
 
-        internal string GenerateDatasetId() => IdGenerator.FromGuid(prefix: DatasetPrefix, separator: "_");
+        internal string GenerateDatasetId() => IdGenerator.FromDateTime(prefix: DatasetPrefix);
 
         internal string GenerateTableId() => IdGenerator.FromGuid(separator: "_");
 


### PR DESCRIPTION
(This makes it much easier to work out which dataset was created for
which test.)