### PR TITLE
Hard code the path the the bash we want to use.

### DIFF
--- a/.kokoro/build.bat
+++ b/.kokoro/build.bat
@@ -1,4 +1,4 @@
 :: See documentation in type-shell-output.bat
 
 cd /d %~dp0
-bash build.sh
+"C:\Program Files\Git\bin\bash.exe" build.sh

--- a/.kokoro/builddocs.bat
+++ b/.kokoro/builddocs.bat
@@ -1,4 +1,4 @@
 :: See documentation in type-shell-output.bat
 
 cd /d %~dp0
-bash builddocs.sh
+"C:\Program Files\Git\bin\bash.exe" builddocs.sh

--- a/.kokoro/cleantestdata.bat
+++ b/.kokoro/cleantestdata.bat
@@ -1,4 +1,4 @@
 :: See documentation in type-shell-output.bat
 
 cd /d %~dp0
-bash cleantestdata.sh
+"C:\Program Files\Git\bin\bash.exe" cleantestdata.sh

--- a/.kokoro/release.bat
+++ b/.kokoro/release.bat
@@ -1,4 +1,4 @@
 :: See documentation in type-shell-output.bat
 
 cd /d %~dp0
-bash release.sh
+"C:\Program Files\Git\bin\bash.exe" release.sh

--- a/.kokoro/runintegrationtests.bat
+++ b/.kokoro/runintegrationtests.bat
@@ -1,4 +1,4 @@
 :: See documentation in type-shell-output.bat
 
 cd /d %~dp0
-bash runintegrationtests.sh
+"C:\Program Files\Git\bin\bash.exe" runintegrationtests.sh


### PR DESCRIPTION
The jobs seem to do some set up starting with cygwin that ignore the PATH.