### PR TITLE
[Diagnostics ASP.Net] Fixing flakiness in a snippet.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/ErrorReportingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/ErrorReportingSnippets.cs
@@ -84,7 +84,7 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
 
             var errorEvent = s_polling.GetEvents(_startTime, _testId, 1).Single();
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(
-                errorEvent, _testId, "DoSomething", s_expectedStatusCode);
+                errorEvent, _testId, nameof(HomeController.CatchesAndLogsExceptions), s_expectedStatusCode);
         }
 
         public void Dispose()


### PR DESCRIPTION
Checking for the "first level method" and not for the nested method that actually throws the exception because for some reason (that I haven't found) the StackTrace when running in Jenkins doesn't go "deep".