### PR TITLE
Fix flaky snippet

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/ErrorReportingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/ErrorReportingSnippets.cs
@@ -20,6 +20,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Web;
 using System.Web.Http;
@@ -178,6 +179,10 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
                 return "Something done succesfully.";
             }
 
+            // This is normally not required, but ensures that "DoSomething" is in the stack
+            // trace. The method is otherwise inlined by the JIT compiler for release builds in
+            // some environments.
+            [MethodImpl(MethodImplOptions.NoInlining)]
             private void DoSomething(string id)
             {
                 throw new Exception(id);


### PR DESCRIPTION
The comment wording could definitely be tweaked. It's not clear
whether we should try to give guidance about whether to put the
attribute on or not - the "right choice" is very much customer-based.

(This is an alternative to #2403.)