### PR TITLE
Update docfx to 2.38.1

### DIFF
--- a/toolversions.sh
+++ b/toolversions.sh
@@ -6,7 +6,7 @@
 declare -r REPO_ROOT=$(realpath $(dirname ${BASH_SOURCE}))
 declare -r TOOL_PACKAGES=$REPO_ROOT/packages
 
-declare -r DOCFX_VERSION=2.32.1
+declare -r DOCFX_VERSION=2.38.1
 declare -r DOTCOVER_VERSION=2017.1.20170613.162720 
 declare -r REPORTGENERATOR_VERSION=2.4.5.0
 declare -r PROTOC_VERSION=3.6.0


### PR DESCRIPTION
This is required to work with VS15.8, but is not sufficient: a
workaround is required, as specified in either of these issues:

- https://github.com/dotnet/docfx/issues/3225
- https://github.com/dotnet/docfx/issues/3231

The first workaround can be applied locally in the
packages/docfx.2.38.1 directory which is kept around.

This should still work with VS15.7 though, so is strictly better
than the current situation.