### PR TITLE
Add a sample for connecting to the Datastore emulator

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreDbSnippets.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreDbSnippets.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 using Google.Cloud.ClientTesting;
 using Google.Protobuf;
+using Grpc.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -1157,5 +1158,42 @@ namespace Google.Cloud.Datastore.V1.Snippets
             };
             return db.Insert(entity);
         }
+
+        // Sample: EmulatorInit
+        private const string EmulatorHostVariable = "DATASTORE_EMULATOR_HOST";
+        private const string ProjectIdVariable = "DATASTORE_PROJECT_ID";
+
+        /// <summary>
+        /// Creates a <see cref="DatastoreDb"/>, using environment variables to support
+        /// the Datastore Emulator if they have been set.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If the DATASTORE_EMULATOR_HOST environment variable is set and not empty,
+        /// this method will use the value to connect to the emulator. Otherwise, the default
+        /// endpoint (and credentials) will be used.
+        /// </para>
+        /// <para>
+        /// If the DATASTORE_PROJECT_ID environment variable is set and not empty, this
+        /// overrides the value of <paramref name="projectId"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="projectId">The project ID to use, unless overridden by DATASTORE_PROJECT_ID</param>
+        /// <param name="namespaceId">The namespace ID to use in operations requiring a partition.</param>
+        /// <returns>A <see cref="DatastoreDb"/> connected to either an emulator or production servers.</returns>
+        public static DatastoreDb CreateDatastoreDb(string projectId, string namespaceId = "")
+        {
+            string emulatorHost = Environment.GetEnvironmentVariable(EmulatorHostVariable);
+            string projectIdOverride = Environment.GetEnvironmentVariable(ProjectIdVariable);
+            if (!string.IsNullOrEmpty(projectIdOverride))
+            {
+                projectId = projectIdOverride;
+            }
+            DatastoreClient client = string.IsNullOrEmpty(emulatorHost)
+                ? DatastoreClient.Create()
+                : DatastoreClient.Create(new Channel(emulatorHost, ChannelCredentials.Insecure));
+            return DatastoreDb.Create(projectId, namespaceId, client);
+        }
+        // End sample
     }
 }

--- a/apis/Google.Cloud.Datastore.V1/docs/index.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/index.md
@@ -23,15 +23,33 @@ Several custom conversions, additional constructors,
 factory methods (particularly on [Filter](obj/api/Google.Cloud.Datastore.V1.Filter.yml)
 are provided to simplify working with the protobuf messages.
 
+# Using the Datastore Emulator
+
+This package does not automatically connect to an emulator via
+environment variables. However, it is reasonably simple do so. If
+you wish to automatically connect to an emulator, simply include the
+following method in your code, and call that instead of
+`DatastoreDb.Create`.
+
+{{sample:DatastoreDb.EmulatorInit}}
+
+Note that if you use this technique for automated testing with large
+amounts of data, you may wish to write an alternative method that
+*only* connects to the emulator and fails if the emulator has not
+been configured. That avoids accidentally connecting to the
+production Datastore service and potentially incurring large bills
+due to forgetting to set an environment variable.
+
 # Sample code
 
-Inserting data:
+## Inserting data
 
 {{sample:DatastoreDb.InsertOverview}}
 
-Querying data:
+## Querying data
 
 {{sample:DatastoreDb.QueryOverview}}
 
 Lots more samples:
 [github.com/GoogleCloudPlatform/dotnet-docs-samples](https://github.com/GoogleCloudPlatform/dotnet-docs-samples/tree/master/datastore/api)
+


### PR DESCRIPTION
Fixes #2419 as far as we wish to for now. (In terms of changes for
this repo; we'll probably want to ask the emulator page to be
updated to link to our docs too.)