### PR TITLE
Stop skipping a storage test

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/KmsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/KmsTest.cs
@@ -191,7 +191,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             TestHelpers.ValidateData(bucketName, objectName, data);
         }
 
-        [SkippableFact(Skip = "See https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/2412")]
+        [SkippableFact]
         public void UploadObject_BucketHasDefaultKmsKey_UploadWithNoSpecifiedKey_DownloadWithClientWithCsek()
         {
             _fixture.SkipIf(SkipTests);


### PR DESCRIPTION
This should now pass, as server fixes have been applied