### PR TITLE
[Bigtable] Pass appProfileId to request from client

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Program.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Program.cs
@@ -472,7 +472,7 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
 
                 // Replace the body with something like this:
                 //------------------------------------------------------------------------
-                //  if (request.AppProfileId == null)
+                //  if (_appProfileId != null && request.AppProfileId.Length == 0)
                 //  {
                 //      request.AppProfileId = _appProfileId;
                 //  }
@@ -493,7 +493,7 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
                     resultExpression = underlyingMethod.Invoke(node.ParameterList.AsArguments());
                 }
                 node = node.WithBodySafe(Block(
-                    If(appProfileIdProperty.EqualTo(Null()),
+                    If(AppProfileIdFieldName.NotEqualTo(Null()).And(appProfileIdProperty.IsEmpty()),
                         appProfileIdProperty.AssignFrom(AppProfileIdFieldName).ToStatement()),
                     ReturnStatement(resultExpression)));
 

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Program.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Program.cs
@@ -492,8 +492,10 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
                     var underlyingMethod = IdentifierName(GetUnderlyingClientMethodName).Invoke().Member(node.Identifier);
                     resultExpression = underlyingMethod.Invoke(node.ParameterList.AsArguments());
                 }
+
                 node = node.WithBodySafe(Block(
-                    If(AppProfileIdFieldName.NotEqualTo(Null()).And(appProfileIdProperty.IsEmpty()),
+                    If(IdentifierName(AppProfileIdFieldName).NotEqualTo(Null())
+                            .And(appProfileIdProperty.Member("Length").EqualTo(Zero())),
                         appProfileIdProperty.AssignFrom(AppProfileIdFieldName).ToStatement()),
                     ReturnStatement(resultExpression)));
 

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/RoslynHelpers.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/RoslynHelpers.cs
@@ -31,6 +31,9 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
         internal static IEnumerable<ArgumentSyntax> AddArgument(this IEnumerable<ArgumentSyntax> arguments, ExpressionSyntax additionalArgument) =>
             arguments.Concat(Enumerable.Repeat(SyntaxFactory.Argument(additionalArgument), 1));
 
+        internal static BinaryExpressionSyntax And(this ExpressionSyntax left, ExpressionSyntax right) =>
+            BinaryExpression(SyntaxKind.LogicalAndExpression, left, right);
+
         internal static ArgumentSyntax Argument(SyntaxToken identifier) =>
             SyntaxFactory.Argument(IdentifierName(identifier));
 
@@ -48,12 +51,6 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
 
         internal static BinaryExpressionSyntax EqualTo(this ExpressionSyntax left, ExpressionSyntax right) =>
             BinaryExpression(SyntaxKind.EqualsExpression, left, right);
-
-        internal static BinaryExpressionSyntax NotEqualTo(this string left, ExpressionSyntax right) =>
-            BinaryExpression(SyntaxKind.NotEqualsExpression, left.ToExpression(), right);
-
-        internal static BinaryExpressionSyntax And(this ExpressionSyntax left, ExpressionSyntax right) =>
-            BinaryExpression(SyntaxKind.LogicalAndExpression, left, right);
 
         internal static IfStatementSyntax If(ExpressionSyntax condition, params StatementSyntax[] statements) =>
             IfStatement(condition, Block(statements));
@@ -94,17 +91,11 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
         internal static ObjectCreationExpressionSyntax New(this TypeSyntax type, IEnumerable<ArgumentSyntax> arguments) =>
             ObjectCreationExpression(type, ArgumentList(SeparatedList(arguments)), initializer: null);
 
+        internal static BinaryExpressionSyntax NotEqualTo(this ExpressionSyntax left, ExpressionSyntax right) =>
+            BinaryExpression(SyntaxKind.NotEqualsExpression, left, right);
+
         internal static LiteralExpressionSyntax Null() =>
             LiteralExpression(SyntaxKind.NullLiteralExpression);
-
-        internal static ExpressionSyntax Zero() =>
-            0.ToExpression();
-
-        internal static ExpressionSyntax IsEmpty(this ExpressionSyntax value) =>
-            value.Member("Length").EqualTo(Zero());
-
-        internal static ExpressionSyntax ToExpression<T>(this T a) =>
-            ParseExpression(a.ToString());
 
         internal static AliasQualifiedNameSyntax Of(this AliasQualifiedNameSyntax typeName, params TypeSyntax[] typeArguments) =>
             typeName.WithName((SimpleNameSyntax)typeName.Name.Of(typeArguments));
@@ -151,5 +142,8 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
 
         internal static MethodDeclarationSyntax WithBodySafe(this MethodDeclarationSyntax method, BlockSyntax body) =>
             method.WithExpressionBody(null).WithSemicolonToken(Token(SyntaxKind.None)).WithBody(body);
+
+        internal static LiteralExpressionSyntax Zero() =>
+            LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0));
     }
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/RoslynHelpers.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/RoslynHelpers.cs
@@ -49,6 +49,12 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
         internal static BinaryExpressionSyntax EqualTo(this ExpressionSyntax left, ExpressionSyntax right) =>
             BinaryExpression(SyntaxKind.EqualsExpression, left, right);
 
+        internal static BinaryExpressionSyntax NotEqualTo(this string left, ExpressionSyntax right) =>
+            BinaryExpression(SyntaxKind.NotEqualsExpression, left.ToExpression(), right);
+
+        internal static BinaryExpressionSyntax And(this ExpressionSyntax left, ExpressionSyntax right) =>
+            BinaryExpression(SyntaxKind.LogicalAndExpression, left, right);
+
         internal static IfStatementSyntax If(ExpressionSyntax condition, params StatementSyntax[] statements) =>
             IfStatement(condition, Block(statements));
 
@@ -90,6 +96,15 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
 
         internal static LiteralExpressionSyntax Null() =>
             LiteralExpression(SyntaxKind.NullLiteralExpression);
+
+        internal static ExpressionSyntax Zero() =>
+            0.ToExpression();
+
+        internal static ExpressionSyntax IsEmpty(this ExpressionSyntax value) =>
+            value.Member("Length").EqualTo(Zero());
+
+        internal static ExpressionSyntax ToExpression<T>(this T a) =>
+            ParseExpression(a.ToString());
 
         internal static AliasQualifiedNameSyntax Of(this AliasQualifiedNameSyntax typeName, params TypeSyntax[] typeArguments) =>
             typeName.WithName((SimpleNameSyntax)typeName.Name.Of(typeArguments));

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableClientTest.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableClientTest.cs
@@ -76,30 +76,43 @@ namespace Google.Cloud.Bigtable.V2.Tests
         [Fact]
         public async Task CheckAndMutateRow_AppProfileId_From_Client()
         {
-            var expectedRequest = new CheckAndMutateRowRequest
+            var appProfileId_on_client = "csharp";
+            var appProfileId_on_request = "other";
+            var request = new CheckAndMutateRowRequest
             {
                 TableNameAsTableName = new TableName("project", "instance", "table"),
                 RowKey = ByteString.CopyFromUtf8("abc"),
                 FalseMutations = {new Mutation()},
                 TrueMutations = {new Mutation()}
             };
-            var expectedRequest2 = new CheckAndMutateRowRequest(expectedRequest);
-            Assert.Empty(expectedRequest.AppProfileId);
-            var appProfileId = "csharp";
+            var request2 = new CheckAndMutateRowRequest(request);
+            var request_with_appProfileId = new CheckAndMutateRowRequest(request) { AppProfileId = appProfileId_on_request };
             Mock<BigtableServiceApiClient> mockGrpcClient =
                 new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
             mockGrpcClient
-                .Setup(x => x.CheckAndMutateRow(expectedRequest, It.IsAny<CallSettings>()))
+                .Setup(x => x.CheckAndMutateRow(request, It.IsAny<CallSettings>()))
                 .Returns(new CheckAndMutateRowResponse());
             mockGrpcClient
-                .Setup(x => x.CheckAndMutateRowAsync(expectedRequest2, It.IsAny<CallSettings>()))
+                .Setup(x => x.CheckAndMutateRow(request_with_appProfileId, It.IsAny<CallSettings>()))
+                .Returns(new CheckAndMutateRowResponse());
+            mockGrpcClient
+                .Setup(x => x.CheckAndMutateRowAsync(request, It.IsAny<CallSettings>()))
+                .ReturnsAsync(new CheckAndMutateRowResponse());
+            mockGrpcClient
+                .Setup(x => x.CheckAndMutateRowAsync(request_with_appProfileId, It.IsAny<CallSettings>()))
                 .ReturnsAsync(new CheckAndMutateRowResponse());
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId, BigtableServiceApiSettings.GetDefault());
-            client.CheckAndMutateRow(expectedRequest);
-            await client.CheckAndMutateRowAsync(expectedRequest2);
-            Assert.Equal(appProfileId, expectedRequest.AppProfileId);
-            Assert.Equal(appProfileId, expectedRequest2.AppProfileId);
+                new[] { mockGrpcClient.Object }, appProfileId_on_client, BigtableServiceApiSettings.GetDefault());
+            client.CheckAndMutateRow(request);
+            await client.CheckAndMutateRowAsync(request2);
+            Assert.Equal(appProfileId_on_client, request.AppProfileId);
+            Assert.Equal(appProfileId_on_client, request2.AppProfileId);
+            client.CheckAndMutateRow(request_with_appProfileId);
+            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
+            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
+            await client.CheckAndMutateRowAsync(request_with_appProfileId);
+            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
+            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
         }
 
         [Fact]
@@ -214,29 +227,40 @@ namespace Google.Cloud.Bigtable.V2.Tests
         }
 
         [Fact]
-        public async Task MutateRow_AppProfileId_from_client()
+        public async Task MutateRow_AppProfileId_From_client()
         {
-            var expectedRequest = new MutateRowRequest
+            var appProfileId_on_client = "csharp";
+            var appProfileId_on_request = "other";
+            var request = new MutateRowRequest
             {
                 Mutations = {new Mutation()},
                 RowKey = ByteString.CopyFromUtf8("abc"),
                 TableNameAsTableName = new TableName("project", "instance", "table"),
             };
-            var expectedRequest2 = new MutateRowRequest(expectedRequest);
-            Assert.Empty(expectedRequest.AppProfileId);
-            var appProfileId = "csharp";
+            var request2 = new MutateRowRequest(request);
+            var request_with_appProfileId = new MutateRowRequest(request) { AppProfileId = appProfileId_on_request };
             Mock<BigtableServiceApiClient> mockGrpcClient =
                 new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
-            mockGrpcClient.Setup(x => x.MutateRow(expectedRequest, It.IsAny<CallSettings>()))
+            mockGrpcClient.Setup(x => x.MutateRow(request, It.IsAny<CallSettings>()))
                 .Returns(new MutateRowResponse());
-            mockGrpcClient.Setup(x => x.MutateRowAsync(expectedRequest2, It.IsAny<CallSettings>()))
-                .ReturnsAsync(new MutateRowResponse());    
+            mockGrpcClient.Setup(x => x.MutateRow(request_with_appProfileId, It.IsAny<CallSettings>()))
+                .Returns(new MutateRowResponse());
+            mockGrpcClient.Setup(x => x.MutateRowAsync(request, It.IsAny<CallSettings>()))
+                .ReturnsAsync(new MutateRowResponse());
+            mockGrpcClient.Setup(x => x.MutateRowAsync(request_with_appProfileId, It.IsAny<CallSettings>()))
+                .ReturnsAsync(new MutateRowResponse());
             BigtableClient client = new BigtableClientImpl(
-                new[] {mockGrpcClient.Object}, appProfileId, BigtableServiceApiSettings.GetDefault());
-            client.MutateRow(expectedRequest);
-            await client.MutateRowAsync(expectedRequest2);
-            Assert.Equal(appProfileId, expectedRequest.AppProfileId);
-            Assert.Equal(appProfileId, expectedRequest2.AppProfileId);
+                new[] {mockGrpcClient.Object}, appProfileId_on_client, BigtableServiceApiSettings.GetDefault());
+            client.MutateRow(request);
+            await client.MutateRowAsync(request2);
+            Assert.Equal(appProfileId_on_client, request.AppProfileId);
+            Assert.Equal(appProfileId_on_client, request2.AppProfileId);
+            client.MutateRow(request_with_appProfileId);
+            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
+            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
+            await client.MutateRowAsync(request_with_appProfileId);
+            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
+            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
         }
 
         [Fact]
@@ -305,23 +329,29 @@ namespace Google.Cloud.Bigtable.V2.Tests
         }
 
         [Fact]
-        public void MutateRows_AppProfileId_from_client()
+        public void MutateRows_AppProfileId_From_client()
         {
-            var expectedRequest = new MutateRowsRequest
+            var appProfileId_on_client = "csharp";
+            var appProfileId_on_request = "other";
+            var request = new MutateRowsRequest
             {
                 Entries ={Mutations.CreateEntry("abc", new Mutation())},
                 TableNameAsTableName = new TableName("project", "instance", "table")
             };
-            Assert.Empty(expectedRequest.AppProfileId);
-            var appProfileId = "csharp";
+            var request_with_appProfileId = new MutateRowsRequest(request) { AppProfileId = appProfileId_on_request };
             Mock<BigtableServiceApiClient> mockGrpcClient =
                 new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
-            mockGrpcClient.Setup(x => x.MutateRows(expectedRequest, It.IsAny<CallSettings>()))
+            mockGrpcClient.Setup(x => x.MutateRows(request, It.IsAny<CallSettings>()))
+                .Returns(new BigtableServiceApiClientImpl.MutateRowsStreamImpl(null));
+            mockGrpcClient.Setup(x => x.MutateRows(request_with_appProfileId, It.IsAny<CallSettings>()))
                 .Returns(new BigtableServiceApiClientImpl.MutateRowsStreamImpl(null));
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId, BigtableServiceApiSettings.GetDefault());
-            client.MutateRowsAsync(expectedRequest);
-            Assert.Equal(appProfileId, expectedRequest.AppProfileId);
+                new[] { mockGrpcClient.Object }, appProfileId_on_client, BigtableServiceApiSettings.GetDefault());
+            client.MutateRowsAsync(request);
+            Assert.Equal(appProfileId_on_client, request.AppProfileId);
+            client.MutateRowsAsync(request);
+            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
+            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
         }
 
         [Fact]
@@ -380,29 +410,42 @@ namespace Google.Cloud.Bigtable.V2.Tests
         [Fact]
         public async Task ReadModifyWriteRow_AppProfileId_From_Client()
         {
-            var expectedRequest = new ReadModifyWriteRowRequest
+            var appProfileId_on_client = "csharp";
+            var appProfileId_on_request = "other";
+            var request = new ReadModifyWriteRowRequest
             {
                 RowKey = ByteString.CopyFromUtf8("abc"),
                 TableNameAsTableName = new TableName("project", "instance", "table"),
                 Rules = { ReadModifyWriteRules.Append("familyName", "CQ1", "Append")}
             };
-            var expectedRequest2 = new ReadModifyWriteRowRequest(expectedRequest);
-            Assert.Empty(expectedRequest.AppProfileId);
-            var appProfileId = "csharp";
+            var request2 = new ReadModifyWriteRowRequest(request);
+            var request_with_appProfileId = new ReadModifyWriteRowRequest(request) { AppProfileId = appProfileId_on_request };
             Mock<BigtableServiceApiClient> mockGrpcClient =
                 new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
             mockGrpcClient
-                .Setup(x => x.ReadModifyWriteRow(expectedRequest, It.IsAny<CallSettings>()))
+                .Setup(x => x.ReadModifyWriteRow(request, It.IsAny<CallSettings>()))
                 .Returns(new ReadModifyWriteRowResponse());
             mockGrpcClient
-                .Setup(x => x.ReadModifyWriteRowAsync(expectedRequest2, It.IsAny<CallSettings>()))
+                .Setup(x => x.ReadModifyWriteRow(request_with_appProfileId, It.IsAny<CallSettings>()))
+                .Returns(new ReadModifyWriteRowResponse());
+            mockGrpcClient
+                 .Setup(x => x.ReadModifyWriteRowAsync(request, It.IsAny<CallSettings>()))
+                .ReturnsAsync(new ReadModifyWriteRowResponse());
+            mockGrpcClient
+                .Setup(x => x.ReadModifyWriteRowAsync(request_with_appProfileId, It.IsAny<CallSettings>()))
                 .ReturnsAsync(new ReadModifyWriteRowResponse());
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId, BigtableServiceApiSettings.GetDefault());
-            client.ReadModifyWriteRow(expectedRequest);
-            await client.ReadModifyWriteRowAsync(expectedRequest2);
-            Assert.Equal(appProfileId, expectedRequest.AppProfileId);
-            Assert.Equal(appProfileId, expectedRequest2.AppProfileId);
+                new[] { mockGrpcClient.Object }, appProfileId_on_client, BigtableServiceApiSettings.GetDefault());
+            client.ReadModifyWriteRow(request);
+            await client.ReadModifyWriteRowAsync(request2);
+            Assert.Equal(appProfileId_on_client, request.AppProfileId);
+            Assert.Equal(appProfileId_on_client, request2.AppProfileId);
+            client.ReadModifyWriteRow(request_with_appProfileId);
+            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
+            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
+            await client.ReadModifyWriteRowAsync(request_with_appProfileId);
+            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
+            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
         }
 
         [Fact]
@@ -600,18 +643,26 @@ namespace Google.Cloud.Bigtable.V2.Tests
         [Fact]
         public void ReadRows_AppProfileId_From_Client()
         {
-            var expectedRequest =
+            var appProfileId_on_client = "csharp";
+            var appProfileId_on_request = "other";
+            var request =
                 new ReadRowsRequest {TableNameAsTableName = new TableName("project", "instance", "table")};
-            var appProfileId = "csharp";
+            var request_with_appProfileId = new ReadRowsRequest(request) { AppProfileId = appProfileId_on_request };
             Mock<BigtableServiceApiClient> mockGrpcClient =
                 new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
             mockGrpcClient
-                .Setup(x => x.ReadRows(expectedRequest, It.IsAny<CallSettings>()))
+                .Setup(x => x.ReadRows(request, It.IsAny<CallSettings>()))
+                .Returns(new BigtableServiceApiClientImpl.ReadRowsStreamImpl(null));
+            mockGrpcClient
+                .Setup(x => x.ReadRows(request_with_appProfileId, It.IsAny<CallSettings>()))
                 .Returns(new BigtableServiceApiClientImpl.ReadRowsStreamImpl(null));
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId, BigtableServiceApiSettings.GetDefault());
-            client.ReadRows(expectedRequest);
-            Assert.Equal(appProfileId, expectedRequest.AppProfileId);
+                new[] { mockGrpcClient.Object }, appProfileId_on_client, BigtableServiceApiSettings.GetDefault());
+            client.ReadRows(request);
+            Assert.Equal(appProfileId_on_client, request.AppProfileId);
+            client.ReadRows(request_with_appProfileId);
+            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
+            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
         }
 
         [Fact]
@@ -667,22 +718,28 @@ namespace Google.Cloud.Bigtable.V2.Tests
         }
 
         [Fact]
-        public void SampleRowKeys_AppProfileId_from_client()
+        public void SampleRowKeys_AppProfileId_From_client()
         {
-            var expectedRequest = new SampleRowKeysRequest
+            var appProfileId_on_client = "csharp";
+            var appProfileId_on_request = "other";
+            var request = new SampleRowKeysRequest
             {
                 TableNameAsTableName = new TableName("project", "instance", "table"),
             };
-            Assert.Empty(expectedRequest.AppProfileId);
-            var appProfileId = "csharp";
+            var request_with_appProfileId = new SampleRowKeysRequest(request) { AppProfileId = appProfileId_on_request };
             Mock<BigtableServiceApiClient> mockGrpcClient =
                 new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
-            mockGrpcClient.Setup(x => x.SampleRowKeys(expectedRequest, It.IsAny<CallSettings>()))
+            mockGrpcClient.Setup(x => x.SampleRowKeys(request, It.IsAny<CallSettings>()))
+                .Returns(new BigtableServiceApiClientImpl.SampleRowKeysStreamImpl(null));
+            mockGrpcClient.Setup(x => x.SampleRowKeys(request_with_appProfileId, It.IsAny<CallSettings>()))
                 .Returns(new BigtableServiceApiClientImpl.SampleRowKeysStreamImpl(null));
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId, BigtableServiceApiSettings.GetDefault());
-            client.SampleRowKeys(expectedRequest);
-            Assert.Equal(appProfileId, expectedRequest.AppProfileId);
+                new[] { mockGrpcClient.Object }, appProfileId_on_client, BigtableServiceApiSettings.GetDefault());
+            client.SampleRowKeys(request);
+            Assert.Equal(appProfileId_on_client, request.AppProfileId);
+            client.SampleRowKeys(request_with_appProfileId);
+            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
+            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableClientTest.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableClientTest.cs
@@ -102,7 +102,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
                 .Setup(x => x.CheckAndMutateRowAsync(request_with_appProfileId, It.IsAny<CallSettings>()))
                 .ReturnsAsync(new CheckAndMutateRowResponse());
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId_on_client, BigtableServiceApiSettings.GetDefault());
+                new[] { mockGrpcClient.Object }, appProfileId_on_client);
             client.CheckAndMutateRow(request);
             await client.CheckAndMutateRowAsync(request2);
             Assert.Equal(appProfileId_on_client, request.AppProfileId);
@@ -250,7 +250,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
             mockGrpcClient.Setup(x => x.MutateRowAsync(request_with_appProfileId, It.IsAny<CallSettings>()))
                 .ReturnsAsync(new MutateRowResponse());
             BigtableClient client = new BigtableClientImpl(
-                new[] {mockGrpcClient.Object}, appProfileId_on_client, BigtableServiceApiSettings.GetDefault());
+                new[] {mockGrpcClient.Object}, appProfileId_on_client);
             client.MutateRow(request);
             await client.MutateRowAsync(request2);
             Assert.Equal(appProfileId_on_client, request.AppProfileId);
@@ -346,7 +346,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
             mockGrpcClient.Setup(x => x.MutateRows(request_with_appProfileId, It.IsAny<CallSettings>()))
                 .Returns(new BigtableServiceApiClientImpl.MutateRowsStreamImpl(null));
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId_on_client, BigtableServiceApiSettings.GetDefault());
+                new[] { mockGrpcClient.Object }, appProfileId_on_client);
             client.MutateRowsAsync(request);
             Assert.Equal(appProfileId_on_client, request.AppProfileId);
             client.MutateRowsAsync(request);
@@ -435,7 +435,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
                 .Setup(x => x.ReadModifyWriteRowAsync(request_with_appProfileId, It.IsAny<CallSettings>()))
                 .ReturnsAsync(new ReadModifyWriteRowResponse());
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId_on_client, BigtableServiceApiSettings.GetDefault());
+                new[] { mockGrpcClient.Object }, appProfileId_on_client);
             client.ReadModifyWriteRow(request);
             await client.ReadModifyWriteRowAsync(request2);
             Assert.Equal(appProfileId_on_client, request.AppProfileId);
@@ -657,7 +657,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
                 .Setup(x => x.ReadRows(request_with_appProfileId, It.IsAny<CallSettings>()))
                 .Returns(new BigtableServiceApiClientImpl.ReadRowsStreamImpl(null));
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId_on_client, BigtableServiceApiSettings.GetDefault());
+                new[] { mockGrpcClient.Object }, appProfileId_on_client);
             client.ReadRows(request);
             Assert.Equal(appProfileId_on_client, request.AppProfileId);
             client.ReadRows(request_with_appProfileId);
@@ -734,7 +734,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
             mockGrpcClient.Setup(x => x.SampleRowKeys(request_with_appProfileId, It.IsAny<CallSettings>()))
                 .Returns(new BigtableServiceApiClientImpl.SampleRowKeysStreamImpl(null));
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId_on_client, BigtableServiceApiSettings.GetDefault());
+                new[] { mockGrpcClient.Object }, appProfileId_on_client);
             client.SampleRowKeys(request);
             Assert.Equal(appProfileId_on_client, request.AppProfileId);
             client.SampleRowKeys(request_with_appProfileId);

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableClientTest.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableClientTest.cs
@@ -76,8 +76,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
         [Fact]
         public async Task CheckAndMutateRow_AppProfileId_From_Client()
         {
-            var appProfileId_on_client = "csharp";
-            var appProfileId_on_request = "other";
+            var appProfileIdOnClient = "csharp";
             var request = new CheckAndMutateRowRequest
             {
                 TableNameAsTableName = new TableName("project", "instance", "table"),
@@ -86,33 +85,51 @@ namespace Google.Cloud.Bigtable.V2.Tests
                 TrueMutations = {new Mutation()}
             };
             var request2 = new CheckAndMutateRowRequest(request);
-            var request_with_appProfileId = new CheckAndMutateRowRequest(request) { AppProfileId = appProfileId_on_request };
             Mock<BigtableServiceApiClient> mockGrpcClient =
                 new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
             mockGrpcClient
                 .Setup(x => x.CheckAndMutateRow(request, It.IsAny<CallSettings>()))
                 .Returns(new CheckAndMutateRowResponse());
             mockGrpcClient
-                .Setup(x => x.CheckAndMutateRow(request_with_appProfileId, It.IsAny<CallSettings>()))
-                .Returns(new CheckAndMutateRowResponse());
-            mockGrpcClient
                 .Setup(x => x.CheckAndMutateRowAsync(request, It.IsAny<CallSettings>()))
                 .ReturnsAsync(new CheckAndMutateRowResponse());
-            mockGrpcClient
-                .Setup(x => x.CheckAndMutateRowAsync(request_with_appProfileId, It.IsAny<CallSettings>()))
-                .ReturnsAsync(new CheckAndMutateRowResponse());
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId_on_client);
+                new[] { mockGrpcClient.Object }, appProfileIdOnClient);
             client.CheckAndMutateRow(request);
             await client.CheckAndMutateRowAsync(request2);
-            Assert.Equal(appProfileId_on_client, request.AppProfileId);
-            Assert.Equal(appProfileId_on_client, request2.AppProfileId);
-            client.CheckAndMutateRow(request_with_appProfileId);
-            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
-            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
-            await client.CheckAndMutateRowAsync(request_with_appProfileId);
-            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
-            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
+            Assert.Equal(appProfileIdOnClient, request.AppProfileId);
+            Assert.Equal(appProfileIdOnClient, request2.AppProfileId);
+        }
+
+        [Fact]
+        public async Task CheckAndMutateRow_With_AppProfileId()
+        {
+            var appProfileIdOnClient = "csharp";
+            var appProfileIdOnRequest = "other";
+            var requestWithAppProfileId = new CheckAndMutateRowRequest
+            {
+                TableNameAsTableName = new TableName("project", "instance", "table"),
+                RowKey = ByteString.CopyFromUtf8("abc"),
+                FalseMutations = {new Mutation()},
+                TrueMutations = {new Mutation()},
+                AppProfileId = appProfileIdOnRequest
+            };
+            Mock<BigtableServiceApiClient> mockGrpcClient =
+                new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
+            mockGrpcClient
+                .Setup(x => x.CheckAndMutateRow(requestWithAppProfileId, It.IsAny<CallSettings>()))
+                .Returns(new CheckAndMutateRowResponse());
+            mockGrpcClient
+                .Setup(x => x.CheckAndMutateRowAsync(requestWithAppProfileId, It.IsAny<CallSettings>()))
+                .ReturnsAsync(new CheckAndMutateRowResponse());
+            BigtableClient client = new BigtableClientImpl(
+                new[] { mockGrpcClient.Object }, appProfileIdOnClient);
+            client.CheckAndMutateRow(requestWithAppProfileId);
+            Assert.NotEqual(appProfileIdOnClient, requestWithAppProfileId.AppProfileId);
+            Assert.Equal(appProfileIdOnRequest, requestWithAppProfileId.AppProfileId);
+            await client.CheckAndMutateRowAsync(requestWithAppProfileId);
+            Assert.NotEqual(appProfileIdOnClient, requestWithAppProfileId.AppProfileId);
+            Assert.Equal(appProfileIdOnRequest, requestWithAppProfileId.AppProfileId);
         }
 
         [Fact]
@@ -229,38 +246,54 @@ namespace Google.Cloud.Bigtable.V2.Tests
         [Fact]
         public async Task MutateRow_AppProfileId_From_client()
         {
-            var appProfileId_on_client = "csharp";
-            var appProfileId_on_request = "other";
+            var appProfileIdOnClient = "csharp";
             var request = new MutateRowRequest
             {
                 Mutations = {new Mutation()},
                 RowKey = ByteString.CopyFromUtf8("abc"),
-                TableNameAsTableName = new TableName("project", "instance", "table"),
+                TableNameAsTableName = new TableName("project", "instance", "table")
             };
             var request2 = new MutateRowRequest(request);
-            var request_with_appProfileId = new MutateRowRequest(request) { AppProfileId = appProfileId_on_request };
             Mock<BigtableServiceApiClient> mockGrpcClient =
                 new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
             mockGrpcClient.Setup(x => x.MutateRow(request, It.IsAny<CallSettings>()))
                 .Returns(new MutateRowResponse());
-            mockGrpcClient.Setup(x => x.MutateRow(request_with_appProfileId, It.IsAny<CallSettings>()))
-                .Returns(new MutateRowResponse());
             mockGrpcClient.Setup(x => x.MutateRowAsync(request, It.IsAny<CallSettings>()))
                 .ReturnsAsync(new MutateRowResponse());
-            mockGrpcClient.Setup(x => x.MutateRowAsync(request_with_appProfileId, It.IsAny<CallSettings>()))
-                .ReturnsAsync(new MutateRowResponse());
             BigtableClient client = new BigtableClientImpl(
-                new[] {mockGrpcClient.Object}, appProfileId_on_client);
+                new[] {mockGrpcClient.Object}, appProfileIdOnClient);
             client.MutateRow(request);
             await client.MutateRowAsync(request2);
-            Assert.Equal(appProfileId_on_client, request.AppProfileId);
-            Assert.Equal(appProfileId_on_client, request2.AppProfileId);
-            client.MutateRow(request_with_appProfileId);
-            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
-            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
-            await client.MutateRowAsync(request_with_appProfileId);
-            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
-            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
+            Assert.Equal(appProfileIdOnClient, request.AppProfileId);
+            Assert.Equal(appProfileIdOnClient, request2.AppProfileId);
+        }
+
+        [Fact]
+        public async Task MutateRow_With_AppProfileId()
+        {
+            var appProfileIdOnClient = "csharp";
+            var appProfileIdOnRequest = "other";
+            var requestWithAppProfileId = new MutateRowRequest
+            {
+                Mutations = {new Mutation()},
+                RowKey = ByteString.CopyFromUtf8("abc"),
+                TableNameAsTableName = new TableName("project", "instance", "table"),
+                AppProfileId = appProfileIdOnRequest
+            };
+            Mock<BigtableServiceApiClient> mockGrpcClient =
+                new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.MutateRow(requestWithAppProfileId, It.IsAny<CallSettings>()))
+                .Returns(new MutateRowResponse());
+            mockGrpcClient.Setup(x => x.MutateRowAsync(requestWithAppProfileId, It.IsAny<CallSettings>()))
+                .ReturnsAsync(new MutateRowResponse());
+            BigtableClient client = new BigtableClientImpl(
+                new[] {mockGrpcClient.Object}, appProfileIdOnClient);
+            client.MutateRow(requestWithAppProfileId);
+            Assert.NotEqual(appProfileIdOnClient, requestWithAppProfileId.AppProfileId);
+            Assert.Equal(appProfileIdOnRequest, requestWithAppProfileId.AppProfileId);
+            await client.MutateRowAsync(requestWithAppProfileId);
+            Assert.NotEqual(appProfileIdOnClient, requestWithAppProfileId.AppProfileId);
+            Assert.Equal(appProfileIdOnRequest, requestWithAppProfileId.AppProfileId);
         }
 
         [Fact]
@@ -331,27 +364,42 @@ namespace Google.Cloud.Bigtable.V2.Tests
         [Fact]
         public void MutateRows_AppProfileId_From_client()
         {
-            var appProfileId_on_client = "csharp";
-            var appProfileId_on_request = "other";
+            var appProfileIdOnClient = "csharp";
             var request = new MutateRowsRequest
             {
                 Entries ={Mutations.CreateEntry("abc", new Mutation())},
                 TableNameAsTableName = new TableName("project", "instance", "table")
             };
-            var request_with_appProfileId = new MutateRowsRequest(request) { AppProfileId = appProfileId_on_request };
             Mock<BigtableServiceApiClient> mockGrpcClient =
                 new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
             mockGrpcClient.Setup(x => x.MutateRows(request, It.IsAny<CallSettings>()))
                 .Returns(new BigtableServiceApiClientImpl.MutateRowsStreamImpl(null));
-            mockGrpcClient.Setup(x => x.MutateRows(request_with_appProfileId, It.IsAny<CallSettings>()))
+            BigtableClient client = new BigtableClientImpl(
+                new[] {mockGrpcClient.Object}, appProfileIdOnClient);
+            client.MutateRowsAsync(request);
+            Assert.Equal(appProfileIdOnClient, request.AppProfileId);
+        }
+
+                [Fact]
+        public void MutateRows_With_AppProfileId()
+        {
+            var appProfileIdOnClient = "csharp";
+            var appProfileIdOnRequest = "other";
+            var requestWithAppProfileId = new MutateRowsRequest
+            {
+                Entries ={Mutations.CreateEntry("abc", new Mutation())},
+                TableNameAsTableName = new TableName("project", "instance", "table"),
+                AppProfileId = appProfileIdOnRequest
+            };
+            Mock<BigtableServiceApiClient> mockGrpcClient =
+                new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.MutateRows(requestWithAppProfileId, It.IsAny<CallSettings>()))
                 .Returns(new BigtableServiceApiClientImpl.MutateRowsStreamImpl(null));
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId_on_client);
-            client.MutateRowsAsync(request);
-            Assert.Equal(appProfileId_on_client, request.AppProfileId);
-            client.MutateRowsAsync(request);
-            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
-            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
+                new[] {mockGrpcClient.Object}, appProfileIdOnClient);
+            client.MutateRowsAsync(requestWithAppProfileId);
+            Assert.NotEqual(appProfileIdOnClient, requestWithAppProfileId.AppProfileId);
+            Assert.Equal(appProfileIdOnRequest, requestWithAppProfileId.AppProfileId);
         }
 
         [Fact]
@@ -410,8 +458,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
         [Fact]
         public async Task ReadModifyWriteRow_AppProfileId_From_Client()
         {
-            var appProfileId_on_client = "csharp";
-            var appProfileId_on_request = "other";
+            var appProfileIdOnClient = "csharp";
             var request = new ReadModifyWriteRowRequest
             {
                 RowKey = ByteString.CopyFromUtf8("abc"),
@@ -419,33 +466,50 @@ namespace Google.Cloud.Bigtable.V2.Tests
                 Rules = { ReadModifyWriteRules.Append("familyName", "CQ1", "Append")}
             };
             var request2 = new ReadModifyWriteRowRequest(request);
-            var request_with_appProfileId = new ReadModifyWriteRowRequest(request) { AppProfileId = appProfileId_on_request };
             Mock<BigtableServiceApiClient> mockGrpcClient =
                 new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
             mockGrpcClient
                 .Setup(x => x.ReadModifyWriteRow(request, It.IsAny<CallSettings>()))
                 .Returns(new ReadModifyWriteRowResponse());
             mockGrpcClient
-                .Setup(x => x.ReadModifyWriteRow(request_with_appProfileId, It.IsAny<CallSettings>()))
-                .Returns(new ReadModifyWriteRowResponse());
-            mockGrpcClient
                  .Setup(x => x.ReadModifyWriteRowAsync(request, It.IsAny<CallSettings>()))
                 .ReturnsAsync(new ReadModifyWriteRowResponse());
-            mockGrpcClient
-                .Setup(x => x.ReadModifyWriteRowAsync(request_with_appProfileId, It.IsAny<CallSettings>()))
-                .ReturnsAsync(new ReadModifyWriteRowResponse());
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId_on_client);
+                new[] { mockGrpcClient.Object }, appProfileIdOnClient);
             client.ReadModifyWriteRow(request);
             await client.ReadModifyWriteRowAsync(request2);
-            Assert.Equal(appProfileId_on_client, request.AppProfileId);
-            Assert.Equal(appProfileId_on_client, request2.AppProfileId);
-            client.ReadModifyWriteRow(request_with_appProfileId);
-            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
-            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
-            await client.ReadModifyWriteRowAsync(request_with_appProfileId);
-            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
-            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
+            Assert.Equal(appProfileIdOnClient, request.AppProfileId);
+            Assert.Equal(appProfileIdOnClient, request2.AppProfileId);
+        }
+
+        [Fact]
+        public async Task ReadModifyWriteRow_With_AppProfileIdt()
+        {
+            var appProfileIdOnClient = "csharp";
+            var appProfileIdOnRequest = "other";
+            var requestWithAppProfileId = new ReadModifyWriteRowRequest
+            {
+                RowKey = ByteString.CopyFromUtf8("abc"),
+                TableNameAsTableName = new TableName("project", "instance", "table"),
+                Rules = { ReadModifyWriteRules.Append("familyName", "CQ1", "Append")},
+                AppProfileId = appProfileIdOnRequest
+            };
+            Mock<BigtableServiceApiClient> mockGrpcClient =
+                new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
+            mockGrpcClient
+                .Setup(x => x.ReadModifyWriteRow(requestWithAppProfileId, It.IsAny<CallSettings>()))
+                .Returns(new ReadModifyWriteRowResponse());
+            mockGrpcClient
+                .Setup(x => x.ReadModifyWriteRowAsync(requestWithAppProfileId, It.IsAny<CallSettings>()))
+                .ReturnsAsync(new ReadModifyWriteRowResponse());
+            BigtableClient client = new BigtableClientImpl(
+                new[] { mockGrpcClient.Object }, appProfileIdOnClient);
+            client.ReadModifyWriteRow(requestWithAppProfileId);
+            Assert.NotEqual(appProfileIdOnClient, requestWithAppProfileId.AppProfileId);
+            Assert.Equal(appProfileIdOnRequest, requestWithAppProfileId.AppProfileId);
+            await client.ReadModifyWriteRowAsync(requestWithAppProfileId);
+            Assert.NotEqual(appProfileIdOnClient, requestWithAppProfileId.AppProfileId);
+            Assert.Equal(appProfileIdOnRequest, requestWithAppProfileId.AppProfileId);
         }
 
         [Fact]
@@ -643,26 +707,40 @@ namespace Google.Cloud.Bigtable.V2.Tests
         [Fact]
         public void ReadRows_AppProfileId_From_Client()
         {
-            var appProfileId_on_client = "csharp";
-            var appProfileId_on_request = "other";
+            var appProfileIdOnClient = "csharp";
             var request =
                 new ReadRowsRequest {TableNameAsTableName = new TableName("project", "instance", "table")};
-            var request_with_appProfileId = new ReadRowsRequest(request) { AppProfileId = appProfileId_on_request };
             Mock<BigtableServiceApiClient> mockGrpcClient =
                 new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
             mockGrpcClient
                 .Setup(x => x.ReadRows(request, It.IsAny<CallSettings>()))
                 .Returns(new BigtableServiceApiClientImpl.ReadRowsStreamImpl(null));
+            BigtableClient client = new BigtableClientImpl(
+                new[] { mockGrpcClient.Object }, appProfileIdOnClient);
+            client.ReadRows(request);
+            Assert.Equal(appProfileIdOnClient, request.AppProfileId);
+        }
+
+        [Fact]
+        public void ReadRows_With_AppProfileId()
+        {
+            var appProfileIdOnClient = "csharp";
+            var appProfileIdOnRequest = "other";
+            var requestWithAppProfileId = new ReadRowsRequest 
+            {
+                TableNameAsTableName = new TableName("project", "instance", "table"),
+                AppProfileId = appProfileIdOnRequest
+            };
+            Mock<BigtableServiceApiClient> mockGrpcClient =
+                new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
             mockGrpcClient
-                .Setup(x => x.ReadRows(request_with_appProfileId, It.IsAny<CallSettings>()))
+                .Setup(x => x.ReadRows(requestWithAppProfileId, It.IsAny<CallSettings>()))
                 .Returns(new BigtableServiceApiClientImpl.ReadRowsStreamImpl(null));
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId_on_client);
-            client.ReadRows(request);
-            Assert.Equal(appProfileId_on_client, request.AppProfileId);
-            client.ReadRows(request_with_appProfileId);
-            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
-            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
+                new[] { mockGrpcClient.Object }, appProfileIdOnClient);
+            client.ReadRows(requestWithAppProfileId);
+            Assert.NotEqual(appProfileIdOnClient, requestWithAppProfileId.AppProfileId);
+            Assert.Equal(appProfileIdOnRequest, requestWithAppProfileId.AppProfileId);
         }
 
         [Fact]
@@ -720,26 +798,38 @@ namespace Google.Cloud.Bigtable.V2.Tests
         [Fact]
         public void SampleRowKeys_AppProfileId_From_client()
         {
-            var appProfileId_on_client = "csharp";
-            var appProfileId_on_request = "other";
-            var request = new SampleRowKeysRequest
-            {
-                TableNameAsTableName = new TableName("project", "instance", "table"),
-            };
-            var request_with_appProfileId = new SampleRowKeysRequest(request) { AppProfileId = appProfileId_on_request };
+            var appProfileIdOnClient = "csharp";
+            var request =
+                new SampleRowKeysRequest {TableNameAsTableName = new TableName("project", "instance", "table")};
             Mock<BigtableServiceApiClient> mockGrpcClient =
                 new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
             mockGrpcClient.Setup(x => x.SampleRowKeys(request, It.IsAny<CallSettings>()))
                 .Returns(new BigtableServiceApiClientImpl.SampleRowKeysStreamImpl(null));
-            mockGrpcClient.Setup(x => x.SampleRowKeys(request_with_appProfileId, It.IsAny<CallSettings>()))
+            BigtableClient client = new BigtableClientImpl(
+                new[] { mockGrpcClient.Object }, appProfileIdOnClient);
+            client.SampleRowKeys(request);
+            Assert.Equal(appProfileIdOnClient, request.AppProfileId);
+        }
+
+        [Fact]
+        public void SampleRowKeys_With_AppProfileId()
+        {
+            var appProfileIdOnClient = "csharp";
+            var appProfileIdOnRequest = "other";
+            var requestWithAppProfileId = new SampleRowKeysRequest
+            {
+                TableNameAsTableName = new TableName("project", "instance", "table"),
+                 AppProfileId = appProfileIdOnRequest
+            };
+            Mock<BigtableServiceApiClient> mockGrpcClient =
+                new Mock<BigtableServiceApiClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.SampleRowKeys(requestWithAppProfileId, It.IsAny<CallSettings>()))
                 .Returns(new BigtableServiceApiClientImpl.SampleRowKeysStreamImpl(null));
             BigtableClient client = new BigtableClientImpl(
-                new[] { mockGrpcClient.Object }, appProfileId_on_client);
-            client.SampleRowKeys(request);
-            Assert.Equal(appProfileId_on_client, request.AppProfileId);
-            client.SampleRowKeys(request_with_appProfileId);
-            Assert.NotEqual(appProfileId_on_client, request_with_appProfileId.AppProfileId);
-            Assert.Equal(appProfileId_on_request, request_with_appProfileId.AppProfileId);
+                new[] { mockGrpcClient.Object }, appProfileIdOnClient);
+            client.SampleRowKeys(requestWithAppProfileId);
+            Assert.NotEqual(appProfileIdOnClient, requestWithAppProfileId.AppProfileId);
+            Assert.Equal(appProfileIdOnRequest, requestWithAppProfileId.AppProfileId);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableClientTest.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableClientTest.cs
@@ -244,7 +244,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
         }
 
         [Fact]
-        public async Task MutateRow_AppProfileId_From_client()
+        public async Task MutateRow_AppProfileId_From_Client()
         {
             var appProfileIdOnClient = "csharp";
             var request = new MutateRowRequest
@@ -362,7 +362,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
         }
 
         [Fact]
-        public void MutateRows_AppProfileId_From_client()
+        public void MutateRows_AppProfileId_From_Client()
         {
             var appProfileIdOnClient = "csharp";
             var request = new MutateRowsRequest
@@ -380,7 +380,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
             Assert.Equal(appProfileIdOnClient, request.AppProfileId);
         }
 
-                [Fact]
+        [Fact]
         public void MutateRows_With_AppProfileId()
         {
             var appProfileIdOnClient = "csharp";
@@ -483,7 +483,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
         }
 
         [Fact]
-        public async Task ReadModifyWriteRow_With_AppProfileIdt()
+        public async Task ReadModifyWriteRow_With_AppProfileId()
         {
             var appProfileIdOnClient = "csharp";
             var appProfileIdOnRequest = "other";
@@ -796,7 +796,7 @@ namespace Google.Cloud.Bigtable.V2.Tests
         }
 
         [Fact]
-        public void SampleRowKeys_AppProfileId_From_client()
+        public void SampleRowKeys_AppProfileId_From_Client()
         {
             var appProfileIdOnClient = "csharp";
             var request =

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.cs
@@ -361,7 +361,7 @@ namespace Google.Cloud.Bigtable.V2
             ReadRowsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            if (request.AppProfileId == null)
+            if (_appProfileId != null && request.AppProfileId.Length == 0)
             {
                 request.AppProfileId = _appProfileId;
             }
@@ -374,7 +374,7 @@ namespace Google.Cloud.Bigtable.V2
             SampleRowKeysRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            if (request.AppProfileId == null)
+            if (_appProfileId != null && request.AppProfileId.Length == 0)
             {
                 request.AppProfileId = _appProfileId;
             }
@@ -387,7 +387,7 @@ namespace Google.Cloud.Bigtable.V2
             MutateRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            if (request.AppProfileId == null)
+            if (_appProfileId != null && request.AppProfileId.Length == 0)
             {
                 request.AppProfileId = _appProfileId;
             }
@@ -400,7 +400,7 @@ namespace Google.Cloud.Bigtable.V2
             MutateRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            if (request.AppProfileId == null)
+            if (_appProfileId != null && request.AppProfileId.Length == 0)
             {
                 request.AppProfileId = _appProfileId;
             }
@@ -418,7 +418,7 @@ namespace Google.Cloud.Bigtable.V2
             MutateRowsRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            if (request.AppProfileId == null)
+            if (_appProfileId != null && request.AppProfileId.Length == 0)
             {
                 request.AppProfileId = _appProfileId;
             }
@@ -431,7 +431,7 @@ namespace Google.Cloud.Bigtable.V2
             CheckAndMutateRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            if (request.AppProfileId == null)
+            if (_appProfileId != null && request.AppProfileId.Length == 0)
             {
                 request.AppProfileId = _appProfileId;
             }
@@ -444,7 +444,7 @@ namespace Google.Cloud.Bigtable.V2
             CheckAndMutateRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            if (request.AppProfileId == null)
+            if (_appProfileId != null && request.AppProfileId.Length == 0)
             {
                 request.AppProfileId = _appProfileId;
             }
@@ -457,7 +457,7 @@ namespace Google.Cloud.Bigtable.V2
             ReadModifyWriteRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            if (request.AppProfileId == null)
+            if (_appProfileId != null && request.AppProfileId.Length == 0)
             {
                 request.AppProfileId = _appProfileId;
             }
@@ -470,7 +470,7 @@ namespace Google.Cloud.Bigtable.V2
             ReadModifyWriteRowRequest request,
             gaxgrpc::CallSettings callSettings = null)
         {
-            if (request.AppProfileId == null)
+            if (_appProfileId != null && request.AppProfileId.Length == 0)
             {
                 request.AppProfileId = _appProfileId;
             }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientPartial.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientPartial.cs
@@ -1080,7 +1080,7 @@ namespace Google.Cloud.Bigtable.V2
         internal BigtableClientImpl(
             BigtableServiceApiClient[] clients,
             string appProfileId,
-            BigtableServiceApiSettings underlyingClientSettings)
+            BigtableServiceApiSettings underlyingClientSettings=null)
         {
             _clients = clients;
             _appProfileId = appProfileId;

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientPartial.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientPartial.cs
@@ -1080,7 +1080,7 @@ namespace Google.Cloud.Bigtable.V2
         internal BigtableClientImpl(
             BigtableServiceApiClient[] clients,
             string appProfileId,
-            BigtableServiceApiSettings underlyingClientSettings=null)
+            BigtableServiceApiSettings underlyingClientSettings = null)
         {
             _clients = clients;
             _appProfileId = appProfileId;


### PR DESCRIPTION
There is an issue with [these](https://github.com/GoogleCloudPlatform/google-cloud-dotnet/blob/ae2e0995be4f62bcb68e0e24e16b60732b253cfd/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.cs#L364-L367) if statements

https://github.com/GoogleCloudPlatform/google-cloud-dotnet/blob/ae2e0995be4f62bcb68e0e24e16b60732b253cfd/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.cs#L364-L367

The condition can never be `true` since `request.AppProfileId` can never be initialized or assigned to `null` and by default is initialized to an [empty string](https://github.com/GoogleCloudPlatform/google-cloud-dotnet/blob/ae2e0995be4f62bcb68e0e24e16b60732b253cfd/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Bigtable.cs#L177).
`_appProfileId` property from the `client` by default is [initialized](https://github.com/GoogleCloudPlatform/google-cloud-dotnet/blob/ae2e0995be4f62bcb68e0e24e16b60732b253cfd/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientPartial.cs#L107) to `null`.

Corrected condition on `BigtableClient` methods to pass `appProfileId` from the `client` to check whether `appProfileId` in the `request` is an empty string (default value).
Added unit tests for each request and corresponding method.
