### PR TITLE
Revert "Stop skipping a storage test"

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/KmsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/KmsTest.cs
@@ -191,7 +191,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             TestHelpers.ValidateData(bucketName, objectName, data);
         }
 
-        [SkippableFact]
+        [SkippableFact(Skip = "See https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/2412")]
         public void UploadObject_BucketHasDefaultKmsKey_UploadWithNoSpecifiedKey_DownloadWithClientWithCsek()
         {
             _fixture.SkipIf(SkipTests);


### PR DESCRIPTION
This reverts commit ad382b5b6a87781bc4f4c9ccc6fb583a3456b060.

(The test is still failing.)

Will reopen #2412.