### PR TITLE
Make the test for GetStorageServiceAccountEmail less brittle

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/NotificationsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/NotificationsTest.cs
@@ -45,7 +45,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             {
                 projectId = projectId.Substring(orgSeparatorIndex + 1);
             }
-            Assert.Equal($"{projectId}@gs-project-accounts.iam.gserviceaccount.com", email);
+            Assert.EndsWith("@gs-project-accounts.iam.gserviceaccount.com", email);
         }
 
         /// <summary>


### PR DESCRIPTION
It looks like the email isn't always in the format we were expecting
before.