### PR TITLE
Avoid exhaustively listing jobs

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/JobsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/JobsTest.cs
@@ -66,11 +66,12 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             // Find all jobs started in the last minute.
             // Using TakeWhile because, as documented:
             // The job list is sorted in reverse chronological order, by job creation time.
-            var recentJobs = client.ListJobs().TakeWhile(job => job.Statistics.CreationTime >= oneMinuteAgo).ToList();
+            var foundJob = client
+                .ListJobs()
+                .TakeWhile(job => job.Statistics.CreationTime >= oneMinuteAgo)
+                .FirstOrDefault(job => job.Reference.JobId == jobToFind.Reference.JobId);
 
-            // Note: can't find the job reference itself, as that would check equality by reference :(
-            var jobIds = recentJobs.Select(job => job.Reference.JobId).ToList();
-            Assert.Contains(jobToFind.Reference.JobId, jobIds);
+            Assert.NotNull(foundJob);
         }
 
         [Fact]
@@ -83,8 +84,9 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
 
             // Find the job after listing with full projection.
             var options = new ListJobsOptions { Projection = ProjectionEnum.Full };
-            var jobFound = client.ListJobs(options).Single(job => job.Reference.JobId == jobToFind.Reference.JobId);
+            var jobFound = client.ListJobs(options).FirstOrDefault(job => job.Reference.JobId == jobToFind.Reference.JobId);
 
+            Assert.NotNull(jobFound);
             Assert.NotNull(jobFound.Resource.Configuration);
         }
 
@@ -98,8 +100,9 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
 
             // Find the job after listing with full projection.
             var options = new ListJobsOptions { Projection = ProjectionEnum.Full };
-            var jobFound = client.ListJobs(options).Single(job => job.Reference.JobId == jobToFind.Reference.JobId);
+            var jobFound = client.ListJobs(options).FirstOrDefault(job => job.Reference.JobId == jobToFind.Reference.JobId);
 
+            Assert.NotNull(jobFound);
             VerifyJobLabels(jobFound.Resource.Configuration.Labels);
         }
 

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/JobCreationOptionsSnippets.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/JobCreationOptionsSnippets.cs
@@ -65,14 +65,13 @@ namespace Google.Cloud.BigQuery.V2.Snippets
 
             // Find jobs marked with a certain label.
             KeyValuePair<string, string> labelToBeFound = labels.First();
-            List<BigQueryJob> jobs = client
-                .ListJobs(new ListJobsOptions
-                {
                     // Specify full projection to make sure that
                     // label information, if it exists, is returned for listed jobs.
-                    Projection = ProjectionEnum.Full
-                })
+            ListJobsOptions options = new ListJobsOptions { Projection = ProjectionEnum.Full };
+            List <BigQueryJob> jobs = client
+                .ListJobs(options)
                 .Where(job => job.Resource.Configuration.Labels?.Contains(labelToBeFound) ?? false)
+                .Take(2)
                 .ToList();
             foreach (BigQueryJob job in jobs)
             {


### PR DESCRIPTION
These four tests appear to take a large proportion of the time of the snippet/integration tests.

Currently in CI, the integration tests take ~44 minutes and the snippets take ~25 minutes.
I'm hoping these small changes can radically reduce this time without affecting test integrity.