### PR TITLE
Fix a NullReferenceException when using Precondition.None in Update

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DocumentMutationTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/DocumentMutationTest.cs
@@ -66,6 +66,18 @@ namespace Google.Cloud.Firestore.IntegrationTests
             AssertSerialized(snapshot, new { Name = "Changed again", Level = 2, Score = new { CustomTime = timestamp, Value = 40 } });
         }
 
+        // https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/2479
+        [Fact]
+        public async Task Update_NewDocument_PreconditionNone()
+        {
+            var doc = _fixture.NonQueryCollection.Document();
+            var updates = new Dictionary<FieldPath, object> { { new FieldPath("Score"), 20 } };
+            await doc.UpdateAsync(updates, Precondition.None);
+
+            var snapshot = await doc.GetSnapshotAsync();
+            Assert.Equal(20, snapshot.GetValue<int>("Score"));
+        }
+
         [Fact]
         public async Task Update_SentinelValues()
         {

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WriteBatchTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WriteBatchTest.cs
@@ -136,6 +136,31 @@ namespace Google.Cloud.Firestore.Tests
         }
 
         [Fact]
+        public void Update_WithPreconditionNone()
+        {
+            var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());
+            var batch = db.StartBatch();
+            var doc = db.Document("col/doc");
+            var updates = new Dictionary<FieldPath, object>
+            {
+                { new FieldPath("x"), "y" }
+            };
+
+            batch.Update(doc, updates, Precondition.None);
+
+            var expectedWrite = new Write
+            {
+                Update = new Document
+                {
+                    Name = doc.Path,
+                    Fields = { { "x", CreateValue("y") } }
+                },
+                UpdateMask = new DocumentMask { FieldPaths = { "x" } }
+            };
+            AssertWrites(batch, (expectedWrite, true));
+        }
+
+        [Fact]
         public void Update_StringKeyedDictionary_WithPrecondition()
         {
             var db = FirestoreDb.Create("project", "db", new FakeFirestoreClient());

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WriteBatch.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WriteBatch.cs
@@ -123,7 +123,7 @@ namespace Google.Cloud.Firestore
             GaxPreconditions.CheckNotNull(documentReference, nameof(documentReference));
             GaxPreconditions.CheckNotNull(updates, nameof(updates));
             GaxPreconditions.CheckArgument(updates.Count != 0, nameof(updates), "Empty set of updates specified");
-            GaxPreconditions.CheckArgument(precondition?.Proto.Exists != true, nameof(precondition), "Cannot specify a must-exist precondition for update");
+            GaxPreconditions.CheckArgument(precondition?.Exists != true, nameof(precondition), "Cannot specify a must-exist precondition for update");
 
             var serializedUpdates = updates.ToDictionary(pair => pair.Key, pair => ValueSerializer.Serialize(pair.Value));
             var expanded = ExpandObject(serializedUpdates);


### PR DESCRIPTION
Update checks that if you specify a precondition, its proto doesn't
have Exists set to true... but in the case of Precondition.None,
there *is* no proto. As it happens, we have a handy property on
Precondition we can use anyway.

I've done a quick check for similar occurrences, and haven't found any.

Fixes #2479.