### PR TITLE
Remove invalid Object Lifecycle test

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UpdateBucketTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UpdateBucketTest.cs
@@ -82,27 +82,5 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             Assert.Equal(5, rule.Condition.Age);
             Assert.Equal("Delete", rule.Action.Type);
         }
-
-        [Fact]
-        public void ObjectLifeCycle_Invalid()
-        {
-            var client = _fixture.Client;
-            var bucketName = _fixture.GenerateBucketName();
-            var bucket = _fixture.CreateBucket(bucketName, false);
-
-            bucket.Lifecycle = new LifecycleData
-            {
-                Rule = new List<RuleData>
-                {
-                    new RuleData
-                    {
-                        Condition = new ConditionData { Age = 5 },
-                        Action = new ActionData { Type = "HideDownBackOfSofa" }
-                    }
-                }
-            };
-
-            Assert.Throws<GoogleApiException>(() => client.UpdateBucket(bucket));
-        }
     }
 }


### PR DESCRIPTION
The Storage team has indicated that this isn't necessary. If it
were quick-running, I'd leave it in - but any test that requires
creating a new bucket is going to take a few seconds, and those add
up over time.