### PR TITLE
Clone values when deserializing

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
@@ -134,14 +134,20 @@ namespace Google.Cloud.Firestore.Tests
         public void DeserializeNullToValue()
         {
             var value = new Value { NullValue = wkt::NullValue.NullValue };
-            Assert.Same(value, DeserializeDefault(value, typeof(Value)));
+            var deserialized = DeserializeDefault(value, typeof(Value));
+            // We should get a clone back.
+            Assert.NotSame(value, deserialized);
+            Assert.Equal(value, deserialized);
         }
 
         [Fact]
         public void DeserializeToValue()
         {
             var value = new Value { DoubleValue = 1.234 };
-            Assert.Same(value, DeserializeDefault(value, typeof(Value)));
+            var deserialized = DeserializeDefault(value, typeof(Value));
+            // We should get a clone back.
+            Assert.NotSame(value, deserialized);
+            Assert.Equal(value, deserialized);
         }
 
         // These three classes exist for testing unknown property handling

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueDeserializer.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueDeserializer.cs
@@ -73,7 +73,7 @@ namespace Google.Cloud.Firestore
             // FIXME: Should we clone?
             if (targetType == typeof(Value))
             {
-                return value;
+                return value.Clone();
             }
 
             checked
@@ -90,7 +90,7 @@ namespace Google.Cloud.Firestore
                             ?? NoConversion();
                     case GeoPointValue:
                         return ConvertDefault(v => GeoPoint.FromProto(v.GeoPointValue))
-                            ?? ConvertSpecific(v => v.GeoPointValue)
+                            ?? ConvertSpecific(v => v.GeoPointValue.Clone())
                             ?? NoConversion();
                     case IntegerValue:
                         return ConvertDefault(v => v.IntegerValue)
@@ -109,7 +109,7 @@ namespace Google.Cloud.Firestore
                             ?? NoConversion();
                     case TimestampValue:
                         return ConvertDefault(v => Timestamp.FromProto(v.TimestampValue))
-                            ?? ConvertSpecific(v => v.TimestampValue)
+                            ?? ConvertSpecific(v => v.TimestampValue.Clone())
                             ?? ConvertSpecific(v => v.TimestampValue.ToDateTime())
                             ?? ConvertSpecific(v => v.TimestampValue.ToDateTimeOffset())
                             ?? NoConversion();
@@ -118,6 +118,7 @@ namespace Google.Cloud.Firestore
                     case BytesValue:
                         return ConvertDefault(v => Blob.FromByteString(v.BytesValue))
                             ?? ConvertSpecific(v => v.BytesValue.ToByteArray())
+                            // No need to clone this; ByteString is immutable
                             ?? ConvertSpecific(v => v.BytesValue)
                             ?? NoConversion();
                     case Value.ValueTypeOneofCase.MapValue:


### PR DESCRIPTION
(They were already cloned when serializing.)

This allows users to safely perform "custom" deserialization by
deserializing a DocumentSnapshot directly to a
Dictionary<string, Value> without risk of mutation.