### PR TITLE
Slightly simplify API

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/PublisherClientTest.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/PublisherClientTest.cs
@@ -203,18 +203,6 @@ namespace Google.Cloud.PubSub.V1.Tests
             Assert.ThrowsAny<ArgumentException>(() => new PublisherClient.Settings { BatchingSettings = new BatchingSettings(null, PublisherClient.ApiMaxBatchingSettings.ByteCountThreshold + 1, null) }.Validate());
             new PublisherClient.Settings { BatchingSettings = new BatchingSettings(null, 1, null) }.Validate();
             new PublisherClient.Settings { BatchingSettings = new BatchingSettings(null, PublisherClient.ApiMaxBatchingSettings.ByteCountThreshold, null) }.Validate();
-
-            Assert.ThrowsAny<ArgumentException>(() => new PublisherClient.Settings { MaxBatchingSettings = new BatchingSettings(null, null, TimeSpan.Zero) }.Validate());
-            Assert.ThrowsAny<ArgumentException>(() => new PublisherClient.Settings { MaxBatchingSettings = new BatchingSettings(null, null, TimeSpan.FromSeconds(-1)) }.Validate());
-            new PublisherClient.Settings { MaxBatchingSettings = new BatchingSettings(null, null, TimeSpan.FromMilliseconds(1)) }.Validate();
-            Assert.ThrowsAny<ArgumentException>(() => new PublisherClient.Settings { MaxBatchingSettings = new BatchingSettings(0, null, null) }.Validate());
-            Assert.ThrowsAny<ArgumentException>(() => new PublisherClient.Settings { MaxBatchingSettings = new BatchingSettings(PublisherClient.ApiMaxBatchingSettings.ElementCountThreshold.Value + 1, null, null) }.Validate());
-            new PublisherClient.Settings { MaxBatchingSettings = new BatchingSettings(1, null, null) }.Validate();
-            new PublisherClient.Settings { MaxBatchingSettings = new BatchingSettings(PublisherClient.ApiMaxBatchingSettings.ElementCountThreshold, null, null) }.Validate();
-            Assert.ThrowsAny<ArgumentException>(() => new PublisherClient.Settings { MaxBatchingSettings = new BatchingSettings(null, 0, null) }.Validate());
-            Assert.ThrowsAny<ArgumentException>(() => new PublisherClient.Settings { MaxBatchingSettings = new BatchingSettings(null, PublisherClient.ApiMaxBatchingSettings.ByteCountThreshold + 1, null) }.Validate());
-            new PublisherClient.Settings { MaxBatchingSettings = new BatchingSettings(null, 1, null) }.Validate();
-            new PublisherClient.Settings { MaxBatchingSettings = new BatchingSettings(null, PublisherClient.ApiMaxBatchingSettings.ByteCountThreshold, null) }.Validate();
         }
     }
 }

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
@@ -277,7 +277,7 @@ namespace Google.Cloud.PubSub.V1
         /// For high performance, these should all use distinct <see cref="Channel"/>s.</param>
         /// <param name="settings">Optional. <see cref="Settings"/> for creating a <see cref="SubscriberClient"/>.</param>
         /// <returns>A <see cref="SubscriberClient"/> instance associated with the specified <see cref="SubscriptionName"/>.</returns>
-        public static SubscriberClient Create(SubscriptionName subscriptionName, IEnumerable<SubscriberServiceApiClient> clients, Settings settings = null) =>
+        internal static SubscriberClient Create(SubscriptionName subscriptionName, IEnumerable<SubscriberServiceApiClient> clients, Settings settings = null) =>
             new SubscriberClientImpl(subscriptionName, clients, settings?.Clone() ?? new Settings(), null);
 
         /// <summary>


### PR DESCRIPTION
As requested by pubsub team.

Rationale for removing public Create(...) method is to not provide a way for users to create under-performing clients

Removing MaxBatchingSettings as it adds complexity with almost no beneifit.