### PR TITLE
Rename StreamAckDeadline to AckDeadline

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/PubSubClientTest.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/PubSubClientTest.cs
@@ -109,7 +109,7 @@ namespace Google.Cloud.PubSub.V1.IntegrationTests
                 clientCreationSettings: new SubscriberClient.ClientCreationSettings(clientCount: clientCount),
                 settings: new SubscriberClient.Settings
                 {
-                    StreamAckDeadline = timeouts,
+                    AckDeadline = timeouts,
                     FlowControlSettings = new FlowControlSettings(maxMessagesInFlight, null)
                 }).ConfigureAwait(false);
 

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/SubscriberClientTest.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/SubscriberClientTest.cs
@@ -297,7 +297,7 @@ namespace Google.Cloud.PubSub.V1.Tests
                 var settings = new SubscriberClient.Settings
                 {
                     Scheduler = scheduler,
-                    StreamAckDeadline = ackDeadline,
+                    AckDeadline = ackDeadline,
                     AckExtensionWindow = ackExtendWindow,
                     FlowControlSettings = new FlowControlSettings(flowMaxElements, flowMaxBytes),
                 };
@@ -725,13 +725,13 @@ namespace Google.Cloud.PubSub.V1.Tests
 
             var settingsAckDeadline1 = new SubscriberClient.Settings
             {
-                StreamAckDeadline = SubscriberClient.MinimumStreamAckDeadline
+                AckDeadline = SubscriberClient.MinimumAckDeadline
             };
             new SubscriberClientImpl(subscriptionName, clients, settingsAckDeadline1, null);
 
             var settingsAckDeadline2 = new SubscriberClient.Settings
             {
-                StreamAckDeadline = SubscriberClient.MaximumStreamAckDeadline
+                AckDeadline = SubscriberClient.MaximumAckDeadline
             };
             new SubscriberClientImpl(subscriptionName, clients, settingsAckDeadline2, null);
 
@@ -743,7 +743,7 @@ namespace Google.Cloud.PubSub.V1.Tests
             
             var settingsAckExtension2 = new SubscriberClient.Settings
             {
-                AckExtensionWindow = TimeSpan.FromTicks(SubscriberClient.DefaultStreamAckDeadline.Ticks / 2)
+                AckExtensionWindow = TimeSpan.FromTicks(SubscriberClient.DefaultAckDeadline.Ticks / 2)
             };
             new SubscriberClientImpl(subscriptionName, clients, settingsAckExtension2, null);
         }
@@ -769,17 +769,17 @@ namespace Google.Cloud.PubSub.V1.Tests
 
             var settingsBadAckDeadline1 = new SubscriberClient.Settings
             {
-                StreamAckDeadline = SubscriberClient.MinimumStreamAckDeadline - TimeSpan.FromMilliseconds(1)
+                AckDeadline = SubscriberClient.MinimumAckDeadline - TimeSpan.FromMilliseconds(1)
             };
             var ex5 = Assert.Throws<ArgumentOutOfRangeException>(() => new SubscriberClientImpl(subscriptionName, clients, settingsBadAckDeadline1, null));
-            Assert.Equal("StreamAckDeadline", ex5.ParamName);
+            Assert.Equal("AckDeadline", ex5.ParamName);
 
             var settingsBadAckDeadline2 = new SubscriberClient.Settings
             {
-                StreamAckDeadline = SubscriberClient.MaximumStreamAckDeadline + TimeSpan.FromMilliseconds(1)
+                AckDeadline = SubscriberClient.MaximumAckDeadline + TimeSpan.FromMilliseconds(1)
             };
             var ex6 = Assert.Throws<ArgumentOutOfRangeException>(() => new SubscriberClientImpl(subscriptionName, clients, settingsBadAckDeadline2, null));
-            Assert.Equal("StreamAckDeadline", ex6.ParamName);
+            Assert.Equal("AckDeadline", ex6.ParamName);
 
             var settingsBadAckExtension1 = new SubscriberClient.Settings
             {
@@ -791,7 +791,7 @@ namespace Google.Cloud.PubSub.V1.Tests
             var settingsBadAckExtension2 = new SubscriberClient.Settings
             {
                 // This is too large. The ack extension window must be less than half the ack deadline.
-                AckExtensionWindow = TimeSpan.FromTicks(SubscriberClient.DefaultStreamAckDeadline.Ticks / 2 + 1)
+                AckExtensionWindow = TimeSpan.FromTicks(SubscriberClient.DefaultAckDeadline.Ticks / 2 + 1)
             };
             var ex8 = Assert.Throws<ArgumentOutOfRangeException>(() => new SubscriberClientImpl(subscriptionName, clients, settingsBadAckExtension2, null));
             Assert.Equal("AckExtensionWindow", ex8.ParamName);

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.PubSub.V1
             internal Settings(Settings other)
             {
                 FlowControlSettings = other.FlowControlSettings;
-                StreamAckDeadline = other.StreamAckDeadline;
+                AckDeadline = other.AckDeadline;
                 AckExtensionWindow = other.AckExtensionWindow;
                 Scheduler = other.Scheduler;
             }
@@ -89,12 +89,12 @@ namespace Google.Cloud.PubSub.V1
             /// <summary>
             /// The lease time before which a message must either be ACKed
             /// or have its lease extended. This is truncated to the nearest second.
-            /// If <c>null</c>, uses the default of <see cref="DefaultStreamAckDeadline"/>.
+            /// If <c>null</c>, uses the default of <see cref="AckDeadline"/>.
             /// </summary>
-            public TimeSpan? StreamAckDeadline { get; set; }
+            public TimeSpan? AckDeadline { get; set; }
 
             /// <summary>
-            /// Duration before <see cref="StreamAckDeadline"/> at which the message ACK deadline
+            /// Duration before <see cref="AckDeadline"/> at which the message ACK deadline
             /// is automatically extended.
             /// If <c>null</c>, uses the default of <see cref="DefaultAckExtensionWindow"/>.
             /// </summary>
@@ -109,8 +109,8 @@ namespace Google.Cloud.PubSub.V1
 
             internal void Validate()
             {
-                GaxPreconditions.CheckArgumentRange(StreamAckDeadline, nameof(StreamAckDeadline), MinimumStreamAckDeadline, MaximumStreamAckDeadline);
-                var maxAckExtension = TimeSpan.FromTicks((StreamAckDeadline ?? DefaultStreamAckDeadline).Ticks / 2);
+                GaxPreconditions.CheckArgumentRange(AckDeadline, nameof(AckDeadline), MinimumAckDeadline, MaximumAckDeadline);
+                var maxAckExtension = TimeSpan.FromTicks((AckDeadline ?? DefaultAckDeadline).Ticks / 2);
                 GaxPreconditions.CheckArgumentRange(AckExtensionWindow, nameof(AckExtensionWindow), MinimumAckExtensionWindow, maxAckExtension);
             }
 
@@ -189,17 +189,17 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>
         /// The service-defined minimum message ACKnowledgement deadline of 10 seconds.
         /// </summary>
-        public static TimeSpan MinimumStreamAckDeadline { get; } = TimeSpan.FromSeconds(10);
+        public static TimeSpan MinimumAckDeadline { get; } = TimeSpan.FromSeconds(10);
 
         /// <summary>
         /// The service-defined maximum message ACKnowledgement deadline of 10 minutes.
         /// </summary>
-        public static TimeSpan MaximumStreamAckDeadline { get; } = TimeSpan.FromMinutes(10);
+        public static TimeSpan MaximumAckDeadline { get; } = TimeSpan.FromMinutes(10);
 
         /// <summary>
         /// The default message ACKnowledgement deadline of 60 seconds.
         /// </summary>
-        public static TimeSpan DefaultStreamAckDeadline { get; } = TimeSpan.FromSeconds(60);
+        public static TimeSpan DefaultAckDeadline { get; } = TimeSpan.FromSeconds(60);
 
         /// <summary>
         /// The minimum message ACKnowledgement extension window of 50 milliseconds.
@@ -215,7 +215,7 @@ namespace Google.Cloud.PubSub.V1
         /// Create a <see cref="SubscriberClient"/> instance associated with the specified <see cref="SubscriptionName"/>.
         /// The default <paramref name="settings"/> and <paramref name="clientCreationSettings"/> are suitable for machines with
         /// high network bandwidth (e.g. Google Compute Engine instances). If running with more limited network bandwidth, some
-        /// settings may need changing; especially <see cref="Settings.StreamAckDeadline"/>.
+        /// settings may need changing; especially <see cref="Settings.AckDeadline"/>.
         /// </summary>
         /// <param name="subscriptionName">The <see cref="SubscriptionName"/> to receive messages from.</param>
         /// <param name="clientCreationSettings">Optional. <see cref="ClientCreationSettings"/> specifying how to create
@@ -270,7 +270,7 @@ namespace Google.Cloud.PubSub.V1
         /// possibly causing a deadlock.
         /// The default <paramref name="settings"/> are suitable for machines with high network bandwidth (e.g. Google
         /// Compute Engine instances). If running with more limited network bandwidth, some settings may need changing;
-        /// especially <see cref="Settings.StreamAckDeadline"/>.
+        /// especially <see cref="Settings.AckDeadline"/>.
         /// </summary>
         /// <param name="subscriptionName">The <see cref="SubscriptionName"/> to receive messages from.</param>
         /// <param name="clients">The <see cref="SubscriberServiceApiClient"/>s to use in a <see cref="SubscriberClient"/>.
@@ -351,7 +351,7 @@ namespace Google.Cloud.PubSub.V1
             GaxPreconditions.CheckNotNull(settings, nameof(settings));
             settings.Validate();
             // These values are validated in Settings.Validate() above, so no need to re-validate here.
-            _modifyDeadlineSeconds = (int)((settings.StreamAckDeadline ?? DefaultStreamAckDeadline).TotalSeconds);
+            _modifyDeadlineSeconds = (int)((settings.AckDeadline ?? DefaultAckDeadline).TotalSeconds);
             _autoExtendInterval = TimeSpan.FromSeconds(_modifyDeadlineSeconds) - (settings.AckExtensionWindow ?? DefaultAckExtensionWindow);
             _shutdown = shutdown;
             _scheduler = settings.Scheduler ?? SystemScheduler.Instance;


### PR DESCRIPTION
As requested by pubsub team, to remove an implementation detail from the public surface.