### PR TITLE
Remove FlowState from Publisher

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/PublisherClientTest.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/PublisherClientTest.cs
@@ -166,28 +166,6 @@ namespace Google.Cloud.PubSub.V1.Tests
         }
 
         [Fact]
-        public void FlowState()
-        {
-            var topicName = new TopicName("FakeProject", "FakeTopic");
-            var scheduler = new TestScheduler();
-            TaskHelper taskHelper = scheduler.TaskHelper;
-            var client = new FakePublisherServiceApiClient(scheduler, taskHelper, TimeSpan.FromSeconds(1));
-            var settings = MakeSettings(scheduler);
-            var pub = new PublisherClientImpl(topicName, new[] { client }, settings, null, taskHelper);
-            var msgSize = new PubsubMessage { Data = ByteString.CopyFromUtf8("1") }.CalculateSize();
-            scheduler.Run(async () =>
-            {
-                // Publish 2 msgs; 1st will be immediately sent, 2nd will stay in queue for 1 second.
-                var pubTask = Task.WhenAll(pub.PublishAsync("1"), pub.PublishAsync("2"));
-                Assert.Equal(1, pub.GetCurrentFlowState().ElementCount);
-                Assert.Equal(msgSize, pub.GetCurrentFlowState().ByteCount);
-                await taskHelper.ConfigureAwait(pubTask);
-                Assert.Equal(0, pub.GetCurrentFlowState().ElementCount);
-                Assert.Equal(0, pub.GetCurrentFlowState().ByteCount);
-            });
-        }
-
-        [Fact]
         public void SettingsValidation()
         {
             new PublisherClient.Settings().Validate();

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClient.cs
@@ -145,33 +145,6 @@ namespace Google.Cloud.PubSub.V1
             }
         }
 
-        /// <summary>
-        /// A snapshot of the flow state of a <see cref="PublisherClient"/>.
-        /// </summary>
-        public struct FlowState
-        {
-            /// <summary>
-            /// Instantiate a <see cref="FlowState"/>.
-            /// </summary>
-            /// <param name="elementCount">The number of elements (messages) currently queued.</param>
-            /// <param name="byteCount">The number of bytes currently queued.</param>
-            public FlowState(long elementCount, long byteCount)
-            {
-                ElementCount = elementCount;
-                ByteCount = byteCount;
-            }
-
-            /// <summary>
-            /// The number of elements (messages) currently queued.
-            /// </summary>
-            public long ElementCount { get; }
-
-            /// <summary>
-            /// The number of bytes currently queued.
-            /// </summary>
-            public long ByteCount { get; }
-        }
-
         // All defaults taken from Java (reference) implementation.
 
         /// <summary>
@@ -325,12 +298,6 @@ namespace Google.Cloud.PubSub.V1
             });
 
         /// <summary>
-        /// Retrieve a snapshot of the flow state.
-        /// </summary>
-        /// <returns></returns>
-        public virtual FlowState GetCurrentFlowState() => throw new NotImplementedException();
-
-        /// <summary>
         /// Shutdown this <see cref="PublisherClient"/>. Cancelling <paramref name="hardStopToken"/> aborts the
         /// clean shutdown process, and may leave some locally queued messages unsent.
         /// The returned <see cref="Task"/> completes when all queued messages have been published.
@@ -471,9 +438,6 @@ namespace Google.Cloud.PubSub.V1
             // Return the message ID sent from the server.
             return ids[index];
         }
-
-        /// <inheritdoc/>
-        public override FlowState GetCurrentFlowState() => _lock.Locked(() => new FlowState(_queueElementCount, _queueByteCount));
 
         /// <inheritdoc/>
         public override Task ShutdownAsync(CancellationToken hardStopToken)


### PR DESCRIPTION
As requested by pubsub team. Rationale is that no other languages currently implement this functionality, and althought they may wish to have it in the future they would like it to be consistent across languages. Having it now just in C# may preclude this.