### PR TITLE
Avoid broken links in docs

### DIFF
--- a/buildrelease.sh
+++ b/buildrelease.sh
@@ -65,6 +65,11 @@ fi
 
 ./build.sh $projects
 
+# Build LRO and IAM to make docs simpler. We always build the docs from "current" even if there's
+# a different package reference version... which means it's *possible* they'll be inaccurate,
+# but it's simpler than getting it perfectly correct.
+./build.sh Google.LongRunning Google.Cloud.Iam.V1
+
 # Retry integration tests up to 3 times as they can sometimes
 # be a little flakey.
 if [[ "$run_tests" = true ]]


### PR DESCRIPTION
Currently building a release that requires LRO or IAM will cause
broken links and odd-looking documentation. Building the packages
first fixes that, effectively by making sure that LRO/IAM
dependencies are present.

We should notice the difference next time we do a release of a
package that requires either of these.